### PR TITLE
feat(image): allow white color usage and improve color matching

### DIFF
--- a/Auto-Farm.js
+++ b/Auto-Farm.js
@@ -1,11 +1,1819 @@
-/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-20T07:30:02.928Z */
-(()=>{var d=(...e)=>console.log("[WPA-UI]",...e);var b={SITEKEY:"0x4AAAAAABpqJe8FO0N84q0F",TILE_X:1086,TILE_Y:1565,TILE_SIZE:3e3,DELAY_MS:15e3,MIN_CHARGES:10,CHARGE_REGEN_MS:3e4,PIXELS_PER_BATCH:20,COLOR_MIN:1,COLOR_MAX:32,COLOR_MODE:"random",COLOR_FIXED:1,CUSTOM_PALETTE:["#FF0000","#00FF00","#0000FF","#FFFF00","#FF00FF","#00FFFF"],BASE_X:null,BASE_Y:null,FARM_RADIUS:500,POSITION_SELECTED:!1,UI_THEME:{primary:"#000000",secondary:"#111111",accent:"#222222",text:"#ffffff",highlight:"#775ce3",success:"#00ff00",error:"#ff0000",running:"#00cc00"}},g={running:!1,painted:0,last:null,charges:{count:0,max:0,cooldownMs:3e4},user:null,panel:null,captureMode:!1,selectingPosition:!1,originalFetch:window.fetch,retryCount:0,inCooldown:!1,nextPaintTime:0,cooldownEndTime:0,health:null};function q(e){return{...e}}function de(){console.log("[WPA-UI]","Configuraci\xF3n del farm reseteada (localStorage deshabilitado)")}function ue(){console.log("[WPA-UI]","Configuraci\xF3n reseteada a valores seguros (localStorage deshabilitado)")}var H="https://backend.wplace.live";async function G(){var e,o,t;try{let r=await fetch(`${H}/me`,{credentials:"include"}).then(p=>p.json()),n=r||null,c=(r==null?void 0:r.charges)||{},i={count:(e=c.count)!=null?e:0,max:(o=c.max)!=null?o:0,cooldownMs:(t=c.cooldownMs)!=null?t:3e4};return{success:!0,data:{user:n,charges:i.count,maxCharges:i.max,chargeRegen:i.cooldownMs}}}catch(r){return{success:!1,error:r.message,data:{user:null,charges:0,maxCharges:0,chargeRegen:3e4}}}}async function pe(){try{let e=await fetch(`${H}/health`,{method:"GET",credentials:"include"});return e.ok?{...await e.json(),lastCheck:Date.now(),status:"online"}:{database:!1,up:!1,uptime:"N/A",lastCheck:Date.now(),status:"error",statusCode:e.status}}catch(e){return{database:!1,up:!1,uptime:"N/A",lastCheck:Date.now(),status:"offline",error:e.message}}}async function me(e,o,t,r,n){try{let c=JSON.stringify({colors:r,coords:t,t:n}),i=await fetch(`${H}/s0/pixel/${e}/${o}`,{method:"POST",credentials:"include",headers:{"Content-Type":"text/plain;charset=UTF-8"},body:c}),p=null;try{p=await i.json()}catch{p={}}return{status:i.status,json:p,success:i.ok,painted:(p==null?void 0:p.painted)||0}}catch(c){return{status:0,json:{error:c.message},success:!1,painted:0}}}function M(e,o,t){return Math.max(o,Math.min(t,e))}function ge(e,o){let t=0,r=0,n=0,c=0;e.style.cursor="move",e.addEventListener("mousedown",i);function i(a){a.preventDefault(),n=a.clientX,c=a.clientY,document.addEventListener("mouseup",u),document.addEventListener("mousemove",p)}function p(a){a.preventDefault(),t=n-a.clientX,r=c-a.clientY,n=a.clientX,c=a.clientY;let f=o.offsetTop-r,s=o.offsetLeft-t;o.style.top=Math.max(0,f)+"px",o.style.left=Math.max(0,s)+"px"}function u(){document.removeEventListener("mouseup",u),document.removeEventListener("mousemove",p)}}var fe={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selecci\xF3n",user:"Usuario",charges:"Cargas",backend:"Backend",database:"Database",uptime:"Uptime",close:"Cerrar",launch:"Lanzar",loading:"Cargando\u2026",executing:"Ejecutando\u2026",downloading:"Descargando script\u2026",chooseBot:"Elige un bot y presiona Lanzar",readyToLaunch:"Listo para lanzar",loadError:"Error al cargar",loadErrorMsg:"No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",checking:"\u{1F504} Verificando...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Iniciar Auto-BOT",uploadImage:"Subir Imagen",resizeImage:"Redimensionar Imagen",selectPosition:"Seleccionar Posici\xF3n",startPainting:"Iniciar Pintura",stopPainting:"Detener Pintura",saveProgress:"Guardar Progreso",loadProgress:"Cargar Progreso",checkingColors:"\u{1F50D} Verificando colores disponibles...",noColorsFound:"\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",colorsFound:"\u2705 {count} colores disponibles encontrados",loadingImage:"\u{1F5BC}\uFE0F Cargando imagen...",imageLoaded:"\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",imageError:"\u274C Error al cargar la imagen",selectPositionAlert:"\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Posici\xF3n establecida con \xE9xito!",positionTimeout:"\u274C Tiempo agotado para seleccionar posici\xF3n",positionDetected:"\u{1F3AF} Posici\xF3n detectada, procesando...",positionError:"\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",startPaintingMsg:"\u{1F3A8} Iniciando pintura...",paintingProgress:"\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",noCharges:"\u231B Sin cargas. Esperando {time}...",paintingStopped:"\u23F9\uFE0F Pintura detenida por el usuario",paintingComplete:"\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",paintingError:"\u274C Error durante la pintura",missingRequirements:"\u274C Carga una imagen y selecciona una posici\xF3n primero",progress:"Progreso",userName:"Usuario",pixels:"P\xEDxeles",charges:"Cargas",estimatedTime:"Tiempo estimado",initMessage:"Haz clic en 'Iniciar Auto-BOT' para comenzar",waitingInit:"Esperando inicializaci\xF3n...",resizeSuccess:"\u2705 Imagen redimensionada a {width}x{height}",paintingPaused:"\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",pixelsPerBatch:"P\xEDxeles por lote",batchSize:"Tama\xF1o del lote",nextBatchTime:"Siguiente lote en",useAllCharges:"Usar todas las cargas disponibles",showOverlay:"Mostrar overlay",maxCharges:"Cargas m\xE1ximas por lote",waitingForCharges:"\u23F3 Esperando cargas: {current}/{needed}",timeRemaining:"Tiempo restante",cooldownWaiting:"\u23F3 Esperando {time} para continuar...",progressSaved:"\u2705 Progreso guardado como {filename}",progressLoaded:"\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",progressLoadError:"\u274C Error al cargar progreso: {error}",progressSaveError:"\u274C Error al guardar progreso: {error}",confirmSaveProgress:"\xBFDeseas guardar el progreso actual antes de detener?",saveProgressTitle:"Guardar Progreso",discardProgress:"Descartar",cancel:"Cancelar",minimize:"Minimizar",width:"Ancho",height:"Alto",keepAspect:"Mantener proporci\xF3n",apply:"Aplicar",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",waitingChargesCountdown:"\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Bot iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",manualInitRequired:"\u{1F527} Inicio manual requerido",retryAttempt:"\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",retryError:"\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",retryFailed:"\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",networkError:"\u{1F310} Error de red. Reintentando...",serverError:"\u{1F525} Error del servidor. Reintentando...",timeoutError:"\u23F0 Timeout del servidor. Reintentando..."},farm:{title:"WPlace Farm Bot",start:"Iniciar",stop:"Detener",stopped:"Bot detenido",calibrate:"Calibrar",paintOnce:"Una vez",checkingStatus:"Verificando estado...",configuration:"Configuraci\xF3n",delay:"Delay (ms)",pixelsPerBatch:"P\xEDxeles/lote",minCharges:"Cargas m\xEDn",colorMode:"Modo color",random:"Aleatorio",fixed:"Fijo",range:"Rango",fixedColor:"Color fijo",advanced:"Avanzado",tileX:"Tile X",tileY:"Tile Y",customPalette:"Paleta personalizada",paletteExample:"ej: #FF0000,#00FF00,#0000FF",capture:"Capturar",painted:"Pintados",charges:"Cargas",retries:"Fallos",tile:"Tile",configSaved:"Configuraci\xF3n guardada",configLoaded:"Configuraci\xF3n cargada",configReset:"Configuraci\xF3n reiniciada",captureInstructions:"Pinta un p\xEDxel manualmente para capturar coordenadas...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Iniciando bot...",stoppingBot:"Deteniendo bot...",calibrating:"Calibrando...",alreadyRunning:"Auto-Farm ya est\xE1 corriendo.",imageRunningWarning:"Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",selectPosition:"Seleccionar Zona",selectPositionAlert:"\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Zona establecida! Radio: 500px",positionTimeout:"\u274C Tiempo agotado para seleccionar zona",missingPosition:"\u274C Selecciona una zona primero usando 'Seleccionar Zona'",farmRadius:"Radio farm",positionInfo:"Zona actual",farmingInRadius:"\u{1F33E} Farming en radio {radius}px desde ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",noPosition:"Sin zona",currentZone:"Zona: ({x},{y})",autoSelectPosition:"\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"},common:{yes:"S\xED",no:"No",ok:"Aceptar",cancel:"Cancelar",close:"Cerrar",save:"Guardar",load:"Cargar",delete:"Eliminar",edit:"Editar",start:"Iniciar",stop:"Detener",pause:"Pausar",resume:"Reanudar",reset:"Reiniciar",settings:"Configuraci\xF3n",help:"Ayuda",about:"Acerca de",language:"Idioma",loading:"Cargando...",error:"Error",success:"\xC9xito",warning:"Advertencia",info:"Informaci\xF3n",languageChanged:"Idioma cambiado a {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Inicializar Guard-BOT",selectArea:"Seleccionar \xC1rea",captureArea:"Capturar \xC1rea",startProtection:"Iniciar Protecci\xF3n",stopProtection:"Detener Protecci\xF3n",upperLeft:"Esquina Superior Izquierda",lowerRight:"Esquina Inferior Derecha",protectedPixels:"P\xEDxeles Protegidos",detectedChanges:"Cambios Detectados",repairedPixels:"P\xEDxeles Reparados",charges:"Cargas",waitingInit:"Esperando inicializaci\xF3n...",checkingColors:"\u{1F3A8} Verificando colores disponibles...",noColorsFound:"\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",colorsFound:"\u2705 {count} colores disponibles encontrados",initSuccess:"\u2705 Guard-BOT inicializado correctamente",initError:"\u274C Error inicializando Guard-BOT",invalidCoords:"\u274C Coordenadas inv\xE1lidas",invalidArea:"\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",areaTooLarge:"\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",capturingArea:"\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",areaCaptured:"\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",captureError:"\u274C Error capturando \xE1rea: {error}",captureFirst:"\u274C Primero captura un \xE1rea de protecci\xF3n",protectionStarted:"\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",protectionStopped:"\u23F9\uFE0F Protecci\xF3n detenida",noChanges:"\u2705 \xC1rea protegida - sin cambios detectados",changesDetected:"\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",repairing:"\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",repairedSuccess:"\u2705 Reparados {count} p\xEDxeles correctamente",repairError:"\u274C Error reparando p\xEDxeles: {error}",noCharges:"\u26A0\uFE0F Sin cargas suficientes para reparar cambios",checkingChanges:"\u{1F50D} Verificando cambios en \xE1rea protegida...",errorChecking:"\u274C Error verificando cambios: {error}",guardActive:"\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",lastCheck:"\xDAltima verificaci\xF3n: {time}",nextCheck:"Pr\xF3xima verificaci\xF3n en: {time}s",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Guard-BOT iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",manualInitRequired:"\u{1F527} Inicio manual requerido",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",selectUpperLeft:"\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",selectLowerRight:"\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",waitingUpperLeft:"\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",waitingLowerRight:"\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",upperLeftCaptured:"\u2705 Esquina superior izquierda capturada: ({x}, {y})",lowerRightCaptured:"\u2705 Esquina inferior derecha capturada: ({x}, {y})",selectionTimeout:"\u274C Tiempo agotado para selecci\xF3n",selectionError:"\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"}};var he={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selection",user:"User",charges:"Charges",backend:"Backend",database:"Database",uptime:"Uptime",close:"Close",launch:"Launch",loading:"Loading\u2026",executing:"Executing\u2026",downloading:"Downloading script\u2026",chooseBot:"Choose a bot and press Launch",readyToLaunch:"Ready to launch",loadError:"Load error",loadErrorMsg:"Could not load the selected bot. Check your connection or try again.",checking:"\u{1F504} Checking...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialize Auto-BOT",uploadImage:"Upload Image",resizeImage:"Resize Image",selectPosition:"Select Position",startPainting:"Start Painting",stopPainting:"Stop Painting",saveProgress:"Save Progress",loadProgress:"Load Progress",checkingColors:"\u{1F50D} Checking available colors...",noColorsFound:"\u274C Open the color palette on the site and try again!",colorsFound:"\u2705 Found {count} available colors",loadingImage:"\u{1F5BC}\uFE0F Loading image...",imageLoaded:"\u2705 Image loaded with {count} valid pixels",imageError:"\u274C Error loading image",selectPositionAlert:"Paint the first pixel at the location where you want the art to start!",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Position set successfully!",positionTimeout:"\u274C Timeout for position selection",positionDetected:"\u{1F3AF} Position detected, processing...",positionError:"\u274C Error detecting position, please try again",startPaintingMsg:"\u{1F3A8} Starting painting...",paintingProgress:"\u{1F9F1} Progress: {painted}/{total} pixels...",noCharges:"\u231B No charges. Waiting {time}...",paintingStopped:"\u23F9\uFE0F Painting stopped by user",paintingComplete:"\u2705 Painting completed! {count} pixels painted.",paintingError:"\u274C Error during painting",missingRequirements:"\u274C Load an image and select a position first",progress:"Progress",userName:"User",pixels:"Pixels",charges:"Charges",estimatedTime:"Estimated time",initMessage:"Click 'Initialize Auto-BOT' to begin",waitingInit:"Waiting for initialization...",resizeSuccess:"\u2705 Image resized to {width}x{height}",paintingPaused:"\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",pixelsPerBatch:"Pixels per batch",batchSize:"Batch size",nextBatchTime:"Next batch in",useAllCharges:"Use all available charges",showOverlay:"Show overlay",maxCharges:"Max charges per batch",waitingForCharges:"\u23F3 Waiting for charges: {current}/{needed}",timeRemaining:"Time remaining",cooldownWaiting:"\u23F3 Waiting {time} to continue...",progressSaved:"\u2705 Progress saved as {filename}",progressLoaded:"\u2705 Progress loaded: {painted}/{total} pixels painted",progressLoadError:"\u274C Error loading progress: {error}",progressSaveError:"\u274C Error saving progress: {error}",confirmSaveProgress:"Do you want to save the current progress before stopping?",saveProgressTitle:"Save Progress",discardProgress:"Discard",cancel:"Cancel",minimize:"Minimize",width:"Width",height:"Height",keepAspect:"Keep aspect ratio",apply:"Apply",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",waitingChargesCountdown:"\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Bot auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",manualInitRequired:"\u{1F527} Manual initialization required",retryAttempt:"\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",retryError:"\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",retryFailed:"\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",networkError:"\u{1F310} Network error. Retrying...",serverError:"\u{1F525} Server error. Retrying...",timeoutError:"\u23F0 Server timeout. Retrying..."},farm:{title:"WPlace Farm Bot",start:"Start",stop:"Stop",stopped:"Bot stopped",calibrate:"Calibrate",paintOnce:"Once",checkingStatus:"Checking status...",configuration:"Configuration",delay:"Delay (ms)",pixelsPerBatch:"Pixels/batch",minCharges:"Min charges",colorMode:"Color mode",random:"Random",fixed:"Fixed",range:"Range",fixedColor:"Fixed color",advanced:"Advanced",tileX:"Tile X",tileY:"Tile Y",customPalette:"Custom palette",paletteExample:"e.g: #FF0000,#00FF00,#0000FF",capture:"Capture",painted:"Painted",charges:"Charges",retries:"Retries",tile:"Tile",configSaved:"Configuration saved",configLoaded:"Configuration loaded",configReset:"Configuration reset",captureInstructions:"Paint a pixel manually to capture coordinates...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Starting bot...",stoppingBot:"Stopping bot...",calibrating:"Calibrating...",alreadyRunning:"Auto-Farm is already running.",imageRunningWarning:"Auto-Image is running. Close it before starting Auto-Farm.",selectPosition:"Select Area",selectPositionAlert:"\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Area set! Radius: 500px",positionTimeout:"\u274C Timeout for area selection",missingPosition:"\u274C Select an area first using 'Select Area'",farmRadius:"Farm radius",positionInfo:"Current area",farmingInRadius:"\u{1F33E} Farming in {radius}px radius from ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",noPosition:"No area",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"},common:{yes:"Yes",no:"No",ok:"OK",cancel:"Cancel",close:"Close",save:"Save",load:"Load",delete:"Delete",edit:"Edit",start:"Start",stop:"Stop",pause:"Pause",resume:"Resume",reset:"Reset",settings:"Settings",help:"Help",about:"About",language:"Language",loading:"Loading...",error:"Error",success:"Success",warning:"Warning",info:"Information",languageChanged:"Language changed to {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialize Guard-BOT",selectArea:"Select Area",captureArea:"Capture Area",startProtection:"Start Protection",stopProtection:"Stop Protection",upperLeft:"Upper Left Corner",lowerRight:"Lower Right Corner",protectedPixels:"Protected Pixels",detectedChanges:"Detected Changes",repairedPixels:"Repaired Pixels",charges:"Charges",waitingInit:"Waiting for initialization...",checkingColors:"\u{1F3A8} Checking available colors...",noColorsFound:"\u274C No colors found. Open the color palette on the site.",colorsFound:"\u2705 Found {count} available colors",initSuccess:"\u2705 Guard-BOT initialized successfully",initError:"\u274C Error initializing Guard-BOT",invalidCoords:"\u274C Invalid coordinates",invalidArea:"\u274C Area must have upper left corner less than lower right corner",areaTooLarge:"\u274C Area too large: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capturing protection area...",areaCaptured:"\u2705 Area captured: {count} pixels under protection",captureError:"\u274C Error capturing area: {error}",captureFirst:"\u274C First capture a protection area",protectionStarted:"\u{1F6E1}\uFE0F Protection started - monitoring area",protectionStopped:"\u23F9\uFE0F Protection stopped",noChanges:"\u2705 Protected area - no changes detected",changesDetected:"\u{1F6A8} {count} changes detected in protected area",repairing:"\u{1F6E0}\uFE0F Repairing {count} altered pixels...",repairedSuccess:"\u2705 Successfully repaired {count} pixels",repairError:"\u274C Error repairing pixels: {error}",noCharges:"\u26A0\uFE0F Insufficient charges to repair changes",checkingChanges:"\u{1F50D} Checking changes in protected area...",errorChecking:"\u274C Error checking changes: {error}",guardActive:"\u{1F6E1}\uFE0F Guardian active - area under protection",lastCheck:"Last check: {time}",nextCheck:"Next check in: {time}s",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Guard-BOT auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",manualInitRequired:"\u{1F527} Manual initialization required",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",selectUpperLeft:"\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",selectLowerRight:"\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",waitingUpperLeft:"\u{1F446} Waiting for upper left corner selection...",waitingLowerRight:"\u{1F446} Waiting for lower right corner selection...",upperLeftCaptured:"\u2705 Upper left corner captured: ({x}, {y})",lowerRightCaptured:"\u2705 Lower right corner captured: ({x}, {y})",selectionTimeout:"\u274C Selection timeout",selectionError:"\u274C Selection error, please try again"}};var xe={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"S\xE9lection",user:"Utilisateur",charges:"Charges",backend:"Backend",database:"Base de donn\xE9es",uptime:"Temps actif",close:"Fermer",launch:"Lancer",loading:"Chargement\u2026",executing:"Ex\xE9cution\u2026",downloading:"T\xE9l\xE9chargement du script\u2026",chooseBot:"Choisissez un bot et appuyez sur Lancer",readyToLaunch:"Pr\xEAt \xE0 lancer",loadError:"Erreur de chargement",loadErrorMsg:"Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",checking:"\u{1F504} V\xE9rification...",online:"\u{1F7E2} En ligne",offline:"\u{1F534} Hors ligne",ok:"\u{1F7E2} OK",error:"\u{1F534} Erreur",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialiser Auto-BOT",uploadImage:"T\xE9l\xE9charger Image",resizeImage:"Redimensionner Image",selectPosition:"S\xE9lectionner Position",startPainting:"Commencer Peinture",stopPainting:"Arr\xEAter Peinture",saveProgress:"Sauvegarder Progr\xE8s",loadProgress:"Charger Progr\xE8s",checkingColors:"\u{1F50D} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",loadingImage:"\u{1F5BC}\uFE0F Chargement de l'image...",imageLoaded:"\u2705 Image charg\xE9e avec {count} pixels valides",imageError:"\u274C Erreur lors du chargement de l'image",selectPositionAlert:"Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Position d\xE9finie avec succ\xE8s!",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",positionDetected:"\u{1F3AF} Position d\xE9tect\xE9e, traitement...",positionError:"\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",startPaintingMsg:"\u{1F3A8} D\xE9but de la peinture...",paintingProgress:"\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",noCharges:"\u231B Aucune charge. Attendre {time}...",paintingStopped:"\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",paintingComplete:"\u2705 Peinture termin\xE9e! {count} pixels peints.",paintingError:"\u274C Erreur pendant la peinture",missingRequirements:"\u274C Chargez une image et s\xE9lectionnez une position d'abord",progress:"Progr\xE8s",userName:"Usager",pixels:"Pixels",charges:"Charges",estimatedTime:"Temps estim\xE9",initMessage:"Cliquez sur 'Initialiser Auto-BOT' pour commencer",waitingInit:"En attente d'initialisation...",resizeSuccess:"\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",paintingPaused:"\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",pixelsPerBatch:"Pixels par lot",batchSize:"Taille du lot",nextBatchTime:"Prochain lot dans",useAllCharges:"Utiliser toutes les charges disponibles",showOverlay:"Afficher l'overlay",maxCharges:"Charges max par lot",waitingForCharges:"\u23F3 En attente de charges: {current}/{needed}",timeRemaining:"Temps restant",cooldownWaiting:"\u23F3 Attendre {time} pour continuer...",progressSaved:"\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",progressLoaded:"\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",progressLoadError:"\u274C Erreur lors du chargement du progr\xE8s: {error}",progressSaveError:"\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",confirmSaveProgress:"Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",saveProgressTitle:"Sauvegarder Progr\xE8s",discardProgress:"Abandonner",cancel:"Annuler",minimize:"Minimiser",width:"Largeur",height:"Hauteur",keepAspect:"Garder les proportions",apply:"Appliquer",overlayOn:"Overlay : ON",overlayOff:"Overlay : OFF",passCompleted:"\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",waitingChargesCountdown:"\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Bot d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",manualInitRequired:"\u{1F527} Initialisation manuelle requise",retryAttempt:"\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",retryError:"\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",retryFailed:"\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",networkError:"\u{1F310} Erreur r\xE9seau. Nouvel essai...",serverError:"\u{1F525} Erreur serveur. Nouvel essai...",timeoutError:"\u23F0 Timeout serveur. Nouvel essai..."},farm:{title:"WPlace Farm Bot",start:"D\xE9marrer",stop:"Arr\xEAter",stopped:"Bot arr\xEAt\xE9",calibrate:"Calibrer",paintOnce:"Une fois",checkingStatus:"V\xE9rification du statut...",configuration:"Configuration",delay:"D\xE9lai (ms)",pixelsPerBatch:"Pixels/lot",minCharges:"Charges min",colorMode:"Mode couleur",random:"Al\xE9atoire",fixed:"Fixe",range:"Plage",fixedColor:"Couleur fixe",advanced:"Avanc\xE9",tileX:"Tuile X",tileY:"Tuile Y",customPalette:"Palette personnalis\xE9e",paletteExample:"ex: #FF0000,#00FF00,#0000FF",capture:"Capturer",painted:"Peints",charges:"Charges",retries:"\xC9checs",tile:"Tuile",configSaved:"Configuration sauvegard\xE9e",configLoaded:"Configuration charg\xE9e",configReset:"Configuration r\xE9initialis\xE9e",captureInstructions:"Peindre un pixel manuellement pour capturer les coordonn\xE9es...",backendOnline:"Backend En ligne",backendOffline:"Backend Hors ligne",startingBot:"D\xE9marrage du bot...",stoppingBot:"Arr\xEAt du bot...",calibrating:"Calibrage...",alreadyRunning:"Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",imageRunningWarning:"Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",selectPosition:"S\xE9lectionner Zone",selectPositionAlert:"\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Zone d\xE9finie! Rayon: 500px",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",missingPosition:"\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",farmRadius:"Rayon farm",positionInfo:"Zone actuelle",farmingInRadius:"\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",noPosition:"Aucune zone",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"},common:{yes:"Oui",no:"Non",ok:"OK",cancel:"Annuler",close:"Fermer",save:"Sauvegarder",load:"Charger",delete:"Supprimer",edit:"Modifier",start:"D\xE9marrer",stop:"Arr\xEAter",pause:"Pause",resume:"Reprendre",reset:"R\xE9initialiser",settings:"Param\xE8tres",help:"Aide",about:"\xC0 propos",language:"Langue",loading:"Chargement...",error:"Erreur",success:"Succ\xE8s",warning:"Avertissement",info:"Information",languageChanged:"Langue chang\xE9e en {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialiser Guard-BOT",selectArea:"S\xE9lectionner Zone",captureArea:"Capturer Zone",startProtection:"D\xE9marrer Protection",stopProtection:"Arr\xEAter Protection",upperLeft:"Coin Sup\xE9rieur Gauche",lowerRight:"Coin Inf\xE9rieur Droit",protectedPixels:"Pixels Prot\xE9g\xE9s",detectedChanges:"Changements D\xE9tect\xE9s",repairedPixels:"Pixels R\xE9par\xE9s",charges:"Charges",waitingInit:"En attente d'initialisation...",checkingColors:"\u{1F3A8} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",initSuccess:"\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",initError:"\u274C Erreur lors de l'initialisation de Guard-BOT",invalidCoords:"\u274C Coordonn\xE9es invalides",invalidArea:"\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",areaTooLarge:"\u274C Zone trop grande: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capture de la zone de protection...",areaCaptured:"\u2705 Zone captur\xE9e: {count} pixels sous protection",captureError:"\u274C Erreur lors de la capture de zone: {error}",captureFirst:"\u274C Capturez d'abord une zone de protection",protectionStarted:"\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",protectionStopped:"\u23F9\uFE0F Protection arr\xEAt\xE9e",noChanges:"\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",changesDetected:"\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",repairing:"\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",repairedSuccess:"\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",repairError:"\u274C Erreur lors de la r\xE9paration des pixels: {error}",noCharges:"\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",checkingChanges:"\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",errorChecking:"\u274C Erreur lors de la v\xE9rification des changements: {error}",guardActive:"\u{1F6E1}\uFE0F Gardien actif - zone sous protection",lastCheck:"Derni\xE8re v\xE9rification: {time}",nextCheck:"Prochaine v\xE9rification dans: {time}s",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",manualInitRequired:"\u{1F527} Initialisation manuelle requise",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",selectUpperLeft:"\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",selectLowerRight:"\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",waitingUpperLeft:"\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",waitingLowerRight:"\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",upperLeftCaptured:"\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",lowerRightCaptured:"\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",selectionTimeout:"\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",selectionError:"\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"}};var Ee={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",autoImage:"\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",autoGuard:"\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",selection:"\u0412\u044B\u0431\u0440\u0430\u043D\u043E",user:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",charges:"\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",backend:"\u0411\u044D\u043A\u0435\u043D\u0434",database:"\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",uptime:"\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",launch:"\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",executing:"\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",downloading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",chooseBot:"\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",readyToLaunch:"\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",loadError:"\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",loadErrorMsg:"\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",checking:"\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",online:"\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",offline:"\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",ok:"\u{1F7E2} \u041E\u041A",error:"\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",unknown:"-"},image:{title:"WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",uploadImage:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",resizeImage:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",startPainting:"\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",stopPainting:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",saveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",loadProgress:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",checkingColors:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",loadingImage:"\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",imageLoaded:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",imageError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPositionAlert:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",positionDetected:"\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",positionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",startPaintingMsg:"\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",paintingProgress:"\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",noCharges:"\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",paintingStopped:"\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",paintingComplete:"\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",paintingError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",missingRequirements:"\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",progress:"\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",userName:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",pixels:"\u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",estimatedTime:"\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",initMessage:"\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",resizeSuccess:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",paintingPaused:"\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",batchSize:"\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",nextBatchTime:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",useAllCharges:"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",showOverlay:"\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",maxCharges:"\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",waitingForCharges:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",timeRemaining:"\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",cooldownWaiting:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",progressSaved:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",progressLoaded:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",progressLoadError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",progressSaveError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",confirmSaveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",saveProgressTitle:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",discardProgress:"\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",minimize:"\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",width:"\u0428\u0438\u0440\u0438\u043D\u0430",height:"\u0412\u044B\u0441\u043E\u0442\u0430",keepAspect:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",apply:"\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",passCompleted:"\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",waitingChargesRegen:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",waitingChargesCountdown:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",retryAttempt:"\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryError:"\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryFailed:"\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",networkError:"\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",serverError:"\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",timeoutError:"\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."},farm:{title:"WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",stopped:"\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",calibrate:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",paintOnce:"\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",checkingStatus:"\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",configuration:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",delay:"\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",minCharges:"\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",colorMode:"\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",random:"\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",fixed:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",range:"\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",fixedColor:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",advanced:"\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",tileX:"\u041F\u043B\u0438\u0442\u043A\u0430 X",tileY:"\u041F\u043B\u0438\u0442\u043A\u0430 Y",customPalette:"\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",paletteExample:"\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",capture:"\u0417\u0430\u0445\u0432\u0430\u0442",painted:"\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",retries:"\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",tile:"\u041F\u043B\u0438\u0442\u043A\u0430",configSaved:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",configLoaded:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",configReset:"\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",captureInstructions:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",backendOnline:"\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",backendOffline:"\u0411\u044D\u043A\u044D\u043D\u0434",startingBot:"\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",stoppingBot:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",calibrating:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",alreadyRunning:"\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",imageRunningWarning:"\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C",selectPositionAlert:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",missingPosition:"\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",farmRadius:"\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",positionInfo:"\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",farmingInRadius:"\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",selectEmptyArea:"\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",noPosition:"\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",currentZone:"\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",autoSelectPosition:"\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."},common:{yes:"\u0414\u0430",no:"\u041D\u0435\u0442",ok:"\u041E\u041A",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",save:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",load:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",delete:"\u0423\u0434\u0430\u043B\u0438\u0442\u044C",edit:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",pause:"\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",resume:"\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",reset:"\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",settings:"\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",help:"\u041F\u043E\u043C\u043E\u0449\u044C",about:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",language:"\u042F\u0437\u044B\u043A",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",error:"\u041E\u0448\u0438\u0431\u043A\u0430",success:"\u0423\u0441\u043F\u0435\u0445",warning:"\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",info:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",languageChanged:"\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"},guard:{title:"WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",selectArea:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",captureArea:"\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",startProtection:"\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",stopProtection:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",upperLeft:"\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",lowerRight:"\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",protectedPixels:"\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",detectedChanges:"\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",repairedPixels:"\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",checkingColors:"\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",initSuccess:"\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",initError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",invalidCoords:"\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",invalidArea:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",areaTooLarge:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",capturingArea:"\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",areaCaptured:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",captureError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",captureFirst:"\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",protectionStarted:"\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",protectionStopped:"\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",noChanges:"\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",changesDetected:"\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",repairing:"\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",repairedSuccess:"\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",repairError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",noCharges:"\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",checkingChanges:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",errorChecking:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",guardActive:"\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",lastCheck:"\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",nextCheck:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",selectUpperLeft:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",selectLowerRight:"\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",waitingUpperLeft:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",waitingLowerRight:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",upperLeftCaptured:"\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",lowerRightCaptured:"\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",selectionTimeout:"\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",selectionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"}};var F={es:fe,en:he,fr:xe,ru:Ee},Z="es",j=F[Z];function Ae(){let o=(window.navigator.language||window.navigator.userLanguage||"es").split("-")[0].toLowerCase();return F[o]?o:"es"}function Te(){return null}function V(){let e=Te(),o=Ae(),t="es";return e&&F[e]?t=e:o&&F[o]&&(t=o),Le(t),t}function Le(e){if(!F[e]){console.warn(`Idioma '${e}' no disponible. Usando '${Z}'`);return}Z=e,j=F[e],typeof window!="undefined"&&window.CustomEvent&&window.dispatchEvent(new window.CustomEvent("languageChanged",{detail:{language:e,translations:j}}))}function l(e,o={}){let t=e.split("."),r=j;for(let n of t)if(r&&typeof r=="object"&&n in r)r=r[n];else return console.warn(`Clave de traducci\xF3n no encontrada: '${e}'`),e;return typeof r!="string"?(console.warn(`Clave de traducci\xF3n no es string: '${e}'`),e):Be(r,o)}function Be(e,o){return!o||Object.keys(o).length===0?e:e.replace(/\{(\w+)\}/g,(t,r)=>o[r]!==void 0?o[r]:t)}V();function we(e,o,t){var Y,X,N,te,ae,ne,oe,re,ie,se,le,ce;let r=document.createElement("div");r.id="wplace-farm-ui",r.style.cssText=`
+/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-21T06:28:30.591Z */
+(() => {
+  // src/core/logger.js
+  var log = (...a) => console.log("[WPA-UI]", ...a);
+
+  // src/farm/config.js
+  var FARM_DEFAULTS = {
+    SITEKEY: "0x4AAAAAABpqJe8FO0N84q0F",
+    // Turnstile sitekey (ajústalo si cambia)
+    TILE_X: 1086,
+    TILE_Y: 1565,
+    TILE_SIZE: 3e3,
+    // Tiles son de ~3000x3000 según investigación
+    DELAY_MS: 15e3,
+    // 15 segundos entre pintadas (predeterminado)
+    MIN_CHARGES: 10,
+    // mínimo de cargas para empezar a pintar
+    CHARGE_REGEN_MS: 3e4,
+    // 1 carga cada 30 segundos
+    PIXELS_PER_BATCH: 20,
+    // número de píxeles a pintar por lote
+    COLOR_MIN: 1,
+    COLOR_MAX: 32,
+    COLOR_MODE: "random",
+    // 'random' | 'fixed'
+    COLOR_FIXED: 1,
+    CUSTOM_PALETTE: ["#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF", "#00FFFF"],
+    // Nueva funcionalidad de posición y radio
+    BASE_X: null,
+    // Posición X base (local al tile) - se establece al seleccionar zona
+    BASE_Y: null,
+    // Posición Y base (local al tile) - se establece al seleccionar zona
+    FARM_RADIUS: 500,
+    // Radio de farming en píxeles (500px por defecto para zona segura)
+    POSITION_SELECTED: false,
+    // Flag para indicar si se seleccionó una posición
+    UI_THEME: {
+      primary: "#000000",
+      secondary: "#111111",
+      accent: "#222222",
+      text: "#ffffff",
+      highlight: "#775ce3",
+      success: "#00ff00",
+      error: "#ff0000",
+      running: "#00cc00"
+      // Verde para cuando está corriendo
+    }
+  };
+  var farmState = {
+    running: false,
+    painted: 0,
+    last: null,
+    // {x,y,color,status,json}
+    charges: { count: 0, max: 0, cooldownMs: 3e4 },
+    user: null,
+    panel: null,
+    captureMode: false,
+    // sniffer activo para capturar TILE_X/Y desde un POST real
+    selectingPosition: false,
+    // sniffer activo para capturar posición base
+    originalFetch: window.fetch,
+    retryCount: 0,
+    // contador de reintentos
+    inCooldown: false,
+    // si está en cooldown de 2 minutos
+    nextPaintTime: 0,
+    // timestamp de la próxima pintada
+    cooldownEndTime: 0,
+    // timestamp del final del cooldown
+    health: null
+    // estado de salud del backend
+  };
+
+  // src/core/storage.js
+  function saveFarmCfg(cfg) {
+    return;
+  }
+  function loadFarmCfg(defaults) {
+    return { ...defaults };
+  }
+  function resetFarmCfg() {
+    console.log("[WPA-UI]", "Configuraci\xF3n del farm reseteada (localStorage deshabilitado)");
+  }
+  function resetToSafeDefaults() {
+    console.log("[WPA-UI]", "Configuraci\xF3n reseteada a valores seguros (localStorage deshabilitado)");
+  }
+
+  // src/core/wplace-api.js
+  var BASE = "https://backend.wplace.live";
+  async function getSession() {
+    var _a, _b, _c;
+    try {
+      const me = await fetch(`${BASE}/me`, { credentials: "include" }).then((r) => r.json());
+      const user = me || null;
+      const c = (me == null ? void 0 : me.charges) || {};
+      const charges = {
+        count: (_a = c.count) != null ? _a : 0,
+        // Mantener valor decimal original
+        max: (_b = c.max) != null ? _b : 0,
+        // Mantener valor original (puede variar por usuario)
+        cooldownMs: (_c = c.cooldownMs) != null ? _c : 3e4
+      };
+      return {
+        success: true,
+        data: {
+          user,
+          charges: charges.count,
+          maxCharges: charges.max,
+          chargeRegen: charges.cooldownMs
+        }
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message,
+        data: {
+          user: null,
+          charges: 0,
+          maxCharges: 0,
+          chargeRegen: 3e4
+        }
+      };
+    }
+  }
+  async function checkHealth() {
+    try {
+      const response = await fetch(`${BASE}/health`, {
+        method: "GET",
+        credentials: "include"
+      });
+      if (response.ok) {
+        const health = await response.json();
+        return {
+          ...health,
+          lastCheck: Date.now(),
+          status: "online"
+        };
+      } else {
+        return {
+          database: false,
+          up: false,
+          uptime: "N/A",
+          lastCheck: Date.now(),
+          status: "error",
+          statusCode: response.status
+        };
+      }
+    } catch (error) {
+      return {
+        database: false,
+        up: false,
+        uptime: "N/A",
+        lastCheck: Date.now(),
+        status: "offline",
+        error: error.message
+      };
+    }
+  }
+  async function postPixelBatchImage(tileX, tileY, coords, colors, turnstileToken) {
+    try {
+      const body = JSON.stringify({
+        colors,
+        coords,
+        t: turnstileToken
+      });
+      const response = await fetch(`${BASE}/s0/pixel/${tileX}/${tileY}`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        body
+      });
+      let responseData = null;
+      try {
+        responseData = await response.json();
+      } catch {
+        responseData = {};
+      }
+      return {
+        status: response.status,
+        json: responseData,
+        success: response.ok,
+        painted: (responseData == null ? void 0 : responseData.painted) || 0
+      };
+    } catch (error) {
+      return {
+        status: 0,
+        json: { error: error.message },
+        success: false,
+        painted: 0
+      };
+    }
+  }
+
+  // src/core/utils.js
+  function clamp(n, a, b) {
+    return Math.max(a, Math.min(b, n));
+  }
+  function dragHeader(headerEl, panelEl) {
+    let offsetX = 0, offsetY = 0, mouseX = 0, mouseY = 0;
+    headerEl.style.cursor = "move";
+    headerEl.addEventListener("mousedown", startDrag);
+    function startDrag(e) {
+      e.preventDefault();
+      mouseX = e.clientX;
+      mouseY = e.clientY;
+      document.addEventListener("mouseup", stopDrag);
+      document.addEventListener("mousemove", doDrag);
+    }
+    function doDrag(e) {
+      e.preventDefault();
+      offsetX = mouseX - e.clientX;
+      offsetY = mouseY - e.clientY;
+      mouseX = e.clientX;
+      mouseY = e.clientY;
+      const newTop = panelEl.offsetTop - offsetY;
+      const newLeft = panelEl.offsetLeft - offsetX;
+      panelEl.style.top = Math.max(0, newTop) + "px";
+      panelEl.style.left = Math.max(0, newLeft) + "px";
+    }
+    function stopDrag() {
+      document.removeEventListener("mouseup", stopDrag);
+      document.removeEventListener("mousemove", doDrag);
+    }
+  }
+
+  // src/locales/es.js
+  var es = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selecci\xF3n",
+      user: "Usuario",
+      charges: "Cargas",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Cerrar",
+      launch: "Lanzar",
+      loading: "Cargando\u2026",
+      executing: "Ejecutando\u2026",
+      downloading: "Descargando script\u2026",
+      chooseBot: "Elige un bot y presiona Lanzar",
+      readyToLaunch: "Listo para lanzar",
+      loadError: "Error al cargar",
+      loadErrorMsg: "No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",
+      checking: "\u{1F504} Verificando...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Iniciar Auto-BOT",
+      uploadImage: "Subir Imagen",
+      resizeImage: "Redimensionar Imagen",
+      selectPosition: "Seleccionar Posici\xF3n",
+      startPainting: "Iniciar Pintura",
+      stopPainting: "Detener Pintura",
+      saveProgress: "Guardar Progreso",
+      loadProgress: "Cargar Progreso",
+      checkingColors: "\u{1F50D} Verificando colores disponibles...",
+      noColorsFound: "\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      loadingImage: "\u{1F5BC}\uFE0F Cargando imagen...",
+      imageLoaded: "\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",
+      imageError: "\u274C Error al cargar la imagen",
+      selectPositionAlert: "\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Posici\xF3n establecida con \xE9xito!",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar posici\xF3n",
+      positionDetected: "\u{1F3AF} Posici\xF3n detectada, procesando...",
+      positionError: "\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",
+      startPaintingMsg: "\u{1F3A8} Iniciando pintura...",
+      paintingProgress: "\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",
+      noCharges: "\u231B Sin cargas. Esperando {time}...",
+      paintingStopped: "\u23F9\uFE0F Pintura detenida por el usuario",
+      paintingComplete: "\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",
+      paintingError: "\u274C Error durante la pintura",
+      missingRequirements: "\u274C Carga una imagen y selecciona una posici\xF3n primero",
+      progress: "Progreso",
+      userName: "Usuario",
+      pixels: "P\xEDxeles",
+      charges: "Cargas",
+      estimatedTime: "Tiempo estimado",
+      initMessage: "Haz clic en 'Iniciar Auto-BOT' para comenzar",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      resizeSuccess: "\u2705 Imagen redimensionada a {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",
+      pixelsPerBatch: "P\xEDxeles por lote",
+      batchSize: "Tama\xF1o del lote",
+      nextBatchTime: "Siguiente lote en",
+      useAllCharges: "Usar todas las cargas disponibles",
+      showOverlay: "Mostrar overlay",
+      maxCharges: "Cargas m\xE1ximas por lote",
+      waitingForCharges: "\u23F3 Esperando cargas: {current}/{needed}",
+      timeRemaining: "Tiempo restante",
+      cooldownWaiting: "\u23F3 Esperando {time} para continuar...",
+      progressSaved: "\u2705 Progreso guardado como {filename}",
+      progressLoaded: "\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",
+      progressLoadError: "\u274C Error al cargar progreso: {error}",
+      progressSaveError: "\u274C Error al guardar progreso: {error}",
+      confirmSaveProgress: "\xBFDeseas guardar el progreso actual antes de detener?",
+      saveProgressTitle: "Guardar Progreso",
+      discardProgress: "Descartar",
+      cancel: "Cancelar",
+      minimize: "Minimizar",
+      width: "Ancho",
+      height: "Alto",
+      keepAspect: "Mantener proporci\xF3n",
+      apply: "Aplicar",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",
+      waitingChargesCountdown: "\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Bot iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      retryAttempt: "\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",
+      retryError: "\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",
+      retryFailed: "\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",
+      networkError: "\u{1F310} Error de red. Reintentando...",
+      serverError: "\u{1F525} Error del servidor. Reintentando...",
+      timeoutError: "\u23F0 Timeout del servidor. Reintentando..."
+    },
+    // Farm Module (por implementar)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Iniciar",
+      stop: "Detener",
+      stopped: "Bot detenido",
+      calibrate: "Calibrar",
+      paintOnce: "Una vez",
+      checkingStatus: "Verificando estado...",
+      configuration: "Configuraci\xF3n",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "P\xEDxeles/lote",
+      minCharges: "Cargas m\xEDn",
+      colorMode: "Modo color",
+      random: "Aleatorio",
+      fixed: "Fijo",
+      range: "Rango",
+      fixedColor: "Color fijo",
+      advanced: "Avanzado",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Paleta personalizada",
+      paletteExample: "ej: #FF0000,#00FF00,#0000FF",
+      capture: "Capturar",
+      painted: "Pintados",
+      charges: "Cargas",
+      retries: "Fallos",
+      tile: "Tile",
+      configSaved: "Configuraci\xF3n guardada",
+      configLoaded: "Configuraci\xF3n cargada",
+      configReset: "Configuraci\xF3n reiniciada",
+      captureInstructions: "Pinta un p\xEDxel manualmente para capturar coordenadas...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Iniciando bot...",
+      stoppingBot: "Deteniendo bot...",
+      calibrating: "Calibrando...",
+      alreadyRunning: "Auto-Farm ya est\xE1 corriendo.",
+      imageRunningWarning: "Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",
+      selectPosition: "Seleccionar Zona",
+      selectPositionAlert: "\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Zona establecida! Radio: 500px",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar zona",
+      missingPosition: "\u274C Selecciona una zona primero usando 'Seleccionar Zona'",
+      farmRadius: "Radio farm",
+      positionInfo: "Zona actual",
+      farmingInRadius: "\u{1F33E} Farming en radio {radius}px desde ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",
+      noPosition: "Sin zona",
+      currentZone: "Zona: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "S\xED",
+      no: "No",
+      ok: "Aceptar",
+      cancel: "Cancelar",
+      close: "Cerrar",
+      save: "Guardar",
+      load: "Cargar",
+      delete: "Eliminar",
+      edit: "Editar",
+      start: "Iniciar",
+      stop: "Detener",
+      pause: "Pausar",
+      resume: "Reanudar",
+      reset: "Reiniciar",
+      settings: "Configuraci\xF3n",
+      help: "Ayuda",
+      about: "Acerca de",
+      language: "Idioma",
+      loading: "Cargando...",
+      error: "Error",
+      success: "\xC9xito",
+      warning: "Advertencia",
+      info: "Informaci\xF3n",
+      languageChanged: "Idioma cambiado a {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Inicializar Guard-BOT",
+      selectArea: "Seleccionar \xC1rea",
+      captureArea: "Capturar \xC1rea",
+      startProtection: "Iniciar Protecci\xF3n",
+      stopProtection: "Detener Protecci\xF3n",
+      upperLeft: "Esquina Superior Izquierda",
+      lowerRight: "Esquina Inferior Derecha",
+      protectedPixels: "P\xEDxeles Protegidos",
+      detectedChanges: "Cambios Detectados",
+      repairedPixels: "P\xEDxeles Reparados",
+      charges: "Cargas",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      checkingColors: "\u{1F3A8} Verificando colores disponibles...",
+      noColorsFound: "\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      initSuccess: "\u2705 Guard-BOT inicializado correctamente",
+      initError: "\u274C Error inicializando Guard-BOT",
+      invalidCoords: "\u274C Coordenadas inv\xE1lidas",
+      invalidArea: "\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",
+      areaTooLarge: "\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",
+      capturingArea: "\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",
+      areaCaptured: "\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",
+      captureError: "\u274C Error capturando \xE1rea: {error}",
+      captureFirst: "\u274C Primero captura un \xE1rea de protecci\xF3n",
+      protectionStarted: "\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",
+      protectionStopped: "\u23F9\uFE0F Protecci\xF3n detenida",
+      noChanges: "\u2705 \xC1rea protegida - sin cambios detectados",
+      changesDetected: "\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",
+      repairing: "\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",
+      repairedSuccess: "\u2705 Reparados {count} p\xEDxeles correctamente",
+      repairError: "\u274C Error reparando p\xEDxeles: {error}",
+      noCharges: "\u26A0\uFE0F Sin cargas suficientes para reparar cambios",
+      checkingChanges: "\u{1F50D} Verificando cambios en \xE1rea protegida...",
+      errorChecking: "\u274C Error verificando cambios: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",
+      lastCheck: "\xDAltima verificaci\xF3n: {time}",
+      nextCheck: "Pr\xF3xima verificaci\xF3n en: {time}s",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Guard-BOT iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      selectUpperLeft: "\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",
+      selectLowerRight: "\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",
+      waitingUpperLeft: "\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",
+      waitingLowerRight: "\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",
+      upperLeftCaptured: "\u2705 Esquina superior izquierda capturada: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Esquina inferior derecha capturada: ({x}, {y})",
+      selectionTimeout: "\u274C Tiempo agotado para selecci\xF3n",
+      selectionError: "\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"
+    }
+  };
+
+  // src/locales/en.js
+  var en = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selection",
+      user: "User",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Close",
+      launch: "Launch",
+      loading: "Loading\u2026",
+      executing: "Executing\u2026",
+      downloading: "Downloading script\u2026",
+      chooseBot: "Choose a bot and press Launch",
+      readyToLaunch: "Ready to launch",
+      loadError: "Load error",
+      loadErrorMsg: "Could not load the selected bot. Check your connection or try again.",
+      checking: "\u{1F504} Checking...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialize Auto-BOT",
+      uploadImage: "Upload Image",
+      resizeImage: "Resize Image",
+      selectPosition: "Select Position",
+      startPainting: "Start Painting",
+      stopPainting: "Stop Painting",
+      saveProgress: "Save Progress",
+      loadProgress: "Load Progress",
+      checkingColors: "\u{1F50D} Checking available colors...",
+      noColorsFound: "\u274C Open the color palette on the site and try again!",
+      colorsFound: "\u2705 Found {count} available colors",
+      loadingImage: "\u{1F5BC}\uFE0F Loading image...",
+      imageLoaded: "\u2705 Image loaded with {count} valid pixels",
+      imageError: "\u274C Error loading image",
+      selectPositionAlert: "Paint the first pixel at the location where you want the art to start!",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Position set successfully!",
+      positionTimeout: "\u274C Timeout for position selection",
+      positionDetected: "\u{1F3AF} Position detected, processing...",
+      positionError: "\u274C Error detecting position, please try again",
+      startPaintingMsg: "\u{1F3A8} Starting painting...",
+      paintingProgress: "\u{1F9F1} Progress: {painted}/{total} pixels...",
+      noCharges: "\u231B No charges. Waiting {time}...",
+      paintingStopped: "\u23F9\uFE0F Painting stopped by user",
+      paintingComplete: "\u2705 Painting completed! {count} pixels painted.",
+      paintingError: "\u274C Error during painting",
+      missingRequirements: "\u274C Load an image and select a position first",
+      progress: "Progress",
+      userName: "User",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Estimated time",
+      initMessage: "Click 'Initialize Auto-BOT' to begin",
+      waitingInit: "Waiting for initialization...",
+      resizeSuccess: "\u2705 Image resized to {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels per batch",
+      batchSize: "Batch size",
+      nextBatchTime: "Next batch in",
+      useAllCharges: "Use all available charges",
+      showOverlay: "Show overlay",
+      maxCharges: "Max charges per batch",
+      waitingForCharges: "\u23F3 Waiting for charges: {current}/{needed}",
+      timeRemaining: "Time remaining",
+      cooldownWaiting: "\u23F3 Waiting {time} to continue...",
+      progressSaved: "\u2705 Progress saved as {filename}",
+      progressLoaded: "\u2705 Progress loaded: {painted}/{total} pixels painted",
+      progressLoadError: "\u274C Error loading progress: {error}",
+      progressSaveError: "\u274C Error saving progress: {error}",
+      confirmSaveProgress: "Do you want to save the current progress before stopping?",
+      saveProgressTitle: "Save Progress",
+      discardProgress: "Discard",
+      cancel: "Cancel",
+      minimize: "Minimize",
+      width: "Width",
+      height: "Height",
+      keepAspect: "Keep aspect ratio",
+      apply: "Apply",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",
+      waitingChargesCountdown: "\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Bot auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      retryAttempt: "\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",
+      retryError: "\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",
+      retryFailed: "\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",
+      networkError: "\u{1F310} Network error. Retrying...",
+      serverError: "\u{1F525} Server error. Retrying...",
+      timeoutError: "\u23F0 Server timeout. Retrying..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Start",
+      stop: "Stop",
+      stopped: "Bot stopped",
+      calibrate: "Calibrate",
+      paintOnce: "Once",
+      checkingStatus: "Checking status...",
+      configuration: "Configuration",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "Pixels/batch",
+      minCharges: "Min charges",
+      colorMode: "Color mode",
+      random: "Random",
+      fixed: "Fixed",
+      range: "Range",
+      fixedColor: "Fixed color",
+      advanced: "Advanced",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Custom palette",
+      paletteExample: "e.g: #FF0000,#00FF00,#0000FF",
+      capture: "Capture",
+      painted: "Painted",
+      charges: "Charges",
+      retries: "Retries",
+      tile: "Tile",
+      configSaved: "Configuration saved",
+      configLoaded: "Configuration loaded",
+      configReset: "Configuration reset",
+      captureInstructions: "Paint a pixel manually to capture coordinates...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Starting bot...",
+      stoppingBot: "Stopping bot...",
+      calibrating: "Calibrating...",
+      alreadyRunning: "Auto-Farm is already running.",
+      imageRunningWarning: "Auto-Image is running. Close it before starting Auto-Farm.",
+      selectPosition: "Select Area",
+      selectPositionAlert: "\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Area set! Radius: 500px",
+      positionTimeout: "\u274C Timeout for area selection",
+      missingPosition: "\u274C Select an area first using 'Select Area'",
+      farmRadius: "Farm radius",
+      positionInfo: "Current area",
+      farmingInRadius: "\u{1F33E} Farming in {radius}px radius from ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",
+      noPosition: "No area",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"
+    },
+    // Common/Shared
+    common: {
+      yes: "Yes",
+      no: "No",
+      ok: "OK",
+      cancel: "Cancel",
+      close: "Close",
+      save: "Save",
+      load: "Load",
+      delete: "Delete",
+      edit: "Edit",
+      start: "Start",
+      stop: "Stop",
+      pause: "Pause",
+      resume: "Resume",
+      reset: "Reset",
+      settings: "Settings",
+      help: "Help",
+      about: "About",
+      language: "Language",
+      loading: "Loading...",
+      error: "Error",
+      success: "Success",
+      warning: "Warning",
+      info: "Information",
+      languageChanged: "Language changed to {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialize Guard-BOT",
+      selectArea: "Select Area",
+      captureArea: "Capture Area",
+      startProtection: "Start Protection",
+      stopProtection: "Stop Protection",
+      upperLeft: "Upper Left Corner",
+      lowerRight: "Lower Right Corner",
+      protectedPixels: "Protected Pixels",
+      detectedChanges: "Detected Changes",
+      repairedPixels: "Repaired Pixels",
+      charges: "Charges",
+      waitingInit: "Waiting for initialization...",
+      checkingColors: "\u{1F3A8} Checking available colors...",
+      noColorsFound: "\u274C No colors found. Open the color palette on the site.",
+      colorsFound: "\u2705 Found {count} available colors",
+      initSuccess: "\u2705 Guard-BOT initialized successfully",
+      initError: "\u274C Error initializing Guard-BOT",
+      invalidCoords: "\u274C Invalid coordinates",
+      invalidArea: "\u274C Area must have upper left corner less than lower right corner",
+      areaTooLarge: "\u274C Area too large: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capturing protection area...",
+      areaCaptured: "\u2705 Area captured: {count} pixels under protection",
+      captureError: "\u274C Error capturing area: {error}",
+      captureFirst: "\u274C First capture a protection area",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection started - monitoring area",
+      protectionStopped: "\u23F9\uFE0F Protection stopped",
+      noChanges: "\u2705 Protected area - no changes detected",
+      changesDetected: "\u{1F6A8} {count} changes detected in protected area",
+      repairing: "\u{1F6E0}\uFE0F Repairing {count} altered pixels...",
+      repairedSuccess: "\u2705 Successfully repaired {count} pixels",
+      repairError: "\u274C Error repairing pixels: {error}",
+      noCharges: "\u26A0\uFE0F Insufficient charges to repair changes",
+      checkingChanges: "\u{1F50D} Checking changes in protected area...",
+      errorChecking: "\u274C Error checking changes: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardian active - area under protection",
+      lastCheck: "Last check: {time}",
+      nextCheck: "Next check in: {time}s",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Guard-BOT auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      selectUpperLeft: "\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",
+      selectLowerRight: "\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",
+      waitingUpperLeft: "\u{1F446} Waiting for upper left corner selection...",
+      waitingLowerRight: "\u{1F446} Waiting for lower right corner selection...",
+      upperLeftCaptured: "\u2705 Upper left corner captured: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Lower right corner captured: ({x}, {y})",
+      selectionTimeout: "\u274C Selection timeout",
+      selectionError: "\u274C Selection error, please try again"
+    }
+  };
+
+  // src/locales/fr.js
+  var fr = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "S\xE9lection",
+      user: "Utilisateur",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Base de donn\xE9es",
+      uptime: "Temps actif",
+      close: "Fermer",
+      launch: "Lancer",
+      loading: "Chargement\u2026",
+      executing: "Ex\xE9cution\u2026",
+      downloading: "T\xE9l\xE9chargement du script\u2026",
+      chooseBot: "Choisissez un bot et appuyez sur Lancer",
+      readyToLaunch: "Pr\xEAt \xE0 lancer",
+      loadError: "Erreur de chargement",
+      loadErrorMsg: "Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",
+      checking: "\u{1F504} V\xE9rification...",
+      online: "\u{1F7E2} En ligne",
+      offline: "\u{1F534} Hors ligne",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Erreur",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialiser Auto-BOT",
+      uploadImage: "T\xE9l\xE9charger Image",
+      resizeImage: "Redimensionner Image",
+      selectPosition: "S\xE9lectionner Position",
+      startPainting: "Commencer Peinture",
+      stopPainting: "Arr\xEAter Peinture",
+      saveProgress: "Sauvegarder Progr\xE8s",
+      loadProgress: "Charger Progr\xE8s",
+      checkingColors: "\u{1F50D} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      loadingImage: "\u{1F5BC}\uFE0F Chargement de l'image...",
+      imageLoaded: "\u2705 Image charg\xE9e avec {count} pixels valides",
+      imageError: "\u274C Erreur lors du chargement de l'image",
+      selectPositionAlert: "Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Position d\xE9finie avec succ\xE8s!",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",
+      positionDetected: "\u{1F3AF} Position d\xE9tect\xE9e, traitement...",
+      positionError: "\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",
+      startPaintingMsg: "\u{1F3A8} D\xE9but de la peinture...",
+      paintingProgress: "\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",
+      noCharges: "\u231B Aucune charge. Attendre {time}...",
+      paintingStopped: "\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",
+      paintingComplete: "\u2705 Peinture termin\xE9e! {count} pixels peints.",
+      paintingError: "\u274C Erreur pendant la peinture",
+      missingRequirements: "\u274C Chargez une image et s\xE9lectionnez une position d'abord",
+      progress: "Progr\xE8s",
+      userName: "Usager",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Temps estim\xE9",
+      initMessage: "Cliquez sur 'Initialiser Auto-BOT' pour commencer",
+      waitingInit: "En attente d'initialisation...",
+      resizeSuccess: "\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels par lot",
+      batchSize: "Taille du lot",
+      nextBatchTime: "Prochain lot dans",
+      useAllCharges: "Utiliser toutes les charges disponibles",
+      showOverlay: "Afficher l'overlay",
+      maxCharges: "Charges max par lot",
+      waitingForCharges: "\u23F3 En attente de charges: {current}/{needed}",
+      timeRemaining: "Temps restant",
+      cooldownWaiting: "\u23F3 Attendre {time} pour continuer...",
+      progressSaved: "\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",
+      progressLoaded: "\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",
+      progressLoadError: "\u274C Erreur lors du chargement du progr\xE8s: {error}",
+      progressSaveError: "\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",
+      confirmSaveProgress: "Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",
+      saveProgressTitle: "Sauvegarder Progr\xE8s",
+      discardProgress: "Abandonner",
+      cancel: "Annuler",
+      minimize: "Minimiser",
+      width: "Largeur",
+      height: "Hauteur",
+      keepAspect: "Garder les proportions",
+      apply: "Appliquer",
+      overlayOn: "Overlay : ON",
+      overlayOff: "Overlay : OFF",
+      passCompleted: "\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",
+      waitingChargesCountdown: "\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Bot d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      retryAttempt: "\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",
+      retryError: "\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",
+      retryFailed: "\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",
+      networkError: "\u{1F310} Erreur r\xE9seau. Nouvel essai...",
+      serverError: "\u{1F525} Erreur serveur. Nouvel essai...",
+      timeoutError: "\u23F0 Timeout serveur. Nouvel essai..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      stopped: "Bot arr\xEAt\xE9",
+      calibrate: "Calibrer",
+      paintOnce: "Une fois",
+      checkingStatus: "V\xE9rification du statut...",
+      configuration: "Configuration",
+      delay: "D\xE9lai (ms)",
+      pixelsPerBatch: "Pixels/lot",
+      minCharges: "Charges min",
+      colorMode: "Mode couleur",
+      random: "Al\xE9atoire",
+      fixed: "Fixe",
+      range: "Plage",
+      fixedColor: "Couleur fixe",
+      advanced: "Avanc\xE9",
+      tileX: "Tuile X",
+      tileY: "Tuile Y",
+      customPalette: "Palette personnalis\xE9e",
+      paletteExample: "ex: #FF0000,#00FF00,#0000FF",
+      capture: "Capturer",
+      painted: "Peints",
+      charges: "Charges",
+      retries: "\xC9checs",
+      tile: "Tuile",
+      configSaved: "Configuration sauvegard\xE9e",
+      configLoaded: "Configuration charg\xE9e",
+      configReset: "Configuration r\xE9initialis\xE9e",
+      captureInstructions: "Peindre un pixel manuellement pour capturer les coordonn\xE9es...",
+      backendOnline: "Backend En ligne",
+      backendOffline: "Backend Hors ligne",
+      startingBot: "D\xE9marrage du bot...",
+      stoppingBot: "Arr\xEAt du bot...",
+      calibrating: "Calibrage...",
+      alreadyRunning: "Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",
+      imageRunningWarning: "Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",
+      selectPosition: "S\xE9lectionner Zone",
+      selectPositionAlert: "\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Zone d\xE9finie! Rayon: 500px",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",
+      missingPosition: "\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",
+      farmRadius: "Rayon farm",
+      positionInfo: "Zone actuelle",
+      farmingInRadius: "\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",
+      noPosition: "Aucune zone",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "Oui",
+      no: "Non",
+      ok: "OK",
+      cancel: "Annuler",
+      close: "Fermer",
+      save: "Sauvegarder",
+      load: "Charger",
+      delete: "Supprimer",
+      edit: "Modifier",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      pause: "Pause",
+      resume: "Reprendre",
+      reset: "R\xE9initialiser",
+      settings: "Param\xE8tres",
+      help: "Aide",
+      about: "\xC0 propos",
+      language: "Langue",
+      loading: "Chargement...",
+      error: "Erreur",
+      success: "Succ\xE8s",
+      warning: "Avertissement",
+      info: "Information",
+      languageChanged: "Langue chang\xE9e en {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialiser Guard-BOT",
+      selectArea: "S\xE9lectionner Zone",
+      captureArea: "Capturer Zone",
+      startProtection: "D\xE9marrer Protection",
+      stopProtection: "Arr\xEAter Protection",
+      upperLeft: "Coin Sup\xE9rieur Gauche",
+      lowerRight: "Coin Inf\xE9rieur Droit",
+      protectedPixels: "Pixels Prot\xE9g\xE9s",
+      detectedChanges: "Changements D\xE9tect\xE9s",
+      repairedPixels: "Pixels R\xE9par\xE9s",
+      charges: "Charges",
+      waitingInit: "En attente d'initialisation...",
+      checkingColors: "\u{1F3A8} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      initSuccess: "\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",
+      initError: "\u274C Erreur lors de l'initialisation de Guard-BOT",
+      invalidCoords: "\u274C Coordonn\xE9es invalides",
+      invalidArea: "\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",
+      areaTooLarge: "\u274C Zone trop grande: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capture de la zone de protection...",
+      areaCaptured: "\u2705 Zone captur\xE9e: {count} pixels sous protection",
+      captureError: "\u274C Erreur lors de la capture de zone: {error}",
+      captureFirst: "\u274C Capturez d'abord une zone de protection",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",
+      protectionStopped: "\u23F9\uFE0F Protection arr\xEAt\xE9e",
+      noChanges: "\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",
+      changesDetected: "\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",
+      repairing: "\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",
+      repairedSuccess: "\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",
+      repairError: "\u274C Erreur lors de la r\xE9paration des pixels: {error}",
+      noCharges: "\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",
+      checkingChanges: "\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",
+      errorChecking: "\u274C Erreur lors de la v\xE9rification des changements: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Gardien actif - zone sous protection",
+      lastCheck: "Derni\xE8re v\xE9rification: {time}",
+      nextCheck: "Prochaine v\xE9rification dans: {time}s",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      selectUpperLeft: "\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",
+      selectLowerRight: "\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",
+      waitingUpperLeft: "\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",
+      waitingLowerRight: "\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",
+      upperLeftCaptured: "\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",
+      selectionTimeout: "\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",
+      selectionError: "\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"
+    }
+  };
+
+  // src/locales/ru.js
+  var ru = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      autoImage: "\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      autoGuard: "\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      selection: "\u0412\u044B\u0431\u0440\u0430\u043D\u043E",
+      user: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      charges: "\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      backend: "\u0411\u044D\u043A\u0435\u043D\u0434",
+      database: "\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",
+      uptime: "\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      launch: "\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",
+      executing: "\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",
+      downloading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",
+      chooseBot: "\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      readyToLaunch: "\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",
+      loadError: "\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",
+      loadErrorMsg: "\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",
+      checking: "\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",
+      online: "\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",
+      offline: "\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",
+      ok: "\u{1F7E2} \u041E\u041A",
+      error: "\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",
+      uploadImage: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      resizeImage: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      startPainting: "\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",
+      stopPainting: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",
+      saveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      loadProgress: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      checkingColors: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      loadingImage: "\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",
+      imageLoaded: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",
+      imageError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPositionAlert: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",
+      positionDetected: "\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",
+      positionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",
+      startPaintingMsg: "\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",
+      paintingProgress: "\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      noCharges: "\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",
+      paintingComplete: "\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",
+      paintingError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",
+      missingRequirements: "\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      progress: "\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      userName: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      pixels: "\u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      estimatedTime: "\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",
+      initMessage: "\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      resizeSuccess: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",
+      batchSize: "\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",
+      nextBatchTime: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",
+      useAllCharges: "\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",
+      showOverlay: "\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",
+      maxCharges: "\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      waitingForCharges: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",
+      timeRemaining: "\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",
+      cooldownWaiting: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",
+      progressSaved: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",
+      progressLoaded: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",
+      progressLoadError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      progressSaveError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      confirmSaveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",
+      saveProgressTitle: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      discardProgress: "\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      minimize: "\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",
+      width: "\u0428\u0438\u0440\u0438\u043D\u0430",
+      height: "\u0412\u044B\u0441\u043E\u0442\u0430",
+      keepAspect: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",
+      apply: "\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",
+      passCompleted: "\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",
+      waitingChargesRegen: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",
+      waitingChargesCountdown: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      retryAttempt: "\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryError: "\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryFailed: "\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",
+      networkError: "\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      serverError: "\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      timeoutError: "\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      stopped: "\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",
+      calibrate: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",
+      paintOnce: "\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",
+      checkingStatus: "\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",
+      configuration: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",
+      delay: "\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      minCharges: "\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",
+      colorMode: "\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",
+      random: "\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",
+      fixed: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",
+      range: "\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",
+      fixedColor: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",
+      advanced: "\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",
+      tileX: "\u041F\u043B\u0438\u0442\u043A\u0430 X",
+      tileY: "\u041F\u043B\u0438\u0442\u043A\u0430 Y",
+      customPalette: "\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",
+      paletteExample: "\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",
+      capture: "\u0417\u0430\u0445\u0432\u0430\u0442",
+      painted: "\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      retries: "\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",
+      tile: "\u041F\u043B\u0438\u0442\u043A\u0430",
+      configSaved: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",
+      configLoaded: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",
+      configReset: "\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",
+      captureInstructions: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",
+      backendOnline: "\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",
+      backendOffline: "\u0411\u044D\u043A\u044D\u043D\u0434",
+      startingBot: "\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",
+      stoppingBot: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",
+      calibrating: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",
+      alreadyRunning: "\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",
+      imageRunningWarning: "\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C",
+      selectPositionAlert: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      missingPosition: "\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",
+      farmRadius: "\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",
+      positionInfo: "\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",
+      farmingInRadius: "\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",
+      noPosition: "\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      currentZone: "\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."
+    },
+    // Common/Shared
+    common: {
+      yes: "\u0414\u0430",
+      no: "\u041D\u0435\u0442",
+      ok: "\u041E\u041A",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      save: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",
+      load: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",
+      delete: "\u0423\u0434\u0430\u043B\u0438\u0442\u044C",
+      edit: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",
+      pause: "\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      resume: "\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",
+      reset: "\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",
+      settings: "\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",
+      help: "\u041F\u043E\u043C\u043E\u0449\u044C",
+      about: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      language: "\u042F\u0437\u044B\u043A",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",
+      error: "\u041E\u0448\u0438\u0431\u043A\u0430",
+      success: "\u0423\u0441\u043F\u0435\u0445",
+      warning: "\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",
+      info: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      languageChanged: "\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",
+      selectArea: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      captureArea: "\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      startProtection: "\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      stopProtection: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      upperLeft: "\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      lowerRight: "\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      protectedPixels: "\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      detectedChanges: "\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      repairedPixels: "\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      checkingColors: "\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      initSuccess: "\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",
+      initError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",
+      invalidCoords: "\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",
+      invalidArea: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",
+      areaTooLarge: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",
+      capturingArea: "\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",
+      areaCaptured: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      captureError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",
+      captureFirst: "\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",
+      protectionStarted: "\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      protectionStopped: "\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",
+      noChanges: "\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",
+      changesDetected: "\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      repairing: "\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      repairedSuccess: "\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",
+      repairError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",
+      noCharges: "\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",
+      checkingChanges: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",
+      errorChecking: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      lastCheck: "\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",
+      nextCheck: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      selectUpperLeft: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",
+      selectLowerRight: "\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      waitingUpperLeft: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      waitingLowerRight: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      upperLeftCaptured: "\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      selectionTimeout: "\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",
+      selectionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"
+    }
+  };
+
+  // src/locales/zh-Hans.js
+  var zhHans = {
+    // 启动器
+    launcher: {
+      title: "WPlace \u81EA\u52A8\u673A\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52A8\u519C\u573A",
+      autoImage: "\u{1F3A8} \u81EA\u52A8\u7ED8\u56FE",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52A8\u5B88\u62A4",
+      selection: "\u9009\u62E9",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6570",
+      backend: "\u540E\u7AEF",
+      database: "\u6570\u636E\u5E93",
+      uptime: "\u8FD0\u884C\u65F6\u95F4",
+      close: "\u5173\u95ED",
+      launch: "\u542F\u52A8",
+      loading: "\u52A0\u8F7D\u4E2D\u2026",
+      executing: "\u6267\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F7D\u811A\u672C\u2026",
+      chooseBot: "\u9009\u62E9\u4E00\u4E2A\u673A\u5668\u4EBA\u5E76\u70B9\u51FB\u542F\u52A8",
+      readyToLaunch: "\u51C6\u5907\u542F\u52A8",
+      loadError: "\u52A0\u8F7D\u9519\u8BEF",
+      loadErrorMsg: "\u65E0\u6CD5\u52A0\u8F7D\u6240\u9009\u673A\u5668\u4EBA\u3002\u8BF7\u68C0\u67E5\u7F51\u7EDC\u8FDE\u63A5\u6216\u91CD\u8BD5\u3002",
+      checking: "\u{1F504} \u68C0\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7EBF",
+      offline: "\u{1F534} \u79BB\u7EBF",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u9519\u8BEF",
+      unknown: "-"
+    },
+    // 绘图模块
+    image: {
+      title: "WPlace \u81EA\u52A8\u7ED8\u56FE",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA",
+      uploadImage: "\u4E0A\u4F20\u56FE\u7247",
+      resizeImage: "\u8C03\u6574\u56FE\u7247\u5927\u5C0F",
+      selectPosition: "\u9009\u62E9\u4F4D\u7F6E",
+      startPainting: "\u5F00\u59CB\u7ED8\u5236",
+      stopPainting: "\u505C\u6B62\u7ED8\u5236",
+      saveProgress: "\u4FDD\u5B58\u8FDB\u5EA6",
+      loadProgress: "\u52A0\u8F7D\u8FDB\u5EA6",
+      checkingColors: "\u{1F50D} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u540E\u91CD\u8BD5\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F7D\u56FE\u7247...",
+      imageLoaded: "\u2705 \u56FE\u7247\u5DF2\u52A0\u8F7D\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u4E2A",
+      imageError: "\u274C \u56FE\u7247\u52A0\u8F7D\u5931\u8D25",
+      selectPositionAlert: "\u8BF7\u5728\u4F60\u60F3\u5F00\u59CB\u7ED8\u5236\u7684\u5730\u65B9\u6D82\u7B2C\u4E00\u4E2A\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8BBE\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9009\u62E9\u8D85\u65F6",
+      positionDetected: "\u{1F3AF} \u5DF2\u68C0\u6D4B\u5230\u4F4D\u7F6E\uFF0C\u5904\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u68C0\u6D4B\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5",
+      startPaintingMsg: "\u{1F3A8} \u5F00\u59CB\u7ED8\u5236...",
+      paintingProgress: "\u{1F9F1} \u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6CA1\u6709\u6B21\u6570\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7ED8\u5236",
+      paintingComplete: "\u2705 \u7ED8\u5236\u5B8C\u6210\uFF01\u5171\u7ED8\u5236 {count} \u4E2A\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7ED8\u5236\u8FC7\u7A0B\u4E2D\u51FA\u9519",
+      missingRequirements: "\u274C \u8BF7\u5148\u52A0\u8F7D\u56FE\u7247\u5E76\u9009\u62E9\u4F4D\u7F6E",
+      progress: "\u8FDB\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      estimatedTime: "\u9884\u8BA1\u65F6\u95F4",
+      initMessage: "\u70B9\u51FB\u201C\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA\u201D\u5F00\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u56FE\u7247\u5DF2\u8C03\u6574\u4E3A {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7ED8\u5236\u6682\u505C\u4E8E\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6570",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u65F6\u95F4",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6570",
+      showOverlay: "\u663E\u793A\u8986\u76D6\u5C42",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6570",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed}",
+      timeRemaining: "\u5269\u4F59\u65F6\u95F4",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u540E\u7EE7\u7EED...",
+      progressSaved: "\u2705 \u8FDB\u5EA6\u5DF2\u4FDD\u5B58\u4E3A {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F7D\u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7ED8\u5236",
+      progressLoadError: "\u274C \u52A0\u8F7D\u8FDB\u5EA6\u5931\u8D25: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u8FDB\u5EA6\u5931\u8D25: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u5F53\u524D\u8FDB\u5EA6\u5417\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u8FDB\u5EA6",
+      discardProgress: "\u653E\u5F03",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BBD\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7EB5\u6A2A\u6BD4",
+      apply: "\u5E94\u7528",
+      overlayOn: "\u8986\u76D6\u5C42: \u5F00\u542F",
+      overlayOff: "\u8986\u76D6\u5C42: \u5173\u95ED",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7ED8\u5236 {painted} \u50CF\u7D20 | \u8FDB\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6570\u6062\u590D: {current}/{needed} - \u65F6\u95F4: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed} - \u5269\u4F59: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8BD5 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5C1D\u8BD5\u51FA\u9519\uFF0C\u5C06\u5728 {delay} \u79D2\u540E\u91CD\u8BD5...",
+      retryFailed: "\u274C \u8D85\u8FC7 {maxAttempts} \u6B21\u5C1D\u8BD5\u5931\u8D25\u3002\u7EE7\u7EED\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7F51\u7EDC\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      serverError: "\u{1F525} \u670D\u52A1\u5668\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      timeoutError: "\u23F0 \u670D\u52A1\u5668\u8D85\u65F6\uFF0C\u6B63\u5728\u91CD\u8BD5..."
+    },
+    // 农场模块（待实现）
+    farm: {
+      title: "WPlace \u519C\u573A\u673A\u5668\u4EBA",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u673A\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u51C6",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u68C0\u67E5\u72B6\u6001\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u8FDF (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6570",
+      colorMode: "\u989C\u8272\u6A21\u5F0F",
+      random: "\u968F\u673A",
+      fixed: "\u56FA\u5B9A",
+      range: "\u8303\u56F4",
+      fixedColor: "\u56FA\u5B9A\u989C\u8272",
+      advanced: "\u9AD8\u7EA7",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u4E49\u8C03\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u83B7",
+      painted: "\u5DF2\u7ED8\u5236",
+      charges: "\u6B21\u6570",
+      retries: "\u91CD\u8BD5",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F7D",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8BF7\u624B\u52A8\u7ED8\u5236\u4E00\u4E2A\u50CF\u7D20\u4EE5\u6355\u83B7\u5750\u6807...",
+      backendOnline: "\u540E\u7AEF\u5728\u7EBF",
+      backendOffline: "\u540E\u7AEF\u79BB\u7EBF",
+      startingBot: "\u6B63\u5728\u542F\u52A8\u673A\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u673A\u5668\u4EBA...",
+      calibrating: "\u6821\u51C6\u4E2D...",
+      alreadyRunning: "\u81EA\u52A8\u519C\u573A\u5DF2\u5728\u8FD0\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52A8\u7ED8\u56FE\u6B63\u5728\u8FD0\u884C\uFF0C\u8BF7\u5148\u5173\u95ED\u518D\u542F\u52A8\u81EA\u52A8\u519C\u573A\u3002",
+      selectPosition: "\u9009\u62E9\u533A\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u56FE\u7684\u7A7A\u767D\u533A\u57DF\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u533A\u57DF\u8BBE\u7F6E\u6210\u529F\uFF01\u534A\u5F84: 500px",
+      positionTimeout: "\u274C \u533A\u57DF\u9009\u62E9\u8D85\u65F6",
+      missingPosition: "\u274C \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF08\u4F7F\u7528\u201C\u9009\u62E9\u533A\u57DF\u201D\u6309\u94AE\uFF09",
+      farmRadius: "\u519C\u573A\u534A\u5F84",
+      positionInfo: "\u5F53\u524D\u533A\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F84 {radius}px \u5728 ({x},{y}) \u519C\u573A",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8BF7\u9009\u62E9\u7A7A\u767D\u533A\u57DF\u4EE5\u907F\u514D\u51B2\u7A81",
+      noPosition: "\u672A\u9009\u62E9\u533A\u57DF",
+      currentZone: "\u533A\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF0C\u5728\u5730\u56FE\u4E0A\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u786E\u8BA4",
+      cancel: "\u53D6\u6D88",
+      close: "\u5173\u95ED",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F7D",
+      delete: "\u5220\u9664",
+      edit: "\u7F16\u8F91",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u6682\u505C",
+      resume: "\u7EE7\u7EED",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8BBE\u7F6E",
+      help: "\u5E2E\u52A9",
+      about: "\u5173\u4E8E",
+      language: "\u8BED\u8A00",
+      loading: "\u52A0\u8F7D\u4E2D...",
+      error: "\u9519\u8BEF",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8BED\u8A00\u5DF2\u5207\u6362\u4E3A {language}"
+    },
+    // 守护模块
+    guard: {
+      title: "WPlace \u81EA\u52A8\u5B88\u62A4",
+      initBot: "\u521D\u59CB\u5316\u5B88\u62A4\u673A\u5668\u4EBA",
+      selectArea: "\u9009\u62E9\u533A\u57DF",
+      captureArea: "\u6355\u83B7\u533A\u57DF",
+      startProtection: "\u5F00\u59CB\u5B88\u62A4",
+      stopProtection: "\u505C\u6B62\u5B88\u62A4",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u62A4\u50CF\u7D20",
+      detectedChanges: "\u68C0\u6D4B\u5230\u7684\u53D8\u5316",
+      repairedPixels: "\u4FEE\u590D\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u989C\u8272\uFF0C\u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      initSuccess: "\u2705 \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u5931\u8D25",
+      invalidCoords: "\u274C \u5750\u6807\u65E0\u6548",
+      invalidArea: "\u274C \u533A\u57DF\u65E0\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u987B\u5C0F\u4E8E\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u533A\u57DF\u8FC7\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u83B7\u5B88\u62A4\u533A\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u533A\u57DF\u6355\u83B7\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u62A4",
+      captureError: "\u274C \u6355\u83B7\u533A\u57DF\u51FA\u9519: {error}",
+      captureFirst: "\u274C \u8BF7\u5148\u6355\u83B7\u4E00\u4E2A\u5B88\u62A4\u533A\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u62A4\u5DF2\u542F\u52A8 - \u533A\u57DF\u76D1\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u62A4\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u533A\u57DF\u5B89\u5168 - \u672A\u68C0\u6D4B\u5230\u53D8\u5316",
+      changesDetected: "\u{1F6A8} \u68C0\u6D4B\u5230 {count} \u4E2A\u53D8\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u590D {count} \u4E2A\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u590D {count} \u4E2A\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u590D\u51FA\u9519: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6570\u4E0D\u8DB3\uFF0C\u65E0\u6CD5\u4FEE\u590D",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u68C0\u67E5\u533A\u57DF\u53D8\u5316...",
+      errorChecking: "\u274C \u68C0\u67E5\u51FA\u9519: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u62A4\u4E2D - \u533A\u57DF\u53D7\u4FDD\u62A4",
+      lastCheck: "\u4E0A\u6B21\u68C0\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u68C0\u67E5: {time} \u79D2\u540E",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u62A4\u533A\u57DF\u7684\u5DE6\u4E0A\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73B0\u5728\u5728\u53F3\u4E0B\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u83B7\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u83B7\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9009\u62E9\u8D85\u65F6",
+      selectionError: "\u274C \u9009\u62E9\u51FA\u9519\uFF0C\u8BF7\u91CD\u8BD5"
+    }
+  };
+
+  // src/locales/zh-Hant.js
+  var zhHant = {
+    // 啓動器
+    launcher: {
+      title: "WPlace \u81EA\u52D5\u6A5F\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52D5\u8FB2\u5834",
+      autoImage: "\u{1F3A8} \u81EA\u52D5\u7E6A\u5716",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52D5\u5B88\u8B77",
+      selection: "\u9078\u64C7",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6578",
+      backend: "\u5F8C\u7AEF",
+      database: "\u6578\u64DA\u5EAB",
+      uptime: "\u904B\u884C\u6642\u9593",
+      close: "\u95DC\u9589",
+      launch: "\u5553\u52D5",
+      loading: "\u52A0\u8F09\u4E2D\u2026",
+      executing: "\u57F7\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F09\u8173\u672C\u2026",
+      chooseBot: "\u9078\u64C7\u4E00\u500B\u6A5F\u5668\u4EBA\u4E26\u9EDE\u64CA\u5553\u52D5",
+      readyToLaunch: "\u6E96\u5099\u5553\u52D5",
+      loadError: "\u52A0\u8F09\u932F\u8AA4",
+      loadErrorMsg: "\u7121\u6CD5\u52A0\u8F09\u6240\u9078\u6A5F\u5668\u4EBA\u3002\u8ACB\u6AA2\u67E5\u7DB2\u7D61\u9023\u63A5\u6216\u91CD\u8A66\u3002",
+      checking: "\u{1F504} \u6AA2\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7DDA",
+      offline: "\u{1F534} \u96E2\u7DDA",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u932F\u8AA4",
+      unknown: "-"
+    },
+    // 繪圖模塊
+    image: {
+      title: "WPlace \u81EA\u52D5\u7E6A\u5716",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA",
+      uploadImage: "\u4E0A\u50B3\u5716\u7247",
+      resizeImage: "\u8ABF\u6574\u5716\u7247\u5927\u5C0F",
+      selectPosition: "\u9078\u64C7\u4F4D\u7F6E",
+      startPainting: "\u958B\u59CB\u7E6A\u88FD",
+      stopPainting: "\u505C\u6B62\u7E6A\u88FD",
+      saveProgress: "\u4FDD\u5B58\u9032\u5EA6",
+      loadProgress: "\u52A0\u8F09\u9032\u5EA6",
+      checkingColors: "\u{1F50D} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u5F8C\u91CD\u8A66\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F09\u5716\u7247...",
+      imageLoaded: "\u2705 \u5716\u7247\u5DF2\u52A0\u8F09\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u500B",
+      imageError: "\u274C \u5716\u7247\u52A0\u8F09\u5931\u6557",
+      selectPositionAlert: "\u8ACB\u5728\u4F60\u60F3\u958B\u59CB\u7E6A\u88FD\u7684\u5730\u65B9\u5857\u7B2C\u4E00\u500B\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8A2D\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9078\u64C7\u8D85\u6642",
+      positionDetected: "\u{1F3AF} \u5DF2\u6AA2\u6E2C\u5230\u4F4D\u7F6E\uFF0C\u8655\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u6AA2\u6E2C\u5931\u6557\uFF0C\u8ACB\u91CD\u8A66",
+      startPaintingMsg: "\u{1F3A8} \u958B\u59CB\u7E6A\u88FD...",
+      paintingProgress: "\u{1F9F1} \u9032\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6C92\u6709\u6B21\u6578\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7E6A\u88FD",
+      paintingComplete: "\u2705 \u7E6A\u88FD\u5B8C\u6210\uFF01\u5171\u7E6A\u88FD {count} \u500B\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7E6A\u88FD\u904E\u7A0B\u4E2D\u51FA\u932F",
+      missingRequirements: "\u274C \u8ACB\u5148\u52A0\u8F09\u5716\u7247\u4E26\u9078\u64C7\u4F4D\u7F6E",
+      progress: "\u9032\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      estimatedTime: "\u9810\u8A08\u6642\u9593",
+      initMessage: "\u9EDE\u64CA\u201C\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA\u201D\u958B\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u5716\u7247\u5DF2\u8ABF\u6574\u70BA {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7E6A\u88FD\u66AB\u505C\u65BC\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6578",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u6642\u9593",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6578",
+      showOverlay: "\u986F\u793A\u8986\u84CB\u5C64",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6578",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed}",
+      timeRemaining: "\u5269\u9918\u6642\u9593",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u5F8C\u7E7C\u7E8C...",
+      progressSaved: "\u2705 \u9032\u5EA6\u5DF2\u4FDD\u5B58\u70BA {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F09\u9032\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7E6A\u88FD",
+      progressLoadError: "\u274C \u52A0\u8F09\u9032\u5EA6\u5931\u6557: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u9032\u5EA6\u5931\u6557: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u7576\u524D\u9032\u5EA6\u55CE\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u9032\u5EA6",
+      discardProgress: "\u653E\u68C4",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BEC\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7E31\u6A6B\u6BD4",
+      apply: "\u61C9\u7528",
+      overlayOn: "\u8986\u84CB\u5C64: \u958B\u5553",
+      overlayOff: "\u8986\u84CB\u5C64: \u95DC\u9589",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7E6A\u88FD {painted} \u50CF\u7D20 | \u9032\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6578\u6062\u5FA9: {current}/{needed} - \u6642\u9593: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed} - \u5269\u9918: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8A66 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5617\u8A66\u51FA\u932F\uFF0C\u5C07\u5728 {delay} \u79D2\u5F8C\u91CD\u8A66...",
+      retryFailed: "\u274C \u8D85\u904E {maxAttempts} \u6B21\u5617\u8A66\u5931\u6557\u3002\u7E7C\u7E8C\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7DB2\u7D61\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      serverError: "\u{1F525} \u670D\u52D9\u5668\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      timeoutError: "\u23F0 \u670D\u52D9\u5668\u8D85\u6642\uFF0C\u6B63\u5728\u91CD\u8A66..."
+    },
+    // 農場模塊（待實現）
+    farm: {
+      title: "WPlace \u8FB2\u5834\u6A5F\u5668\u4EBA",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u6A5F\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u6E96",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u6AA2\u67E5\u72C0\u614B\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u9072 (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6578",
+      colorMode: "\u984F\u8272\u6A21\u5F0F",
+      random: "\u96A8\u6A5F",
+      fixed: "\u56FA\u5B9A",
+      range: "\u7BC4\u570D",
+      fixedColor: "\u56FA\u5B9A\u984F\u8272",
+      advanced: "\u9AD8\u7D1A",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u7FA9\u8ABF\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u7372",
+      painted: "\u5DF2\u7E6A\u88FD",
+      charges: "\u6B21\u6578",
+      retries: "\u91CD\u8A66",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F09",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8ACB\u624B\u52D5\u7E6A\u88FD\u4E00\u500B\u50CF\u7D20\u4EE5\u6355\u7372\u5EA7\u6A19...",
+      backendOnline: "\u5F8C\u7AEF\u5728\u7DDA",
+      backendOffline: "\u5F8C\u7AEF\u96E2\u7DDA",
+      startingBot: "\u6B63\u5728\u5553\u52D5\u6A5F\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u6A5F\u5668\u4EBA...",
+      calibrating: "\u6821\u6E96\u4E2D...",
+      alreadyRunning: "\u81EA\u52D5\u8FB2\u5834\u5DF2\u5728\u904B\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52D5\u7E6A\u5716\u6B63\u5728\u904B\u884C\uFF0C\u8ACB\u5148\u95DC\u9589\u518D\u5553\u52D5\u81EA\u52D5\u8FB2\u5834\u3002",
+      selectPosition: "\u9078\u64C7\u5340\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u5716\u7684\u7A7A\u767D\u5340\u57DF\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u5340\u57DF\u8A2D\u7F6E\u6210\u529F\uFF01\u534A\u5F91: 500px",
+      positionTimeout: "\u274C \u5340\u57DF\u9078\u64C7\u8D85\u6642",
+      missingPosition: "\u274C \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF08\u4F7F\u7528\u201C\u9078\u64C7\u5340\u57DF\u201D\u6309\u9215\uFF09",
+      farmRadius: "\u8FB2\u5834\u534A\u5F91",
+      positionInfo: "\u7576\u524D\u5340\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F91 {radius}px \u5728 ({x},{y}) \u8FB2\u5834",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8ACB\u9078\u64C7\u7A7A\u767D\u5340\u57DF\u4EE5\u907F\u514D\u885D\u7A81",
+      noPosition: "\u672A\u9078\u64C7\u5340\u57DF",
+      currentZone: "\u5340\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF0C\u5728\u5730\u5716\u4E0A\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u78BA\u8A8D",
+      cancel: "\u53D6\u6D88",
+      close: "\u95DC\u9589",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F09",
+      delete: "\u522A\u9664",
+      edit: "\u7DE8\u8F2F",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u66AB\u505C",
+      resume: "\u7E7C\u7E8C",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8A2D\u7F6E",
+      help: "\u5E6B\u52A9",
+      about: "\u95DC\u65BC",
+      language: "\u8A9E\u8A00",
+      loading: "\u52A0\u8F09\u4E2D...",
+      error: "\u932F\u8AA4",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8A9E\u8A00\u5DF2\u5207\u63DB\u70BA {language}"
+    },
+    // 守護模塊
+    guard: {
+      title: "WPlace \u81EA\u52D5\u5B88\u8B77",
+      initBot: "\u521D\u59CB\u5316\u5B88\u8B77\u6A5F\u5668\u4EBA",
+      selectArea: "\u9078\u64C7\u5340\u57DF",
+      captureArea: "\u6355\u7372\u5340\u57DF",
+      startProtection: "\u958B\u59CB\u5B88\u8B77",
+      stopProtection: "\u505C\u6B62\u5B88\u8B77",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u8B77\u50CF\u7D20",
+      detectedChanges: "\u6AA2\u6E2C\u5230\u7684\u8B8A\u5316",
+      repairedPixels: "\u4FEE\u5FA9\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u984F\u8272\uFF0C\u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      initSuccess: "\u2705 \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u5931\u6557",
+      invalidCoords: "\u274C \u5EA7\u6A19\u7121\u6548",
+      invalidArea: "\u274C \u5340\u57DF\u7121\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u9808\u5C0F\u65BC\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u5340\u57DF\u904E\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u7372\u5B88\u8B77\u5340\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u5340\u57DF\u6355\u7372\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u8B77",
+      captureError: "\u274C \u6355\u7372\u5340\u57DF\u51FA\u932F: {error}",
+      captureFirst: "\u274C \u8ACB\u5148\u6355\u7372\u4E00\u500B\u5B88\u8B77\u5340\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u8B77\u5DF2\u5553\u52D5 - \u5340\u57DF\u76E3\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u8B77\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u5340\u57DF\u5B89\u5168 - \u672A\u6AA2\u6E2C\u5230\u8B8A\u5316",
+      changesDetected: "\u{1F6A8} \u6AA2\u6E2C\u5230 {count} \u500B\u8B8A\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u5FA9\u51FA\u932F: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6578\u4E0D\u8DB3\uFF0C\u7121\u6CD5\u4FEE\u5FA9",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u6AA2\u67E5\u5340\u57DF\u8B8A\u5316...",
+      errorChecking: "\u274C \u6AA2\u67E5\u51FA\u932F: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u8B77\u4E2D - \u5340\u57DF\u53D7\u4FDD\u8B77",
+      lastCheck: "\u4E0A\u6B21\u6AA2\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u6AA2\u67E5: {time} \u79D2\u5F8C",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u8B77\u5340\u57DF\u7684\u5DE6\u4E0A\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73FE\u5728\u5728\u53F3\u4E0B\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u7372\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u7372\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9078\u64C7\u8D85\u6642",
+      selectionError: "\u274C \u9078\u64C7\u51FA\u932F\uFF0C\u8ACB\u91CD\u8A66"
+    }
+  };
+
+  // src/locales/index.js
+  var translations = {
+    es,
+    en,
+    fr,
+    ru,
+    zhHans,
+    zhHant
+  };
+  var currentLanguage = "es";
+  var currentTranslations = translations[currentLanguage];
+  function detectBrowserLanguage() {
+    const browserLang = window.navigator.language || window.navigator.userLanguage || "es";
+    const langCode = browserLang.split("-")[0].toLowerCase();
+    if (translations[langCode]) {
+      return langCode;
+    }
+    return "es";
+  }
+  function getSavedLanguage() {
+    return null;
+  }
+  function saveLanguage(langCode) {
+    return;
+  }
+  function initializeLanguage() {
+    const savedLang = getSavedLanguage();
+    const browserLang = detectBrowserLanguage();
+    let selectedLang = "es";
+    if (savedLang && translations[savedLang]) {
+      selectedLang = savedLang;
+    } else if (browserLang && translations[browserLang]) {
+      selectedLang = browserLang;
+    }
+    setLanguage(selectedLang);
+    return selectedLang;
+  }
+  function setLanguage(langCode) {
+    if (!translations[langCode]) {
+      console.warn(`Idioma '${langCode}' no disponible. Usando '${currentLanguage}'`);
+      return;
+    }
+    currentLanguage = langCode;
+    currentTranslations = translations[langCode];
+    saveLanguage(langCode);
+    if (typeof window !== "undefined" && window.CustomEvent) {
+      window.dispatchEvent(new window.CustomEvent("languageChanged", {
+        detail: { language: langCode, translations: currentTranslations }
+      }));
+    }
+  }
+  function t(key, params = {}) {
+    const keys = key.split(".");
+    let value = currentTranslations;
+    for (const k of keys) {
+      if (value && typeof value === "object" && k in value) {
+        value = value[k];
+      } else {
+        console.warn(`Clave de traducci\xF3n no encontrada: '${key}'`);
+        return key;
+      }
+    }
+    if (typeof value !== "string") {
+      console.warn(`Clave de traducci\xF3n no es string: '${key}'`);
+      return key;
+    }
+    return interpolate(value, params);
+  }
+  function interpolate(text, params) {
+    if (!params || Object.keys(params).length === 0) {
+      return text;
+    }
+    return text.replace(/\{(\w+)\}/g, (match, key) => {
+      return params[key] !== void 0 ? params[key] : match;
+    });
+  }
+  initializeLanguage();
+
+  // src/farm/ui.js
+  function createFarmUI(config, onStart, onStop) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l;
+    const shadowHost = document.createElement("div");
+    shadowHost.id = "wplace-farm-ui";
+    shadowHost.style.cssText = `
     position: fixed;
     top: 10px;
     right: 10px;
     z-index: 2147483647;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  `;let n=r.attachShadow({mode:"open"}),c=document.createElement("style");c.textContent=`
+  `;
+    const shadow = shadowHost.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    style.textContent = `
     .wplace-container {
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
       border: 2px solid #4a5568;
@@ -284,10 +2092,18 @@
       font-weight: bold;
       color: #90cdf4;
     }
-  `,n.appendChild(c);let i=document.createElement("div");i.className="wplace-container";let p={minimized:!1,showAdvanced:!1};i.innerHTML=`
+  `;
+    shadow.appendChild(style);
+    const container = document.createElement("div");
+    container.className = "wplace-container";
+    const uiState = {
+      minimized: false,
+      showAdvanced: false
+    };
+    container.innerHTML = `
     <div class="wplace-header">
       <div class="wplace-title">
-        \u{1F916} ${l("farm.title")}
+        \u{1F916} ${t("farm.title")}
       </div>
       <button class="wplace-minimize">\u2212</button>
     </div>
@@ -295,79 +2111,79 @@
     <div class="wplace-content">
       <!-- Estado y controles principales -->
       <div class="wplace-section">
-        <div class="wplace-status" id="status">\u{1F4A4} ${l("farm.stopped")}</div>
+        <div class="wplace-status" id="status">\u{1F4A4} ${t("farm.stopped")}</div>
         
         <div class="wplace-stats">
           <div class="wplace-stat">
             <div class="wplace-stat-value" id="painted-count">0</div>
-            <div class="wplace-stat-label">${l("farm.painted")}</div>
+            <div class="wplace-stat-label">${t("farm.painted")}</div>
           </div>
           <div class="wplace-stat">
             <div class="wplace-stat-value" id="charges-count">0</div>
-            <div class="wplace-stat-label">${l("farm.charges")}</div>
+            <div class="wplace-stat-label">${t("farm.charges")}</div>
           </div>
           <div class="wplace-stat">
             <div class="wplace-stat-value" id="retry-count">0</div>
-            <div class="wplace-stat-label">${l("farm.retries")}</div>
+            <div class="wplace-stat-label">${t("farm.retries")}</div>
           </div>
           <div class="wplace-stat">
             <div class="wplace-stat-value" id="tile-pos">0,0</div>
-            <div class="wplace-stat-label">${l("farm.tile")}</div>
+            <div class="wplace-stat-label">${t("farm.tile")}</div>
           </div>
         </div>
         
         <div class="wplace-buttons">
-          <button class="wplace-button start" id="start-btn">\u25B6\uFE0F ${l("farm.start")}</button>
-          <button class="wplace-button stop" id="stop-btn" disabled>\u23F9\uFE0F ${l("farm.stop")}</button>
-          <button class="wplace-button small" id="select-position-btn">\u{1F30D} ${l("farm.selectPosition")}</button>
-          <button class="wplace-button small" id="once-btn">\u{1F3A8} ${l("farm.paintOnce")}</button>
+          <button class="wplace-button start" id="start-btn">\u25B6\uFE0F ${t("farm.start")}</button>
+          <button class="wplace-button stop" id="stop-btn" disabled>\u23F9\uFE0F ${t("farm.stop")}</button>
+          <button class="wplace-button small" id="select-position-btn">\u{1F30D} ${t("farm.selectPosition")}</button>
+          <button class="wplace-button small" id="once-btn">\u{1F3A8} ${t("farm.paintOnce")}</button>
         </div>
         
         <!-- Informaci\xF3n de la zona seleccionada -->
         <div class="wplace-zone-info" id="zone-info">
-          <div class="wplace-zone-text">\u{1F4CD} ${l("farm.positionInfo")}: <span id="zone-display">${l("farm.noPosition")}</span></div>
-          <div class="wplace-zone-warning">\u26A0\uFE0F ${l("farm.selectEmptyArea")}</div>
+          <div class="wplace-zone-text">\u{1F4CD} ${t("farm.positionInfo")}: <span id="zone-display">${t("farm.noPosition")}</span></div>
+          <div class="wplace-zone-warning">\u26A0\uFE0F ${t("farm.selectEmptyArea")}</div>
         </div>
         
-        <div class="wplace-health" id="health-status">\u{1F50D} ${l("farm.checkingStatus")}</div>
+        <div class="wplace-health" id="health-status">\u{1F50D} ${t("farm.checkingStatus")}</div>
       </div>
       
       <!-- Configuraci\xF3n b\xE1sica -->
       <div class="wplace-section">
-        <div class="wplace-section-title">\u2699\uFE0F ${l("farm.configuration")}</div>
+        <div class="wplace-section-title">\u2699\uFE0F ${t("farm.configuration")}</div>
         
         <div class="wplace-row">
-          <span class="wplace-label">${l("farm.delay")}:</span>
+          <span class="wplace-label">${t("farm.delay")}:</span>
           <input type="number" class="wplace-input" id="delay-input" min="1000" max="300000" step="1000">
         </div>
         
         <div class="wplace-row">
-          <span class="wplace-label">${l("farm.pixelsPerBatch")}:</span>
+          <span class="wplace-label">${t("farm.pixelsPerBatch")}:</span>
           <input type="number" class="wplace-input" id="pixels-input" min="1" max="50">
         </div>
         
         <div class="wplace-row">
-          <span class="wplace-label">${l("farm.minCharges")}:</span>
+          <span class="wplace-label">${t("farm.minCharges")}:</span>
           <input type="number" class="wplace-input" id="min-charges-input" min="0" max="50" step="0.1">
         </div>
         
         <div class="wplace-row">
-          <span class="wplace-label">${l("farm.colorMode")}:</span>
+          <span class="wplace-label">${t("farm.colorMode")}:</span>
           <select class="wplace-select" id="color-mode-select">
-            <option value="random">${l("farm.random")}</option>
-            <option value="fixed">${l("farm.fixed")}</option>
+            <option value="random">${t("farm.random")}</option>
+            <option value="fixed">${t("farm.fixed")}</option>
           </select>
         </div>
         
         <div class="wplace-row" id="color-range-row">
-          <span class="wplace-label">${l("farm.range")}:</span>
+          <span class="wplace-label">${t("farm.range")}:</span>
           <input type="number" class="wplace-input" id="color-min-input" min="1" max="32" style="width: 35px;">
           <span style="color: #cbd5e0;">-</span>
           <input type="number" class="wplace-input" id="color-max-input" min="1" max="32" style="width: 35px;">
         </div>
         
         <div class="wplace-row" id="color-fixed-row" style="display: none;">
-          <span class="wplace-label">${l("farm.fixedColor")}:</span>
+          <span class="wplace-label">${t("farm.fixedColor")}:</span>
           <input type="number" class="wplace-input" id="color-fixed-input" min="1" max="32">
         </div>
       </div>
@@ -375,35 +2191,1285 @@
       <!-- Configuraci\xF3n avanzada (colapsable) -->
       <div class="wplace-section">
         <div class="wplace-section-title" id="advanced-toggle">
-          \u{1F527} ${l("farm.advanced")} <span id="advanced-arrow">\u25B6</span>
+          \u{1F527} ${t("farm.advanced")} <span id="advanced-arrow">\u25B6</span>
         </div>
         
         <div class="wplace-advanced" id="advanced-section" style="display: none;">
           <div class="wplace-row">
-            <span class="wplace-label">${l("farm.tileX")}:</span>
+            <span class="wplace-label">${t("farm.tileX")}:</span>
             <input type="number" class="wplace-input" id="tile-x-input">
           </div>
           
           <div class="wplace-row">
-            <span class="wplace-label">${l("farm.tileY")}:</span>
+            <span class="wplace-label">${t("farm.tileY")}:</span>
             <input type="number" class="wplace-input" id="tile-y-input">
           </div>
           
           <div class="wplace-row">
-            <span class="wplace-label">${l("farm.customPalette")}:</span>
+            <span class="wplace-label">${t("farm.customPalette")}:</span>
           </div>
           <div class="wplace-row">
             <input type="text" class="wplace-input wide" id="custom-palette-input" 
-                   placeholder="${l("farm.paletteExample")}">
+                   placeholder="${t("farm.paletteExample")}">
           </div>
           
           <div class="wplace-buttons">
-            <button class="wplace-button small" id="save-btn">\u{1F4BE} ${l("common.save")}</button>
-            <button class="wplace-button small" id="load-btn">\u{1F4C1} ${l("common.load")}</button>
-            <button class="wplace-button small" id="reset-btn">\u{1F504} ${l("common.reset")}</button>
-            <button class="wplace-button small" id="capture-btn">\u{1F4F8} ${l("farm.capture")}</button>
+            <button class="wplace-button small" id="save-btn">\u{1F4BE} ${t("common.save")}</button>
+            <button class="wplace-button small" id="load-btn">\u{1F4C1} ${t("common.load")}</button>
+            <button class="wplace-button small" id="reset-btn">\u{1F504} ${t("common.reset")}</button>
+            <button class="wplace-button small" id="capture-btn">\u{1F4F8} ${t("farm.capture")}</button>
           </div>
         </div>
       </div>
     </div>
-  `,n.appendChild(i),document.body.appendChild(r);let u=n.querySelector(".wplace-header");ge(u,r);let a={minimizeBtn:n.querySelector(".wplace-minimize"),content:n.querySelector(".wplace-content"),status:n.getElementById("status"),paintedCount:n.getElementById("painted-count"),chargesCount:n.getElementById("charges-count"),retryCount:n.getElementById("retry-count"),tilePos:n.getElementById("tile-pos"),startBtn:n.getElementById("start-btn"),stopBtn:n.getElementById("stop-btn"),selectPositionBtn:n.getElementById("select-position-btn"),onceBtn:n.getElementById("once-btn"),zoneInfo:n.getElementById("zone-info"),zoneDisplay:n.getElementById("zone-display"),healthStatus:n.getElementById("health-status"),delayInput:n.getElementById("delay-input"),pixelsInput:n.getElementById("pixels-input"),minChargesInput:n.getElementById("min-charges-input"),colorModeSelect:n.getElementById("color-mode-select"),colorRangeRow:n.getElementById("color-range-row"),colorFixedRow:n.getElementById("color-fixed-row"),colorMinInput:n.getElementById("color-min-input"),colorMaxInput:n.getElementById("color-max-input"),colorFixedInput:n.getElementById("color-fixed-input"),advancedToggle:n.getElementById("advanced-toggle"),advancedSection:n.getElementById("advanced-section"),advancedArrow:n.getElementById("advanced-arrow"),tileXInput:n.getElementById("tile-x-input"),tileYInput:n.getElementById("tile-y-input"),customPaletteInput:n.getElementById("custom-palette-input"),saveBtn:n.getElementById("save-btn"),loadBtn:n.getElementById("load-btn"),resetBtn:n.getElementById("reset-btn"),captureBtn:n.getElementById("capture-btn")};function f(){var m;a.delayInput.value=e.DELAY_MS,a.pixelsInput.value=e.PIXELS_PER_BATCH,a.minChargesInput.value=e.MIN_CHARGES,a.colorModeSelect.value=e.COLOR_MODE,a.colorMinInput.value=e.COLOR_MIN,a.colorMaxInput.value=e.COLOR_MAX,a.colorFixedInput.value=e.COLOR_FIXED,a.tileXInput.value=e.TILE_X||"",a.tileYInput.value=e.TILE_Y||"",a.customPaletteInput.value=(e.CUSTOM_PALETTE||[]).join(","),h(),w(),x(),C(((m=g)==null?void 0:m.running)||!1)}function s(){e.DELAY_MS=parseInt(a.delayInput.value)||b.DELAY_MS,e.PIXELS_PER_BATCH=M(parseInt(a.pixelsInput.value)||b.PIXELS_PER_BATCH,1,50),e.MIN_CHARGES=parseFloat(a.minChargesInput.value)||b.MIN_CHARGES,e.COLOR_MODE=a.colorModeSelect.value,e.COLOR_MIN=M(parseInt(a.colorMinInput.value)||b.COLOR_MIN,1,32),e.COLOR_MAX=M(parseInt(a.colorMaxInput.value)||b.COLOR_MAX,1,32),e.COLOR_FIXED=M(parseInt(a.colorFixedInput.value)||b.COLOR_FIXED,1,32),e.COLOR_MIN>e.COLOR_MAX&&(e.COLOR_MAX=e.COLOR_MIN,a.colorMaxInput.value=e.COLOR_MAX);let m=parseInt(a.tileXInput.value),E=parseInt(a.tileYInput.value);Number.isFinite(m)&&(e.TILE_X=m),Number.isFinite(E)&&(e.TILE_Y=E),w(),x()}function h(){let m=a.colorModeSelect.value;a.colorRangeRow.style.display=m==="random"?"flex":"none",a.colorFixedRow.style.display=m==="fixed"?"flex":"none"}function w(){a.tilePos&&(a.tilePos.textContent=`${e.TILE_X||0},${e.TILE_Y||0}`)}function x(){var m;a.zoneDisplay&&(e.POSITION_SELECTED&&e.BASE_X!==null&&e.BASE_Y!==null?(a.zoneDisplay.textContent=l("farm.currentZone",{x:e.BASE_X,y:e.BASE_Y}),a.zoneDisplay.style.color="#48bb78"):(a.zoneDisplay.textContent=l("farm.noPosition"),a.zoneDisplay.style.color="#f56565")),C(((m=g)==null?void 0:m.running)||!1)}(Y=a.minimizeBtn)==null||Y.addEventListener("click",()=>{p.minimized=!p.minimized,a.content.classList.toggle("minimized",p.minimized),a.minimizeBtn.textContent=p.minimized?"+":"\u2212"}),(X=a.startBtn)==null||X.addEventListener("click",()=>{s(),o(),C(!0)}),(N=a.stopBtn)==null||N.addEventListener("click",()=>{t(),C(!1)}),(te=a.onceBtn)==null||te.addEventListener("click",()=>{f(),s(),window.WPAUI&&window.WPAUI.once&&window.WPAUI.once()}),(ae=a.selectPositionBtn)==null||ae.addEventListener("click",()=>{y(e,P,x)}),(ne=a.colorModeSelect)==null||ne.addEventListener("change",()=>{h(),s()}),(oe=a.customPaletteInput)==null||oe.addEventListener("input",()=>{s()}),(re=a.advancedToggle)==null||re.addEventListener("click",()=>{p.showAdvanced=!p.showAdvanced,a.advancedSection.style.display=p.showAdvanced?"block":"none",a.advancedArrow.textContent=p.showAdvanced?"\u25BC":"\u25B6"}),["delayInput","pixelsInput","minChargesInput","colorMinInput","colorMaxInput","colorFixedInput","tileXInput","tileYInput"].forEach(m=>{var E;(E=a[m])==null||E.addEventListener("change",s)}),(ie=a.saveBtn)==null||ie.addEventListener("click",()=>{s(),P(`\u{1F4BE} ${l("farm.configSaved")}`,"success")}),(se=a.loadBtn)==null||se.addEventListener("click",()=>{let m=q(b);Object.assign(e,m),f(),P(`\u{1F4C1} ${l("farm.configLoaded")}`,"success")}),(le=a.resetBtn)==null||le.addEventListener("click",()=>{de(),Object.assign(e,b),f(),P(`\u{1F504} ${l("farm.configReset")}`,"success")}),(ce=a.captureBtn)==null||ce.addEventListener("click",()=>{P(`\u{1F4F8} ${l("farm.captureInstructions")}`,"status")});function C(m){if(a.startBtn){let E=!e.POSITION_SELECTED||e.BASE_X===null||e.BASE_Y===null;a.startBtn.disabled=m||E,E?(a.startBtn.textContent=`\u{1F6AB} ${l("farm.selectPosition")} \u26A0\uFE0F`,a.startBtn.title=l("farm.missingPosition")):(a.startBtn.textContent=`\u25B6\uFE0F ${l("farm.start")}`,a.startBtn.title="")}a.stopBtn&&(a.stopBtn.disabled=!m)}function P(m,E="status"){a.status&&(a.status.textContent=m,a.status.className=`wplace-status ${E}`,d(`Status: ${m}`))}function z(m,E,R=0,S=null){a.paintedCount&&(a.paintedCount.textContent=m||0),a.chargesCount&&(a.chargesCount.textContent=typeof E=="number"?E.toFixed(1):"0"),a.retryCount&&(a.retryCount.textContent=R||0),a.healthStatus&&S&&(a.healthStatus.textContent=S.up?`\u{1F7E2} ${l("farm.backendOnline")}`:`\u{1F534} ${l("farm.backendOffline")}`,a.healthStatus.className=`wplace-health ${S.up?"online":"offline"}`)}function D(){i.style.boxShadow="0 0 20px #48bb78",setTimeout(()=>{i.style.boxShadow="0 10px 25px rgba(0,0,0,0.3)"},200)}f();function I(){var O;let m=n.querySelector(".wplace-title");m&&(m.innerHTML=`\u{1F916} ${l("farm.title")}`),a.startBtn&&(a.startBtn.innerHTML=`\u25B6\uFE0F ${l("farm.start")}`),a.stopBtn&&(a.stopBtn.innerHTML=`\u23F9\uFE0F ${l("farm.stop")}`),a.selectPositionBtn&&(a.selectPositionBtn.innerHTML=`\u{1F30D} ${l("farm.selectPosition")}`),a.onceBtn&&(a.onceBtn.innerHTML=`\u{1F3A8} ${l("farm.paintOnce")}`);let E=n.querySelector("#painted-count").parentElement.querySelector(".wplace-stat-label"),R=n.querySelector("#charges-count").parentElement.querySelector(".wplace-stat-label"),S=n.querySelector("#retry-count").parentElement.querySelector(".wplace-stat-label"),T=n.querySelector("#tile-pos").parentElement.querySelector(".wplace-stat-label");E&&(E.textContent=l("farm.painted")),R&&(R.textContent=l("farm.charges")),S&&(S.textContent=l("farm.retries")),T&&(T.textContent=l("farm.tile"));let L=n.querySelector(".wplace-section-title");L&&(L.innerHTML=`\u2699\uFE0F ${l("farm.configuration")}`);let v=n.getElementById("advanced-toggle");if(v){let A=v.querySelector("#advanced-arrow"),U=A?A.textContent:"\u25B6";v.innerHTML=`\u{1F527} ${l("farm.advanced")} <span id="advanced-arrow">${U}</span>`}let B=a.colorModeSelect;if(B){let A=B.querySelector('option[value="random"]'),U=B.querySelector('option[value="fixed"]');A&&(A.textContent=l("farm.random")),U&&(U.textContent=l("farm.fixed"))}a.customPaletteInput&&(a.customPaletteInput.placeholder=l("farm.paletteExample")),a.saveBtn&&(a.saveBtn.innerHTML=`\u{1F4BE} ${l("common.save")}`),a.loadBtn&&(a.loadBtn.innerHTML=`\u{1F4C1} ${l("common.load")}`),a.resetBtn&&(a.resetBtn.innerHTML=`\u{1F504} ${l("common.reset")}`),a.captureBtn&&(a.captureBtn.innerHTML=`\u{1F4F8} ${l("farm.capture")}`),x(),C(((O=g)==null?void 0:O.running)||!1);let _=a.healthStatus;_&&_.textContent.includes("\u{1F50D}")&&(_.textContent=`\u{1F50D} ${l("farm.checkingStatus")}`);let $=a.status;$&&$.textContent.includes("\u{1F4A4}")&&($.textContent=`\u{1F4A4} ${l("farm.stopped")}`)}async function y(m,E,R){return new Promise(S=>{E(l("farm.selectPositionAlert"),"info"),m.selectingPosition=!0;let T=window.fetch;window.fetch=async(L,v)=>{if(m.selectingPosition&&L.includes("/s0/pixel/"))try{let B=await T(L,v);if(B.ok&&v&&v.body){let _=JSON.parse(v.body);if(_.coords&&_.coords.length>=2){let $=_.coords[0],O=_.coords[1],A=L.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);A&&(m.TILE_X=parseInt(A[1]),m.TILE_Y=parseInt(A[2])),m.BASE_X=$,m.BASE_Y=O,m.POSITION_SELECTED=!0,m.selectingPosition=!1,window.fetch=T,R(),w(),f(),E(l("farm.positionSet"),"success"),d(`\u2705 Zona de farming establecida: tile(${m.TILE_X},${m.TILE_Y}) base(${$},${O}) radio(${m.FARM_RADIUS}px)`),S(!0)}}return B}catch(B){return d("Error interceptando pixel:",B),T(L,v)}return T(L,v)},setTimeout(()=>{m.selectingPosition&&(window.fetch=T,m.selectingPosition=!1,E(l("farm.positionTimeout"),"error"),S(!1))},12e4)})}return window.addEventListener("languageChanged",I),{setStatus:P,updateStats:z,flashEffect:D,updateButtonStates:C,updateTexts:I,destroy:()=>{window.removeEventListener("languageChanged",I),document.body.removeChild(r)},updateConfig:f,getElement:()=>r}}async function K(e){try{if(d("\u{1F3AF} Iniciando auto-calibraci\xF3n del tile..."),e.POSITION_SELECTED&&e.BASE_X!=null&&e.BASE_Y!=null&&Number.isFinite(e.TILE_X)&&Number.isFinite(e.TILE_Y))return d(`\u2139\uFE0F Ya existe zona seleccionada. Se mantiene tile actual: (${e.TILE_X}, ${e.TILE_Y})`),{tileX:e.TILE_X,tileY:e.TILE_Y,success:!0};let o=new window.URLSearchParams(window.location.search),t=window.location.hash,r,n;if(o.has("x")&&o.has("y")&&(r=parseInt(o.get("x")),n=parseInt(o.get("y"))),!r&&!n&&t){let c=t.match(/#(-?\d+),(-?\d+)/);c&&(r=parseInt(c[1]),n=parseInt(c[2]))}if(!r&&!n){let c=document.querySelectorAll("[data-x], [data-y], .coordinates, .position");for(let i of c){let p=i.getAttribute("data-x")||i.getAttribute("x"),u=i.getAttribute("data-y")||i.getAttribute("y");if(p&&u){r=parseInt(p),n=parseInt(u);break}}}if(!r&&!n){let i=(document.body.textContent||"").match(/(?:tile|pos|position)?\s*[([]?\s*(-?\d+)\s*[,;]\s*(-?\d+)\s*[)\]]?/i);i&&(r=parseInt(i[1]),n=parseInt(i[2]))}return(!Number.isFinite(r)||!Number.isFinite(n))&&(r=0,n=0,d("\u26A0\uFE0F No se pudieron detectar coordenadas autom\xE1ticamente, usando (0,0)")),(Math.abs(r)>1e6||Math.abs(n)>1e6)&&(d("\u26A0\uFE0F Coordenadas detectadas parecen incorrectas, limitando a rango v\xE1lido"),r=Math.max(-1e6,Math.min(1e6,r)),n=Math.max(-1e6,Math.min(1e6,n))),e.TILE_X=r,e.TILE_Y=n,d(`\u2705 Tile calibrado autom\xE1ticamente: (${r}, ${n})`),{tileX:r,tileY:n,success:!0}}catch(o){return d("\u274C Error en auto-calibraci\xF3n:",o),{tileX:0,tileY:0,success:!1,error:o.message}}}var be=!1;async function Me(){if(!(be||window.turnstile))return new Promise((e,o)=>{let t=document.createElement("script");t.src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit",t.async=!0,t.defer=!0,t.onload=()=>{be=!0,e()},t.onerror=()=>o(new Error("No se pudo cargar Turnstile")),document.head.appendChild(t)})}async function Re(e,o="paint"){var t;if(await Me(),typeof((t=window.turnstile)==null?void 0:t.execute)=="function")try{let r=await window.turnstile.execute(e,{action:o});if(r&&r.length>20)return r}catch{}return await new Promise(r=>{let n=document.createElement("div");n.style.position="fixed",n.style.left="-9999px",document.body.appendChild(n),window.turnstile.render(n,{sitekey:e,callback:c=>{document.body.removeChild(n),r(c)}})})}async function Ce(e){return Re(e,"paint")}var $e=e=>Math.floor(Math.random()*e);function Ie(e,o){if(!o.POSITION_SELECTED||o.BASE_X===null||o.BASE_Y===null){d("\u26A0\uFE0F No se ha seleccionado una posici\xF3n base. Usando coordenadas aleatorias fallback.");let i=[],p=Math.floor(o.TILE_SIZE*.05),u=o.TILE_SIZE-p*2;for(let a=0;a<e;a++){let f=p+Math.floor(Math.random()*u),s=p+Math.floor(Math.random()*u);i.push(f,s)}return i}let t=[],r=o.TILE_SIZE-1,n=Math.max(0,Math.min(r,o.BASE_X)),c=Math.max(0,Math.min(r,o.BASE_Y));for(let i=0;i<e;i++)n=Math.max(0,Math.min(r,n)),c=Math.max(0,Math.min(r,c)),t.push(n,c),n++,n>r&&(n=Math.max(0,Math.min(r,o.BASE_X)),c++,c>r&&(c=Math.max(0,Math.min(r,o.BASE_Y))));return t.length>=4&&d(`\u{1F3AF} L\xEDnea recta generada: [${t.slice(0,8).join(",")}...] total: ${t.length/2} p\xEDxeles`),t}function ye(e,o){let t=[];for(let r=0;r<e;r++)t.push(Fe(o));return t}function Fe(e){if(e.COLOR_MODE==="fixed")return e.COLOR_FIXED;{let o=e.COLOR_MAX-e.COLOR_MIN+1;return e.COLOR_MIN+$e(o)}}var W=e=>new Promise(o=>setTimeout(o,e));async function k(e,o,t){let n=Date.now()+e;for(;Date.now()<n&&(!t||t.running);){let c=n-Date.now();o&&o(c),await W(Math.min(1e3,c))}}async function Oe(e,o,t){try{let r=document.querySelectorAll("canvas");for(let n of r){let c=n.getContext("2d");if(c){let i=typeof t=="number"?`#${t.toString(16).padStart(6,"0")}`:t;c.fillStyle=i,c.fillRect(e,o,1,1),typeof window!="undefined"&&window.Event&&n.dispatchEvent(new window.Event("pixel-updated"))}}}catch(r){d("Error actualizando canvas:",r)}}async function ke(e,o){try{let t=`[data-tile="${e}-${o}"], .tile-${e}-${o}, [data-tile-x="${e}"][data-tile-y="${o}"]`,r=document.querySelector(t);r?(r.classList.add("tile-updating"),setTimeout(()=>{r.classList.remove("tile-updating"),r.classList.add("tile-updated"),setTimeout(()=>r.classList.remove("tile-updated"),1e3)},100),d(`Tile (${e},${o}) actualizado visualmente`)):(document.querySelectorAll("canvas").forEach(c=>{let i=c.getContext("2d");if(i){let p=i.getImageData(0,0,1,1);i.putImageData(p,0,0)}}),d(`Actualizaci\xF3n visual gen\xE9rica realizada para tile (${e},${o})`))}catch(t){d("Error en actualizaci\xF3n visual del tile:",t)}}async function ze(e,o,t,r,n,c){var C,P,z,D;if(!e.POSITION_SELECTED||e.BASE_X===null||e.BASE_Y===null)return t("\u{1F3AF} Selecciona una zona primero usando 'Seleccionar Zona'","error"),d("Pintado cancelado: no se ha seleccionado una posici\xF3n base"),!1;if(!Number.isFinite(e.TILE_X)||!Number.isFinite(e.TILE_Y))return t(`\u{1F6AB} Coordenadas del tile inv\xE1lidas (${e.TILE_X},${e.TILE_Y}). Calibra primero`,"error"),d("Pintado cancelado: coordenadas del tile inv\xE1lidas"),!1;let i=Math.floor(o.charges.count);if(i<1)return t("\u{1F50B} Sin cargas disponibles. Esperando...","error"),!1;let p=Math.min(i,e.PIXELS_PER_BATCH,50),u=Math.max(1,p);u<e.PIXELS_PER_BATCH&&d(`Ajustando p\xEDxeles por cargas completas disponibles: ${u}/${e.PIXELS_PER_BATCH} (${i} cargas completas de ${o.charges.count.toFixed(2)} totales)`);let a=Ie(u,e),f=ye(u,e),s=a[0],h=a[1];t(`\u{1F33E} Farmeando ${u} p\xEDxeles en radio ${e.FARM_RADIUS}px desde (${e.BASE_X},${e.BASE_Y}) tile(${e.TILE_X},${e.TILE_Y})...`,"status");let w=await Ce(e.SITEKEY),x=await me(e.TILE_X,e.TILE_Y,a,f,w);if(o.last={x:s,y:h,color:f[0],pixelCount:u,availableCharges:i,status:x.status,json:x.json},x.status===200&&x.json&&(x.json.painted>0||x.json.painted===u||x.json.ok)){let I=x.json.painted||u;o.painted+=I,o.retryCount=0;for(let y=0;y<a.length;y+=2){let Y=a[y],X=a[y+1],N=f[Math.floor(y/2)];await Oe(Y,X,N)}if(await ke(e.TILE_X,e.TILE_Y),await n(),t(`\u2705 Lote pintado: ${I}/${u} p\xEDxeles en zona (${e.BASE_X},${e.BASE_Y}) radio ${e.FARM_RADIUS}px`,"success"),r(),typeof window!="undefined"&&window.CustomEvent){let y=new window.CustomEvent("wplace-batch-painted",{detail:{firstX:s,firstY:h,pixelCount:I,totalPixels:u,colors:f,coords:a,tileX:e.TILE_X,tileY:e.TILE_Y,baseX:e.BASE_X,baseY:e.BASE_Y,radius:e.FARM_RADIUS,timestamp:Date.now()}});window.dispatchEvent(y)}return!0}if(x.status===403)t("\u26A0\uFE0F 403 (token expirado o Cloudflare). Reintentar\xE1...","error");else if(x.status===401)t("\u{1F512} 401 (no autorizado). Verifica tu sesi\xF3n.","error");else if(x.status===429)t("\u23F3 429 (l\xEDmite de tasa). Esperando...","error");else if(x.status===408)t("\u23F0 Timeout del servidor. Coordenadas problem\xE1ticas o servidor sobrecargado","error");else if(x.status===0)t("\u{1F310} Error de red. Verificando conectividad...","error");else if(x.status===500)t("\u{1F525} 500 (error interno del servidor). Reintentar\xE1...","error");else if(x.status===502||x.status===503||x.status===504)t(`\u{1F6AB} ${x.status} (servidor no disponible). Reintentar\xE1...`,"error");else if(x.status===404)t(`\u{1F5FA}\uFE0F 404 (tile no encontrado). Verificando coordenadas tile(${e.TILE_X},${e.TILE_Y})`,"error");else try{let I=await c(),y=I!=null&&I.up?"\u{1F7E2} Online":"\u{1F534} Offline";t(`\u274C Error ${x.status}: ${((C=x.json)==null?void 0:C.message)||((P=x.json)==null?void 0:P.error)||"Fallo al pintar"} (Backend: ${y})`,"error")}catch{t(`\u274C Error ${x.status}: ${((z=x.json)==null?void 0:z.message)||((D=x.json)==null?void 0:D.error)||"Fallo al pintar"} (Health check fall\xF3)`,"error")}return d(`Fallo en pintado: status=${x.status}, json=`,x.json,"coords=",a,"colors=",f),!1}async function J(e,o,t,r,n,c){for(let u=1;u<=5;u++)try{if(await ze(e,o,t,r,n,c))return o.retryCount=0,!0;if(o.retryCount=u,u<5){let f=3e3*Math.pow(2,u-1);t(`\u{1F504} Reintento ${u}/5 en ${f/1e3}s...`,"error"),await W(f)}}catch(a){if(d(`Error en intento ${u}:`,a),o.retryCount=u,u<5){let f=3e3*Math.pow(2,u-1);t(`\u{1F4A5} Error en intento ${u}/5, reintentando en ${f/1e3}s...`,"error"),await W(f)}}return o.retryCount=5,t("\u274C Fall\xF3 despu\xE9s de 5 intentos. Se requiere intervenci\xF3n manual.","error"),!1}async function ve(e,o,t,r,n,c,i){for(d("\u{1F680} Loop iniciado"),o.running=!0;o.running;)try{if(await i(),o.charges.count<e.MIN_CHARGES){let u=Math.max(0,(e.MIN_CHARGES-o.charges.count)*e.CHARGE_REGEN_MS);t(`\u23F3 Esperando cargas: ${o.charges.count.toFixed(1)}/${e.MIN_CHARGES} (${Math.round(u/1e3)}s)`,"status"),await k(Math.min(u,e.DELAY_MS),a=>{t(`\u23F3 Esperando cargas: ${o.charges.count.toFixed(1)}/${e.MIN_CHARGES} (~${Math.round(a/1e3)}s)`,"status")},o);continue}if(!await J(e,o,t,r,n,c)){t("\u{1F634} Esperando antes del siguiente intento...","error"),await k(e.DELAY_MS*2,u=>{t(`\u{1F634} Cooldown extendido: ${Math.round(u/1e3)}s`,"error")});continue}o.running&&await k(e.DELAY_MS,u=>{t(`\u{1F4A4} Esperando ${Math.round(u/1e3)}s hasta siguiente pintada...`,"status")})}catch(p){d("Error cr\xEDtico en loop:",p),t(`\u{1F4A5} Error cr\xEDtico: ${p.message}`,"error"),o.running&&await k(e.DELAY_MS*3,u=>{t(`\u{1F6A8} Recuper\xE1ndose de error cr\xEDtico: ${Math.round(u/1e3)}s`,"error")})}d("\u23F9\uFE0F Loop detenido"),t("\u23F9\uFE0F Bot detenido","status")}var Q=class{constructor(){this.active=!1,this.originalFetch=window.fetch,this.callback=null}enable(o){if(this.active){d("\u26A0\uFE0F Captura ya est\xE1 activa");return}this.active=!0,this.callback=o,d("\u{1F575}\uFE0F Captura de coordenadas activada. Pinta un p\xEDxel manualmente..."),window.fetch=async(...t)=>{let r=await this.originalFetch.apply(window,t);return this.active&&this.shouldCapture(t[0],t[1])&&await this.handleCapture(t[0],t[1],r.clone()),r},setTimeout(()=>{this.active&&(this.disable(),d("\u23F0 Captura de coordenadas expirada"))},3e4)}shouldCapture(o,t){if(!o||!t)return!1;let r=o.toString();return!(!r.includes("paint")&&!r.includes("pixel")&&!r.includes("place")||!t.method||t.method.toUpperCase()!=="POST")}async handleCapture(o,t,r){try{let n=null,c=null,i=null;if(t.body){let a;if(typeof t.body=="string")try{a=JSON.parse(t.body)}catch{a=t.body}else a=t.body;a.coords&&Array.isArray(a.coords)?n=a.coords:a.x!==void 0&&a.y!==void 0?n=[a.x,a.y]:a.coordinates&&(n=a.coordinates)}let p=o.toString(),u=p.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);if(u&&(c=parseInt(u[1]),i=parseInt(u[2])),!n){let a=p.match(/[?&](?:x|coords?)=([^&]+)/);if(a){let f=decodeURIComponent(a[1]);try{n=JSON.parse(f)}catch{let s=f.split(",");s.length>=2&&(n=[parseInt(s[0]),parseInt(s[1])])}}}if(n&&n.length>=2){let a,f,s,h;Number.isInteger(c)&&Number.isInteger(i)?(s=n[0],h=n[1],a=c*3e3+s,f=i*3e3+h,d(`\u{1F3AF} Coordenadas capturadas (locales): tile(${c},${i}) local(${s},${h}) -> global(${a},${f})`)):(a=n[0],f=n[1],c=Math.floor(a/3e3),i=Math.floor(f/3e3),s=a%3e3,h=f%3e3,d(`\u{1F3AF} Coordenadas capturadas (globales): global(${a},${f}) -> tile(${c},${i}) local(${s},${h})`)),r.ok?(this.disable(),this.callback&&this.callback({success:!0,tileX:c,tileY:i,globalX:a,globalY:f,localX:s,localY:h})):d("\u26A0\uFE0F Captura realizada pero la respuesta no fue exitosa")}}catch(n){d("Error procesando captura:",n)}}disable(){this.active&&(this.active=!1,window.fetch=this.originalFetch,this.callback=null,d("\u{1F512} Captura de coordenadas desactivada"))}},ee=new Q;function Pe(e=!1){let o=['[data-testid="color-picker"]',".color-picker",".palette",'[class*="color"][class*="picker"]','[class*="palette"]'];for(let n of o){let c=document.querySelector(n);if(c&&c.offsetParent!==null)return e&&console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por selector: ${n}`),!0}let t=document.querySelectorAll('[style*="background-color"], [style*="background:"], .color, [class*="color"]'),r=0;for(let n of t)if(n.offsetParent!==null&&n.offsetWidth>10&&n.offsetHeight>10&&(r++,r>=5))return e&&console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por colores visibles: ${r}`),!0;return e&&console.log(`[WPA-UI] \u{1F50D} Paleta no detectada. Colores visibles: ${r}`),!1}function De(e=!1,o=!1){let t=document.querySelector("button.btn.btn-primary.btn-lg, button.btn.btn-primary.sm\\:btn-xl");if(t){let n=t.textContent.toLowerCase(),c=n.includes("paint")||n.includes("pintar"),i=t.querySelector('svg path[d*="240-120"]')||t.querySelector('svg path[d*="M15"]');if(c||i)return e&&console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por selector espec\xEDfico: "${n}"`),t.click(),o&&setTimeout(()=>{e&&console.log("[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint"),t.click()},500),!0}let r=document.querySelectorAll("button");for(let n of r){let c=n.textContent.toLowerCase();if((c.includes("paint")||c.includes("pintar"))&&n.offsetParent!==null&&!n.disabled)return e&&console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por texto: "${n.textContent.trim()}"`),n.click(),o&&setTimeout(()=>{e&&console.log("[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint"),n.click()},500),!0}return e&&console.log("[WPA-UI] \u274C Bot\xF3n Paint no encontrado"),!1}async function Se(e=3,o=!0){o&&console.log(`[WPA-UI] \u{1F916} Iniciando auto-click del bot\xF3n Paint (m\xE1ximo ${e} intentos)`);for(let t=1;t<=e;t++){if(o&&console.log(`[WPA-UI] \u{1F3AF} Intento ${t}/${e} - Buscando bot\xF3n Paint...`),Pe())return o&&console.log("[WPA-UI] \u2705 Paleta ya est\xE1 abierta, auto-click completado"),!0;if(De(o,!1)){if(o&&console.log("[WPA-UI] \u{1F446} Clic en bot\xF3n Paint realizado (sin segundo clic)"),await new Promise(r=>setTimeout(r,1500)),Pe())return o&&console.log(`[WPA-UI] \u2705 Paleta abierta exitosamente despu\xE9s del intento ${t}`),!0;o&&console.log(`[WPA-UI] \u26A0\uFE0F Paleta no detectada tras el clic en intento ${t}. Reintentar\xE1.`)}else o&&console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado para clic en intento ${t}`);t<e&&await new Promise(r=>setTimeout(r,1e3))}return o&&console.log(`[WPA-UI] \u274C Auto-click fall\xF3 despu\xE9s de ${e} intentos`),!1}(async function(){"use strict";var a,f;await V();try{d("\u{1F916} [FARM] Iniciando auto-click del bot\xF3n Paint..."),await Se(3,!0)}catch(s){d("\u26A0\uFE0F [FARM] Error en auto-click del bot\xF3n Paint:",s)}if((a=window.__wplaceBot)!=null&&a.farmRunning){alert(l("farm.alreadyRunning","Auto-Farm ya est\xE1 corriendo."));return}if((f=window.__wplaceBot)!=null&&f.imageRunning){alert(l("farm.imageRunningWarning","Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm."));return}window.__wplaceBot||(window.__wplaceBot={}),window.__wplaceBot.farmRunning=!0,window.addEventListener("languageChanged",()=>{var s,h;(h=(s=window.__wplaceBot)==null?void 0:s.ui)!=null&&h.updateTexts&&window.__wplaceBot.ui.updateTexts()}),d("\u{1F680} Iniciando WPlace Farm Bot (versi\xF3n modular)");function e(s){let h=!!s.POSITION_SELECTED&&s.BASE_X!=null&&s.BASE_Y!=null,w=s.TILE_X===b.TILE_X&&s.TILE_Y===b.TILE_Y,x=!Number.isFinite(s.TILE_X)||!Number.isFinite(s.TILE_Y),C=!h&&(w||x);return d(`Verificaci\xF3n calibraci\xF3n: defaults=${w}, selected=${h}, invalid=${x}, coords=(${s.TILE_X},${s.TILE_Y})`),C}function o(){d("\u{1F575}\uFE0F Activando captura de coordenadas..."),ee.enable(s=>{s.success?(t.TILE_X=s.tileX,t.TILE_Y=s.tileY,i.updateConfig(),i.setStatus(`\u{1F3AF} Coordenadas capturadas: tile(${s.tileX},${s.tileY})`,"success"),d(`\u2705 Coordenadas capturadas autom\xE1ticamente: tile(${s.tileX},${s.tileY})`)):i.setStatus(`\u274C ${l("common.error","No se pudieron capturar coordenadas")}`,"error")}),i.setStatus(`\u{1F4F8} ${l("farm.captureInstructions")}`,"status")}let t={...b,...q(b)};if(!t.SITEKEY){let s=document.querySelector("*[data-sitekey]");s?(t.SITEKEY=s.getAttribute("data-sitekey"),d(`\u{1F4DD} Sitekey encontrada autom\xE1ticamente: ${t.SITEKEY.substring(0,20)}...`),void 0):d("\u26A0\uFE0F No se pudo encontrar la sitekey autom\xE1ticamente")}async function r(){try{let s=await G();if(s.success&&s.data){g.charges.count=s.data.charges||0,g.charges.max=s.data.maxCharges||50,g.charges.regen=s.data.chargeRegen||3e4,g.user=s.data.user,t.CHARGE_REGEN_MS=g.charges.regen;let h=await n();return g.health=h,i.updateStats(g.painted,g.charges.count,g.retryCount,h),s.data}return null}catch(s){return d("Error actualizando estad\xEDsticas:",s),null}}async function n(){try{return await pe()}catch(s){return d("Error verificando health:",s),{up:!1,error:s.message}}}async function c(){return await J(t,g,i.setStatus,i.flashEffect,()=>G(),n)}let i=we(t,async()=>{if(g.running){i.setStatus("\u26A0\uFE0F El bot ya est\xE1 ejecut\xE1ndose","error");return}if(!t.POSITION_SELECTED||t.BASE_X===null||t.BASE_Y===null){i.setStatus(l("farm.autoSelectPosition"),"info");let w=i.getElement().shadowRoot.getElementById("select-position-btn");w&&w.click();return}if(e(t)){i.setStatus("\u{1F3AF} Calibrando autom\xE1ticamente...","status");let w=await K(t);if(w.success)i.setStatus(`\u2705 Calibrado: tile(${w.tileX},${w.tileY})`,"success"),i.updateConfig();else{i.setStatus("\u274C Error en calibraci\xF3n. Configura manualmente.","error");return}}if(i.setStatus("\u{1F50D} Verificando conectividad...","status"),!(await n()).up){i.setStatus("\u{1F534} Backend no disponible. Verifica tu conexi\xF3n.","error");return}if(i.setStatus("\u{1F504} Obteniendo informaci\xF3n de sesi\xF3n...","status"),!await r()){i.setStatus("\u274C Error obteniendo sesi\xF3n. Verifica tu login.","error");return}i.setStatus("\u{1F680} Iniciando bot...","status"),i.updateButtonStates(!0),ve(t,g,i.setStatus,i.flashEffect,r,n,r)},()=>{g.running=!1,window.__wplaceBot&&(window.__wplaceBot.farmRunning=!1),i.setStatus("\u23F9\uFE0F Deteniendo bot...","status"),i.updateButtonStates(!1)},async()=>{i.setStatus("\u{1F3AF} Calibrando posici\xF3n...","status");let s=await K(t);s.success?(i.setStatus(`\u2705 Calibrado: tile(${s.tileX},${s.tileY})`,"success"),i.updateConfig()):i.setStatus(`\u274C Error en calibraci\xF3n: ${s.error||"Desconocido"}`,"error")}),p=i.getElement().shadowRoot.getElementById("capture-btn");p&&p.addEventListener("click",o);let u=i.getElement().shadowRoot.getElementById("once-btn");u&&u.addEventListener("click",async()=>{if(g.running){i.setStatus("\u26A0\uFE0F Det\xE9n el bot primero","error");return}await r(),i.setStatus("\u{1F3A8} Pintando una vez...","status"),await c()?i.setStatus("\u2705 P\xEDxel pintado exitosamente","success"):i.setStatus("\u274C Error al pintar p\xEDxel","error")}),await r(),window.addEventListener("wplace-batch-painted",s=>{d(`\u{1F3A8} Lote pintado: ${s.detail.pixelCount} p\xEDxeles en tile(${s.detail.tileX},${s.detail.tileY})`)}),window.WPAUI={once:c,get:()=>({...t}),capture:o,refreshCanvas:()=>{g.last&&d(`Refrescando canvas en posici\xF3n (${g.last.x},${g.last.y})`)},verifyPixel:async(s,h)=>(d(`Verificando p\xEDxel en (${s},${h})...`),{verified:!0,x:s,y:h}),getStats:()=>({painted:g.painted,last:g.last,charges:g.charges,user:g.user,running:g.running,minCharges:t.MIN_CHARGES,delay:t.DELAY_MS,tileInfo:{tileX:t.TILE_X,tileY:t.TILE_Y,tileSize:t.TILE_SIZE,safeMargin:Math.floor(t.TILE_SIZE*.05),safeArea:{minX:Math.floor(t.TILE_SIZE*.05),maxX:t.TILE_SIZE-Math.floor(t.TILE_SIZE*.05)-1,minY:Math.floor(t.TILE_SIZE*.05),maxY:t.TILE_SIZE-Math.floor(t.TILE_SIZE*.05)-1}}}),setPixelsPerBatch:s=>{t.PIXELS_PER_BATCH=M(s,1,50),i.updateConfig(),d(`P\xEDxeles por lote configurado a: ${t.PIXELS_PER_BATCH}`)},setMinCharges:s=>{t.MIN_CHARGES=Math.max(0,s),i.updateConfig(),d(`Cargas m\xEDnimas configuradas a: ${t.MIN_CHARGES}`)},setDelay:s=>{t.DELAY_MS=Math.max(1e3,s*1e3),i.updateConfig(),d(`Delay configurado a: ${t.DELAY_MS}ms`)},diagnose:()=>{var w;let s=window.WPAUI.getStats(),h={configValid:Number.isFinite(t.TILE_X)&&Number.isFinite(t.TILE_Y),hasCharges:g.charges.count>0,backendHealthy:((w=g.health)==null?void 0:w.up)||!1,userLoggedIn:!!g.user,coordinates:`(${t.TILE_X},${t.TILE_Y})`,safeArea:s.tileInfo.safeArea,recommendations:[]};return h.configValid||h.recommendations.push("Calibrar coordenadas del tile"),h.hasCharges||h.recommendations.push("Esperar a que se regeneren las cargas"),h.backendHealthy||h.recommendations.push("Verificar conexi\xF3n al backend"),h.userLoggedIn||h.recommendations.push("Iniciar sesi\xF3n en la plataforma"),console.table(h),h},checkHealth:n,resetConfig:()=>{ue(),t={...b},i.updateConfig(),d("Configuraci\xF3n reseteada a valores por defecto")},debugRetries:()=>({currentRetries:g.retryCount,inCooldown:g.inCooldown,nextPaintTime:g.nextPaintTime,cooldownEndTime:g.cooldownEndTime}),forceClearCooldown:()=>{g.inCooldown=!1,g.nextPaintTime=0,g.cooldownEndTime=0,g.retryCount=0,d("Cooldown forzado a limpiar")},simulateError:(s=500)=>{d(`Simulando error ${s} para testing...`),i.setStatus(`\u{1F9EA} Simulando error ${s}`,"error")}},window.addEventListener("beforeunload",()=>{g.running=!1,window.__wplaceBot&&(window.__wplaceBot.farmRunning=!1),ee.disable(),i.destroy()}),d("\u2705 Farm Bot inicializado correctamente"),d("\u{1F4A1} Usa console.log(window.WPAUI) para ver la API disponible")})().catch(e=>{console.error("[BOT] Error en Auto-Farm:",e),window.__wplaceBot&&(window.__wplaceBot.farmRunning=!1),alert("Auto-Farm: error inesperado. Revisa consola.")});})();
+  `;
+    shadow.appendChild(container);
+    document.body.appendChild(shadowHost);
+    const header = shadow.querySelector(".wplace-header");
+    dragHeader(header, shadowHost);
+    const elements = {
+      minimizeBtn: shadow.querySelector(".wplace-minimize"),
+      content: shadow.querySelector(".wplace-content"),
+      status: shadow.getElementById("status"),
+      paintedCount: shadow.getElementById("painted-count"),
+      chargesCount: shadow.getElementById("charges-count"),
+      retryCount: shadow.getElementById("retry-count"),
+      tilePos: shadow.getElementById("tile-pos"),
+      startBtn: shadow.getElementById("start-btn"),
+      stopBtn: shadow.getElementById("stop-btn"),
+      selectPositionBtn: shadow.getElementById("select-position-btn"),
+      onceBtn: shadow.getElementById("once-btn"),
+      zoneInfo: shadow.getElementById("zone-info"),
+      zoneDisplay: shadow.getElementById("zone-display"),
+      healthStatus: shadow.getElementById("health-status"),
+      delayInput: shadow.getElementById("delay-input"),
+      pixelsInput: shadow.getElementById("pixels-input"),
+      minChargesInput: shadow.getElementById("min-charges-input"),
+      colorModeSelect: shadow.getElementById("color-mode-select"),
+      colorRangeRow: shadow.getElementById("color-range-row"),
+      colorFixedRow: shadow.getElementById("color-fixed-row"),
+      colorMinInput: shadow.getElementById("color-min-input"),
+      colorMaxInput: shadow.getElementById("color-max-input"),
+      colorFixedInput: shadow.getElementById("color-fixed-input"),
+      advancedToggle: shadow.getElementById("advanced-toggle"),
+      advancedSection: shadow.getElementById("advanced-section"),
+      advancedArrow: shadow.getElementById("advanced-arrow"),
+      tileXInput: shadow.getElementById("tile-x-input"),
+      tileYInput: shadow.getElementById("tile-y-input"),
+      customPaletteInput: shadow.getElementById("custom-palette-input"),
+      saveBtn: shadow.getElementById("save-btn"),
+      loadBtn: shadow.getElementById("load-btn"),
+      resetBtn: shadow.getElementById("reset-btn"),
+      captureBtn: shadow.getElementById("capture-btn")
+    };
+    function updateInputsFromConfig() {
+      var _a2;
+      elements.delayInput.value = config.DELAY_MS;
+      elements.pixelsInput.value = config.PIXELS_PER_BATCH;
+      elements.minChargesInput.value = config.MIN_CHARGES;
+      elements.colorModeSelect.value = config.COLOR_MODE;
+      elements.colorMinInput.value = config.COLOR_MIN;
+      elements.colorMaxInput.value = config.COLOR_MAX;
+      elements.colorFixedInput.value = config.COLOR_FIXED;
+      elements.tileXInput.value = config.TILE_X || "";
+      elements.tileYInput.value = config.TILE_Y || "";
+      elements.customPaletteInput.value = (config.CUSTOM_PALETTE || []).join(",");
+      updateColorModeVisibility();
+      updateTileDisplay();
+      updateZoneDisplay();
+      updateButtonStates(((_a2 = farmState) == null ? void 0 : _a2.running) || false);
+    }
+    function updateConfigFromInputs() {
+      config.DELAY_MS = parseInt(elements.delayInput.value) || FARM_DEFAULTS.DELAY_MS;
+      config.PIXELS_PER_BATCH = clamp(parseInt(elements.pixelsInput.value) || FARM_DEFAULTS.PIXELS_PER_BATCH, 1, 50);
+      config.MIN_CHARGES = parseFloat(elements.minChargesInput.value) || FARM_DEFAULTS.MIN_CHARGES;
+      config.COLOR_MODE = elements.colorModeSelect.value;
+      config.COLOR_MIN = clamp(parseInt(elements.colorMinInput.value) || FARM_DEFAULTS.COLOR_MIN, 1, 32);
+      config.COLOR_MAX = clamp(parseInt(elements.colorMaxInput.value) || FARM_DEFAULTS.COLOR_MAX, 1, 32);
+      config.COLOR_FIXED = clamp(parseInt(elements.colorFixedInput.value) || FARM_DEFAULTS.COLOR_FIXED, 1, 32);
+      if (config.COLOR_MIN > config.COLOR_MAX) {
+        config.COLOR_MAX = config.COLOR_MIN;
+        elements.colorMaxInput.value = config.COLOR_MAX;
+      }
+      const tileX = parseInt(elements.tileXInput.value);
+      const tileY = parseInt(elements.tileYInput.value);
+      if (Number.isFinite(tileX)) config.TILE_X = tileX;
+      if (Number.isFinite(tileY)) config.TILE_Y = tileY;
+      updateTileDisplay();
+      updateZoneDisplay();
+    }
+    function updateColorModeVisibility() {
+      const mode = elements.colorModeSelect.value;
+      elements.colorRangeRow.style.display = mode === "random" ? "flex" : "none";
+      elements.colorFixedRow.style.display = mode === "fixed" ? "flex" : "none";
+    }
+    function updateTileDisplay() {
+      if (elements.tilePos) {
+        elements.tilePos.textContent = `${config.TILE_X || 0},${config.TILE_Y || 0}`;
+      }
+    }
+    function updateZoneDisplay() {
+      var _a2;
+      if (elements.zoneDisplay) {
+        if (config.POSITION_SELECTED && config.BASE_X !== null && config.BASE_Y !== null) {
+          elements.zoneDisplay.textContent = t("farm.currentZone", { x: config.BASE_X, y: config.BASE_Y });
+          elements.zoneDisplay.style.color = "#48bb78";
+        } else {
+          elements.zoneDisplay.textContent = t("farm.noPosition");
+          elements.zoneDisplay.style.color = "#f56565";
+        }
+      }
+      updateButtonStates(((_a2 = farmState) == null ? void 0 : _a2.running) || false);
+    }
+    (_a = elements.minimizeBtn) == null ? void 0 : _a.addEventListener("click", () => {
+      uiState.minimized = !uiState.minimized;
+      elements.content.classList.toggle("minimized", uiState.minimized);
+      elements.minimizeBtn.textContent = uiState.minimized ? "+" : "\u2212";
+    });
+    (_b = elements.startBtn) == null ? void 0 : _b.addEventListener("click", () => {
+      updateConfigFromInputs();
+      onStart();
+      updateButtonStates(true);
+    });
+    (_c = elements.stopBtn) == null ? void 0 : _c.addEventListener("click", () => {
+      onStop();
+      updateButtonStates(false);
+    });
+    (_d = elements.onceBtn) == null ? void 0 : _d.addEventListener("click", () => {
+      updateInputsFromConfig();
+      updateConfigFromInputs();
+      if (window.WPAUI && window.WPAUI.once) {
+        window.WPAUI.once();
+      }
+    });
+    (_e = elements.selectPositionBtn) == null ? void 0 : _e.addEventListener("click", () => {
+      selectFarmPosition(config, setStatus, updateZoneDisplay);
+    });
+    (_f = elements.colorModeSelect) == null ? void 0 : _f.addEventListener("change", () => {
+      updateColorModeVisibility();
+      updateConfigFromInputs();
+    });
+    (_g = elements.customPaletteInput) == null ? void 0 : _g.addEventListener("input", () => {
+      updateConfigFromInputs();
+    });
+    (_h = elements.advancedToggle) == null ? void 0 : _h.addEventListener("click", () => {
+      uiState.showAdvanced = !uiState.showAdvanced;
+      elements.advancedSection.style.display = uiState.showAdvanced ? "block" : "none";
+      elements.advancedArrow.textContent = uiState.showAdvanced ? "\u25BC" : "\u25B6";
+    });
+    ["delayInput", "pixelsInput", "minChargesInput", "colorMinInput", "colorMaxInput", "colorFixedInput", "tileXInput", "tileYInput"].forEach((inputName) => {
+      var _a2;
+      (_a2 = elements[inputName]) == null ? void 0 : _a2.addEventListener("change", updateConfigFromInputs);
+    });
+    (_i = elements.saveBtn) == null ? void 0 : _i.addEventListener("click", () => {
+      updateConfigFromInputs();
+      saveFarmCfg(config);
+      setStatus(`\u{1F4BE} ${t("farm.configSaved")}`, "success");
+    });
+    (_j = elements.loadBtn) == null ? void 0 : _j.addEventListener("click", () => {
+      const loaded2 = loadFarmCfg(FARM_DEFAULTS);
+      Object.assign(config, loaded2);
+      updateInputsFromConfig();
+      setStatus(`\u{1F4C1} ${t("farm.configLoaded")}`, "success");
+    });
+    (_k = elements.resetBtn) == null ? void 0 : _k.addEventListener("click", () => {
+      resetFarmCfg();
+      Object.assign(config, FARM_DEFAULTS);
+      updateInputsFromConfig();
+      setStatus(`\u{1F504} ${t("farm.configReset")}`, "success");
+    });
+    (_l = elements.captureBtn) == null ? void 0 : _l.addEventListener("click", () => {
+      setStatus(`\u{1F4F8} ${t("farm.captureInstructions")}`, "status");
+    });
+    function updateButtonStates(running) {
+      if (elements.startBtn) {
+        const noZoneSelected = !config.POSITION_SELECTED || config.BASE_X === null || config.BASE_Y === null;
+        elements.startBtn.disabled = running || noZoneSelected;
+        if (noZoneSelected) {
+          elements.startBtn.textContent = `\u{1F6AB} ${t("farm.selectPosition")} \u26A0\uFE0F`;
+          elements.startBtn.title = t("farm.missingPosition");
+        } else {
+          elements.startBtn.textContent = `\u25B6\uFE0F ${t("farm.start")}`;
+          elements.startBtn.title = "";
+        }
+      }
+      if (elements.stopBtn) elements.stopBtn.disabled = !running;
+    }
+    function setStatus(message, type = "status") {
+      if (elements.status) {
+        elements.status.textContent = message;
+        elements.status.className = `wplace-status ${type}`;
+        log(`Status: ${message}`);
+      }
+    }
+    function updateStats(painted, charges, retries = 0, health = null) {
+      if (elements.paintedCount) {
+        elements.paintedCount.textContent = painted || 0;
+      }
+      if (elements.chargesCount) {
+        elements.chargesCount.textContent = typeof charges === "number" ? charges.toFixed(1) : "0";
+      }
+      if (elements.retryCount) {
+        elements.retryCount.textContent = retries || 0;
+      }
+      if (elements.healthStatus && health) {
+        elements.healthStatus.textContent = health.up ? `\u{1F7E2} ${t("farm.backendOnline")}` : `\u{1F534} ${t("farm.backendOffline")}`;
+        elements.healthStatus.className = `wplace-health ${health.up ? "online" : "offline"}`;
+      }
+    }
+    function flashEffect() {
+      container.style.boxShadow = "0 0 20px #48bb78";
+      setTimeout(() => {
+        container.style.boxShadow = "0 10px 25px rgba(0,0,0,0.3)";
+      }, 200);
+    }
+    updateInputsFromConfig();
+    function updateTexts() {
+      var _a2;
+      const title = shadow.querySelector(".wplace-title");
+      if (title) {
+        title.innerHTML = `\u{1F916} ${t("farm.title")}`;
+      }
+      if (elements.startBtn) elements.startBtn.innerHTML = `\u25B6\uFE0F ${t("farm.start")}`;
+      if (elements.stopBtn) elements.stopBtn.innerHTML = `\u23F9\uFE0F ${t("farm.stop")}`;
+      if (elements.selectPositionBtn) elements.selectPositionBtn.innerHTML = `\u{1F30D} ${t("farm.selectPosition")}`;
+      if (elements.onceBtn) elements.onceBtn.innerHTML = `\u{1F3A8} ${t("farm.paintOnce")}`;
+      const paintedLabel = shadow.querySelector("#painted-count").parentElement.querySelector(".wplace-stat-label");
+      const chargesLabel = shadow.querySelector("#charges-count").parentElement.querySelector(".wplace-stat-label");
+      const retryLabel = shadow.querySelector("#retry-count").parentElement.querySelector(".wplace-stat-label");
+      const tileLabel = shadow.querySelector("#tile-pos").parentElement.querySelector(".wplace-stat-label");
+      if (paintedLabel) paintedLabel.textContent = t("farm.painted");
+      if (chargesLabel) chargesLabel.textContent = t("farm.charges");
+      if (retryLabel) retryLabel.textContent = t("farm.retries");
+      if (tileLabel) tileLabel.textContent = t("farm.tile");
+      const configTitle = shadow.querySelector(".wplace-section-title");
+      if (configTitle) configTitle.innerHTML = `\u2699\uFE0F ${t("farm.configuration")}`;
+      const advancedTitle = shadow.getElementById("advanced-toggle");
+      if (advancedTitle) {
+        const arrow = advancedTitle.querySelector("#advanced-arrow");
+        const arrowText = arrow ? arrow.textContent : "\u25B6";
+        advancedTitle.innerHTML = `\u{1F527} ${t("farm.advanced")} <span id="advanced-arrow">${arrowText}</span>`;
+      }
+      const colorModeSelect = elements.colorModeSelect;
+      if (colorModeSelect) {
+        const randomOption = colorModeSelect.querySelector('option[value="random"]');
+        const fixedOption = colorModeSelect.querySelector('option[value="fixed"]');
+        if (randomOption) randomOption.textContent = t("farm.random");
+        if (fixedOption) fixedOption.textContent = t("farm.fixed");
+      }
+      if (elements.customPaletteInput) {
+        elements.customPaletteInput.placeholder = t("farm.paletteExample");
+      }
+      if (elements.saveBtn) elements.saveBtn.innerHTML = `\u{1F4BE} ${t("common.save")}`;
+      if (elements.loadBtn) elements.loadBtn.innerHTML = `\u{1F4C1} ${t("common.load")}`;
+      if (elements.resetBtn) elements.resetBtn.innerHTML = `\u{1F504} ${t("common.reset")}`;
+      if (elements.captureBtn) elements.captureBtn.innerHTML = `\u{1F4F8} ${t("farm.capture")}`;
+      updateZoneDisplay();
+      updateButtonStates(((_a2 = farmState) == null ? void 0 : _a2.running) || false);
+      const healthStatus = elements.healthStatus;
+      if (healthStatus && healthStatus.textContent.includes("\u{1F50D}")) {
+        healthStatus.textContent = `\u{1F50D} ${t("farm.checkingStatus")}`;
+      }
+      const status = elements.status;
+      if (status && status.textContent.includes("\u{1F4A4}")) {
+        status.textContent = `\u{1F4A4} ${t("farm.stopped")}`;
+      }
+    }
+    async function selectFarmPosition(config2, setStatus2, updateZoneDisplay2) {
+      return new Promise((resolve) => {
+        setStatus2(t("farm.selectPositionAlert"), "info");
+        config2.selectingPosition = true;
+        const originalFetch = window.fetch;
+        window.fetch = async (url, options) => {
+          if (config2.selectingPosition && url.includes("/s0/pixel/")) {
+            try {
+              const response = await originalFetch(url, options);
+              if (response.ok && options && options.body) {
+                const bodyData = JSON.parse(options.body);
+                if (bodyData.coords && bodyData.coords.length >= 2) {
+                  const localX = bodyData.coords[0];
+                  const localY = bodyData.coords[1];
+                  const tileMatch = url.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);
+                  if (tileMatch) {
+                    config2.TILE_X = parseInt(tileMatch[1]);
+                    config2.TILE_Y = parseInt(tileMatch[2]);
+                  }
+                  config2.BASE_X = localX;
+                  config2.BASE_Y = localY;
+                  config2.POSITION_SELECTED = true;
+                  config2.selectingPosition = false;
+                  window.fetch = originalFetch;
+                  updateZoneDisplay2();
+                  updateTileDisplay();
+                  updateInputsFromConfig();
+                  setStatus2(t("farm.positionSet"), "success");
+                  log(`\u2705 Zona de farming establecida: tile(${config2.TILE_X},${config2.TILE_Y}) base(${localX},${localY}) radio(${config2.FARM_RADIUS}px)`);
+                  saveFarmCfg(config2);
+                  resolve(true);
+                }
+              }
+              return response;
+            } catch (error) {
+              log("Error interceptando pixel:", error);
+              return originalFetch(url, options);
+            }
+          }
+          return originalFetch(url, options);
+        };
+        setTimeout(() => {
+          if (config2.selectingPosition) {
+            window.fetch = originalFetch;
+            config2.selectingPosition = false;
+            setStatus2(t("farm.positionTimeout"), "error");
+            resolve(false);
+          }
+        }, 12e4);
+      });
+    }
+    window.addEventListener("languageChanged", updateTexts);
+    return {
+      setStatus,
+      updateStats,
+      flashEffect,
+      updateButtonStates,
+      updateTexts,
+      destroy: () => {
+        window.removeEventListener("languageChanged", updateTexts);
+        document.body.removeChild(shadowHost);
+      },
+      updateConfig: updateInputsFromConfig,
+      getElement: () => shadowHost
+    };
+  }
+  async function autoCalibrateTile(config) {
+    try {
+      log("\u{1F3AF} Iniciando auto-calibraci\xF3n del tile...");
+      if (config.POSITION_SELECTED && config.BASE_X != null && config.BASE_Y != null && Number.isFinite(config.TILE_X) && Number.isFinite(config.TILE_Y)) {
+        log(`\u2139\uFE0F Ya existe zona seleccionada. Se mantiene tile actual: (${config.TILE_X}, ${config.TILE_Y})`);
+        saveFarmCfg(config);
+        return { tileX: config.TILE_X, tileY: config.TILE_Y, success: true };
+      }
+      const urlParams = new window.URLSearchParams(window.location.search);
+      const hashParams = window.location.hash;
+      let tileX, tileY;
+      if (urlParams.has("x") && urlParams.has("y")) {
+        tileX = parseInt(urlParams.get("x"));
+        tileY = parseInt(urlParams.get("y"));
+      }
+      if (!tileX && !tileY && hashParams) {
+        const hashMatch = hashParams.match(/#(-?\d+),(-?\d+)/);
+        if (hashMatch) {
+          tileX = parseInt(hashMatch[1]);
+          tileY = parseInt(hashMatch[2]);
+        }
+      }
+      if (!tileX && !tileY) {
+        const positionElements = document.querySelectorAll("[data-x], [data-y], .coordinates, .position");
+        for (const el of positionElements) {
+          const x = el.getAttribute("data-x") || el.getAttribute("x");
+          const y = el.getAttribute("data-y") || el.getAttribute("y");
+          if (x && y) {
+            tileX = parseInt(x);
+            tileY = parseInt(y);
+            break;
+          }
+        }
+      }
+      if (!tileX && !tileY) {
+        const textContent = document.body.textContent || "";
+        const coordMatch = textContent.match(/(?:tile|pos|position)?\s*[([]?\s*(-?\d+)\s*[,;]\s*(-?\d+)\s*[)\]]?/i);
+        if (coordMatch) {
+          tileX = parseInt(coordMatch[1]);
+          tileY = parseInt(coordMatch[2]);
+        }
+      }
+      if (!Number.isFinite(tileX) || !Number.isFinite(tileY)) {
+        tileX = 0;
+        tileY = 0;
+        log("\u26A0\uFE0F No se pudieron detectar coordenadas autom\xE1ticamente, usando (0,0)");
+      }
+      if (Math.abs(tileX) > 1e6 || Math.abs(tileY) > 1e6) {
+        log("\u26A0\uFE0F Coordenadas detectadas parecen incorrectas, limitando a rango v\xE1lido");
+        tileX = Math.max(-1e6, Math.min(1e6, tileX));
+        tileY = Math.max(-1e6, Math.min(1e6, tileY));
+      }
+      config.TILE_X = tileX;
+      config.TILE_Y = tileY;
+      log(`\u2705 Tile calibrado autom\xE1ticamente: (${tileX}, ${tileY})`);
+      saveFarmCfg(config);
+      return { tileX, tileY, success: true };
+    } catch (error) {
+      log("\u274C Error en auto-calibraci\xF3n:", error);
+      return { tileX: 0, tileY: 0, success: false, error: error.message };
+    }
+  }
+
+  // src/core/turnstile.js
+  var loaded = false;
+  async function loadTurnstile() {
+    if (loaded || window.turnstile) return;
+    return new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+      s.async = true;
+      s.defer = true;
+      s.onload = () => {
+        loaded = true;
+        resolve();
+      };
+      s.onerror = () => reject(new Error("No se pudo cargar Turnstile"));
+      document.head.appendChild(s);
+    });
+  }
+  async function executeTurnstile(siteKey, action = "paint") {
+    var _a;
+    await loadTurnstile();
+    if (typeof ((_a = window.turnstile) == null ? void 0 : _a.execute) === "function") {
+      try {
+        const token = await window.turnstile.execute(siteKey, { action });
+        if (token && token.length > 20) return token;
+      } catch {
+      }
+    }
+    return await new Promise((resolve) => {
+      const host = document.createElement("div");
+      host.style.position = "fixed";
+      host.style.left = "-9999px";
+      document.body.appendChild(host);
+      window.turnstile.render(host, {
+        sitekey: siteKey,
+        callback: (t2) => {
+          document.body.removeChild(host);
+          resolve(t2);
+        }
+      });
+    });
+  }
+  async function getTurnstileToken(siteKey) {
+    return executeTurnstile(siteKey, "paint");
+  }
+
+  // src/farm/coords.js
+  var randInt = (n) => Math.floor(Math.random() * n);
+  function generateMultipleCoords(count, cfg) {
+    if (!cfg.POSITION_SELECTED || cfg.BASE_X === null || cfg.BASE_Y === null) {
+      log("\u26A0\uFE0F No se ha seleccionado una posici\xF3n base. Usando coordenadas aleatorias fallback.");
+      const coords2 = [];
+      const margin = Math.floor(cfg.TILE_SIZE * 0.05);
+      const safeSize = cfg.TILE_SIZE - margin * 2;
+      for (let i = 0; i < count; i++) {
+        const localX = margin + Math.floor(Math.random() * safeSize);
+        const localY = margin + Math.floor(Math.random() * safeSize);
+        coords2.push(localX, localY);
+      }
+      return coords2;
+    }
+    const coords = [];
+    const maxSize = cfg.TILE_SIZE - 1;
+    let currentX = Math.max(0, Math.min(maxSize, cfg.BASE_X));
+    let currentY = Math.max(0, Math.min(maxSize, cfg.BASE_Y));
+    for (let i = 0; i < count; i++) {
+      currentX = Math.max(0, Math.min(maxSize, currentX));
+      currentY = Math.max(0, Math.min(maxSize, currentY));
+      coords.push(currentX, currentY);
+      currentX++;
+      if (currentX > maxSize) {
+        currentX = Math.max(0, Math.min(maxSize, cfg.BASE_X));
+        currentY++;
+        if (currentY > maxSize) {
+          currentY = Math.max(0, Math.min(maxSize, cfg.BASE_Y));
+        }
+      }
+    }
+    if (coords.length >= 4) {
+      log(`\u{1F3AF} L\xEDnea recta generada: [${coords.slice(0, 8).join(",")}...] total: ${coords.length / 2} p\xEDxeles`);
+    }
+    return coords;
+  }
+  function generateMultipleColors(count, cfg) {
+    const colors = [];
+    for (let i = 0; i < count; i++) {
+      colors.push(nextColor(cfg));
+    }
+    return colors;
+  }
+  function nextColor(cfg) {
+    if (cfg.COLOR_MODE === "fixed") {
+      return cfg.COLOR_FIXED;
+    } else {
+      const span = cfg.COLOR_MAX - cfg.COLOR_MIN + 1;
+      return cfg.COLOR_MIN + randInt(span);
+    }
+  }
+
+  // src/core/timing.js
+  var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  async function sleepWithCountdown(ms, onUpdate, state) {
+    const startTime = Date.now();
+    const endTime = startTime + ms;
+    while (Date.now() < endTime && (!state || state.running)) {
+      const remaining = endTime - Date.now();
+      if (onUpdate) {
+        onUpdate(remaining);
+      }
+      await sleep(Math.min(1e3, remaining));
+    }
+  }
+
+  // src/farm/loop.js
+  async function updateCanvasPixel(localX, localY, color) {
+    try {
+      const canvases = document.querySelectorAll("canvas");
+      for (const canvas of canvases) {
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          const colorHex = typeof color === "number" ? `#${color.toString(16).padStart(6, "0")}` : color;
+          ctx.fillStyle = colorHex;
+          ctx.fillRect(localX, localY, 1, 1);
+          if (typeof window !== "undefined" && window.Event) {
+            canvas.dispatchEvent(new window.Event("pixel-updated"));
+          }
+        }
+      }
+    } catch (error) {
+      log("Error actualizando canvas:", error);
+    }
+  }
+  async function refreshTile(tileX, tileY) {
+    try {
+      const tileSelector = `[data-tile="${tileX}-${tileY}"], .tile-${tileX}-${tileY}, [data-tile-x="${tileX}"][data-tile-y="${tileY}"]`;
+      const tileElement = document.querySelector(tileSelector);
+      if (tileElement) {
+        tileElement.classList.add("tile-updating");
+        setTimeout(() => {
+          tileElement.classList.remove("tile-updating");
+          tileElement.classList.add("tile-updated");
+          setTimeout(() => tileElement.classList.remove("tile-updated"), 1e3);
+        }, 100);
+        log(`Tile (${tileX},${tileY}) actualizado visualmente`);
+      } else {
+        const canvasElements = document.querySelectorAll("canvas");
+        canvasElements.forEach((canvas) => {
+          const ctx = canvas.getContext("2d");
+          if (ctx) {
+            const imageData = ctx.getImageData(0, 0, 1, 1);
+            ctx.putImageData(imageData, 0, 0);
+          }
+        });
+        log(`Actualizaci\xF3n visual gen\xE9rica realizada para tile (${tileX},${tileY})`);
+      }
+    } catch (error) {
+      log("Error en actualizaci\xF3n visual del tile:", error);
+    }
+  }
+  async function paintOnce(cfg, state, setStatus, flashEffect, getSession2, checkBackendHealth) {
+    var _a, _b, _c, _d;
+    if (!cfg.POSITION_SELECTED || cfg.BASE_X === null || cfg.BASE_Y === null) {
+      setStatus(`\u{1F3AF} Selecciona una zona primero usando 'Seleccionar Zona'`, "error");
+      log(`Pintado cancelado: no se ha seleccionado una posici\xF3n base`);
+      return false;
+    }
+    if (!Number.isFinite(cfg.TILE_X) || !Number.isFinite(cfg.TILE_Y)) {
+      setStatus(`\u{1F6AB} Coordenadas del tile inv\xE1lidas (${cfg.TILE_X},${cfg.TILE_Y}). Calibra primero`, "error");
+      log(`Pintado cancelado: coordenadas del tile inv\xE1lidas`);
+      return false;
+    }
+    const availableCharges = Math.floor(state.charges.count);
+    if (availableCharges < 1) {
+      setStatus(`\u{1F50B} Sin cargas disponibles. Esperando...`, "error");
+      return false;
+    }
+    const optimalPixelCount = Math.min(availableCharges, cfg.PIXELS_PER_BATCH, 50);
+    const pixelCount = Math.max(1, optimalPixelCount);
+    if (pixelCount < cfg.PIXELS_PER_BATCH) {
+      log(`Ajustando p\xEDxeles por cargas completas disponibles: ${pixelCount}/${cfg.PIXELS_PER_BATCH} (${availableCharges} cargas completas de ${state.charges.count.toFixed(2)} totales)`);
+    }
+    const coords = generateMultipleCoords(pixelCount, cfg);
+    const colors = generateMultipleColors(pixelCount, cfg);
+    const firstLocalX = coords[0];
+    const firstLocalY = coords[1];
+    setStatus(`\u{1F33E} Farmeando ${pixelCount} p\xEDxeles en radio ${cfg.FARM_RADIUS}px desde (${cfg.BASE_X},${cfg.BASE_Y}) tile(${cfg.TILE_X},${cfg.TILE_Y})...`, "status");
+    const t2 = await getTurnstileToken(cfg.SITEKEY);
+    const r = await postPixelBatchImage(cfg.TILE_X, cfg.TILE_Y, coords, colors, t2);
+    state.last = {
+      x: firstLocalX,
+      y: firstLocalY,
+      color: colors[0],
+      pixelCount,
+      availableCharges,
+      status: r.status,
+      json: r.json
+    };
+    if (r.status === 200 && r.json && (r.json.painted > 0 || r.json.painted === pixelCount || r.json.ok)) {
+      const actualPainted = r.json.painted || pixelCount;
+      state.painted += actualPainted;
+      state.retryCount = 0;
+      for (let i = 0; i < coords.length; i += 2) {
+        const localX = coords[i];
+        const localY = coords[i + 1];
+        const color = colors[Math.floor(i / 2)];
+        await updateCanvasPixel(localX, localY, color);
+      }
+      await refreshTile(cfg.TILE_X, cfg.TILE_Y);
+      await getSession2();
+      setStatus(`\u2705 Lote pintado: ${actualPainted}/${pixelCount} p\xEDxeles en zona (${cfg.BASE_X},${cfg.BASE_Y}) radio ${cfg.FARM_RADIUS}px`, "success");
+      flashEffect();
+      if (typeof window !== "undefined" && window.CustomEvent) {
+        const event = new window.CustomEvent("wplace-batch-painted", {
+          detail: {
+            firstX: firstLocalX,
+            firstY: firstLocalY,
+            pixelCount: actualPainted,
+            totalPixels: pixelCount,
+            colors,
+            coords,
+            tileX: cfg.TILE_X,
+            tileY: cfg.TILE_Y,
+            baseX: cfg.BASE_X,
+            baseY: cfg.BASE_Y,
+            radius: cfg.FARM_RADIUS,
+            timestamp: Date.now()
+          }
+        });
+        window.dispatchEvent(event);
+      }
+      return true;
+    }
+    if (r.status === 403) {
+      setStatus("\u26A0\uFE0F 403 (token expirado o Cloudflare). Reintentar\xE1...", "error");
+    } else if (r.status === 401) {
+      setStatus("\u{1F512} 401 (no autorizado). Verifica tu sesi\xF3n.", "error");
+    } else if (r.status === 429) {
+      setStatus("\u23F3 429 (l\xEDmite de tasa). Esperando...", "error");
+    } else if (r.status === 408) {
+      setStatus("\u23F0 Timeout del servidor. Coordenadas problem\xE1ticas o servidor sobrecargado", "error");
+    } else if (r.status === 0) {
+      setStatus("\u{1F310} Error de red. Verificando conectividad...", "error");
+    } else if (r.status === 500) {
+      setStatus("\u{1F525} 500 (error interno del servidor). Reintentar\xE1...", "error");
+    } else if (r.status === 502 || r.status === 503 || r.status === 504) {
+      setStatus(`\u{1F6AB} ${r.status} (servidor no disponible). Reintentar\xE1...`, "error");
+    } else if (r.status === 404) {
+      setStatus(`\u{1F5FA}\uFE0F 404 (tile no encontrado). Verificando coordenadas tile(${cfg.TILE_X},${cfg.TILE_Y})`, "error");
+    } else {
+      try {
+        const health = await checkBackendHealth();
+        const healthStatus = (health == null ? void 0 : health.up) ? "\u{1F7E2} Online" : "\u{1F534} Offline";
+        setStatus(`\u274C Error ${r.status}: ${((_a = r.json) == null ? void 0 : _a.message) || ((_b = r.json) == null ? void 0 : _b.error) || "Fallo al pintar"} (Backend: ${healthStatus})`, "error");
+      } catch {
+        setStatus(`\u274C Error ${r.status}: ${((_c = r.json) == null ? void 0 : _c.message) || ((_d = r.json) == null ? void 0 : _d.error) || "Fallo al pintar"} (Health check fall\xF3)`, "error");
+      }
+    }
+    log(`Fallo en pintado: status=${r.status}, json=`, r.json, "coords=", coords, "colors=", colors);
+    return false;
+  }
+  async function paintWithRetry(cfg, state, setStatus, flashEffect, getSession2, checkBackendHealth) {
+    const maxAttempts = 5;
+    const baseDelay = 3e3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const success = await paintOnce(cfg, state, setStatus, flashEffect, getSession2, checkBackendHealth);
+        if (success) {
+          state.retryCount = 0;
+          return true;
+        }
+        state.retryCount = attempt;
+        if (attempt < maxAttempts) {
+          const delay = baseDelay * Math.pow(2, attempt - 1);
+          setStatus(`\u{1F504} Reintento ${attempt}/${maxAttempts} en ${delay / 1e3}s...`, "error");
+          await sleep(delay);
+        }
+      } catch (error) {
+        log(`Error en intento ${attempt}:`, error);
+        state.retryCount = attempt;
+        if (attempt < maxAttempts) {
+          const delay = baseDelay * Math.pow(2, attempt - 1);
+          setStatus(`\u{1F4A5} Error en intento ${attempt}/${maxAttempts}, reintentando en ${delay / 1e3}s...`, "error");
+          await sleep(delay);
+        }
+      }
+    }
+    state.retryCount = maxAttempts;
+    setStatus(`\u274C Fall\xF3 despu\xE9s de ${maxAttempts} intentos. Se requiere intervenci\xF3n manual.`, "error");
+    return false;
+  }
+  async function loop(cfg, state, setStatus, flashEffect, getSession2, checkBackendHealth, updateStats) {
+    log("\u{1F680} Loop iniciado");
+    state.running = true;
+    while (state.running) {
+      try {
+        await updateStats();
+        if (state.charges.count < cfg.MIN_CHARGES) {
+          const waitTime = Math.max(0, (cfg.MIN_CHARGES - state.charges.count) * cfg.CHARGE_REGEN_MS);
+          setStatus(`\u23F3 Esperando cargas: ${state.charges.count.toFixed(1)}/${cfg.MIN_CHARGES} (${Math.round(waitTime / 1e3)}s)`, "status");
+          await sleepWithCountdown(Math.min(waitTime, cfg.DELAY_MS), (remaining) => {
+            setStatus(`\u23F3 Esperando cargas: ${state.charges.count.toFixed(1)}/${cfg.MIN_CHARGES} (~${Math.round(remaining / 1e3)}s)`, "status");
+          }, state);
+          continue;
+        }
+        const success = await paintWithRetry(cfg, state, setStatus, flashEffect, getSession2, checkBackendHealth);
+        if (!success) {
+          setStatus("\u{1F634} Esperando antes del siguiente intento...", "error");
+          await sleepWithCountdown(cfg.DELAY_MS * 2, (remaining) => {
+            setStatus(`\u{1F634} Cooldown extendido: ${Math.round(remaining / 1e3)}s`, "error");
+          });
+          continue;
+        }
+        if (state.running) {
+          await sleepWithCountdown(cfg.DELAY_MS, (remaining) => {
+            setStatus(`\u{1F4A4} Esperando ${Math.round(remaining / 1e3)}s hasta siguiente pintada...`, "status");
+          });
+        }
+      } catch (error) {
+        log("Error cr\xEDtico en loop:", error);
+        setStatus(`\u{1F4A5} Error cr\xEDtico: ${error.message}`, "error");
+        if (state.running) {
+          await sleepWithCountdown(cfg.DELAY_MS * 3, (remaining) => {
+            setStatus(`\u{1F6A8} Recuper\xE1ndose de error cr\xEDtico: ${Math.round(remaining / 1e3)}s`, "error");
+          });
+        }
+      }
+    }
+    log("\u23F9\uFE0F Loop detenido");
+    setStatus("\u23F9\uFE0F Bot detenido", "status");
+  }
+
+  // src/core/capture.js
+  var CoordinateCapture = class {
+    constructor() {
+      this.active = false;
+      this.originalFetch = window.fetch;
+      this.callback = null;
+    }
+    // Habilitar captura de coordenadas por una vez
+    enable(callback) {
+      if (this.active) {
+        log("\u26A0\uFE0F Captura ya est\xE1 activa");
+        return;
+      }
+      this.active = true;
+      this.callback = callback;
+      log("\u{1F575}\uFE0F Captura de coordenadas activada. Pinta un p\xEDxel manualmente...");
+      window.fetch = async (...args) => {
+        const result = await this.originalFetch.apply(window, args);
+        if (this.active && this.shouldCapture(args[0], args[1])) {
+          await this.handleCapture(args[0], args[1], result.clone());
+        }
+        return result;
+      };
+      setTimeout(() => {
+        if (this.active) {
+          this.disable();
+          log("\u23F0 Captura de coordenadas expirada");
+        }
+      }, 3e4);
+    }
+    // Verificar si debemos capturar esta petición
+    shouldCapture(url, options) {
+      if (!url || !options) return false;
+      const urlStr = url.toString();
+      if (!urlStr.includes("paint") && !urlStr.includes("pixel") && !urlStr.includes("place")) {
+        return false;
+      }
+      if (!options.method || options.method.toUpperCase() !== "POST") {
+        return false;
+      }
+      return true;
+    }
+    // Manejar la captura de coordenadas
+    async handleCapture(url, options, response) {
+      try {
+        let coords = null;
+        let tileX = null, tileY = null;
+        if (options.body) {
+          let body;
+          if (typeof options.body === "string") {
+            try {
+              body = JSON.parse(options.body);
+            } catch {
+              body = options.body;
+            }
+          } else {
+            body = options.body;
+          }
+          if (body.coords && Array.isArray(body.coords)) {
+            coords = body.coords;
+          } else if (body.x !== void 0 && body.y !== void 0) {
+            coords = [body.x, body.y];
+          } else if (body.coordinates) {
+            coords = body.coordinates;
+          }
+        }
+        const urlStr = url.toString();
+        const tileMatch = urlStr.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);
+        if (tileMatch) {
+          tileX = parseInt(tileMatch[1]);
+          tileY = parseInt(tileMatch[2]);
+        }
+        if (!coords) {
+          const urlCoordMatch = urlStr.match(/[?&](?:x|coords?)=([^&]+)/);
+          if (urlCoordMatch) {
+            const coordStr = decodeURIComponent(urlCoordMatch[1]);
+            try {
+              coords = JSON.parse(coordStr);
+            } catch {
+              const parts = coordStr.split(",");
+              if (parts.length >= 2) {
+                coords = [parseInt(parts[0]), parseInt(parts[1])];
+              }
+            }
+          }
+        }
+        if (coords && coords.length >= 2) {
+          let globalX, globalY, localX, localY;
+          if (Number.isInteger(tileX) && Number.isInteger(tileY)) {
+            localX = coords[0];
+            localY = coords[1];
+            globalX = tileX * 3e3 + localX;
+            globalY = tileY * 3e3 + localY;
+            log(`\u{1F3AF} Coordenadas capturadas (locales): tile(${tileX},${tileY}) local(${localX},${localY}) -> global(${globalX},${globalY})`);
+          } else {
+            globalX = coords[0];
+            globalY = coords[1];
+            tileX = Math.floor(globalX / 3e3);
+            tileY = Math.floor(globalY / 3e3);
+            localX = globalX % 3e3;
+            localY = globalY % 3e3;
+            log(`\u{1F3AF} Coordenadas capturadas (globales): global(${globalX},${globalY}) -> tile(${tileX},${tileY}) local(${localX},${localY})`);
+          }
+          if (response.ok) {
+            this.disable();
+            if (this.callback) {
+              this.callback({
+                success: true,
+                tileX,
+                tileY,
+                globalX,
+                globalY,
+                localX,
+                localY
+              });
+            }
+          } else {
+            log("\u26A0\uFE0F Captura realizada pero la respuesta no fue exitosa");
+          }
+        }
+      } catch (error) {
+        log("Error procesando captura:", error);
+      }
+    }
+    // Desactivar captura
+    disable() {
+      if (!this.active) return;
+      this.active = false;
+      window.fetch = this.originalFetch;
+      this.callback = null;
+      log("\u{1F512} Captura de coordenadas desactivada");
+    }
+  };
+  var coordinateCapture = new CoordinateCapture();
+
+  // src/core/dom.js
+  function isPaletteOpen(debug = false) {
+    const paletteSelectors = [
+      '[data-testid="color-picker"]',
+      ".color-picker",
+      ".palette",
+      '[class*="color"][class*="picker"]',
+      '[class*="palette"]'
+    ];
+    for (const selector of paletteSelectors) {
+      const element = document.querySelector(selector);
+      if (element && element.offsetParent !== null) {
+        if (debug) console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por selector: ${selector}`);
+        return true;
+      }
+    }
+    const colorElements = document.querySelectorAll('[style*="background-color"], [style*="background:"], .color, [class*="color"]');
+    let visibleColors = 0;
+    for (const el of colorElements) {
+      if (el.offsetParent !== null && el.offsetWidth > 10 && el.offsetHeight > 10) {
+        visibleColors++;
+        if (visibleColors >= 5) {
+          if (debug) console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por colores visibles: ${visibleColors}`);
+          return true;
+        }
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u{1F50D} Paleta no detectada. Colores visibles: ${visibleColors}`);
+    return false;
+  }
+  function findAndClickPaintButton(debug = false, doubleClick = false) {
+    const specificButton = document.querySelector("button.btn.btn-primary.btn-lg, button.btn.btn-primary.sm\\:btn-xl");
+    if (specificButton) {
+      const buttonText = specificButton.textContent.toLowerCase();
+      const hasPaintText = buttonText.includes("paint") || buttonText.includes("pintar");
+      const hasPaintIcon = specificButton.querySelector('svg path[d*="240-120"]') || specificButton.querySelector('svg path[d*="M15"]');
+      if (hasPaintText || hasPaintIcon) {
+        if (debug) console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por selector espec\xEDfico: "${buttonText}"`);
+        specificButton.click();
+        if (doubleClick) {
+          setTimeout(() => {
+            if (debug) console.log(`[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint`);
+            specificButton.click();
+          }, 500);
+        }
+        return true;
+      }
+    }
+    const buttons = document.querySelectorAll("button");
+    for (const button of buttons) {
+      const buttonText = button.textContent.toLowerCase();
+      if ((buttonText.includes("paint") || buttonText.includes("pintar")) && button.offsetParent !== null && !button.disabled) {
+        if (debug) console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por texto: "${button.textContent.trim()}"`);
+        button.click();
+        if (doubleClick) {
+          setTimeout(() => {
+            if (debug) console.log(`[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint`);
+            button.click();
+          }, 500);
+        }
+        return true;
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado`);
+    return false;
+  }
+  async function autoClickPaintButton(maxAttempts = 3, debug = true) {
+    if (debug) console.log(`[WPA-UI] \u{1F916} Iniciando auto-click del bot\xF3n Paint (m\xE1ximo ${maxAttempts} intentos)`);
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (debug) console.log(`[WPA-UI] \u{1F3AF} Intento ${attempt}/${maxAttempts} - Buscando bot\xF3n Paint...`);
+      if (isPaletteOpen()) {
+        if (debug) console.log(`[WPA-UI] \u2705 Paleta ya est\xE1 abierta, auto-click completado`);
+        return true;
+      }
+      if (findAndClickPaintButton(debug, false)) {
+        if (debug) console.log(`[WPA-UI] \u{1F446} Clic en bot\xF3n Paint realizado (sin segundo clic)`);
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        if (isPaletteOpen()) {
+          if (debug) console.log(`[WPA-UI] \u2705 Paleta abierta exitosamente despu\xE9s del intento ${attempt}`);
+          return true;
+        } else {
+          if (debug) console.log(`[WPA-UI] \u26A0\uFE0F Paleta no detectada tras el clic en intento ${attempt}. Reintentar\xE1.`);
+        }
+      } else {
+        if (debug) console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado para clic en intento ${attempt}`);
+      }
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 1e3));
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u274C Auto-click fall\xF3 despu\xE9s de ${maxAttempts} intentos`);
+    return false;
+  }
+
+  // src/entries/farm.js
+  (async function() {
+    "use strict";
+    var _a, _b;
+    await initializeLanguage();
+    try {
+      log("\u{1F916} [FARM] Iniciando auto-click del bot\xF3n Paint...");
+      await autoClickPaintButton(3, true);
+    } catch (error) {
+      log("\u26A0\uFE0F [FARM] Error en auto-click del bot\xF3n Paint:", error);
+    }
+    if ((_a = window.__wplaceBot) == null ? void 0 : _a.farmRunning) {
+      alert(t("farm.alreadyRunning", "Auto-Farm ya est\xE1 corriendo."));
+      return;
+    }
+    if ((_b = window.__wplaceBot) == null ? void 0 : _b.imageRunning) {
+      alert(t("farm.imageRunningWarning", "Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm."));
+      return;
+    }
+    if (!window.__wplaceBot) {
+      window.__wplaceBot = {};
+    }
+    window.__wplaceBot.farmRunning = true;
+    window.addEventListener("languageChanged", () => {
+      var _a2, _b2;
+      if ((_b2 = (_a2 = window.__wplaceBot) == null ? void 0 : _a2.ui) == null ? void 0 : _b2.updateTexts) {
+        window.__wplaceBot.ui.updateTexts();
+      }
+    });
+    log("\u{1F680} Iniciando WPlace Farm Bot (versi\xF3n modular)");
+    function needsCalibrationCheck(cfg2) {
+      const hasSelectedZone = !!cfg2.POSITION_SELECTED && cfg2.BASE_X != null && cfg2.BASE_Y != null;
+      const hasDefaultCoords = cfg2.TILE_X === FARM_DEFAULTS.TILE_X && cfg2.TILE_Y === FARM_DEFAULTS.TILE_Y;
+      const hasInvalidCoords = !Number.isFinite(cfg2.TILE_X) || !Number.isFinite(cfg2.TILE_Y);
+      const needsCalib = !hasSelectedZone && (hasDefaultCoords || hasInvalidCoords);
+      log(`Verificaci\xF3n calibraci\xF3n: defaults=${hasDefaultCoords}, selected=${hasSelectedZone}, invalid=${hasInvalidCoords}, coords=(${cfg2.TILE_X},${cfg2.TILE_Y})`);
+      return needsCalib;
+    }
+    function enableCaptureOnce() {
+      log("\u{1F575}\uFE0F Activando captura de coordenadas...");
+      coordinateCapture.enable((result) => {
+        if (result.success) {
+          cfg.TILE_X = result.tileX;
+          cfg.TILE_Y = result.tileY;
+          saveFarmCfg(cfg);
+          ui.updateConfig();
+          ui.setStatus(`\u{1F3AF} Coordenadas capturadas: tile(${result.tileX},${result.tileY})`, "success");
+          log(`\u2705 Coordenadas capturadas autom\xE1ticamente: tile(${result.tileX},${result.tileY})`);
+        } else {
+          ui.setStatus(`\u274C ${t("common.error", "No se pudieron capturar coordenadas")}`, "error");
+        }
+      });
+      ui.setStatus(`\u{1F4F8} ${t("farm.captureInstructions")}`, "status");
+    }
+    let cfg = { ...FARM_DEFAULTS, ...loadFarmCfg(FARM_DEFAULTS) };
+    if (!cfg.SITEKEY) {
+      const siteKeyElement = document.querySelector("*[data-sitekey]");
+      if (siteKeyElement) {
+        cfg.SITEKEY = siteKeyElement.getAttribute("data-sitekey");
+        log(`\u{1F4DD} Sitekey encontrada autom\xE1ticamente: ${cfg.SITEKEY.substring(0, 20)}...`);
+        saveFarmCfg(cfg);
+      } else {
+        log("\u26A0\uFE0F No se pudo encontrar la sitekey autom\xE1ticamente");
+      }
+    }
+    async function updateStats() {
+      try {
+        const session = await getSession();
+        if (session.success && session.data) {
+          farmState.charges.count = session.data.charges || 0;
+          farmState.charges.max = session.data.maxCharges || 50;
+          farmState.charges.regen = session.data.chargeRegen || 3e4;
+          farmState.user = session.data.user;
+          cfg.CHARGE_REGEN_MS = farmState.charges.regen;
+          const health = await checkBackendHealth();
+          farmState.health = health;
+          ui.updateStats(farmState.painted, farmState.charges.count, farmState.retryCount, health);
+          return session.data;
+        }
+        return null;
+      } catch (error) {
+        log("Error actualizando estad\xEDsticas:", error);
+        return null;
+      }
+    }
+    async function checkBackendHealth() {
+      try {
+        return await checkHealth();
+      } catch (error) {
+        log("Error verificando health:", error);
+        return { up: false, error: error.message };
+      }
+    }
+    async function paintOnceWrapper() {
+      return await paintWithRetry(cfg, farmState, ui.setStatus, ui.flashEffect, () => getSession(), checkBackendHealth);
+    }
+    const ui = createFarmUI(
+      cfg,
+      // onStart
+      async () => {
+        if (farmState.running) {
+          ui.setStatus("\u26A0\uFE0F El bot ya est\xE1 ejecut\xE1ndose", "error");
+          return;
+        }
+        if (!cfg.POSITION_SELECTED || cfg.BASE_X === null || cfg.BASE_Y === null) {
+          ui.setStatus(t("farm.autoSelectPosition"), "info");
+          const selectButton = ui.getElement().shadowRoot.getElementById("select-position-btn");
+          if (selectButton) {
+            selectButton.click();
+          }
+          return;
+        }
+        if (needsCalibrationCheck(cfg)) {
+          ui.setStatus("\u{1F3AF} Calibrando autom\xE1ticamente...", "status");
+          const calibration = await autoCalibrateTile(cfg);
+          if (calibration.success) {
+            ui.setStatus(`\u2705 Calibrado: tile(${calibration.tileX},${calibration.tileY})`, "success");
+            ui.updateConfig();
+          } else {
+            ui.setStatus("\u274C Error en calibraci\xF3n. Configura manualmente.", "error");
+            return;
+          }
+        }
+        ui.setStatus("\u{1F50D} Verificando conectividad...", "status");
+        const health = await checkBackendHealth();
+        if (!health.up) {
+          ui.setStatus("\u{1F534} Backend no disponible. Verifica tu conexi\xF3n.", "error");
+          return;
+        }
+        ui.setStatus("\u{1F504} Obteniendo informaci\xF3n de sesi\xF3n...", "status");
+        const sessionData = await updateStats();
+        if (!sessionData) {
+          ui.setStatus("\u274C Error obteniendo sesi\xF3n. Verifica tu login.", "error");
+          return;
+        }
+        ui.setStatus("\u{1F680} Iniciando bot...", "status");
+        ui.updateButtonStates(true);
+        loop(cfg, farmState, ui.setStatus, ui.flashEffect, updateStats, checkBackendHealth, updateStats);
+      },
+      // onStop
+      () => {
+        farmState.running = false;
+        if (window.__wplaceBot) {
+          window.__wplaceBot.farmRunning = false;
+        }
+        ui.setStatus("\u23F9\uFE0F Deteniendo bot...", "status");
+        ui.updateButtonStates(false);
+      },
+      // onCalibrate
+      async () => {
+        ui.setStatus("\u{1F3AF} Calibrando posici\xF3n...", "status");
+        const calibration = await autoCalibrateTile(cfg);
+        if (calibration.success) {
+          ui.setStatus(`\u2705 Calibrado: tile(${calibration.tileX},${calibration.tileY})`, "success");
+          ui.updateConfig();
+        } else {
+          ui.setStatus(`\u274C Error en calibraci\xF3n: ${calibration.error || "Desconocido"}`, "error");
+        }
+      }
+    );
+    const captureBtn = ui.getElement().shadowRoot.getElementById("capture-btn");
+    if (captureBtn) {
+      captureBtn.addEventListener("click", enableCaptureOnce);
+    }
+    const onceBtn = ui.getElement().shadowRoot.getElementById("once-btn");
+    if (onceBtn) {
+      onceBtn.addEventListener("click", async () => {
+        if (farmState.running) {
+          ui.setStatus("\u26A0\uFE0F Det\xE9n el bot primero", "error");
+          return;
+        }
+        await updateStats();
+        ui.setStatus("\u{1F3A8} Pintando una vez...", "status");
+        const success = await paintOnceWrapper();
+        if (success) {
+          ui.setStatus("\u2705 P\xEDxel pintado exitosamente", "success");
+        } else {
+          ui.setStatus("\u274C Error al pintar p\xEDxel", "error");
+        }
+      });
+    }
+    await updateStats();
+    window.addEventListener("wplace-batch-painted", (event) => {
+      log(`\u{1F3A8} Lote pintado: ${event.detail.pixelCount} p\xEDxeles en tile(${event.detail.tileX},${event.detail.tileY})`);
+    });
+    window.WPAUI = {
+      once: paintOnceWrapper,
+      get: () => ({ ...cfg }),
+      capture: enableCaptureOnce,
+      refreshCanvas: () => {
+        if (farmState.last) {
+          log(`Refrescando canvas en posici\xF3n (${farmState.last.x},${farmState.last.y})`);
+        }
+      },
+      verifyPixel: async (x, y) => {
+        log(`Verificando p\xEDxel en (${x},${y})...`);
+        return { verified: true, x, y };
+      },
+      getStats: () => ({
+        painted: farmState.painted,
+        last: farmState.last,
+        charges: farmState.charges,
+        user: farmState.user,
+        running: farmState.running,
+        minCharges: cfg.MIN_CHARGES,
+        delay: cfg.DELAY_MS,
+        tileInfo: {
+          tileX: cfg.TILE_X,
+          tileY: cfg.TILE_Y,
+          tileSize: cfg.TILE_SIZE,
+          safeMargin: Math.floor(cfg.TILE_SIZE * 0.05),
+          safeArea: {
+            minX: Math.floor(cfg.TILE_SIZE * 0.05),
+            maxX: cfg.TILE_SIZE - Math.floor(cfg.TILE_SIZE * 0.05) - 1,
+            minY: Math.floor(cfg.TILE_SIZE * 0.05),
+            maxY: cfg.TILE_SIZE - Math.floor(cfg.TILE_SIZE * 0.05) - 1
+          }
+        }
+      }),
+      setPixelsPerBatch: (count) => {
+        cfg.PIXELS_PER_BATCH = clamp(count, 1, 50);
+        saveFarmCfg(cfg);
+        ui.updateConfig();
+        log(`P\xEDxeles por lote configurado a: ${cfg.PIXELS_PER_BATCH}`);
+      },
+      setMinCharges: (min) => {
+        cfg.MIN_CHARGES = Math.max(0, min);
+        saveFarmCfg(cfg);
+        ui.updateConfig();
+        log(`Cargas m\xEDnimas configuradas a: ${cfg.MIN_CHARGES}`);
+      },
+      setDelay: (seconds) => {
+        cfg.DELAY_MS = Math.max(1e3, seconds * 1e3);
+        saveFarmCfg(cfg);
+        ui.updateConfig();
+        log(`Delay configurado a: ${cfg.DELAY_MS}ms`);
+      },
+      diagnose: () => {
+        var _a2;
+        const stats = window.WPAUI.getStats();
+        const diagnosis = {
+          configValid: Number.isFinite(cfg.TILE_X) && Number.isFinite(cfg.TILE_Y),
+          hasCharges: farmState.charges.count > 0,
+          backendHealthy: ((_a2 = farmState.health) == null ? void 0 : _a2.up) || false,
+          userLoggedIn: !!farmState.user,
+          coordinates: `(${cfg.TILE_X},${cfg.TILE_Y})`,
+          safeArea: stats.tileInfo.safeArea,
+          recommendations: []
+        };
+        if (!diagnosis.configValid) {
+          diagnosis.recommendations.push("Calibrar coordenadas del tile");
+        }
+        if (!diagnosis.hasCharges) {
+          diagnosis.recommendations.push("Esperar a que se regeneren las cargas");
+        }
+        if (!diagnosis.backendHealthy) {
+          diagnosis.recommendations.push("Verificar conexi\xF3n al backend");
+        }
+        if (!diagnosis.userLoggedIn) {
+          diagnosis.recommendations.push("Iniciar sesi\xF3n en la plataforma");
+        }
+        console.table(diagnosis);
+        return diagnosis;
+      },
+      checkHealth: checkBackendHealth,
+      resetConfig: () => {
+        resetToSafeDefaults();
+        cfg = { ...FARM_DEFAULTS };
+        ui.updateConfig();
+        log("Configuraci\xF3n reseteada a valores por defecto");
+      },
+      debugRetries: () => {
+        return {
+          currentRetries: farmState.retryCount,
+          inCooldown: farmState.inCooldown,
+          nextPaintTime: farmState.nextPaintTime,
+          cooldownEndTime: farmState.cooldownEndTime
+        };
+      },
+      forceClearCooldown: () => {
+        farmState.inCooldown = false;
+        farmState.nextPaintTime = 0;
+        farmState.cooldownEndTime = 0;
+        farmState.retryCount = 0;
+        log("Cooldown forzado a limpiar");
+      },
+      simulateError: (statusCode = 500) => {
+        log(`Simulando error ${statusCode} para testing...`);
+        ui.setStatus(`\u{1F9EA} Simulando error ${statusCode}`, "error");
+      }
+    };
+    window.addEventListener("beforeunload", () => {
+      farmState.running = false;
+      if (window.__wplaceBot) {
+        window.__wplaceBot.farmRunning = false;
+      }
+      coordinateCapture.disable();
+      ui.destroy();
+    });
+    log("\u2705 Farm Bot inicializado correctamente");
+    log("\u{1F4A1} Usa console.log(window.WPAUI) para ver la API disponible");
+  })().catch((e) => {
+    console.error("[BOT] Error en Auto-Farm:", e);
+    if (window.__wplaceBot) {
+      window.__wplaceBot.farmRunning = false;
+    }
+    alert("Auto-Farm: error inesperado. Revisa consola.");
+  });
+})();
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsic3JjL2NvcmUvbG9nZ2VyLmpzIiwgInNyYy9mYXJtL2NvbmZpZy5qcyIsICJzcmMvY29yZS9zdG9yYWdlLmpzIiwgInNyYy9jb3JlL3dwbGFjZS1hcGkuanMiLCAic3JjL2NvcmUvdXRpbHMuanMiLCAic3JjL2xvY2FsZXMvZXMuanMiLCAic3JjL2xvY2FsZXMvZW4uanMiLCAic3JjL2xvY2FsZXMvZnIuanMiLCAic3JjL2xvY2FsZXMvcnUuanMiLCAic3JjL2xvY2FsZXMvemgtSGFucy5qcyIsICJzcmMvbG9jYWxlcy96aC1IYW50LmpzIiwgInNyYy9sb2NhbGVzL2luZGV4LmpzIiwgInNyYy9mYXJtL3VpLmpzIiwgInNyYy9jb3JlL3R1cm5zdGlsZS5qcyIsICJzcmMvZmFybS9jb29yZHMuanMiLCAic3JjL2NvcmUvdGltaW5nLmpzIiwgInNyYy9mYXJtL2xvb3AuanMiLCAic3JjL2NvcmUvY2FwdHVyZS5qcyIsICJzcmMvY29yZS9kb20uanMiLCAic3JjL2VudHJpZXMvZmFybS5qcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiZXhwb3J0IGNvbnN0IGxvZ2dlciA9IHtcbiAgZGVidWdFbmFibGVkOiBmYWxzZSxcbiAgc2V0RGVidWcodikgeyB0aGlzLmRlYnVnRW5hYmxlZCA9ICEhdjsgfSxcbiAgZGVidWcoLi4uYSkgeyBpZiAodGhpcy5kZWJ1Z0VuYWJsZWQpIGNvbnNvbGUuZGVidWcoXCJbQk9UXVwiLCAuLi5hKTsgfSxcbiAgaW5mbyguLi5hKSAgeyBjb25zb2xlLmluZm8oXCJbQk9UXVwiLCAuLi5hKTsgfSxcbiAgd2FybiguLi5hKSAgeyBjb25zb2xlLndhcm4oXCJbQk9UXVwiLCAuLi5hKTsgfSxcbiAgZXJyb3IoLi4uYSkgeyBjb25zb2xlLmVycm9yKFwiW0JPVF1cIiwgLi4uYSk7IH1cbn07XG5cbi8vIEZhcm0tc3BlY2lmaWMgbG9nZ2VyXG5leHBvcnQgY29uc3QgbG9nID0gKC4uLmEpID0+IGNvbnNvbGUubG9nKCdbV1BBLVVJXScsIC4uLmEpO1xuXG4vLyBVdGlsaXR5IGZ1bmN0aW9uc1xuZXhwb3J0IGNvbnN0IG5vb3AgPSAoKSA9PiB7fTtcbmV4cG9ydCBjb25zdCBjbGFtcCA9IChuLCBhLCBiKSA9PiBNYXRoLm1heChhLCBNYXRoLm1pbihiLCBuKSk7XG4iLCAiLy8gQ29uZmlndXJhY2lcdTAwRjNuIHBvciBkZWZlY3RvIHBhcmEgV1BsYWNlIEF1dG9GYXJtXG5leHBvcnQgY29uc3QgRkFSTV9ERUZBVUxUUyA9IHtcbiAgU0lURUtFWTogJzB4NEFBQUFBQUJwcUplOEZPME44NHEwRicsIC8vIFR1cm5zdGlsZSBzaXRla2V5IChhalx1MDBGQXN0YWxvIHNpIGNhbWJpYSlcbiAgVElMRV9YOiAxMDg2LFxuICBUSUxFX1k6IDE1NjUsXG4gIFRJTEVfU0laRTogMzAwMCwgICAgICAgICAvLyBUaWxlcyBzb24gZGUgfjMwMDB4MzAwMCBzZWdcdTAwRkFuIGludmVzdGlnYWNpXHUwMEYzblxuICBERUxBWV9NUzogMTUwMDAsICAgICAgICAgLy8gMTUgc2VndW5kb3MgZW50cmUgcGludGFkYXMgKHByZWRldGVybWluYWRvKVxuICBNSU5fQ0hBUkdFUzogMTAsICAgICAgICAgLy8gbVx1MDBFRG5pbW8gZGUgY2FyZ2FzIHBhcmEgZW1wZXphciBhIHBpbnRhclxuICBDSEFSR0VfUkVHRU5fTVM6IDMwMDAwLCAgLy8gMSBjYXJnYSBjYWRhIDMwIHNlZ3VuZG9zXG4gIFBJWEVMU19QRVJfQkFUQ0g6IDIwLCAgICAvLyBuXHUwMEZBbWVybyBkZSBwXHUwMEVEeGVsZXMgYSBwaW50YXIgcG9yIGxvdGVcbiAgQ09MT1JfTUlOOiAxLFxuICBDT0xPUl9NQVg6IDMyLFxuICBDT0xPUl9NT0RFOiAncmFuZG9tJywgICAgLy8gJ3JhbmRvbScgfCAnZml4ZWQnXG4gIENPTE9SX0ZJWEVEOiAxLFxuICBDVVNUT01fUEFMRVRURTogWycjRkYwMDAwJywgJyMwMEZGMDAnLCAnIzAwMDBGRicsICcjRkZGRjAwJywgJyNGRjAwRkYnLCAnIzAwRkZGRiddLFxuICAvLyBOdWV2YSBmdW5jaW9uYWxpZGFkIGRlIHBvc2ljaVx1MDBGM24geSByYWRpb1xuICBCQVNFX1g6IG51bGwsICAgICAgICAgICAgLy8gUG9zaWNpXHUwMEYzbiBYIGJhc2UgKGxvY2FsIGFsIHRpbGUpIC0gc2UgZXN0YWJsZWNlIGFsIHNlbGVjY2lvbmFyIHpvbmFcbiAgQkFTRV9ZOiBudWxsLCAgICAgICAgICAgIC8vIFBvc2ljaVx1MDBGM24gWSBiYXNlIChsb2NhbCBhbCB0aWxlKSAtIHNlIGVzdGFibGVjZSBhbCBzZWxlY2Npb25hciB6b25hXG4gIEZBUk1fUkFESVVTOiA1MDAsICAgICAgICAvLyBSYWRpbyBkZSBmYXJtaW5nIGVuIHBcdTAwRUR4ZWxlcyAoNTAwcHggcG9yIGRlZmVjdG8gcGFyYSB6b25hIHNlZ3VyYSlcbiAgUE9TSVRJT05fU0VMRUNURUQ6IGZhbHNlLCAvLyBGbGFnIHBhcmEgaW5kaWNhciBzaSBzZSBzZWxlY2Npb25cdTAwRjMgdW5hIHBvc2ljaVx1MDBGM25cbiAgVUlfVEhFTUU6IHtcbiAgICBwcmltYXJ5OiAnIzAwMDAwMCcsXG4gICAgc2Vjb25kYXJ5OiAnIzExMTExMScsXG4gICAgYWNjZW50OiAnIzIyMjIyMicsXG4gICAgdGV4dDogJyNmZmZmZmYnLFxuICAgIGhpZ2hsaWdodDogJyM3NzVjZTMnLFxuICAgIHN1Y2Nlc3M6ICcjMDBmZjAwJyxcbiAgICBlcnJvcjogJyNmZjAwMDAnLFxuICAgIHJ1bm5pbmc6ICcjMDBjYzAwJyAgICAgLy8gVmVyZGUgcGFyYSBjdWFuZG8gZXN0XHUwMEUxIGNvcnJpZW5kb1xuICB9XG59O1xuXG4vLyBFc3RhZG8gZ2xvYmFsIGRlbCBmYXJtXG5leHBvcnQgY29uc3QgZmFybVN0YXRlID0ge1xuICBydW5uaW5nOiBmYWxzZSxcbiAgcGFpbnRlZDogMCxcbiAgbGFzdDogbnVsbCwgICAgICAgICAgLy8ge3gseSxjb2xvcixzdGF0dXMsanNvbn1cbiAgY2hhcmdlczogeyBjb3VudDogMCwgbWF4OiAwLCBjb29sZG93bk1zOiAzMDAwMCB9LFxuICB1c2VyOiBudWxsLFxuICBwYW5lbDogbnVsbCxcbiAgY2FwdHVyZU1vZGU6IGZhbHNlLCAgLy8gc25pZmZlciBhY3Rpdm8gcGFyYSBjYXB0dXJhciBUSUxFX1gvWSBkZXNkZSB1biBQT1NUIHJlYWxcbiAgc2VsZWN0aW5nUG9zaXRpb246IGZhbHNlLCAvLyBzbmlmZmVyIGFjdGl2byBwYXJhIGNhcHR1cmFyIHBvc2ljaVx1MDBGM24gYmFzZVxuICBvcmlnaW5hbEZldGNoOiB3aW5kb3cuZmV0Y2gsXG4gIHJldHJ5Q291bnQ6IDAsICAgICAgIC8vIGNvbnRhZG9yIGRlIHJlaW50ZW50b3NcbiAgaW5Db29sZG93bjogZmFsc2UsICAgLy8gc2kgZXN0XHUwMEUxIGVuIGNvb2xkb3duIGRlIDIgbWludXRvc1xuICBuZXh0UGFpbnRUaW1lOiAwLCAgICAvLyB0aW1lc3RhbXAgZGUgbGEgcHJcdTAwRjN4aW1hIHBpbnRhZGFcbiAgY29vbGRvd25FbmRUaW1lOiAwLCAgLy8gdGltZXN0YW1wIGRlbCBmaW5hbCBkZWwgY29vbGRvd25cbiAgaGVhbHRoOiBudWxsICAgICAgICAgLy8gZXN0YWRvIGRlIHNhbHVkIGRlbCBiYWNrZW5kXG59O1xuIiwgImV4cG9ydCBmdW5jdGlvbiBsb2FkKGtleSwgZmFsbGJhY2spIHtcbiAgLy8gTm8gdXNhciBsb2NhbFN0b3JhZ2UgLSBzaWVtcHJlIHJldG9ybmFyIGZhbGxiYWNrXG4gIHJldHVybiBmYWxsYmFjaztcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIHNhdmUoa2V5LCB2YWx1ZSkge1xuICAvLyBObyBndWFyZGFyIGVuIGxvY2FsU3RvcmFnZSAtIGZ1bmNpXHUwMEYzbiBkZXNoYWJpbGl0YWRhXG4gIHJldHVybjtcbn1cblxuLy8gRmFybS1zcGVjaWZpYyBzdG9yYWdlIGZ1bmN0aW9uc1xuZXhwb3J0IGZ1bmN0aW9uIHNhdmVGYXJtQ2ZnKGNmZykgeyBcbiAgLy8gTm8gZ3VhcmRhciBlbiBsb2NhbFN0b3JhZ2UgLSBmdW5jaVx1MDBGM24gZGVzaGFiaWxpdGFkYVxuICByZXR1cm47XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBsb2FkRmFybUNmZyhkZWZhdWx0cykge1xuICAvLyBObyBjYXJnYXIgZGUgbG9jYWxTdG9yYWdlIC0gc2llbXByZSB1c2FyIGRlZmF1bHRzXG4gIHJldHVybiB7IC4uLmRlZmF1bHRzIH07XG59XG5cbi8vIFJlc2V0ZWFyIGNvbmZpZ3VyYWNpXHUwMEYzbiBkZWwgZmFybVxuZXhwb3J0IGZ1bmN0aW9uIHJlc2V0RmFybUNmZygpIHtcbiAgLy8gTm8gaGF5IGxvY2FsU3RvcmFnZSBxdWUgcmVzZXRlYXIgLSBmdW5jaVx1MDBGM24gZGVzaGFiaWxpdGFkYVxuICBjb25zb2xlLmxvZygnW1dQQS1VSV0nLCAnQ29uZmlndXJhY2lcdTAwRjNuIGRlbCBmYXJtIHJlc2V0ZWFkYSAobG9jYWxTdG9yYWdlIGRlc2hhYmlsaXRhZG8pJyk7XG59XG5cbi8vIFJlc2V0ZWFyIGEgY29uZmlndXJhY2lcdTAwRjNuIHNlZ3VyYVxuZXhwb3J0IGZ1bmN0aW9uIHJlc2V0VG9TYWZlRGVmYXVsdHMoKSB7XG4gIC8vIE5vIGhheSBsb2NhbFN0b3JhZ2UgcXVlIHJlc2V0ZWFyIC0gZnVuY2lcdTAwRjNuIGRlc2hhYmlsaXRhZGFcbiAgY29uc29sZS5sb2coJ1tXUEEtVUldJywgJ0NvbmZpZ3VyYWNpXHUwMEYzbiByZXNldGVhZGEgYSB2YWxvcmVzIHNlZ3Vyb3MgKGxvY2FsU3RvcmFnZSBkZXNoYWJpbGl0YWRvKScpO1xufVxuXG4vLyBWZXJpZmljYXIgc2kgbmVjZXNpdGEgY2FsaWJyYWNpXHUwMEYzbiBpbmljaWFsXG5leHBvcnQgZnVuY3Rpb24gbmVlZHNDYWxpYnJhdGlvbihjZmcsIGRlZmF1bHRzKSB7XG4gIC8vIFZlcmlmaWNhciBzaSBsYXMgY29vcmRlbmFkYXMgc29uIGxhcyBwb3IgZGVmZWN0b1xuICBjb25zdCBoYXNEZWZhdWx0Q29vcmRzID0gY2ZnLlRJTEVfWCA9PT0gZGVmYXVsdHMuVElMRV9YICYmIGNmZy5USUxFX1kgPT09IGRlZmF1bHRzLlRJTEVfWTtcbiAgLy8gU2luIGxvY2FsU3RvcmFnZSwgc2llbXByZSBjb25zaWRlcmFtb3MgcXVlIG5vIGhheSBjb25maWd1cmFjaVx1MDBGM24gZ3VhcmRhZGFcbiAgY29uc3QgaGFzTm9TYXZlZENvbmZpZyA9IHRydWU7XG4gIC8vIFZlcmlmaWNhciBxdWUgbGFzIGNvb3JkZW5hZGFzIHNlYW4gblx1MDBGQW1lcm9zIHZcdTAwRTFsaWRvc1xuICBjb25zdCBoYXNJbnZhbGlkQ29vcmRzID0gIU51bWJlci5pc0Zpbml0ZShjZmcuVElMRV9YKSB8fCAhTnVtYmVyLmlzRmluaXRlKGNmZy5USUxFX1kpO1xuICBcbiAgY29uc3QgbmVlZHNDYWxpYiA9IGhhc0RlZmF1bHRDb29yZHMgfHwgaGFzTm9TYXZlZENvbmZpZyB8fCBoYXNJbnZhbGlkQ29vcmRzO1xuICBjb25zb2xlLmxvZygnW1dQQS1VSV0nLCBgVmVyaWZpY2FjaVx1MDBGM24gY2FsaWJyYWNpXHUwMEYzbjogZGVmYXVsdHM9JHtoYXNEZWZhdWx0Q29vcmRzfSwgbm9Db25maWc9JHtoYXNOb1NhdmVkQ29uZmlnfSwgaW52YWxpZD0ke2hhc0ludmFsaWRDb29yZHN9LCBjb29yZHM9KCR7Y2ZnLlRJTEVfWH0sJHtjZmcuVElMRV9ZfSlgKTtcbiAgXG4gIHJldHVybiBuZWVkc0NhbGliO1xufVxuIiwgImltcG9ydCB7IGZldGNoV2l0aFRpbWVvdXQgfSBmcm9tIFwiLi9odHRwLmpzXCI7XG5cbmNvbnN0IEJBU0UgPSBcImh0dHBzOi8vYmFja2VuZC53cGxhY2UubGl2ZVwiO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gZ2V0U2Vzc2lvbigpIHtcbiAgdHJ5IHtcbiAgICBjb25zdCBtZSA9IGF3YWl0IGZldGNoKGAke0JBU0V9L21lYCwgeyBjcmVkZW50aWFsczogJ2luY2x1ZGUnIH0pLnRoZW4ociA9PiByLmpzb24oKSk7XG4gICAgY29uc3QgdXNlciA9IG1lIHx8IG51bGw7XG4gICAgY29uc3QgYyA9IG1lPy5jaGFyZ2VzIHx8IHt9O1xuICAgIGNvbnN0IGNoYXJnZXMgPSB7XG4gICAgICBjb3VudDogYy5jb3VudCA/PyAwLCAgICAgICAgLy8gTWFudGVuZXIgdmFsb3IgZGVjaW1hbCBvcmlnaW5hbFxuICAgICAgbWF4OiBjLm1heCA/PyAwLCAgICAgICAgICAgIC8vIE1hbnRlbmVyIHZhbG9yIG9yaWdpbmFsIChwdWVkZSB2YXJpYXIgcG9yIHVzdWFyaW8pXG4gICAgICBjb29sZG93bk1zOiBjLmNvb2xkb3duTXMgPz8gMzAwMDBcbiAgICB9O1xuICAgIFxuICAgIHJldHVybiB7IFxuICAgICAgc3VjY2VzczogdHJ1ZSxcbiAgICAgIGRhdGE6IHtcbiAgICAgICAgdXNlciwgXG4gICAgICAgIGNoYXJnZXM6IGNoYXJnZXMuY291bnQsXG4gICAgICAgIG1heENoYXJnZXM6IGNoYXJnZXMubWF4LFxuICAgICAgICBjaGFyZ2VSZWdlbjogY2hhcmdlcy5jb29sZG93bk1zXG4gICAgICB9XG4gICAgfTtcbiAgfSBjYXRjaCAoZXJyb3IpIHsgXG4gICAgcmV0dXJuIHsgXG4gICAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICAgIGVycm9yOiBlcnJvci5tZXNzYWdlLFxuICAgICAgZGF0YToge1xuICAgICAgICB1c2VyOiBudWxsLCBcbiAgICAgICAgY2hhcmdlczogMCxcbiAgICAgICAgbWF4Q2hhcmdlczogMCxcbiAgICAgICAgY2hhcmdlUmVnZW46IDMwMDAwXG4gICAgICB9XG4gICAgfTsgXG4gIH1cbn1cblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGNoZWNrSGVhbHRoKCkge1xuICB0cnkge1xuICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgZmV0Y2goYCR7QkFTRX0vaGVhbHRoYCwge1xuICAgICAgbWV0aG9kOiAnR0VUJyxcbiAgICAgIGNyZWRlbnRpYWxzOiAnaW5jbHVkZSdcbiAgICB9KTtcbiAgICBcbiAgICBpZiAocmVzcG9uc2Uub2spIHtcbiAgICAgIGNvbnN0IGhlYWx0aCA9IGF3YWl0IHJlc3BvbnNlLmpzb24oKTtcbiAgICAgIHJldHVybiB7XG4gICAgICAgIC4uLmhlYWx0aCxcbiAgICAgICAgbGFzdENoZWNrOiBEYXRlLm5vdygpLFxuICAgICAgICBzdGF0dXM6ICdvbmxpbmUnXG4gICAgICB9O1xuICAgIH0gZWxzZSB7XG4gICAgICByZXR1cm4ge1xuICAgICAgICBkYXRhYmFzZTogZmFsc2UsXG4gICAgICAgIHVwOiBmYWxzZSxcbiAgICAgICAgdXB0aW1lOiAnTi9BJyxcbiAgICAgICAgbGFzdENoZWNrOiBEYXRlLm5vdygpLFxuICAgICAgICBzdGF0dXM6ICdlcnJvcicsXG4gICAgICAgIHN0YXR1c0NvZGU6IHJlc3BvbnNlLnN0YXR1c1xuICAgICAgfTtcbiAgICB9XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIGRhdGFiYXNlOiBmYWxzZSxcbiAgICAgIHVwOiBmYWxzZSxcbiAgICAgIHVwdGltZTogJ04vQScsXG4gICAgICBsYXN0Q2hlY2s6IERhdGUubm93KCksXG4gICAgICBzdGF0dXM6ICdvZmZsaW5lJyxcbiAgICAgIGVycm9yOiBlcnJvci5tZXNzYWdlXG4gICAgfTtcbiAgfVxufVxuXG4vLyBVbmlmaWNhIHBvc3QgZGUgcFx1MDBFRHhlbCBwb3IgbG90ZXMgKGJhdGNoIHBvciB0aWxlKS5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwb3N0UGl4ZWxCYXRjaCh7IHRpbGVYLCB0aWxlWSwgcGl4ZWxzLCB0dXJuc3RpbGVUb2tlbiB9KSB7XG4gIC8vIHBpeGVsczogW3t4LHksY29sb3J9LCBcdTIwMjZdIHJlbGF0aXZvcyBhbCB0aWxlXG4gIGNvbnN0IGJvZHkgPSBKU09OLnN0cmluZ2lmeSh7IHBpeGVscywgdG9rZW46IHR1cm5zdGlsZVRva2VuIH0pO1xuICBjb25zdCByID0gYXdhaXQgZmV0Y2hXaXRoVGltZW91dChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICBtZXRob2Q6IFwiUE9TVFwiLFxuICAgIGhlYWRlcnM6IHsgXCJDb250ZW50LVR5cGVcIjogXCJ0ZXh0L3BsYWluO2NoYXJzZXQ9VVRGLThcIiB9LFxuICAgIGJvZHksXG4gICAgY3JlZGVudGlhbHM6IFwiaW5jbHVkZVwiXG4gIH0pO1xuICBcbiAgLy8gQWxndW5hcyByZXNwdWVzdGFzIHB1ZWRlbiBubyB0cmFlciBKU09OIGF1bnF1ZSBzZWFuIDIwMC5cbiAgaWYgKHIuc3RhdHVzID09PSAyMDApIHtcbiAgICB0cnkgeyByZXR1cm4gYXdhaXQgci5qc29uKCk7IH0gY2F0Y2ggeyByZXR1cm4geyBvazogdHJ1ZSB9OyB9XG4gIH1cbiAgXG4gIGxldCBtc2cgPSBgSFRUUCAke3Iuc3RhdHVzfWA7XG4gIHRyeSB7IFxuICAgIGNvbnN0IGogPSBhd2FpdCByLmpzb24oKTsgXG4gICAgbXNnID0gaj8ubWVzc2FnZSB8fCBtc2c7IFxuICB9IGNhdGNoIHtcbiAgICAvLyBSZXNwb25zZSBub3QgSlNPTlxuICB9XG4gIHRocm93IG5ldyBFcnJvcihgcGFpbnQgZmFpbGVkOiAke21zZ31gKTtcbn1cblxuLy8gVmVyc2lcdTAwRjNuICdzYWZlJyBxdWUgbm8gYXJyb2phIGV4Y2VwY2lvbmVzIHkgcmV0b3JuYSBzdGF0dXMvanNvblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHBvc3RQaXhlbEJhdGNoU2FmZSh0aWxlWCwgdGlsZVksIHBpeGVscywgdHVybnN0aWxlVG9rZW4pIHtcbiAgdHJ5IHtcbiAgICBjb25zdCBib2R5ID0gSlNPTi5zdHJpbmdpZnkoeyBwaXhlbHMsIHRva2VuOiB0dXJuc3RpbGVUb2tlbiB9KTtcbiAgICBjb25zdCByID0gYXdhaXQgZmV0Y2hXaXRoVGltZW91dChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICAgIG1ldGhvZDogXCJQT1NUXCIsXG4gICAgICBoZWFkZXJzOiB7IFwiQ29udGVudC1UeXBlXCI6IFwidGV4dC9wbGFpbjtjaGFyc2V0PVVURi04XCIgfSxcbiAgICAgIGJvZHksXG4gICAgICBjcmVkZW50aWFsczogXCJpbmNsdWRlXCJcbiAgICB9KTtcbiAgbGV0IGpzb24gPSB7fTtcbiAgLy8gSWYgcmVzcG9uc2UgaXMgbm90IEpTT04sIGlnbm9yZSBwYXJzZSBlcnJvclxuICB0cnkgeyBqc29uID0gYXdhaXQgci5qc29uKCk7IH0gY2F0Y2ggeyAvKiBpZ25vcmUgKi8gfVxuICAgIHJldHVybiB7IHN0YXR1czogci5zdGF0dXMsIGpzb24sIHN1Y2Nlc3M6IHIub2sgfTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICByZXR1cm4geyBzdGF0dXM6IDAsIGpzb246IHsgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfSwgc3VjY2VzczogZmFsc2UgfTtcbiAgfVxufVxuXG4vLyBQb3N0IHBcdTAwRUR4ZWwgcGFyYSBmYXJtICh2ZXJzaVx1MDBGM24gY29ycmVnaWRhIGNvbiBmb3JtYXRvIG9yaWdpbmFsKVxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHBvc3RQaXhlbChjb29yZHMsIGNvbG9ycywgdHVybnN0aWxlVG9rZW4sIHRpbGVYLCB0aWxlWSkge1xuICB0cnkge1xuICAgIGNvbnN0IGJvZHkgPSBKU09OLnN0cmluZ2lmeSh7IFxuICAgICAgY29sb3JzOiBjb2xvcnMsIFxuICAgICAgY29vcmRzOiBjb29yZHMsIFxuICAgICAgdDogdHVybnN0aWxlVG9rZW4gXG4gICAgfSk7XG4gICAgXG4gICAgY29uc3QgY29udHJvbGxlciA9IG5ldyBBYm9ydENvbnRyb2xsZXIoKTtcbiAgICBjb25zdCB0aW1lb3V0SWQgPSBzZXRUaW1lb3V0KCgpID0+IGNvbnRyb2xsZXIuYWJvcnQoKSwgMTUwMDApOyAvLyBUaW1lb3V0IGRlIDE1IHNlZ3VuZG9zXG5cbiAgICBjb25zdCByZXNwb25zZSA9IGF3YWl0IGZldGNoKGAke0JBU0V9L3MwL3BpeGVsLyR7dGlsZVh9LyR7dGlsZVl9YCwge1xuICAgICAgbWV0aG9kOiAnUE9TVCcsXG4gICAgICBjcmVkZW50aWFsczogJ2luY2x1ZGUnLFxuICAgICAgaGVhZGVyczogeyAnQ29udGVudC1UeXBlJzogJ3RleHQvcGxhaW47Y2hhcnNldD1VVEYtOCcgfSxcbiAgICAgIGJvZHk6IGJvZHksXG4gICAgICBzaWduYWw6IGNvbnRyb2xsZXIuc2lnbmFsXG4gICAgfSk7XG5cbiAgICBjbGVhclRpbWVvdXQodGltZW91dElkKTtcblxuICAgIGxldCByZXNwb25zZURhdGEgPSBudWxsO1xuICAgIHRyeSB7XG4gICAgICBjb25zdCB0ZXh0ID0gYXdhaXQgcmVzcG9uc2UudGV4dCgpO1xuICAgICAgaWYgKHRleHQpIHtcbiAgICAgICAgcmVzcG9uc2VEYXRhID0gSlNPTi5wYXJzZSh0ZXh0KTtcbiAgICAgIH1cbiAgICB9IGNhdGNoIHtcbiAgICAgIHJlc3BvbnNlRGF0YSA9IHt9OyAvLyBJZ25vcmFyIGVycm9yZXMgZGUgSlNPTiBwYXJzZVxuICAgIH1cblxuICAgIHJldHVybiB7XG4gICAgICBzdGF0dXM6IHJlc3BvbnNlLnN0YXR1cyxcbiAgICAgIGpzb246IHJlc3BvbnNlRGF0YSxcbiAgICAgIHN1Y2Nlc3M6IHJlc3BvbnNlLm9rXG4gICAgfTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICByZXR1cm4ge1xuICAgICAgc3RhdHVzOiAwLFxuICAgICAganNvbjogeyBlcnJvcjogZXJyb3IubWVzc2FnZSB9LFxuICAgICAgc3VjY2VzczogZmFsc2VcbiAgICB9O1xuICB9XG59XG5cbi8vIFBvc3QgcFx1MDBFRHhlbCBwYXJhIEF1dG8tSW1hZ2UgKGZvcm1hdG8gb3JpZ2luYWwgY29ycmVjdG8pXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcG9zdFBpeGVsQmF0Y2hJbWFnZSh0aWxlWCwgdGlsZVksIGNvb3JkcywgY29sb3JzLCB0dXJuc3RpbGVUb2tlbikge1xuICB0cnkge1xuICAgIGNvbnN0IGJvZHkgPSBKU09OLnN0cmluZ2lmeSh7IFxuICAgICAgY29sb3JzOiBjb2xvcnMsIFxuICAgICAgY29vcmRzOiBjb29yZHMsIFxuICAgICAgdDogdHVybnN0aWxlVG9rZW4gXG4gICAgfSk7XG4gICAgXG4gICAgY29uc3QgcmVzcG9uc2UgPSBhd2FpdCBmZXRjaChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICAgIG1ldGhvZDogJ1BPU1QnLFxuICAgICAgY3JlZGVudGlhbHM6ICdpbmNsdWRlJyxcbiAgICAgIGhlYWRlcnM6IHsgJ0NvbnRlbnQtVHlwZSc6ICd0ZXh0L3BsYWluO2NoYXJzZXQ9VVRGLTgnIH0sXG4gICAgICBib2R5OiBib2R5XG4gICAgfSk7XG5cbiAgICBsZXQgcmVzcG9uc2VEYXRhID0gbnVsbDtcbiAgICB0cnkge1xuICAgICAgcmVzcG9uc2VEYXRhID0gYXdhaXQgcmVzcG9uc2UuanNvbigpO1xuICAgIH0gY2F0Y2gge1xuICAgICAgcmVzcG9uc2VEYXRhID0ge307IC8vIElnbm9yYXIgZXJyb3JlcyBkZSBKU09OIHBhcnNlXG4gICAgfVxuXG4gICAgcmV0dXJuIHtcbiAgICAgIHN0YXR1czogcmVzcG9uc2Uuc3RhdHVzLFxuICAgICAganNvbjogcmVzcG9uc2VEYXRhLFxuICAgICAgc3VjY2VzczogcmVzcG9uc2Uub2ssXG4gICAgICBwYWludGVkOiByZXNwb25zZURhdGE/LnBhaW50ZWQgfHwgMFxuICAgIH07XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIHN0YXR1czogMCxcbiAgICAgIGpzb246IHsgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfSxcbiAgICAgIHN1Y2Nlc3M6IGZhbHNlLFxuICAgICAgcGFpbnRlZDogMFxuICAgIH07XG4gIH1cbn1cbiIsICIvLyBVdGlsaXR5IGZ1bmN0aW9uc1xuZXhwb3J0IGNvbnN0IHNsZWVwID0gKG1zKSA9PiBuZXcgUHJvbWlzZShyID0+IHNldFRpbWVvdXQociwgbXMpKTtcbmV4cG9ydCBjb25zdCByYW5kSW50ID0gKG4pID0+IE1hdGguZmxvb3IoTWF0aC5yYW5kb20oKSAqIG4pO1xuZXhwb3J0IGNvbnN0IG5vb3AgPSAoKSA9PiB7fTtcblxuZXhwb3J0IGZ1bmN0aW9uIGNsYW1wKG4sIGEsIGIpIHtcbiAgcmV0dXJuIE1hdGgubWF4KGEsIE1hdGgubWluKGIsIG4pKTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgc2VsZWN0b3IgZGUgZWxlbWVudG9zIERPTVxuZXhwb3J0IGZ1bmN0aW9uICQoc2VsZWN0b3IsIHJvb3QgPSBkb2N1bWVudCkge1xuICByZXR1cm4gcm9vdC5xdWVyeVNlbGVjdG9yKHNlbGVjdG9yKTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgaGFjZXIgZWxlbWVudG9zIGFycmFzdHJhYmxlc1xuZXhwb3J0IGZ1bmN0aW9uIGRyYWdIZWFkZXIoaGVhZGVyRWwsIHBhbmVsRWwpIHtcbiAgbGV0IG9mZnNldFggPSAwLCBvZmZzZXRZID0gMCwgbW91c2VYID0gMCwgbW91c2VZID0gMDtcblxuICBoZWFkZXJFbC5zdHlsZS5jdXJzb3IgPSAnbW92ZSc7XG4gIGhlYWRlckVsLmFkZEV2ZW50TGlzdGVuZXIoJ21vdXNlZG93bicsIHN0YXJ0RHJhZyk7XG5cbiAgZnVuY3Rpb24gc3RhcnREcmFnKGUpIHtcbiAgICBlLnByZXZlbnREZWZhdWx0KCk7XG4gICAgbW91c2VYID0gZS5jbGllbnRYO1xuICAgIG1vdXNlWSA9IGUuY2xpZW50WTtcbiAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdtb3VzZXVwJywgc3RvcERyYWcpO1xuICAgIGRvY3VtZW50LmFkZEV2ZW50TGlzdGVuZXIoJ21vdXNlbW92ZScsIGRvRHJhZyk7XG4gIH1cblxuICBmdW5jdGlvbiBkb0RyYWcoZSkge1xuICAgIGUucHJldmVudERlZmF1bHQoKTtcbiAgICBvZmZzZXRYID0gbW91c2VYIC0gZS5jbGllbnRYO1xuICAgIG9mZnNldFkgPSBtb3VzZVkgLSBlLmNsaWVudFk7XG4gICAgbW91c2VYID0gZS5jbGllbnRYO1xuICAgIG1vdXNlWSA9IGUuY2xpZW50WTtcbiAgICBcbiAgICBjb25zdCBuZXdUb3AgPSBwYW5lbEVsLm9mZnNldFRvcCAtIG9mZnNldFk7XG4gICAgY29uc3QgbmV3TGVmdCA9IHBhbmVsRWwub2Zmc2V0TGVmdCAtIG9mZnNldFg7XG4gICAgXG4gICAgcGFuZWxFbC5zdHlsZS50b3AgPSBNYXRoLm1heCgwLCBuZXdUb3ApICsgJ3B4JztcbiAgICBwYW5lbEVsLnN0eWxlLmxlZnQgPSBNYXRoLm1heCgwLCBuZXdMZWZ0KSArICdweCc7XG4gIH1cblxuICBmdW5jdGlvbiBzdG9wRHJhZygpIHtcbiAgICBkb2N1bWVudC5yZW1vdmVFdmVudExpc3RlbmVyKCdtb3VzZXVwJywgc3RvcERyYWcpO1xuICAgIGRvY3VtZW50LnJlbW92ZUV2ZW50TGlzdGVuZXIoJ21vdXNlbW92ZScsIGRvRHJhZyk7XG4gIH1cbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgZm9ybWF0ZWFyIHRpZW1wb1xuZXhwb3J0IGZ1bmN0aW9uIGZvcm1hdFRpbWUobXMpIHtcbiAgY29uc3Qgc2Vjb25kcyA9IE1hdGguZmxvb3IobXMgLyAxMDAwKTtcbiAgY29uc3QgbWludXRlcyA9IE1hdGguZmxvb3Ioc2Vjb25kcyAvIDYwKTtcbiAgY29uc3QgaG91cnMgPSBNYXRoLmZsb29yKG1pbnV0ZXMgLyA2MCk7XG4gIFxuICBpZiAoaG91cnMgPiAwKSB7XG4gICAgcmV0dXJuIGAke2hvdXJzfWggJHttaW51dGVzICUgNjB9bWA7XG4gIH0gZWxzZSBpZiAobWludXRlcyA+IDApIHtcbiAgICByZXR1cm4gYCR7bWludXRlc31tICR7c2Vjb25kcyAlIDYwfXNgO1xuICB9IGVsc2Uge1xuICAgIHJldHVybiBgJHtzZWNvbmRzfXNgO1xuICB9XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIHBhcnNlYXIgaGV4YWRlY2ltYWxcbmV4cG9ydCBmdW5jdGlvbiBwYXJzZUhleChzdHIpIHtcbiAgcmV0dXJuIHBhcnNlSW50KHN0ci5yZXBsYWNlKCcjJywgJycpLCAxNik7XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIGNvbnZlcnRpciBuXHUwMEZBbWVybyBhIGhleFxuZXhwb3J0IGZ1bmN0aW9uIHRvSGV4KG51bSkge1xuICByZXR1cm4gJyMnICsgbnVtLnRvU3RyaW5nKDE2KS5wYWRTdGFydCg2LCAnMCcpO1xufVxuIiwgImV4cG9ydCBjb25zdCBlcyA9IHtcbiAgLy8gTGF1bmNoZXJcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBBdXRvQk9UJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBBdXRvLUZhcm0nLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBBdXRvLUltYWdlJyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgQXV0by1HdWFyZCcsXG4gICAgc2VsZWN0aW9uOiAnU2VsZWNjaVx1MDBGM24nLFxuICAgIHVzZXI6ICdVc3VhcmlvJyxcbiAgICBjaGFyZ2VzOiAnQ2FyZ2FzJyxcbiAgICBiYWNrZW5kOiAnQmFja2VuZCcsXG4gICAgZGF0YWJhc2U6ICdEYXRhYmFzZScsXG4gICAgdXB0aW1lOiAnVXB0aW1lJyxcbiAgICBjbG9zZTogJ0NlcnJhcicsXG4gICAgbGF1bmNoOiAnTGFuemFyJyxcbiAgICBsb2FkaW5nOiAnQ2FyZ2FuZG9cdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ0VqZWN1dGFuZG9cdTIwMjYnLFxuICAgIGRvd25sb2FkaW5nOiAnRGVzY2FyZ2FuZG8gc2NyaXB0XHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdFbGlnZSB1biBib3QgeSBwcmVzaW9uYSBMYW56YXInLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdMaXN0byBwYXJhIGxhbnphcicsXG4gICAgbG9hZEVycm9yOiAnRXJyb3IgYWwgY2FyZ2FyJyxcbiAgICBsb2FkRXJyb3JNc2c6ICdObyBzZSBwdWRvIGNhcmdhciBlbCBib3Qgc2VsZWNjaW9uYWRvLiBSZXZpc2EgdHUgY29uZXhpXHUwMEYzbiBvIGludFx1MDBFOW50YWxvIGRlIG51ZXZvLicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgVmVyaWZpY2FuZG8uLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBPbmxpbmUnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgT2ZmbGluZScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgT0snLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IEVycm9yJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1JbWFnZVwiLFxuICAgIGluaXRCb3Q6IFwiSW5pY2lhciBBdXRvLUJPVFwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlN1YmlyIEltYWdlblwiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlJlZGltZW5zaW9uYXIgSW1hZ2VuXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU2VsZWNjaW9uYXIgUG9zaWNpXHUwMEYzblwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiSW5pY2lhciBQaW50dXJhXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIkRldGVuZXIgUGludHVyYVwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJHdWFyZGFyIFByb2dyZXNvXCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIkNhcmdhciBQcm9ncmVzb1wiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzRFx1REQwRCBWZXJpZmljYW5kbyBjb2xvcmVzIGRpc3BvbmlibGVzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHUwMEExQWJyZSBsYSBwYWxldGEgZGUgY29sb3JlcyBlbiBlbCBzaXRpbyBlIGludFx1MDBFOW50YWxvIGRlIG51ZXZvIVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSB7Y291bnR9IGNvbG9yZXMgZGlzcG9uaWJsZXMgZW5jb250cmFkb3NcIixcbiAgICBsb2FkaW5nSW1hZ2U6IFwiXHVEODNEXHVEREJDXHVGRTBGIENhcmdhbmRvIGltYWdlbi4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBJbWFnZW4gY2FyZ2FkYSBjb24ge2NvdW50fSBwXHUwMEVEeGVsZXMgdlx1MDBFMWxpZG9zXCIsXG4gICAgaW1hZ2VFcnJvcjogXCJcdTI3NEMgRXJyb3IgYWwgY2FyZ2FyIGxhIGltYWdlblwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHUwMEExUGludGEgZWwgcHJpbWVyIHBcdTAwRUR4ZWwgZW4gbGEgdWJpY2FjaVx1MDBGM24gZG9uZGUgcXVpZXJlcyBxdWUgY29taWVuY2UgZWwgYXJ0ZSFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBxdWUgcGludGVzIGVsIHBcdTAwRUR4ZWwgZGUgcmVmZXJlbmNpYS4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTAwQTFQb3NpY2lcdTAwRjNuIGVzdGFibGVjaWRhIGNvbiBcdTAwRTl4aXRvIVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgVGllbXBvIGFnb3RhZG8gcGFyYSBzZWxlY2Npb25hciBwb3NpY2lcdTAwRjNuXCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgUG9zaWNpXHUwMEYzbiBkZXRlY3RhZGEsIHByb2Nlc2FuZG8uLi5cIixcbiAgICBwb3NpdGlvbkVycm9yOiBcIlx1Mjc0QyBFcnJvciBkZXRlY3RhbmRvIHBvc2ljaVx1MDBGM24sIGludFx1MDBFOW50YWxvIGRlIG51ZXZvXCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggSW5pY2lhbmRvIHBpbnR1cmEuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBQcm9ncmVzbzoge3BhaW50ZWR9L3t0b3RhbH0gcFx1MDBFRHhlbGVzLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBTaW4gY2FyZ2FzLiBFc3BlcmFuZG8ge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQaW50dXJhIGRldGVuaWRhIHBvciBlbCB1c3VhcmlvXCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgXHUwMEExUGludHVyYSBjb21wbGV0YWRhISB7Y291bnR9IHBcdTAwRUR4ZWxlcyBwaW50YWRvcy5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBFcnJvciBkdXJhbnRlIGxhIHBpbnR1cmFcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBDYXJnYSB1bmEgaW1hZ2VuIHkgc2VsZWNjaW9uYSB1bmEgcG9zaWNpXHUwMEYzbiBwcmltZXJvXCIsXG4gICAgcHJvZ3Jlc3M6IFwiUHJvZ3Jlc29cIixcbiAgICB1c2VyTmFtZTogXCJVc3VhcmlvXCIsXG4gICAgcGl4ZWxzOiBcIlBcdTAwRUR4ZWxlc1wiLFxuICAgIGNoYXJnZXM6IFwiQ2FyZ2FzXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJUaWVtcG8gZXN0aW1hZG9cIixcbiAgICBpbml0TWVzc2FnZTogXCJIYXogY2xpYyBlbiAnSW5pY2lhciBBdXRvLUJPVCcgcGFyYSBjb21lbnphclwiLFxuICAgIHdhaXRpbmdJbml0OiBcIkVzcGVyYW5kbyBpbmljaWFsaXphY2lcdTAwRjNuLi4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgSW1hZ2VuIHJlZGltZW5zaW9uYWRhIGEge3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBQaW50dXJhIHBhdXNhZGEgZW4gbGEgcG9zaWNpXHUwMEYzbiBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlBcdTAwRUR4ZWxlcyBwb3IgbG90ZVwiLFxuICAgIGJhdGNoU2l6ZTogXCJUYW1hXHUwMEYxbyBkZWwgbG90ZVwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiU2lndWllbnRlIGxvdGUgZW5cIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlVzYXIgdG9kYXMgbGFzIGNhcmdhcyBkaXNwb25pYmxlc1wiLFxuICAgIHNob3dPdmVybGF5OiBcIk1vc3RyYXIgb3ZlcmxheVwiLFxuICAgIG1heENoYXJnZXM6IFwiQ2FyZ2FzIG1cdTAwRTF4aW1hcyBwb3IgbG90ZVwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBFc3BlcmFuZG8gY2FyZ2FzOiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlRpZW1wbyByZXN0YW50ZVwiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgRXNwZXJhbmRvIHt0aW1lfSBwYXJhIGNvbnRpbnVhci4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFByb2dyZXNvIGd1YXJkYWRvIGNvbW8ge2ZpbGVuYW1lfVwiLFxuICAgIHByb2dyZXNzTG9hZGVkOiBcIlx1MjcwNSBQcm9ncmVzbyBjYXJnYWRvOiB7cGFpbnRlZH0ve3RvdGFsfSBwXHUwMEVEeGVsZXMgcGludGFkb3NcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgRXJyb3IgYWwgY2FyZ2FyIHByb2dyZXNvOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGFsIGd1YXJkYXIgcHJvZ3Jlc286IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1MDBCRkRlc2VhcyBndWFyZGFyIGVsIHByb2dyZXNvIGFjdHVhbCBhbnRlcyBkZSBkZXRlbmVyP1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIkd1YXJkYXIgUHJvZ3Jlc29cIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiRGVzY2FydGFyXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbGFyXCIsXG4gICAgbWluaW1pemU6IFwiTWluaW1pemFyXCIsXG4gICAgd2lkdGg6IFwiQW5jaG9cIixcbiAgICBoZWlnaHQ6IFwiQWx0b1wiLCBcbiAgICBrZWVwQXNwZWN0OiBcIk1hbnRlbmVyIHByb3BvcmNpXHUwMEYzblwiLFxuICAgIGFwcGx5OiBcIkFwbGljYXJcIixcbiAgb3ZlcmxheU9uOiBcIk92ZXJsYXk6IE9OXCIsXG4gIG92ZXJsYXlPZmY6IFwiT3ZlcmxheTogT0ZGXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgUGFzYWRhIGNvbXBsZXRhZGE6IHtwYWludGVkfSBwXHUwMEVEeGVsZXMgcGludGFkb3MgfCBQcm9ncmVzbzoge3BlcmNlbnR9JSAoe2N1cnJlbnR9L3t0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgRXNwZXJhbmRvIHJlZ2VuZXJhY2lcdTAwRjNuIGRlIGNhcmdhczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gVGllbXBvOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgRXNwZXJhbmRvIGNhcmdhczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gUXVlZGFuOiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbmljaWFsaXphbmRvIGF1dG9tXHUwMEUxdGljYW1lbnRlLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBCb3QgaW5pY2lhZG8gYXV0b21cdTAwRTF0aWNhbWVudGVcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgTm8gc2UgcHVkbyBpbmljaWFyIGF1dG9tXHUwMEUxdGljYW1lbnRlLiBVc2EgZWwgYm90XHUwMEYzbiBtYW51YWwuXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBQYWxldGEgZGUgY29sb3JlcyBkZXRlY3RhZGFcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIEJ1c2NhbmRvIHBhbGV0YSBkZSBjb2xvcmVzLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgSGFjaWVuZG8gY2xpYyBlbiBlbCBib3RcdTAwRjNuIFBhaW50Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgQm90XHUwMEYzbiBQYWludCBubyBlbmNvbnRyYWRvXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbmljaW8gbWFudWFsIHJlcXVlcmlkb1wiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgUmVpbnRlbnRvIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IGVuIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgRXJyb3IgZW4gaW50ZW50byB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSwgcmVpbnRlbnRhbmRvIGVuIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIEZhbGxcdTAwRjMgZGVzcHVcdTAwRTlzIGRlIHttYXhBdHRlbXB0c30gaW50ZW50b3MuIENvbnRpbnVhbmRvIGNvbiBzaWd1aWVudGUgbG90ZS4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgRXJyb3IgZGUgcmVkLiBSZWludGVudGFuZG8uLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgRXJyb3IgZGVsIHNlcnZpZG9yLiBSZWludGVudGFuZG8uLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFRpbWVvdXQgZGVsIHNlcnZpZG9yLiBSZWludGVudGFuZG8uLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlIChwb3IgaW1wbGVtZW50YXIpXG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgRmFybSBCb3RcIixcbiAgICBzdGFydDogXCJJbmljaWFyXCIsXG4gICAgc3RvcDogXCJEZXRlbmVyXCIsIFxuICAgIHN0b3BwZWQ6IFwiQm90IGRldGVuaWRvXCIsXG4gICAgY2FsaWJyYXRlOiBcIkNhbGlicmFyXCIsXG4gICAgcGFpbnRPbmNlOiBcIlVuYSB2ZXpcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJWZXJpZmljYW5kbyBlc3RhZG8uLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIkNvbmZpZ3VyYWNpXHUwMEYzblwiLFxuICAgIGRlbGF5OiBcIkRlbGF5IChtcylcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQXHUwMEVEeGVsZXMvbG90ZVwiLFxuICAgIG1pbkNoYXJnZXM6IFwiQ2FyZ2FzIG1cdTAwRURuXCIsXG4gICAgY29sb3JNb2RlOiBcIk1vZG8gY29sb3JcIixcbiAgICByYW5kb206IFwiQWxlYXRvcmlvXCIsXG4gICAgZml4ZWQ6IFwiRmlqb1wiLFxuICAgIHJhbmdlOiBcIlJhbmdvXCIsXG4gICAgZml4ZWRDb2xvcjogXCJDb2xvciBmaWpvXCIsXG4gICAgYWR2YW5jZWQ6IFwiQXZhbnphZG9cIixcbiAgICB0aWxlWDogXCJUaWxlIFhcIixcbiAgICB0aWxlWTogXCJUaWxlIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlBhbGV0YSBwZXJzb25hbGl6YWRhXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiZWo6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJDYXB0dXJhclwiLFxuICAgIHBhaW50ZWQ6IFwiUGludGFkb3NcIixcbiAgICBjaGFyZ2VzOiBcIkNhcmdhc1wiLFxuICAgIHJldHJpZXM6IFwiRmFsbG9zXCIsXG4gICAgdGlsZTogXCJUaWxlXCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiQ29uZmlndXJhY2lcdTAwRjNuIGd1YXJkYWRhXCIsXG4gICAgY29uZmlnTG9hZGVkOiBcIkNvbmZpZ3VyYWNpXHUwMEYzbiBjYXJnYWRhXCIsXG4gICAgY29uZmlnUmVzZXQ6IFwiQ29uZmlndXJhY2lcdTAwRjNuIHJlaW5pY2lhZGFcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlBpbnRhIHVuIHBcdTAwRUR4ZWwgbWFudWFsbWVudGUgcGFyYSBjYXB0dXJhciBjb29yZGVuYWRhcy4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiQmFja2VuZCBPbmxpbmVcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJCYWNrZW5kIE9mZmxpbmVcIixcbiAgICBzdGFydGluZ0JvdDogXCJJbmljaWFuZG8gYm90Li4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiRGV0ZW5pZW5kbyBib3QuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJDYWxpYnJhbmRvLi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiQXV0by1GYXJtIHlhIGVzdFx1MDBFMSBjb3JyaWVuZG8uXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJBdXRvLUltYWdlIGVzdFx1MDBFMSBlamVjdXRcdTAwRTFuZG9zZS4gQ2lcdTAwRTlycmFsbyBhbnRlcyBkZSBpbmljaWFyIEF1dG8tRmFybS5cIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTZWxlY2Npb25hciBab25hXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgUGludGEgdW4gcFx1MDBFRHhlbCBlbiB1bmEgem9uYSBERVNQT0JMQURBIGRlbCBtYXBhIHBhcmEgZXN0YWJsZWNlciBlbCBcdTAwRTFyZWEgZGUgZmFybWluZ1wiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgRXNwZXJhbmRvIHF1ZSBwaW50ZXMgZWwgcFx1MDBFRHhlbCBkZSByZWZlcmVuY2lhLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1MDBBMVpvbmEgZXN0YWJsZWNpZGEhIFJhZGlvOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgVGllbXBvIGFnb3RhZG8gcGFyYSBzZWxlY2Npb25hciB6b25hXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBTZWxlY2Npb25hIHVuYSB6b25hIHByaW1lcm8gdXNhbmRvICdTZWxlY2Npb25hciBab25hJ1wiLFxuICAgIGZhcm1SYWRpdXM6IFwiUmFkaW8gZmFybVwiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJab25hIGFjdHVhbFwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgRmFybWluZyBlbiByYWRpbyB7cmFkaXVzfXB4IGRlc2RlICh7eH0se3l9KVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgSU1QT1JUQU5URTogU2VsZWNjaW9uYSB1bmEgem9uYSBERVNQT0JMQURBIHBhcmEgZXZpdGFyIGNvbmZsaWN0b3NcIixcbiAgICBub1Bvc2l0aW9uOiBcIlNpbiB6b25hXCIsXG4gICAgY3VycmVudFpvbmU6IFwiWm9uYTogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBTZWxlY2Npb25hIHVuYSB6b25hIHByaW1lcm8uIFBpbnRhIHVuIHBcdTAwRUR4ZWwgZW4gZWwgbWFwYSBwYXJhIGVzdGFibGVjZXIgbGEgem9uYSBkZSBmYXJtaW5nXCJcbiAgfSxcblxuICAvLyBDb21tb24vU2hhcmVkXG4gIGNvbW1vbjoge1xuICAgIHllczogXCJTXHUwMEVEXCIsXG4gICAgbm86IFwiTm9cIixcbiAgICBvazogXCJBY2VwdGFyXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbGFyXCIsXG4gICAgY2xvc2U6IFwiQ2VycmFyXCIsXG4gICAgc2F2ZTogXCJHdWFyZGFyXCIsXG4gICAgbG9hZDogXCJDYXJnYXJcIixcbiAgICBkZWxldGU6IFwiRWxpbWluYXJcIixcbiAgICBlZGl0OiBcIkVkaXRhclwiLFxuICAgIHN0YXJ0OiBcIkluaWNpYXJcIixcbiAgICBzdG9wOiBcIkRldGVuZXJcIixcbiAgICBwYXVzZTogXCJQYXVzYXJcIixcbiAgICByZXN1bWU6IFwiUmVhbnVkYXJcIixcbiAgICByZXNldDogXCJSZWluaWNpYXJcIixcbiAgICBzZXR0aW5nczogXCJDb25maWd1cmFjaVx1MDBGM25cIixcbiAgICBoZWxwOiBcIkF5dWRhXCIsXG4gICAgYWJvdXQ6IFwiQWNlcmNhIGRlXCIsXG4gICAgbGFuZ3VhZ2U6IFwiSWRpb21hXCIsXG4gICAgbG9hZGluZzogXCJDYXJnYW5kby4uLlwiLFxuICAgIGVycm9yOiBcIkVycm9yXCIsXG4gICAgc3VjY2VzczogXCJcdTAwQzl4aXRvXCIsXG4gICAgd2FybmluZzogXCJBZHZlcnRlbmNpYVwiLFxuICAgIGluZm86IFwiSW5mb3JtYWNpXHUwMEYzblwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJJZGlvbWEgY2FtYmlhZG8gYSB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1HdWFyZFwiLFxuICAgIGluaXRCb3Q6IFwiSW5pY2lhbGl6YXIgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJTZWxlY2Npb25hciBcdTAwQzFyZWFcIixcbiAgICBjYXB0dXJlQXJlYTogXCJDYXB0dXJhciBcdTAwQzFyZWFcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiSW5pY2lhciBQcm90ZWNjaVx1MDBGM25cIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJEZXRlbmVyIFByb3RlY2NpXHUwMEYzblwiLFxuICAgIHVwcGVyTGVmdDogXCJFc3F1aW5hIFN1cGVyaW9yIEl6cXVpZXJkYVwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiRXNxdWluYSBJbmZlcmlvciBEZXJlY2hhXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlBcdTAwRUR4ZWxlcyBQcm90ZWdpZG9zXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIkNhbWJpb3MgRGV0ZWN0YWRvc1wiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlBcdTAwRUR4ZWxlcyBSZXBhcmFkb3NcIixcbiAgICBjaGFyZ2VzOiBcIkNhcmdhc1wiLFxuICAgIHdhaXRpbmdJbml0OiBcIkVzcGVyYW5kbyBpbmljaWFsaXphY2lcdTAwRjNuLi4uXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNDXHVERkE4IFZlcmlmaWNhbmRvIGNvbG9yZXMgZGlzcG9uaWJsZXMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBObyBzZSBlbmNvbnRyYXJvbiBjb2xvcmVzLiBBYnJlIGxhIHBhbGV0YSBkZSBjb2xvcmVzIGVuIGVsIHNpdGlvLlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSB7Y291bnR9IGNvbG9yZXMgZGlzcG9uaWJsZXMgZW5jb250cmFkb3NcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaWNpYWxpemFkbyBjb3JyZWN0YW1lbnRlXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBFcnJvciBpbmljaWFsaXphbmRvIEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIENvb3JkZW5hZGFzIGludlx1MDBFMWxpZGFzXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIEVsIFx1MDBFMXJlYSBkZWJlIHRlbmVyIGVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhIG1lbm9yIHF1ZSBpbmZlcmlvciBkZXJlY2hhXCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBcdTAwQzFyZWEgZGVtYXNpYWRvIGdyYW5kZToge3NpemV9IHBcdTAwRUR4ZWxlcyAobVx1MDBFMXhpbW86IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IENhcHR1cmFuZG8gXHUwMEUxcmVhIGRlIHByb3RlY2NpXHUwMEYzbi4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHUwMEMxcmVhIGNhcHR1cmFkYToge2NvdW50fSBwXHUwMEVEeGVsZXMgYmFqbyBwcm90ZWNjaVx1MDBGM25cIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGNhcHR1cmFuZG8gXHUwMEUxcmVhOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBQcmltZXJvIGNhcHR1cmEgdW4gXHUwMEUxcmVhIGRlIHByb3RlY2NpXHUwMEYzblwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBQcm90ZWNjaVx1MDBGM24gaW5pY2lhZGEgLSBtb25pdG9yZWFuZG8gXHUwMEUxcmVhXCIsXG4gICAgcHJvdGVjdGlvblN0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFByb3RlY2NpXHUwMEYzbiBkZXRlbmlkYVwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHUwMEMxcmVhIHByb3RlZ2lkYSAtIHNpbiBjYW1iaW9zIGRldGVjdGFkb3NcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gY2FtYmlvcyBkZXRlY3RhZG9zIGVuIGVsIFx1MDBFMXJlYSBwcm90ZWdpZGFcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFJlcGFyYW5kbyB7Y291bnR9IHBcdTAwRUR4ZWxlcyBhbHRlcmFkb3MuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFJlcGFyYWRvcyB7Y291bnR9IHBcdTAwRUR4ZWxlcyBjb3JyZWN0YW1lbnRlXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIEVycm9yIHJlcGFyYW5kbyBwXHUwMEVEeGVsZXM6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIFNpbiBjYXJnYXMgc3VmaWNpZW50ZXMgcGFyYSByZXBhcmFyIGNhbWJpb3NcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFZlcmlmaWNhbmRvIGNhbWJpb3MgZW4gXHUwMEUxcmVhIHByb3RlZ2lkYS4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIEVycm9yIHZlcmlmaWNhbmRvIGNhbWJpb3M6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgR3VhcmRpXHUwMEUxbiBhY3Rpdm8gLSBcdTAwRTFyZWEgYmFqbyBwcm90ZWNjaVx1MDBGM25cIixcbiAgICBsYXN0Q2hlY2s6IFwiXHUwMERBbHRpbWEgdmVyaWZpY2FjaVx1MDBGM246IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJQclx1MDBGM3hpbWEgdmVyaWZpY2FjaVx1MDBGM24gZW46IHt0aW1lfXNcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbmljaWFsaXphbmRvIGF1dG9tXHUwMEUxdGljYW1lbnRlLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgaW5pY2lhZG8gYXV0b21cdTAwRTF0aWNhbWVudGVcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgTm8gc2UgcHVkbyBpbmljaWFyIGF1dG9tXHUwMEUxdGljYW1lbnRlLiBVc2EgZWwgYm90XHUwMEYzbiBtYW51YWwuXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbmljaW8gbWFudWFsIHJlcXVlcmlkb1wiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXRhIGRlIGNvbG9yZXMgZGV0ZWN0YWRhXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBCdXNjYW5kbyBwYWxldGEgZGUgY29sb3Jlcy4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IEhhY2llbmRvIGNsaWMgZW4gZWwgYm90XHUwMEYzbiBQYWludC4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkb1wiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgUGludGEgdW4gcFx1MDBFRHhlbCBlbiBsYSBlc3F1aW5hIFNVUEVSSU9SIElaUVVJRVJEQSBkZWwgXHUwMEUxcmVhIGEgcHJvdGVnZXJcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBBaG9yYSBwaW50YSB1biBwXHUwMEVEeGVsIGVuIGxhIGVzcXVpbmEgSU5GRVJJT1IgREVSRUNIQSBkZWwgXHUwMEUxcmVhXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgRXNwZXJhbmRvIHNlbGVjY2lcdTAwRjNuIGRlIGVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBzZWxlY2NpXHUwMEYzbiBkZSBlc3F1aW5hIGluZmVyaW9yIGRlcmVjaGEuLi5cIixcbiAgICB1cHBlckxlZnRDYXB0dXJlZDogXCJcdTI3MDUgRXNxdWluYSBzdXBlcmlvciBpenF1aWVyZGEgY2FwdHVyYWRhOiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBFc3F1aW5hIGluZmVyaW9yIGRlcmVjaGEgY2FwdHVyYWRhOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgVGllbXBvIGFnb3RhZG8gcGFyYSBzZWxlY2NpXHUwMEYzblwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBFcnJvciBlbiBzZWxlY2NpXHUwMEYzbiwgaW50XHUwMEU5bnRhbG8gZGUgbnVldm9cIlxuICB9XG59O1xuIiwgImV4cG9ydCBjb25zdCBlbiA9IHtcbiAgLy8gTGF1bmNoZXJcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBBdXRvQk9UJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBBdXRvLUZhcm0nLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBBdXRvLUltYWdlJyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgQXV0by1HdWFyZCcsXG4gICAgc2VsZWN0aW9uOiAnU2VsZWN0aW9uJyxcbiAgICB1c2VyOiAnVXNlcicsXG4gICAgY2hhcmdlczogJ0NoYXJnZXMnLFxuICAgIGJhY2tlbmQ6ICdCYWNrZW5kJyxcbiAgICBkYXRhYmFzZTogJ0RhdGFiYXNlJyxcbiAgICB1cHRpbWU6ICdVcHRpbWUnLFxuICAgIGNsb3NlOiAnQ2xvc2UnLFxuICAgIGxhdW5jaDogJ0xhdW5jaCcsXG4gICAgbG9hZGluZzogJ0xvYWRpbmdcdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ0V4ZWN1dGluZ1x1MjAyNicsXG4gICAgZG93bmxvYWRpbmc6ICdEb3dubG9hZGluZyBzY3JpcHRcdTIwMjYnLFxuICAgIGNob29zZUJvdDogJ0Nob29zZSBhIGJvdCBhbmQgcHJlc3MgTGF1bmNoJyxcbiAgICByZWFkeVRvTGF1bmNoOiAnUmVhZHkgdG8gbGF1bmNoJyxcbiAgICBsb2FkRXJyb3I6ICdMb2FkIGVycm9yJyxcbiAgICBsb2FkRXJyb3JNc2c6ICdDb3VsZCBub3QgbG9hZCB0aGUgc2VsZWN0ZWQgYm90LiBDaGVjayB5b3VyIGNvbm5lY3Rpb24gb3IgdHJ5IGFnYWluLicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgQ2hlY2tpbmcuLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBPbmxpbmUnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgT2ZmbGluZScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgT0snLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IEVycm9yJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1JbWFnZVwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGl6ZSBBdXRvLUJPVFwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlVwbG9hZCBJbWFnZVwiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlJlc2l6ZSBJbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNlbGVjdCBQb3NpdGlvblwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiU3RhcnQgUGFpbnRpbmdcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiU3RvcCBQYWludGluZ1wiLFxuICAgIHNhdmVQcm9ncmVzczogXCJTYXZlIFByb2dyZXNzXCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIkxvYWQgUHJvZ3Jlc3NcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgQ2hlY2tpbmcgYXZhaWxhYmxlIGNvbG9ycy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIE9wZW4gdGhlIGNvbG9yIHBhbGV0dGUgb24gdGhlIHNpdGUgYW5kIHRyeSBhZ2FpbiFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgRm91bmQge2NvdW50fSBhdmFpbGFibGUgY29sb3JzXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBMb2FkaW5nIGltYWdlLi4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IEltYWdlIGxvYWRlZCB3aXRoIHtjb3VudH0gdmFsaWQgcGl4ZWxzXCIsXG4gICAgaW1hZ2VFcnJvcjogXCJcdTI3NEMgRXJyb3IgbG9hZGluZyBpbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiUGFpbnQgdGhlIGZpcnN0IHBpeGVsIGF0IHRoZSBsb2NhdGlvbiB3aGVyZSB5b3Ugd2FudCB0aGUgYXJ0IHRvIHN0YXJ0IVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgV2FpdGluZyBmb3IgeW91IHRvIHBhaW50IHRoZSByZWZlcmVuY2UgcGl4ZWwuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgUG9zaXRpb24gc2V0IHN1Y2Nlc3NmdWxseSFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpbWVvdXQgZm9yIHBvc2l0aW9uIHNlbGVjdGlvblwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFBvc2l0aW9uIGRldGVjdGVkLCBwcm9jZXNzaW5nLi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgRXJyb3IgZGV0ZWN0aW5nIHBvc2l0aW9uLCBwbGVhc2UgdHJ5IGFnYWluXCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggU3RhcnRpbmcgcGFpbnRpbmcuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBQcm9ncmVzczoge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBObyBjaGFyZ2VzLiBXYWl0aW5nIHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUGFpbnRpbmcgc3RvcHBlZCBieSB1c2VyXCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgUGFpbnRpbmcgY29tcGxldGVkISB7Y291bnR9IHBpeGVscyBwYWludGVkLlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIEVycm9yIGR1cmluZyBwYWludGluZ1wiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIExvYWQgYW4gaW1hZ2UgYW5kIHNlbGVjdCBhIHBvc2l0aW9uIGZpcnN0XCIsXG4gICAgcHJvZ3Jlc3M6IFwiUHJvZ3Jlc3NcIixcbiAgICB1c2VyTmFtZTogXCJVc2VyXCIsXG4gICAgcGl4ZWxzOiBcIlBpeGVsc1wiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiRXN0aW1hdGVkIHRpbWVcIixcbiAgICBpbml0TWVzc2FnZTogXCJDbGljayAnSW5pdGlhbGl6ZSBBdXRvLUJPVCcgdG8gYmVnaW5cIixcbiAgICB3YWl0aW5nSW5pdDogXCJXYWl0aW5nIGZvciBpbml0aWFsaXphdGlvbi4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IEltYWdlIHJlc2l6ZWQgdG8ge3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBQYWludGluZyBwYXVzZWQgYXQgcG9zaXRpb24gWDoge3h9LCBZOiB7eX1cIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQaXhlbHMgcGVyIGJhdGNoXCIsXG4gICAgYmF0Y2hTaXplOiBcIkJhdGNoIHNpemVcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIk5leHQgYmF0Y2ggaW5cIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlVzZSBhbGwgYXZhaWxhYmxlIGNoYXJnZXNcIixcbiAgICBzaG93T3ZlcmxheTogXCJTaG93IG92ZXJsYXlcIixcbiAgICBtYXhDaGFyZ2VzOiBcIk1heCBjaGFyZ2VzIHBlciBiYXRjaFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBXYWl0aW5nIGZvciBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlRpbWUgcmVtYWluaW5nXCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBXYWl0aW5nIHt0aW1lfSB0byBjb250aW51ZS4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFByb2dyZXNzIHNhdmVkIGFzIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgUHJvZ3Jlc3MgbG9hZGVkOiB7cGFpbnRlZH0ve3RvdGFsfSBwaXhlbHMgcGFpbnRlZFwiLFxuICAgIHByb2dyZXNzTG9hZEVycm9yOiBcIlx1Mjc0QyBFcnJvciBsb2FkaW5nIHByb2dyZXNzOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIEVycm9yIHNhdmluZyBwcm9ncmVzczoge2Vycm9yfVwiLFxuICAgIGNvbmZpcm1TYXZlUHJvZ3Jlc3M6IFwiRG8geW91IHdhbnQgdG8gc2F2ZSB0aGUgY3VycmVudCBwcm9ncmVzcyBiZWZvcmUgc3RvcHBpbmc/XCIsXG4gICAgc2F2ZVByb2dyZXNzVGl0bGU6IFwiU2F2ZSBQcm9ncmVzc1wiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJEaXNjYXJkXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbFwiLFxuICAgIG1pbmltaXplOiBcIk1pbmltaXplXCIsXG4gICAgd2lkdGg6IFwiV2lkdGhcIixcbiAgICBoZWlnaHQ6IFwiSGVpZ2h0XCIsIFxuICAgIGtlZXBBc3BlY3Q6IFwiS2VlcCBhc3BlY3QgcmF0aW9cIixcbiAgICBhcHBseTogXCJBcHBseVwiLFxuICBvdmVybGF5T246IFwiT3ZlcmxheTogT05cIixcbiAgb3ZlcmxheU9mZjogXCJPdmVybGF5OiBPRkZcIixcbiAgICBwYXNzQ29tcGxldGVkOiBcIlx1MjcwNSBQYXNzIGNvbXBsZXRlZDoge3BhaW50ZWR9IHBpeGVscyBwYWludGVkIHwgUHJvZ3Jlc3M6IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFdhaXRpbmcgZm9yIGNoYXJnZSByZWdlbmVyYXRpb246IHtjdXJyZW50fS97bmVlZGVkfSAtIFRpbWU6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBXYWl0aW5nIGZvciBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH0gLSBSZW1haW5pbmc6IHt0aW1lfVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IEF1dG8taW5pdGlhbGl6aW5nLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBCb3QgYXV0by1zdGFydGVkIHN1Y2Nlc3NmdWxseVwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBDb3VsZCBub3QgYXV0by1zdGFydC4gVXNlIG1hbnVhbCBidXR0b24uXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBDb2xvciBwYWxldHRlIGRldGVjdGVkXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBTZWFyY2hpbmcgZm9yIGNvbG9yIHBhbGV0dGUuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBDbGlja2luZyBQYWludCBidXR0b24uLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBQYWludCBidXR0b24gbm90IGZvdW5kXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBNYW51YWwgaW5pdGlhbGl6YXRpb24gcmVxdWlyZWRcIixcbiAgICByZXRyeUF0dGVtcHQ6IFwiXHVEODNEXHVERDA0IFJldHJ5IHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IGluIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgRXJyb3IgaW4gYXR0ZW1wdCB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSwgcmV0cnlpbmcgaW4ge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgRmFpbGVkIGFmdGVyIHttYXhBdHRlbXB0c30gYXR0ZW1wdHMuIENvbnRpbnVpbmcgd2l0aCBuZXh0IGJhdGNoLi4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBOZXR3b3JrIGVycm9yLiBSZXRyeWluZy4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBTZXJ2ZXIgZXJyb3IuIFJldHJ5aW5nLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBTZXJ2ZXIgdGltZW91dC4gUmV0cnlpbmcuLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlICh0byBiZSBpbXBsZW1lbnRlZClcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBGYXJtIEJvdFwiLFxuICAgIHN0YXJ0OiBcIlN0YXJ0XCIsXG4gICAgc3RvcDogXCJTdG9wXCIsXG4gICAgc3RvcHBlZDogXCJCb3Qgc3RvcHBlZFwiLFxuICAgIGNhbGlicmF0ZTogXCJDYWxpYnJhdGVcIixcbiAgICBwYWludE9uY2U6IFwiT25jZVwiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIkNoZWNraW5nIHN0YXR1cy4uLlwiLFxuICAgIGNvbmZpZ3VyYXRpb246IFwiQ29uZmlndXJhdGlvblwiLFxuICAgIGRlbGF5OiBcIkRlbGF5IChtcylcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQaXhlbHMvYmF0Y2hcIixcbiAgICBtaW5DaGFyZ2VzOiBcIk1pbiBjaGFyZ2VzXCIsXG4gICAgY29sb3JNb2RlOiBcIkNvbG9yIG1vZGVcIixcbiAgICByYW5kb206IFwiUmFuZG9tXCIsXG4gICAgZml4ZWQ6IFwiRml4ZWRcIixcbiAgICByYW5nZTogXCJSYW5nZVwiLFxuICAgIGZpeGVkQ29sb3I6IFwiRml4ZWQgY29sb3JcIixcbiAgICBhZHZhbmNlZDogXCJBZHZhbmNlZFwiLFxuICAgIHRpbGVYOiBcIlRpbGUgWFwiLFxuICAgIHRpbGVZOiBcIlRpbGUgWVwiLFxuICAgIGN1c3RvbVBhbGV0dGU6IFwiQ3VzdG9tIHBhbGV0dGVcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJlLmc6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJDYXB0dXJlXCIsXG4gICAgcGFpbnRlZDogXCJQYWludGVkXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgcmV0cmllczogXCJSZXRyaWVzXCIsXG4gICAgdGlsZTogXCJUaWxlXCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiQ29uZmlndXJhdGlvbiBzYXZlZFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJDb25maWd1cmF0aW9uIGxvYWRlZFwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIkNvbmZpZ3VyYXRpb24gcmVzZXRcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlBhaW50IGEgcGl4ZWwgbWFudWFsbHkgdG8gY2FwdHVyZSBjb29yZGluYXRlcy4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiQmFja2VuZCBPbmxpbmVcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJCYWNrZW5kIE9mZmxpbmVcIixcbiAgICBzdGFydGluZ0JvdDogXCJTdGFydGluZyBib3QuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJTdG9wcGluZyBib3QuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJDYWxpYnJhdGluZy4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIkF1dG8tRmFybSBpcyBhbHJlYWR5IHJ1bm5pbmcuXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJBdXRvLUltYWdlIGlzIHJ1bm5pbmcuIENsb3NlIGl0IGJlZm9yZSBzdGFydGluZyBBdXRvLUZhcm0uXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU2VsZWN0IEFyZWFcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1RDgzQ1x1REZBRiBQYWludCBhIHBpeGVsIGluIGFuIEVNUFRZIGFyZWEgb2YgdGhlIG1hcCB0byBzZXQgdGhlIGZhcm1pbmcgem9uZVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgV2FpdGluZyBmb3IgeW91IHRvIHBhaW50IHRoZSByZWZlcmVuY2UgcGl4ZWwuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgQXJlYSBzZXQhIFJhZGl1czogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpbWVvdXQgZm9yIGFyZWEgc2VsZWN0aW9uXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBTZWxlY3QgYW4gYXJlYSBmaXJzdCB1c2luZyAnU2VsZWN0IEFyZWEnXCIsXG4gICAgZmFybVJhZGl1czogXCJGYXJtIHJhZGl1c1wiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJDdXJyZW50IGFyZWFcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIEZhcm1pbmcgaW4ge3JhZGl1c31weCByYWRpdXMgZnJvbSAoe3h9LHt5fSlcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIElNUE9SVEFOVDogU2VsZWN0IGFuIEVNUFRZIGFyZWEgdG8gYXZvaWQgY29uZmxpY3RzXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJObyBhcmVhXCIsXG4gICAgY3VycmVudFpvbmU6IFwiWm9uZTogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBTZWxlY3QgYW4gYXJlYSBmaXJzdC4gUGFpbnQgYSBwaXhlbCBvbiB0aGUgbWFwIHRvIHNldCB0aGUgZmFybWluZyB6b25lXCJcbiAgfSxcblxuICAvLyBDb21tb24vU2hhcmVkXG4gIGNvbW1vbjoge1xuICAgIHllczogXCJZZXNcIixcbiAgICBubzogXCJOb1wiLFxuICAgIG9rOiBcIk9LXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbFwiLFxuICAgIGNsb3NlOiBcIkNsb3NlXCIsXG4gICAgc2F2ZTogXCJTYXZlXCIsXG4gICAgbG9hZDogXCJMb2FkXCIsXG4gICAgZGVsZXRlOiBcIkRlbGV0ZVwiLFxuICAgIGVkaXQ6IFwiRWRpdFwiLFxuICAgIHN0YXJ0OiBcIlN0YXJ0XCIsXG4gICAgc3RvcDogXCJTdG9wXCIsXG4gICAgcGF1c2U6IFwiUGF1c2VcIixcbiAgICByZXN1bWU6IFwiUmVzdW1lXCIsXG4gICAgcmVzZXQ6IFwiUmVzZXRcIixcbiAgICBzZXR0aW5nczogXCJTZXR0aW5nc1wiLFxuICAgIGhlbHA6IFwiSGVscFwiLFxuICAgIGFib3V0OiBcIkFib3V0XCIsXG4gICAgbGFuZ3VhZ2U6IFwiTGFuZ3VhZ2VcIixcbiAgICBsb2FkaW5nOiBcIkxvYWRpbmcuLi5cIixcbiAgICBlcnJvcjogXCJFcnJvclwiLFxuICAgIHN1Y2Nlc3M6IFwiU3VjY2Vzc1wiLFxuICAgIHdhcm5pbmc6IFwiV2FybmluZ1wiLFxuICAgIGluZm86IFwiSW5mb3JtYXRpb25cIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiTGFuZ3VhZ2UgY2hhbmdlZCB0byB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1HdWFyZFwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGl6ZSBHdWFyZC1CT1RcIixcbiAgICBzZWxlY3RBcmVhOiBcIlNlbGVjdCBBcmVhXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiQ2FwdHVyZSBBcmVhXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIlN0YXJ0IFByb3RlY3Rpb25cIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJTdG9wIFByb3RlY3Rpb25cIixcbiAgICB1cHBlckxlZnQ6IFwiVXBwZXIgTGVmdCBDb3JuZXJcIixcbiAgICBsb3dlclJpZ2h0OiBcIkxvd2VyIFJpZ2h0IENvcm5lclwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJQcm90ZWN0ZWQgUGl4ZWxzXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIkRldGVjdGVkIENoYW5nZXNcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJSZXBhaXJlZCBQaXhlbHNcIixcbiAgICBjaGFyZ2VzOiBcIkNoYXJnZXNcIixcbiAgICB3YWl0aW5nSW5pdDogXCJXYWl0aW5nIGZvciBpbml0aWFsaXphdGlvbi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBDaGVja2luZyBhdmFpbGFibGUgY29sb3JzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgTm8gY29sb3JzIGZvdW5kLiBPcGVuIHRoZSBjb2xvciBwYWxldHRlIG9uIHRoZSBzaXRlLlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBGb3VuZCB7Y291bnR9IGF2YWlsYWJsZSBjb2xvcnNcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaXRpYWxpemVkIHN1Y2Nlc3NmdWxseVwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgRXJyb3IgaW5pdGlhbGl6aW5nIEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIEludmFsaWQgY29vcmRpbmF0ZXNcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgQXJlYSBtdXN0IGhhdmUgdXBwZXIgbGVmdCBjb3JuZXIgbGVzcyB0aGFuIGxvd2VyIHJpZ2h0IGNvcm5lclwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgQXJlYSB0b28gbGFyZ2U6IHtzaXplfSBwaXhlbHMgKG1heGltdW06IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IENhcHR1cmluZyBwcm90ZWN0aW9uIGFyZWEuLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IEFyZWEgY2FwdHVyZWQ6IHtjb3VudH0gcGl4ZWxzIHVuZGVyIHByb3RlY3Rpb25cIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGNhcHR1cmluZyBhcmVhOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBGaXJzdCBjYXB0dXJlIGEgcHJvdGVjdGlvbiBhcmVhXCIsXG4gICAgcHJvdGVjdGlvblN0YXJ0ZWQ6IFwiXHVEODNEXHVERUUxXHVGRTBGIFByb3RlY3Rpb24gc3RhcnRlZCAtIG1vbml0b3JpbmcgYXJlYVwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQcm90ZWN0aW9uIHN0b3BwZWRcIixcbiAgICBub0NoYW5nZXM6IFwiXHUyNzA1IFByb3RlY3RlZCBhcmVhIC0gbm8gY2hhbmdlcyBkZXRlY3RlZFwiLFxuICAgIGNoYW5nZXNEZXRlY3RlZDogXCJcdUQ4M0RcdURFQTgge2NvdW50fSBjaGFuZ2VzIGRldGVjdGVkIGluIHByb3RlY3RlZCBhcmVhXCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBSZXBhaXJpbmcge2NvdW50fSBhbHRlcmVkIHBpeGVscy4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgU3VjY2Vzc2Z1bGx5IHJlcGFpcmVkIHtjb3VudH0gcGl4ZWxzXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIEVycm9yIHJlcGFpcmluZyBwaXhlbHM6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIEluc3VmZmljaWVudCBjaGFyZ2VzIHRvIHJlcGFpciBjaGFuZ2VzXCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBDaGVja2luZyBjaGFuZ2VzIGluIHByb3RlY3RlZCBhcmVhLi4uXCIsXG4gICAgZXJyb3JDaGVja2luZzogXCJcdTI3NEMgRXJyb3IgY2hlY2tpbmcgY2hhbmdlczoge2Vycm9yfVwiLFxuICAgIGd1YXJkQWN0aXZlOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBHdWFyZGlhbiBhY3RpdmUgLSBhcmVhIHVuZGVyIHByb3RlY3Rpb25cIixcbiAgICBsYXN0Q2hlY2s6IFwiTGFzdCBjaGVjazoge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIk5leHQgY2hlY2sgaW46IHt0aW1lfXNcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBBdXRvLWluaXRpYWxpemluZy4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGF1dG8tc3RhcnRlZCBzdWNjZXNzZnVsbHlcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgQ291bGQgbm90IGF1dG8tc3RhcnQuIFVzZSBtYW51YWwgYnV0dG9uLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgTWFudWFsIGluaXRpYWxpemF0aW9uIHJlcXVpcmVkXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBDb2xvciBwYWxldHRlIGRldGVjdGVkXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBTZWFyY2hpbmcgZm9yIGNvbG9yIHBhbGV0dGUuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBDbGlja2luZyBQYWludCBidXR0b24uLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBQYWludCBidXR0b24gbm90IGZvdW5kXCIsXG4gICAgc2VsZWN0VXBwZXJMZWZ0OiBcIlx1RDgzQ1x1REZBRiBQYWludCBhIHBpeGVsIGF0IHRoZSBVUFBFUiBMRUZUIGNvcm5lciBvZiB0aGUgYXJlYSB0byBwcm90ZWN0XCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgTm93IHBhaW50IGEgcGl4ZWwgYXQgdGhlIExPV0VSIFJJR0hUIGNvcm5lciBvZiB0aGUgYXJlYVwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IFdhaXRpbmcgZm9yIHVwcGVyIGxlZnQgY29ybmVyIHNlbGVjdGlvbi4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBXYWl0aW5nIGZvciBsb3dlciByaWdodCBjb3JuZXIgc2VsZWN0aW9uLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IFVwcGVyIGxlZnQgY29ybmVyIGNhcHR1cmVkOiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBMb3dlciByaWdodCBjb3JuZXIgY2FwdHVyZWQ6ICh7eH0sIHt5fSlcIixcbiAgICBzZWxlY3Rpb25UaW1lb3V0OiBcIlx1Mjc0QyBTZWxlY3Rpb24gdGltZW91dFwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBTZWxlY3Rpb24gZXJyb3IsIHBsZWFzZSB0cnkgYWdhaW5cIlxuICB9XG59O1xuIiwgImV4cG9ydCBjb25zdCBmciA9IHtcbiAgLy8gTGF1bmNoZXJcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBBdXRvQk9UJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBBdXRvLUZhcm0nLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBBdXRvLUltYWdlJyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgQXV0by1HdWFyZCcsXG4gICAgc2VsZWN0aW9uOiAnU1x1MDBFOWxlY3Rpb24nLFxuICAgIHVzZXI6ICdVdGlsaXNhdGV1cicsXG4gICAgY2hhcmdlczogJ0NoYXJnZXMnLFxuICAgIGJhY2tlbmQ6ICdCYWNrZW5kJyxcbiAgICBkYXRhYmFzZTogJ0Jhc2UgZGUgZG9ublx1MDBFOWVzJyxcbiAgICB1cHRpbWU6ICdUZW1wcyBhY3RpZicsXG4gICAgY2xvc2U6ICdGZXJtZXInLFxuICAgIGxhdW5jaDogJ0xhbmNlcicsXG4gICAgbG9hZGluZzogJ0NoYXJnZW1lbnRcdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ0V4XHUwMEU5Y3V0aW9uXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ1RcdTAwRTlsXHUwMEU5Y2hhcmdlbWVudCBkdSBzY3JpcHRcdTIwMjYnLFxuICAgIGNob29zZUJvdDogJ0Nob2lzaXNzZXogdW4gYm90IGV0IGFwcHV5ZXogc3VyIExhbmNlcicsXG4gICAgcmVhZHlUb0xhdW5jaDogJ1ByXHUwMEVBdCBcdTAwRTAgbGFuY2VyJyxcbiAgICBsb2FkRXJyb3I6ICdFcnJldXIgZGUgY2hhcmdlbWVudCcsXG4gICAgbG9hZEVycm9yTXNnOiAnSW1wb3NzaWJsZSBkZSBjaGFyZ2VyIGxlIGJvdCBzXHUwMEU5bGVjdGlvbm5cdTAwRTkuIFZcdTAwRTlyaWZpZXogdm90cmUgY29ubmV4aW9uIG91IHJcdTAwRTllc3NheWV6LicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgVlx1MDBFOXJpZmljYXRpb24uLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBFbiBsaWduZScsXG4gICAgb2ZmbGluZTogJ1x1RDgzRFx1REQzNCBIb3JzIGxpZ25lJyxcbiAgICBvazogJ1x1RDgzRFx1REZFMiBPSycsXG4gICAgZXJyb3I6ICdcdUQ4M0RcdUREMzQgRXJyZXVyJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1JbWFnZVwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGlzZXIgQXV0by1CT1RcIixcbiAgICB1cGxvYWRJbWFnZTogXCJUXHUwMEU5bFx1MDBFOWNoYXJnZXIgSW1hZ2VcIixcbiAgICByZXNpemVJbWFnZTogXCJSZWRpbWVuc2lvbm5lciBJbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNcdTAwRTlsZWN0aW9ubmVyIFBvc2l0aW9uXCIsXG4gICAgc3RhcnRQYWludGluZzogXCJDb21tZW5jZXIgUGVpbnR1cmVcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiQXJyXHUwMEVBdGVyIFBlaW50dXJlXCIsXG4gICAgc2F2ZVByb2dyZXNzOiBcIlNhdXZlZ2FyZGVyIFByb2dyXHUwMEU4c1wiLFxuICAgIGxvYWRQcm9ncmVzczogXCJDaGFyZ2VyIFByb2dyXHUwMEU4c1wiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzRFx1REQwRCBWXHUwMEU5cmlmaWNhdGlvbiBkZXMgY291bGV1cnMgZGlzcG9uaWJsZXMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBPdXZyZXogbGEgcGFsZXR0ZSBkZSBjb3VsZXVycyBzdXIgbGUgc2l0ZSBldCByXHUwMEU5ZXNzYXlleiFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUge2NvdW50fSBjb3VsZXVycyBkaXNwb25pYmxlcyB0cm91dlx1MDBFOWVzXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBDaGFyZ2VtZW50IGRlIGwnaW1hZ2UuLi5cIixcbiAgICBpbWFnZUxvYWRlZDogXCJcdTI3MDUgSW1hZ2UgY2hhcmdcdTAwRTllIGF2ZWMge2NvdW50fSBwaXhlbHMgdmFsaWRlc1wiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGR1IGNoYXJnZW1lbnQgZGUgbCdpbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiUGVpZ25leiBsZSBwcmVtaWVyIHBpeGVsIFx1MDBFMCBsJ2VtcGxhY2VtZW50IG9cdTAwRjkgdm91cyB2b3VsZXogcXVlIGwnYXJ0IGNvbW1lbmNlIVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgRW4gYXR0ZW50ZSBxdWUgdm91cyBwZWlnbmlleiBsZSBwaXhlbCBkZSByXHUwMEU5Zlx1MDBFOXJlbmNlLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFBvc2l0aW9uIGRcdTAwRTlmaW5pZSBhdmVjIHN1Y2NcdTAwRThzIVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgRFx1MDBFOWxhaSBkXHUwMEU5cGFzc1x1MDBFOSBwb3VyIGxhIHNcdTAwRTlsZWN0aW9uIGRlIHBvc2l0aW9uXCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgUG9zaXRpb24gZFx1MDBFOXRlY3RcdTAwRTllLCB0cmFpdGVtZW50Li4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgRXJyZXVyIGRcdTAwRTl0ZWN0YW50IGxhIHBvc2l0aW9uLCBlc3NheWV6IFx1MDBFMCBub3V2ZWF1XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggRFx1MDBFOWJ1dCBkZSBsYSBwZWludHVyZS4uLlwiLFxuICAgIHBhaW50aW5nUHJvZ3Jlc3M6IFwiXHVEODNFXHVEREYxIFByb2dyXHUwMEU4czoge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBBdWN1bmUgY2hhcmdlLiBBdHRlbmRyZSB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFBlaW50dXJlIGFyclx1MDBFQXRcdTAwRTllIHBhciBsJ3V0aWxpc2F0ZXVyXCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgUGVpbnR1cmUgdGVybWluXHUwMEU5ZSEge2NvdW50fSBwaXhlbHMgcGVpbnRzLlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBwZW5kYW50IGxhIHBlaW50dXJlXCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgQ2hhcmdleiB1bmUgaW1hZ2UgZXQgc1x1MDBFOWxlY3Rpb25uZXogdW5lIHBvc2l0aW9uIGQnYWJvcmRcIixcbiAgICBwcm9ncmVzczogXCJQcm9nclx1MDBFOHNcIixcbiAgICB1c2VyTmFtZTogXCJVc2FnZXJcIixcbiAgICBwaXhlbHM6IFwiUGl4ZWxzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJUZW1wcyBlc3RpbVx1MDBFOVwiLFxuICAgIGluaXRNZXNzYWdlOiBcIkNsaXF1ZXogc3VyICdJbml0aWFsaXNlciBBdXRvLUJPVCcgcG91ciBjb21tZW5jZXJcIixcbiAgICB3YWl0aW5nSW5pdDogXCJFbiBhdHRlbnRlIGQnaW5pdGlhbGlzYXRpb24uLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBJbWFnZSByZWRpbWVuc2lvbm5cdTAwRTllIFx1MDBFMCB7d2lkdGh9eHtoZWlnaHR9XCIsXG4gICAgcGFpbnRpbmdQYXVzZWQ6IFwiXHUyM0Y4XHVGRTBGIFBlaW50dXJlIG1pc2UgZW4gcGF1c2UgXHUwMEUwIGxhIHBvc2l0aW9uIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUGl4ZWxzIHBhciBsb3RcIixcbiAgICBiYXRjaFNpemU6IFwiVGFpbGxlIGR1IGxvdFwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiUHJvY2hhaW4gbG90IGRhbnNcIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlV0aWxpc2VyIHRvdXRlcyBsZXMgY2hhcmdlcyBkaXNwb25pYmxlc1wiLFxuICAgIHNob3dPdmVybGF5OiBcIkFmZmljaGVyIGwnb3ZlcmxheVwiLFxuICAgIG1heENoYXJnZXM6IFwiQ2hhcmdlcyBtYXggcGFyIGxvdFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBFbiBhdHRlbnRlIGRlIGNoYXJnZXM6IHtjdXJyZW50fS97bmVlZGVkfVwiLFxuICAgIHRpbWVSZW1haW5pbmc6IFwiVGVtcHMgcmVzdGFudFwiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgQXR0ZW5kcmUge3RpbWV9IHBvdXIgY29udGludWVyLi4uXCIsXG4gICAgcHJvZ3Jlc3NTYXZlZDogXCJcdTI3MDUgUHJvZ3JcdTAwRThzIHNhdXZlZ2FyZFx1MDBFOSBzb3VzIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgUHJvZ3JcdTAwRThzIGNoYXJnXHUwMEU5OiB7cGFpbnRlZH0ve3RvdGFsfSBwaXhlbHMgcGVpbnRzXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGR1IGNoYXJnZW1lbnQgZHUgcHJvZ3JcdTAwRThzOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGRlIGxhIHNhdXZlZ2FyZGUgZHUgcHJvZ3JcdTAwRThzOiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJWb3VsZXotdm91cyBzYXV2ZWdhcmRlciBsZSBwcm9nclx1MDBFOHMgYWN0dWVsIGF2YW50IGQnYXJyXHUwMEVBdGVyP1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlNhdXZlZ2FyZGVyIFByb2dyXHUwMEU4c1wiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJBYmFuZG9ubmVyXCIsXG4gICAgY2FuY2VsOiBcIkFubnVsZXJcIixcbiAgICBtaW5pbWl6ZTogXCJNaW5pbWlzZXJcIixcbiAgICB3aWR0aDogXCJMYXJnZXVyXCIsXG4gICAgaGVpZ2h0OiBcIkhhdXRldXJcIiwgXG4gICAga2VlcEFzcGVjdDogXCJHYXJkZXIgbGVzIHByb3BvcnRpb25zXCIsXG4gICAgYXBwbHk6IFwiQXBwbGlxdWVyXCIsXG4gIG92ZXJsYXlPbjogXCJPdmVybGF5IDogT05cIixcbiAgb3ZlcmxheU9mZjogXCJPdmVybGF5IDogT0ZGXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgUGFzc2FnZSB0ZXJtaW5cdTAwRTk6IHtwYWludGVkfSBwaXhlbHMgcGVpbnRzIHwgUHJvZ3JcdTAwRThzOiB7cGVyY2VudH0lICh7Y3VycmVudH0ve3RvdGFsfSlcIixcbiAgICB3YWl0aW5nQ2hhcmdlc1JlZ2VuOiBcIlx1MjNGMyBBdHRlbnRlIGRlIHJcdTAwRTlnXHUwMEU5blx1MDBFOXJhdGlvbiBkZXMgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gVGVtcHM6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBBdHRlbnRlIGRlcyBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH0gLSBSZXN0YW50OiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbml0aWFsaXNhdGlvbiBhdXRvbWF0aXF1ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgQm90IGRcdTAwRTltYXJyXHUwMEU5IGF1dG9tYXRpcXVlbWVudFwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBJbXBvc3NpYmxlIGRlIGRcdTAwRTltYXJyZXIgYXV0b21hdGlxdWVtZW50LiBVdGlsaXNleiBsZSBib3V0b24gbWFudWVsLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXR0ZSBkZSBjb3VsZXVycyBkXHUwMEU5dGVjdFx1MDBFOWVcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFJlY2hlcmNoZSBkZSBsYSBwYWxldHRlIGRlIGNvdWxldXJzLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpYyBzdXIgbGUgYm91dG9uIFBhaW50Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgQm91dG9uIFBhaW50IGludHJvdXZhYmxlXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbml0aWFsaXNhdGlvbiBtYW51ZWxsZSByZXF1aXNlXCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBUZW50YXRpdmUge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30gZGFucyB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IEVycmV1ciBkYW5zIHRlbnRhdGl2ZSB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSwgbm91dmVsIGVzc2FpIGRhbnMge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgXHUwMEM5Y2hlYyBhcHJcdTAwRThzIHttYXhBdHRlbXB0c30gdGVudGF0aXZlcy4gQ29udGludWFudCBhdmVjIGxlIGxvdCBzdWl2YW50Li4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBFcnJldXIgclx1MDBFOXNlYXUuIE5vdXZlbCBlc3NhaS4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBFcnJldXIgc2VydmV1ci4gTm91dmVsIGVzc2FpLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBUaW1lb3V0IHNlcnZldXIuIE5vdXZlbCBlc3NhaS4uLlwiXG4gIH0sXG5cbiAgLy8gRmFybSBNb2R1bGUgKHRvIGJlIGltcGxlbWVudGVkKVxuICBmYXJtOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEZhcm0gQm90XCIsXG4gICAgc3RhcnQ6IFwiRFx1MDBFOW1hcnJlclwiLFxuICAgIHN0b3A6IFwiQXJyXHUwMEVBdGVyXCIsXG4gICAgc3RvcHBlZDogXCJCb3QgYXJyXHUwMEVBdFx1MDBFOVwiLFxuICAgIGNhbGlicmF0ZTogXCJDYWxpYnJlclwiLFxuICAgIHBhaW50T25jZTogXCJVbmUgZm9pc1wiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIlZcdTAwRTlyaWZpY2F0aW9uIGR1IHN0YXR1dC4uLlwiLFxuICAgIGNvbmZpZ3VyYXRpb246IFwiQ29uZmlndXJhdGlvblwiLFxuICAgIGRlbGF5OiBcIkRcdTAwRTlsYWkgKG1zKVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlBpeGVscy9sb3RcIixcbiAgICBtaW5DaGFyZ2VzOiBcIkNoYXJnZXMgbWluXCIsXG4gICAgY29sb3JNb2RlOiBcIk1vZGUgY291bGV1clwiLFxuICAgIHJhbmRvbTogXCJBbFx1MDBFOWF0b2lyZVwiLFxuICAgIGZpeGVkOiBcIkZpeGVcIixcbiAgICByYW5nZTogXCJQbGFnZVwiLFxuICAgIGZpeGVkQ29sb3I6IFwiQ291bGV1ciBmaXhlXCIsXG4gICAgYWR2YW5jZWQ6IFwiQXZhbmNcdTAwRTlcIixcbiAgICB0aWxlWDogXCJUdWlsZSBYXCIsXG4gICAgdGlsZVk6IFwiVHVpbGUgWVwiLFxuICAgIGN1c3RvbVBhbGV0dGU6IFwiUGFsZXR0ZSBwZXJzb25uYWxpc1x1MDBFOWVcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJleDogI0ZGMDAwMCwjMDBGRjAwLCMwMDAwRkZcIixcbiAgICBjYXB0dXJlOiBcIkNhcHR1cmVyXCIsXG4gICAgcGFpbnRlZDogXCJQZWludHNcIixcbiAgICBjaGFyZ2VzOiBcIkNoYXJnZXNcIixcbiAgICByZXRyaWVzOiBcIlx1MDBDOWNoZWNzXCIsXG4gICAgdGlsZTogXCJUdWlsZVwiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIkNvbmZpZ3VyYXRpb24gc2F1dmVnYXJkXHUwMEU5ZVwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJDb25maWd1cmF0aW9uIGNoYXJnXHUwMEU5ZVwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIkNvbmZpZ3VyYXRpb24gclx1MDBFOWluaXRpYWxpc1x1MDBFOWVcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlBlaW5kcmUgdW4gcGl4ZWwgbWFudWVsbGVtZW50IHBvdXIgY2FwdHVyZXIgbGVzIGNvb3Jkb25uXHUwMEU5ZXMuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIkJhY2tlbmQgRW4gbGlnbmVcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJCYWNrZW5kIEhvcnMgbGlnbmVcIixcbiAgICBzdGFydGluZ0JvdDogXCJEXHUwMEU5bWFycmFnZSBkdSBib3QuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJBcnJcdTAwRUF0IGR1IGJvdC4uLlwiLFxuICAgIGNhbGlicmF0aW5nOiBcIkNhbGlicmFnZS4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIkF1dG8tRmFybSBlc3QgZFx1MDBFOWpcdTAwRTAgZW4gY291cnMgZCdleFx1MDBFOWN1dGlvbi5cIixcbiAgICBpbWFnZVJ1bm5pbmdXYXJuaW5nOiBcIkF1dG8tSW1hZ2UgZXN0IGVuIGNvdXJzIGQnZXhcdTAwRTljdXRpb24uIEZlcm1lei1sZSBhdmFudCBkZSBkXHUwMEU5bWFycmVyIEF1dG8tRmFybS5cIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTXHUwMEU5bGVjdGlvbm5lciBab25lXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgUGVpZ25leiB1biBwaXhlbCBkYW5zIHVuZSB6b25lIFZJREUgZGUgbGEgY2FydGUgcG91ciBkXHUwMEU5ZmluaXIgbGEgem9uZSBkZSBmYXJtaW5nXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBFbiBhdHRlbnRlIHF1ZSB2b3VzIHBlaWduaWV6IGxlIHBpeGVsIGRlIHJcdTAwRTlmXHUwMEU5cmVuY2UuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgWm9uZSBkXHUwMEU5ZmluaWUhIFJheW9uOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgRFx1MDBFOWxhaSBkXHUwMEU5cGFzc1x1MDBFOSBwb3VyIGxhIHNcdTAwRTlsZWN0aW9uIGRlIHpvbmVcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFNcdTAwRTlsZWN0aW9ubmV6IHVuZSB6b25lIGQnYWJvcmQgZW4gdXRpbGlzYW50ICdTXHUwMEU5bGVjdGlvbm5lciBab25lJ1wiLFxuICAgIGZhcm1SYWRpdXM6IFwiUmF5b24gZmFybVwiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJab25lIGFjdHVlbGxlXCIsXG4gICAgZmFybWluZ0luUmFkaXVzOiBcIlx1RDgzQ1x1REYzRSBGYXJtaW5nIGRhbnMgdW4gcmF5b24gZGUge3JhZGl1c31weCBkZXB1aXMgKHt4fSx7eX0pXCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBJTVBPUlRBTlQ6IFNcdTAwRTlsZWN0aW9ubmV6IHVuZSB6b25lIFZJREUgcG91ciBcdTAwRTl2aXRlciBsZXMgY29uZmxpdHNcIixcbiAgICBub1Bvc2l0aW9uOiBcIkF1Y3VuZSB6b25lXCIsXG4gICAgY3VycmVudFpvbmU6IFwiWm9uZTogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBTXHUwMEU5bGVjdGlvbm5leiB1bmUgem9uZSBkJ2Fib3JkLiBQZWlnbmV6IHVuIHBpeGVsIHN1ciBsYSBjYXJ0ZSBwb3VyIGRcdTAwRTlmaW5pciBsYSB6b25lIGRlIGZhcm1pbmdcIlxuICB9LFxuXG4gICAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiT3VpXCIsXG4gICAgbm86IFwiTm9uXCIsXG4gICAgb2s6IFwiT0tcIixcbiAgICBjYW5jZWw6IFwiQW5udWxlclwiLFxuICAgIGNsb3NlOiBcIkZlcm1lclwiLFxuICAgIHNhdmU6IFwiU2F1dmVnYXJkZXJcIixcbiAgICBsb2FkOiBcIkNoYXJnZXJcIixcbiAgICBkZWxldGU6IFwiU3VwcHJpbWVyXCIsXG4gICAgZWRpdDogXCJNb2RpZmllclwiLFxuICAgIHN0YXJ0OiBcIkRcdTAwRTltYXJyZXJcIixcbiAgICBzdG9wOiBcIkFyclx1MDBFQXRlclwiLFxuICAgIHBhdXNlOiBcIlBhdXNlXCIsXG4gICAgcmVzdW1lOiBcIlJlcHJlbmRyZVwiLFxuICAgIHJlc2V0OiBcIlJcdTAwRTlpbml0aWFsaXNlclwiLFxuICAgIHNldHRpbmdzOiBcIlBhcmFtXHUwMEU4dHJlc1wiLFxuICAgIGhlbHA6IFwiQWlkZVwiLFxuICAgIGFib3V0OiBcIlx1MDBDMCBwcm9wb3NcIixcbiAgICBsYW5ndWFnZTogXCJMYW5ndWVcIixcbiAgICBsb2FkaW5nOiBcIkNoYXJnZW1lbnQuLi5cIixcbiAgICBlcnJvcjogXCJFcnJldXJcIixcbiAgICBzdWNjZXNzOiBcIlN1Y2NcdTAwRThzXCIsXG4gICAgd2FybmluZzogXCJBdmVydGlzc2VtZW50XCIsXG4gICAgaW5mbzogXCJJbmZvcm1hdGlvblwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJMYW5ndWUgY2hhbmdcdTAwRTllIGVuIHtsYW5ndWFnZX1cIlxuICB9LFxuXG4gIC8vIEd1YXJkIE1vZHVsZVxuICBndWFyZDoge1xuICAgIHRpdGxlOiBcIldQbGFjZSBBdXRvLUd1YXJkXCIsXG4gICAgaW5pdEJvdDogXCJJbml0aWFsaXNlciBHdWFyZC1CT1RcIixcbiAgICBzZWxlY3RBcmVhOiBcIlNcdTAwRTlsZWN0aW9ubmVyIFpvbmVcIixcbiAgICBjYXB0dXJlQXJlYTogXCJDYXB0dXJlciBab25lXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIkRcdTAwRTltYXJyZXIgUHJvdGVjdGlvblwiLFxuICAgIHN0b3BQcm90ZWN0aW9uOiBcIkFyclx1MDBFQXRlciBQcm90ZWN0aW9uXCIsXG4gICAgdXBwZXJMZWZ0OiBcIkNvaW4gU3VwXHUwMEU5cmlldXIgR2F1Y2hlXCIsXG4gICAgbG93ZXJSaWdodDogXCJDb2luIEluZlx1MDBFOXJpZXVyIERyb2l0XCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlBpeGVscyBQcm90XHUwMEU5Z1x1MDBFOXNcIixcbiAgICBkZXRlY3RlZENoYW5nZXM6IFwiQ2hhbmdlbWVudHMgRFx1MDBFOXRlY3RcdTAwRTlzXCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiUGl4ZWxzIFJcdTAwRTlwYXJcdTAwRTlzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiRW4gYXR0ZW50ZSBkJ2luaXRpYWxpc2F0aW9uLi4uXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNDXHVERkE4IFZcdTAwRTlyaWZpY2F0aW9uIGRlcyBjb3VsZXVycyBkaXNwb25pYmxlcy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIEF1Y3VuZSBjb3VsZXVyIHRyb3V2XHUwMEU5ZS4gT3V2cmV6IGxhIHBhbGV0dGUgZGUgY291bGV1cnMgc3VyIGxlIHNpdGUuXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IHtjb3VudH0gY291bGV1cnMgZGlzcG9uaWJsZXMgdHJvdXZcdTAwRTllc1wiLFxuICAgIGluaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgaW5pdGlhbGlzXHUwMEU5IGF2ZWMgc3VjY1x1MDBFOHNcIixcbiAgICBpbml0RXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGRlIGwnaW5pdGlhbGlzYXRpb24gZGUgR3VhcmQtQk9UXCIsXG4gICAgaW52YWxpZENvb3JkczogXCJcdTI3NEMgQ29vcmRvbm5cdTAwRTllcyBpbnZhbGlkZXNcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgTGEgem9uZSBkb2l0IGF2b2lyIGxlIGNvaW4gc3VwXHUwMEU5cmlldXIgZ2F1Y2hlIGluZlx1MDBFOXJpZXVyIGF1IGNvaW4gaW5mXHUwMEU5cmlldXIgZHJvaXRcIixcbiAgICBhcmVhVG9vTGFyZ2U6IFwiXHUyNzRDIFpvbmUgdHJvcCBncmFuZGU6IHtzaXplfSBwaXhlbHMgKG1heGltdW06IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IENhcHR1cmUgZGUgbGEgem9uZSBkZSBwcm90ZWN0aW9uLi4uXCIsXG4gICAgYXJlYUNhcHR1cmVkOiBcIlx1MjcwNSBab25lIGNhcHR1clx1MDBFOWU6IHtjb3VudH0gcGl4ZWxzIHNvdXMgcHJvdGVjdGlvblwiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgRXJyZXVyIGxvcnMgZGUgbGEgY2FwdHVyZSBkZSB6b25lOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBDYXB0dXJleiBkJ2Fib3JkIHVuZSB6b25lIGRlIHByb3RlY3Rpb25cIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgUHJvdGVjdGlvbiBkXHUwMEU5bWFyclx1MDBFOWUgLSBzdXJ2ZWlsbGFuY2UgZGUgbGEgem9uZVwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQcm90ZWN0aW9uIGFyclx1MDBFQXRcdTAwRTllXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBab25lIHByb3RcdTAwRTlnXHUwMEU5ZSAtIGF1Y3VuIGNoYW5nZW1lbnQgZFx1MDBFOXRlY3RcdTAwRTlcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gY2hhbmdlbWVudHMgZFx1MDBFOXRlY3RcdTAwRTlzIGRhbnMgbGEgem9uZSBwcm90XHUwMEU5Z1x1MDBFOWVcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFJcdTAwRTlwYXJhdGlvbiBkZSB7Y291bnR9IHBpeGVscyBhbHRcdTAwRTlyXHUwMEU5cy4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUge2NvdW50fSBwaXhlbHMgclx1MDBFOXBhclx1MDBFOXMgYXZlYyBzdWNjXHUwMEU4c1wiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsYSByXHUwMEU5cGFyYXRpb24gZGVzIHBpeGVsczoge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgQ2hhcmdlcyBpbnN1ZmZpc2FudGVzIHBvdXIgclx1MDBFOXBhcmVyIGxlcyBjaGFuZ2VtZW50c1wiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgVlx1MDBFOXJpZmljYXRpb24gZGVzIGNoYW5nZW1lbnRzIGRhbnMgbGEgem9uZSBwcm90XHUwMEU5Z1x1MDBFOWUuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsYSB2XHUwMEU5cmlmaWNhdGlvbiBkZXMgY2hhbmdlbWVudHM6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgR2FyZGllbiBhY3RpZiAtIHpvbmUgc291cyBwcm90ZWN0aW9uXCIsXG4gICAgbGFzdENoZWNrOiBcIkRlcm5pXHUwMEU4cmUgdlx1MDBFOXJpZmljYXRpb246IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJQcm9jaGFpbmUgdlx1MDBFOXJpZmljYXRpb24gZGFuczoge3RpbWV9c1wiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IEluaXRpYWxpc2F0aW9uIGF1dG9tYXRpcXVlLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgZFx1MDBFOW1hcnJcdTAwRTkgYXV0b21hdGlxdWVtZW50XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIEltcG9zc2libGUgZGUgZFx1MDBFOW1hcnJlciBhdXRvbWF0aXF1ZW1lbnQuIFV0aWxpc2V6IGxlIGJvdXRvbiBtYW51ZWwuXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbml0aWFsaXNhdGlvbiBtYW51ZWxsZSByZXF1aXNlXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBQYWxldHRlIGRlIGNvdWxldXJzIGRcdTAwRTl0ZWN0XHUwMEU5ZVwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgUmVjaGVyY2hlIGRlIGxhIHBhbGV0dGUgZGUgY291bGV1cnMuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBDbGljIHN1ciBsZSBib3V0b24gUGFpbnQuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBCb3V0b24gUGFpbnQgaW50cm91dmFibGVcIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFBlaWduZXogdW4gcGl4ZWwgYXUgY29pbiBTVVBcdTAwQzlSSUVVUiBHQVVDSEUgZGUgbGEgem9uZSBcdTAwRTAgcHJvdFx1MDBFOWdlclwiLFxuICAgIHNlbGVjdExvd2VyUmlnaHQ6IFwiXHVEODNDXHVERkFGIE1haW50ZW5hbnQgcGVpZ25leiB1biBwaXhlbCBhdSBjb2luIElORlx1MDBDOVJJRVVSIERST0lUIGRlIGxhIHpvbmVcIixcbiAgICB3YWl0aW5nVXBwZXJMZWZ0OiBcIlx1RDgzRFx1REM0NiBFbiBhdHRlbnRlIGRlIGxhIHNcdTAwRTlsZWN0aW9uIGR1IGNvaW4gc3VwXHUwMEU5cmlldXIgZ2F1Y2hlLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IEVuIGF0dGVudGUgZGUgbGEgc1x1MDBFOWxlY3Rpb24gZHUgY29pbiBpbmZcdTAwRTlyaWV1ciBkcm9pdC4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBDb2luIHN1cFx1MDBFOXJpZXVyIGdhdWNoZSBjYXB0dXJcdTAwRTk6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IENvaW4gaW5mXHUwMEU5cmlldXIgZHJvaXQgY2FwdHVyXHUwMEU5OiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgRFx1MDBFOWxhaSBkZSBzXHUwMEU5bGVjdGlvbiBkXHUwMEU5cGFzc1x1MDBFOVwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBFcnJldXIgZGUgc1x1MDBFOWxlY3Rpb24sIHZldWlsbGV6IHJcdTAwRTllc3NheWVyXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgcnUgPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQycsXG4gICAgYXV0b0ltYWdlOiAnXHVEODNDXHVERkE4IFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUnLFxuICAgIGF1dG9HdWFyZDogJ1x1RDgzRFx1REVFMVx1RkUwRiBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwJyxcbiAgICBzZWxlY3Rpb246ICdcdTA0MTJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0M0RcdTA0M0UnLFxuICAgIHVzZXI6ICdcdTA0MUZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NEMnLFxuICAgIGNoYXJnZXM6ICdcdTA0MThcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYnLFxuICAgIGJhY2tlbmQ6ICdcdTA0MTFcdTA0NERcdTA0M0FcdTA0MzVcdTA0M0RcdTA0MzQnLFxuICAgIGRhdGFiYXNlOiAnXHUwNDExXHUwNDMwXHUwNDM3XHUwNDMwIFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQ0NScsXG4gICAgdXB0aW1lOiAnXHUwNDEyXHUwNDQwXHUwNDM1XHUwNDNDXHUwNDRGIFx1MDQ0MFx1MDQzMFx1MDQzMVx1MDQzRVx1MDQ0Mlx1MDQ0QicsXG4gICAgY2xvc2U6ICdcdTA0MTdcdTA0MzBcdTA0M0FcdTA0NDBcdTA0NEJcdTA0NDJcdTA0NEMnLFxuICAgIGxhdW5jaDogJ1x1MDQxN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QycsXG4gICAgbG9hZGluZzogJ1x1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzMCcsXG4gICAgZXhlY3V0aW5nOiAnXHUwNDEyXHUwNDRCXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1JyxcbiAgICBkb3dubG9hZGluZzogJ1x1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzMCBcdTA0NDFcdTA0M0FcdTA0NDBcdTA0MzhcdTA0M0ZcdTA0NDJcdTA0MzAuLi4nLFxuICAgIGNob29zZUJvdDogJ1x1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0MzAgXHUwNDM4IFx1MDQzRFx1MDQzMFx1MDQzNlx1MDQzQ1x1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MTdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzhcdTA0NDJcdTA0NEMnLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdcdTA0MTNcdTA0M0VcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0UgXHUwNDNBIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQVx1MDQ0MycsXG4gICAgbG9hZEVycm9yOiAnXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzOCcsXG4gICAgbG9hZEVycm9yTXNnOiAnXHUwNDFEXHUwNDM1XHUwNDMyXHUwNDNFXHUwNDM3XHUwNDNDXHUwNDNFXHUwNDM2XHUwNDNEXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0M0RcdTA0M0RcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwLiBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NENcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDNFXHUwNDM0XHUwNDNBXHUwNDNCXHUwNDRFXHUwNDQ3XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzOFx1MDQzQlx1MDQzOCBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDM1XHUwNDQ5XHUwNDM1IFx1MDQ0MFx1MDQzMFx1MDQzNy4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMC4uLicsXG4gICAgb25saW5lOiAnXHVEODNEXHVERkUyIFx1MDQxRVx1MDQzRFx1MDQzQlx1MDQzMFx1MDQzOVx1MDQzRCcsXG4gICAgb2ZmbGluZTogJ1x1RDgzRFx1REQzNCBcdTA0MUVcdTA0NDRcdTA0M0JcdTA0MzBcdTA0MzlcdTA0M0QnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIFx1MDQxRVx1MDQxQScsXG4gICAgZXJyb3I6ICdcdUQ4M0RcdUREMzQgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIGluaXRCb3Q6IFwiXHUwNDE4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDIEF1dG8tQk9UXCIsXG4gICAgdXBsb2FkSW1hZ2U6IFwiXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlx1MDQxOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0NDBcdTA0MzBcdTA0MzdcdTA0M0NcdTA0MzVcdTA0NDAgXHUwNDM4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQzQ1x1MDQzNVx1MDQ0MVx1MDQ0Mlx1MDQzRSBcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0MzBcIixcbiAgICBzdGFydFBhaW50aW5nOiBcIlx1MDQxRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0NENcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJcdTA0MjFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIlx1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwIFx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQ0M1x1MDQzRlx1MDQzRFx1MDQ0Qlx1MDQ0NSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDJcdTA0M0FcdTA0NDBcdTA0M0VcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDQzIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMiBcdTA0M0RcdTA0MzAgXHUwNDQxXHUwNDMwXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzOCBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDQxXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDMwIVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTA0MURcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0M0Uge2NvdW50fSBcdTA0MzRcdTA0M0VcdTA0NDFcdTA0NDJcdTA0NDNcdTA0M0ZcdTA0M0RcdTA0NEJcdTA0NDUgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzAgXHUwNDM4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IFx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDQxIHtjb3VudH0gXHUwNDM0XHUwNDM1XHUwNDM5XHUwNDQxXHUwNDQyXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDM1XHUwNDNCXHUwNDRDXHUwNDNEXHUwNDRCXHUwNDNDXHUwNDM4IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0Rlx1MDQzQ1x1MDQzOFwiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzggXHUwNDM4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdTA0MURcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQwXHUwNDQyXHUwNDNFXHUwNDMyXHUwNDRCXHUwNDM5IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDQyXHUwNDNFXHUwNDNDIFx1MDQzQ1x1MDQzNVx1MDQ0MVx1MDQ0Mlx1MDQzNSwgXHUwNDMzXHUwNDM0XHUwNDM1IFx1MDQzMlx1MDQ0QiBcdTA0NDVcdTA0M0VcdTA0NDJcdTA0MzhcdTA0NDJcdTA0MzUsIFx1MDQ0N1x1MDQ0Mlx1MDQzRVx1MDQzMVx1MDQ0QiBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0M0RcdTA0M0VcdTA0M0EgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDM4XHUwNDNEXHUwNDMwXHUwNDNCXHUwNDQxXHUwNDRGIVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQ0MFx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzRVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEYuLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQzRVx1MDQzN1x1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQ0RiBcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcdTA0MzAgXHUwNDQzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHUwNDIyXHUwNDMwXHUwNDM5XHUwNDNDXHUwNDMwXHUwNDQzXHUwNDQyIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0ZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzhcIixcbiAgICBwb3NpdGlvbkRldGVjdGVkOiBcIlx1RDgzQ1x1REZBRiBcdTA0MUZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDNEXHUwNDMwLCBcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0M0FcdTA0MzAuLi5cIixcbiAgICBwb3NpdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwIFx1MDQzRlx1MDQzRVx1MDQzN1x1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzOCwgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzNVx1MDQ0OVx1MDQzNSBcdTA0NDBcdTA0MzBcdTA0MzdcIixcbiAgICBzdGFydFBhaW50aW5nTXNnOiBcIlx1RDgzQ1x1REZBOCBcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0M0UgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxOiB7cGFpbnRlZH0gXHUwNDM4XHUwNDM3IHt0b3RhbH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5Li4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBcdTA0MURcdTA0MzVcdTA0NDIgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDNFXHUwNDMyLiBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTA0MjBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQzRlx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQzN1x1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzQ1wiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1MDQyMFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NDhcdTA0MzVcdTA0M0RcdTA0M0UhIHtjb3VudH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRS5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0Nlx1MDQzNVx1MDQ0MVx1MDQ0MVx1MDQzNSBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NEZcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBcdTA0MjFcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0MzJcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzggXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDM1XHUwNDQwXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzQ1x1MDQzNVx1MDQ0MVx1MDQ0Mlx1MDQzRSBcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0MzBcIixcbiAgICBwcm9ncmVzczogXCJcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICB1c2VyTmFtZTogXCJcdTA0MUZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NENcIixcbiAgICBwaXhlbHM6IFwiXHUwNDFGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM4XCIsXG4gICAgY2hhcmdlczogXCJcdTA0MTdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0NEJcIixcbiAgICBlc3RpbWF0ZWRUaW1lOiBcIlx1MDQxRlx1MDQ0MFx1MDQzNVx1MDQzNFx1MDQzRlx1MDQzRVx1MDQzQlx1MDQzRVx1MDQzNlx1MDQzOFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQzRVx1MDQzNSBcdTA0MzJcdTA0NDBcdTA0MzVcdTA0M0NcdTA0NEZcIixcbiAgICBpbml0TWVzc2FnZTogXCJcdTA0MURcdTA0MzBcdTA0MzZcdTA0M0NcdTA0MzhcdTA0NDJcdTA0MzUgXHUwMEFCXHUwNDE3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDIEF1dG8tQk9UXHUwMEJCLCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOC4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IFx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDM0XHUwNDNFIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgXHUwNDIwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzRlx1MDQ0MFx1MDQzOFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0M0RcdTA0MzAgXHUwNDNGXHUwNDNFXHUwNDM3XHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDM4IFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHUwNDFGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzMiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDVcdTA0M0VcdTA0MzRcdTA0MzVcIixcbiAgICBiYXRjaFNpemU6IFwiXHUwNDIwXHUwNDMwXHUwNDM3XHUwNDNDXHUwNDM1XHUwNDQwIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFx1MDQzMFwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiXHUwNDIxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDQzXHUwNDRFXHUwNDQ5XHUwNDM4XHUwNDM5IFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNCBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0MzdcIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlx1MDQxOFx1MDQ0MVx1MDQzRlx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQzN1x1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0MzJcdTA0NDFcdTA0MzUgXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQ0QlwiLFxuICAgIHNob3dPdmVybGF5OiBcIlx1MDQxRlx1MDQzRVx1MDQzQVx1MDQzMFx1MDQzN1x1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0RcdTA0MzBcdTA0M0JcdTA0M0VcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBtYXhDaGFyZ2VzOiBcIlx1MDQxQ1x1MDQzMFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQzQ1x1MDQzMFx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQzRVx1MDQzNSBcdTA0M0FcdTA0M0VcdTA0M0ItXHUwNDMyXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMiBcdTA0MzdcdTA0MzAgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XCIsXG4gICAgd2FpdGluZ0ZvckNoYXJnZXM6IFwiXHUyM0YzIFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0M0VcdTA0MzI6IHtjdXJyZW50fSBcdTA0MzhcdTA0Mzcge25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlx1MDQxMlx1MDQ0MFx1MDQzNVx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOCBcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0JcdTA0M0VcdTA0NDFcdTA0NENcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSB7dGltZX0gXHUwNDM0XHUwNDNCXHUwNDRGIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzNFx1MDQzRVx1MDQzQlx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0NDFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzVcdTA0M0QgXHUwNDNBXHUwNDMwXHUwNDNBIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRDoge3BhaW50ZWR9IFx1MDQzOFx1MDQzNyB7dG90YWx9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0M0RcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0M0VcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzOCBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcdTA0MzA6IHtlcnJvcn1cIixcbiAgICBwcm9ncmVzc1NhdmVFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQ0MVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcdTA0MzA6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1MDQyMVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0NDJcdTA0MzVcdTA0M0FcdTA0NDNcdTA0NDlcdTA0MzhcdTA0MzkgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxIFx1MDQzRlx1MDQzNVx1MDQ0MFx1MDQzNVx1MDQzNCBcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0FcdTA0M0VcdTA0Mzk/XCIsXG4gICAgc2F2ZVByb2dyZXNzVGl0bGU6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MVwiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJcdTA0MURcdTA0MzUgXHUwNDQxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDRGXHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MVwiLFxuICAgIGNhbmNlbDogXCJcdTA0MUVcdTA0NDJcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBtaW5pbWl6ZTogXCJcdTA0MjFcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0RcdTA0NDNcdTA0NDJcdTA0NENcIixcbiAgICB3aWR0aDogXCJcdTA0MjhcdTA0MzhcdTA0NDBcdTA0MzhcdTA0M0RcdTA0MzBcIixcbiAgICBoZWlnaHQ6IFwiXHUwNDEyXHUwNDRCXHUwNDQxXHUwNDNFXHUwNDQyXHUwNDMwXCIsXG4gICAga2VlcEFzcGVjdDogXCJcdTA0MjFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDQxXHUwNDNFXHUwNDNFXHUwNDQyXHUwNDNEXHUwNDNFXHUwNDQ4XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQ0MVx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzRVx1MDQzRFwiLFxuICAgIGFwcGx5OiBcIlx1MDQxRlx1MDQ0MFx1MDQzOFx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQ0Nlx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0MzdcdTA0MzBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NDhcdTA0MzVcdTA0M0Q6IHtwYWludGVkfSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDNFIHwgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxOiB7cGVyY2VudH0lICh7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHt0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQzRlx1MDQzRVx1MDQzQlx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0MzA6IHtjdXJyZW50fSBcdTA0MzhcdTA0Mzcge25lZWRlZH0gLSBcdTA0MTJcdTA0NDBcdTA0MzVcdTA0M0NcdTA0NEY6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDNFXHUwNDMyOiB7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHtuZWVkZWR9IC0gXHUwNDIyXHUwNDQwXHUwNDM1XHUwNDMxXHUwNDQzXHUwNDM1XHUwNDQyXHUwNDQxXHUwNDRGOiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTA0MTFcdTA0M0VcdTA0NDIgXHUwNDQzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQzQlx1MDQ0MVx1MDQ0RiBcdTA0MzBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzhcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgXHUwNDFEXHUwNDM1IFx1MDQ0M1x1MDQzNFx1MDQzMFx1MDQzQlx1MDQzRVx1MDQ0MVx1MDQ0QyBcdTA0MzJcdTA0NEJcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDMwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBLiBcdTA0MThcdTA0NDFcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDQzIFx1MDQ0MFx1MDQ0M1x1MDQ0N1x1MDQzRFx1MDQzRVx1MDQzM1x1MDQzRSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0M0FcdTA0MzAuXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTA0MjZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDMwIFx1MDQzRVx1MDQzMVx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDNFXHUwNDM4XHUwNDQxXHUwNDNBIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzRVx1MDQzOSBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0NEIuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTA0MURcdTA0MzBcdTA0MzZcdTA0MzBcdTA0NDJcdTA0MzhcdTA0MzUgXHUwNDNBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDM4IFx1MDBBQlBhaW50XHUwMEJCLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHUwNDFBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDMwIFx1MDBBQlBhaW50XHUwMEJCIFx1MDQzRFx1MDQzNSBcdTA0M0RcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1MDQyMlx1MDQ0MFx1MDQzNVx1MDQzMVx1MDQ0M1x1MDQzNVx1MDQ0Mlx1MDQ0MVx1MDQ0RiBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGXCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwIHthdHRlbXB0fSBcdTA0MzhcdTA0Mzcge21heEF0dGVtcHRzfSBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0Mzcge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUVycm9yOiBcIlx1RDgzRFx1RENBNSBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzNSB7YXR0ZW1wdH0gXHUwNDM4XHUwNDM3IHttYXhBdHRlbXB0c30sIFx1MDQzRlx1MDQzRVx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0Mzcge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQ0MVx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQ0RiB7bWF4QXR0ZW1wdHN9IFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzRVx1MDQzQS4gXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDM0XHUwNDNFXHUwNDNCXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMiBcdTA0NDFcdTA0M0JcdTA0MzVcdTA0MzRcdTA0NDNcdTA0NEVcdTA0NDlcdTA0MzVcdTA0M0MgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XHUwNDM1Li4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDM1XHUwNDQyXHUwNDM4LiBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgc2VydmVyRXJyb3I6IFwiXHVEODNEXHVERDI1IFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0NDFcdTA0MzVcdTA0NDBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0MzAuIFx1MDQxRlx1MDQzRVx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzRFx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0FcdTA0MzAuLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFx1MDQyMlx1MDQzMFx1MDQzOVx1MDQzQ1x1MDQzMFx1MDQ0M1x1MDQ0MiBcdTA0NDFcdTA0MzVcdTA0NDBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0MzAuIFx1MDQxRlx1MDQzRVx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzRFx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0FcdTA0MzAuLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlICh0byBiZSBpbXBsZW1lbnRlZClcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDI0XHUwNDMwXHUwNDQwXHUwNDNDXCIsXG4gICAgc3RhcnQ6IFwiXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcDogXCJcdTA0MUVcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBzdG9wcGVkOiBcIlx1MDQxMVx1MDQzRVx1MDQ0MiBcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcIixcbiAgICBjYWxpYnJhdGU6IFwiXHUwNDFBXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDMxXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgcGFpbnRPbmNlOiBcIlx1MDQxNVx1MDQzNFx1MDQzOFx1MDQzRFx1MDQzRVx1MDQ0MFx1MDQzMFx1MDQzN1x1MDQzRVx1MDQzMlx1MDQzRVwiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIlx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0NDFcdTA0NDJcdTA0MzBcdTA0NDJcdTA0NDNcdTA0NDFcdTA0MzAuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIlx1MDQxQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzOFx1MDQzM1x1MDQ0M1x1MDQ0MFx1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIGRlbGF5OiBcIlx1MDQxN1x1MDQzMFx1MDQzNFx1MDQzNVx1MDQ0MFx1MDQzNlx1MDQzQVx1MDQzMCAoXHUwNDNDXHUwNDQxKVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0MzdcdTA0MzAgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XCIsXG4gICAgbWluQ2hhcmdlczogXCJcdTA0MUNcdTA0MzhcdTA0M0RcdTA0MzhcdTA0M0NcdTA0MzBcdTA0M0JcdTA0NENcdTA0M0RcdTA0M0VcdTA0MzUgXHUwNDNBXHUwNDNFXHUwNDNCLVx1MDQzMlx1MDQzRVwiLFxuICAgIGNvbG9yTW9kZTogXCJcdTA0MjBcdTA0MzVcdTA0MzZcdTA0MzhcdTA0M0MgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXCIsXG4gICAgcmFuZG9tOiBcIlx1MDQyMVx1MDQzQlx1MDQ0M1x1MDQ0N1x1MDQzMFx1MDQzOVx1MDQzRFx1MDQ0Qlx1MDQzOVwiLFxuICAgIGZpeGVkOiBcIlx1MDQyNFx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzOVwiLFxuICAgIHJhbmdlOiBcIlx1MDQxNFx1MDQzOFx1MDQzMFx1MDQzRlx1MDQzMFx1MDQzN1x1MDQzRVx1MDQzRFwiLFxuICAgIGZpeGVkQ29sb3I6IFwiXHUwNDI0XHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM5IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0MlwiLFxuICAgIGFkdmFuY2VkOiBcIlx1MDQyMFx1MDQzMFx1MDQ0MVx1MDQ0OFx1MDQzOFx1MDQ0MFx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzNVwiLFxuICAgIHRpbGVYOiBcIlx1MDQxRlx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQzQVx1MDQzMCBYXCIsXG4gICAgdGlsZVk6IFwiXHUwNDFGXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDNBXHUwNDMwIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlx1MDQyMVx1MDQzMlx1MDQzRVx1MDQ0RiBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0MzBcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJcdTA0M0ZcdTA0NDBcdTA0MzhcdTA0M0NcdTA0MzVcdTA0NDA6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJcdTA0MTdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDJcIixcbiAgICBwYWludGVkOiBcIlx1MDQxN1x1MDQzMFx1MDQzQVx1MDQ0MFx1MDQzMFx1MDQ0OFx1MDQzNVx1MDQzRFx1MDQzRVwiLFxuICAgIGNoYXJnZXM6IFwiXHUwNDE3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDRCXCIsXG4gICAgcmV0cmllczogXCJcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0NEJcdTA0MzUgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDM4XCIsXG4gICAgdGlsZTogXCJcdTA0MUZcdTA0M0JcdTA0MzhcdTA0NDJcdTA0M0FcdTA0MzBcIixcbiAgICBjb25maWdTYXZlZDogXCJcdTA0MUFcdTA0M0VcdTA0M0RcdTA0NDRcdTA0MzhcdTA0MzNcdTA0NDNcdTA0NDBcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDQxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgY29uZmlnTG9hZGVkOiBcIlx1MDQxQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzOFx1MDQzM1x1MDQ0M1x1MDQ0MFx1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RiBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBjb25maWdSZXNldDogXCJcdTA0MjFcdTA0MzFcdTA0NDBcdTA0M0VcdTA0NDEgXHUwNDNBXHUwNDNFXHUwNDNEXHUwNDQ0XHUwNDM4XHUwNDMzXHUwNDQzXHUwNDQwXHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDM4XCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJcdTA0MURcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRDIFx1MDQzMlx1MDQ0MFx1MDQ0M1x1MDQ0N1x1MDQzRFx1MDQ0M1x1MDQ0RSBcdTA0MzRcdTA0M0JcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXHUwNDMwIFx1MDQzQVx1MDQzRVx1MDQzRVx1MDQ0MFx1MDQzNFx1MDQzOFx1MDQzRFx1MDQzMFx1MDQ0Mi4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiXHUwNDExXHUwNDREXHUwNDNBXHUwNDREXHUwNDNEXHUwNDM0IFx1MDQxRVx1MDQzRFx1MDQzQlx1MDQzMFx1MDQzOVx1MDQzRFwiLFxuICAgIGJhY2tlbmRPZmZsaW5lOiBcIlx1MDQxMVx1MDQ0RFx1MDQzQVx1MDQ0RFx1MDQzRFx1MDQzNFwiLFxuICAgIHN0YXJ0aW5nQm90OiBcIlx1MDQxN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQSBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0MzAuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJcdTA0MUVcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0FcdTA0MzAgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwLi4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiXHUwNDFBXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDMxXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQyBcdTA0NDNcdTA0MzZcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQ5XHUwNDM1XHUwNDNEXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRS4gXHUwNDE3XHUwNDMwXHUwNDNBXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzNVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0MzVcdTA0MzQgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBXHUwNDNFXHUwNDNDIFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MjRcdTA0MzBcdTA0NDBcdTA0M0NcdTA0MzAuXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDFGXHUwNDIzXHUwNDIxXHUwNDIyXHUwNDFFXHUwNDE5IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOCBcdTA0M0FcdTA0MzBcdTA0NDBcdTA0NDJcdTA0NEIsIFx1MDQ0N1x1MDQ0Mlx1MDQzRVx1MDQzMVx1MDQ0QiBcdTA0M0VcdTA0MzFcdTA0M0VcdTA0MzdcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0NFx1MDQzMFx1MDQ0MFx1MDQzQ1x1MDQzMC5cIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDFcdTA0NDJcdTA0MzBcdTA0NDBcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRGLi4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDMwISBcdTA0MjBcdTA0MzBcdTA0MzRcdTA0MzhcdTA0NDNcdTA0NDE6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTA0MjJcdTA0MzBcdTA0MzlcdTA0M0NcdTA0MzBcdTA0NDNcdTA0NDIgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDM1XHUwNDQwXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0NDEgXHUwNDNGXHUwNDNFXHUwNDNDXHUwNDNFXHUwNDQ5XHUwNDRDXHUwNDRFIFx1MDBBQlx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NENcdTAwQkJcIixcbiAgICBmYXJtUmFkaXVzOiBcIlx1MDQyMFx1MDQzMFx1MDQzNFx1MDQzOFx1MDQ0M1x1MDQ0MSBcdTA0NDRcdTA0MzBcdTA0NDBcdTA0M0NcdTA0MzBcIixcbiAgICBwb3NpdGlvbkluZm86IFwiXHUwNDIyXHUwNDM1XHUwNDNBXHUwNDQzXHUwNDQ5XHUwNDMwXHUwNDRGIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgXHUwNDI0XHUwNDMwXHUwNDQwXHUwNDNDIFx1MDQzMiBcdTA0NDBcdTA0MzBcdTA0MzRcdTA0MzhcdTA0NDNcdTA0NDFcdTA0MzUge3JhZGl1c31weCBcdTA0M0VcdTA0NDIgKHt4fSx7eX0pXCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBcdTA0MTJcdTA0MTBcdTA0MTZcdTA0MURcdTA0MUU6IFx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MUZcdTA0MjNcdTA0MjFcdTA0MjJcdTA0MjNcdTA0MkUgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDLCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDM4XHUwNDM3XHUwNDMxXHUwNDM1XHUwNDM2XHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQzQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzQlx1MDQzOFx1MDQzQVx1MDQ0Mlx1MDQzRVx1MDQzMi5cIixcbiAgICBub1Bvc2l0aW9uOiBcIlx1MDQxRFx1MDQzNVx1MDQ0MiBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICBjdXJyZW50Wm9uZTogXCJcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEM6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgXHUwNDIxXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDMwIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMuIFx1MDQxRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDNEXHUwNDMwIFx1MDQzQVx1MDQzMFx1MDQ0MFx1MDQ0Mlx1MDQzNSwgXHUwNDQ3XHUwNDQyXHUwNDNFXHUwNDMxXHUwNDRCIFx1MDQzRVx1MDQzMVx1MDQzRVx1MDQzN1x1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQ0XHUwNDMwXHUwNDQwXHUwNDNDXHUwNDMwLlwiXG4gIH0sXG5cbiAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiXHUwNDE0XHUwNDMwXCIsXG4gICAgbm86IFwiXHUwNDFEXHUwNDM1XHUwNDQyXCIsXG4gICAgb2s6IFwiXHUwNDFFXHUwNDFBXCIsXG4gICAgY2FuY2VsOiBcIlx1MDQxRVx1MDQ0Mlx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGNsb3NlOiBcIlx1MDQxN1x1MDQzMFx1MDQzQVx1MDQ0MFx1MDQ0Qlx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHNhdmU6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgbG9hZDogXCJcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBkZWxldGU6IFwiXHUwNDIzXHUwNDM0XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgZWRpdDogXCJcdTA0MThcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBzdGFydDogXCJcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0NDJcdTA0NENcIixcbiAgICBzdG9wOiBcIlx1MDQxN1x1MDQzMFx1MDQzQVx1MDQzRVx1MDQzRFx1MDQ0N1x1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHBhdXNlOiBcIlx1MDQxRlx1MDQ0MFx1MDQzOFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHJlc3VtZTogXCJcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzRcdTA0M0VcdTA0M0JcdTA0MzZcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICByZXNldDogXCJcdTA0MjFcdTA0MzFcdTA0NDBcdTA0M0VcdTA0NDFcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBzZXR0aW5nczogXCJcdTA0MURcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NDBcdTA0M0VcdTA0MzlcdTA0M0FcdTA0MzhcIixcbiAgICBoZWxwOiBcIlx1MDQxRlx1MDQzRVx1MDQzQ1x1MDQzRVx1MDQ0OVx1MDQ0Q1wiLFxuICAgIGFib3V0OiBcIlx1MDQxOFx1MDQzRFx1MDQ0NFx1MDQzRVx1MDQ0MFx1MDQzQ1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIGxhbmd1YWdlOiBcIlx1MDQyRlx1MDQzN1x1MDQ0Qlx1MDQzQVwiLFxuICAgIGxvYWRpbmc6IFwiXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgZXJyb3I6IFwiXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwXCIsXG4gICAgc3VjY2VzczogXCJcdTA0MjNcdTA0NDFcdTA0M0ZcdTA0MzVcdTA0NDVcIixcbiAgICB3YXJuaW5nOiBcIlx1MDQxRlx1MDQ0MFx1MDQzNVx1MDQzNFx1MDQ0M1x1MDQzRlx1MDQ0MFx1MDQzNVx1MDQzNlx1MDQzNFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIGluZm86IFwiXHUwNDE4XHUwNDNEXHUwNDQ0XHUwNDNFXHUwNDQwXHUwNDNDXHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGXCIsXG4gICAgbGFuZ3VhZ2VDaGFuZ2VkOiBcIlx1MDQyRlx1MDQzN1x1MDQ0Qlx1MDQzQSBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0QgXHUwNDNEXHUwNDMwIHtsYW5ndWFnZX1cIlxuICB9LFxuXG4gIC8vIEd1YXJkIE1vZHVsZVxuICBndWFyZDoge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwXCIsXG4gICAgaW5pdEJvdDogXCJcdTA0MThcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzhcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0NEMgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJcdTA0MTJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiXHUwNDE3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDQzXCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0M1wiLFxuICAgIHVwcGVyTGVmdDogXCJcdTA0MTJcdTA0MzVcdTA0NDBcdTA0NDVcdTA0M0RcdTA0MzhcdTA0MzkgXHUwNDFCXHUwNDM1XHUwNDMyXHUwNDRCXHUwNDM5IFx1MDQyM1x1MDQzM1x1MDQzRVx1MDQzQlwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiXHUwNDFEXHUwNDM4XHUwNDM2XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQxRlx1MDQ0MFx1MDQzMFx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0MjNcdTA0MzNcdTA0M0VcdTA0M0JcIixcbiAgICBwcm90ZWN0ZWRQaXhlbHM6IFwiXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzOFwiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJcdTA0MUVcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0RcdTA0NEJcdTA0MzUgXHUwNDE4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiXHUwNDEyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzOFwiLFxuICAgIGNoYXJnZXM6IFwiXHUwNDE3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDRCXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOC4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAgXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1MDQyNlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzMCBcdTA0M0RcdTA0MzUgXHUwNDNEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDRCLiBcdTA0MUVcdTA0NDJcdTA0M0FcdTA0NDBcdTA0M0VcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDQzIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMiBcdTA0M0RcdTA0MzAgXHUwNDQxXHUwNDMwXHUwNDM5XHUwNDQyXHUwNDM1LlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTA0MURcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0M0Uge2NvdW50fSBcdTA0MzRcdTA0M0VcdTA0NDFcdTA0NDJcdTA0NDNcdTA0M0ZcdTA0M0RcdTA0NEJcdTA0NDUgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBcdTA0NDNcdTA0NDFcdTA0M0ZcdTA0MzVcdTA0NDhcdTA0M0RcdTA0M0UgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDM4IEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIFx1MDQxRFx1MDQzNVx1MDQzNFx1MDQzNVx1MDQzOVx1MDQ0MVx1MDQ0Mlx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0M0FcdTA0M0VcdTA0M0VcdTA0NDBcdTA0MzRcdTA0MzhcdTA0M0RcdTA0MzBcdTA0NDJcdTA0NEJcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzNFx1MDQzRVx1MDQzQlx1MDQzNlx1MDQzRFx1MDQzMCBcdTA0MzhcdTA0M0NcdTA0MzVcdTA0NDJcdTA0NEMgXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzQlx1MDQzNVx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0NDNcdTA0MzNcdTA0M0VcdTA0M0IgXHUwNDNDXHUwNDM1XHUwNDNEXHUwNDRDXHUwNDQ4XHUwNDM1IFx1MDQzRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzNVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDMwXCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQxXHUwNDNCXHUwNDM4XHUwNDQ4XHUwNDNBXHUwNDNFXHUwNDNDIFx1MDQzMVx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQ0OFx1MDQzMFx1MDQ0Rjoge3NpemV9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSAoXHUwNDNDXHUwNDMwXHUwNDNBXHUwNDQxXHUwNDM4XHUwNDNDXHUwNDQzXHUwNDNDOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBcdTA0MTdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDIgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4IFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0Qi4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0N1x1MDQzNVx1MDQzRFx1MDQzMDoge2NvdW50fSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDNGXHUwNDNFXHUwNDM0IFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzRVx1MDQzOVwiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzMCBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0Mzg6IHtlcnJvcn1cIixcbiAgICBjYXB0dXJlRmlyc3Q6IFwiXHUyNzRDIFx1MDQyMVx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQzQlx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0QlwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDMwIC0gXHUwNDNDXHUwNDNFXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDNFXHUwNDQwXHUwNDM4XHUwNDNEXHUwNDMzIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0MzAgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDlcdTA0MzVcdTA0M0RcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIC0gXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzRFx1MDQzNSBcdTA0M0VcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0VcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzRVx1MDQzMVx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0MzIgXHUwNDM3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDNFXHUwNDM5IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIHJlcGFpcmluZzogXCJcdUQ4M0RcdURFRTBcdUZFMEYgXHUwNDEyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IHtjb3VudH0gXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOS4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgXHUwNDIzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSB7Y291bnR9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOVwiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGIFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOToge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgXHUwNDFEXHUwNDM1XHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQyXHUwNDNFXHUwNDQ3XHUwNDNEXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMiBcdTA0MzRcdTA0M0JcdTA0NEYgXHUwNDMyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGIFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOVwiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwIFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0MzIgXHUwNDM3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDNFXHUwNDM5IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOC4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzggXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM5OiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIFx1MDQyMVx1MDQ0Mlx1MDQ0MFx1MDQzMFx1MDQzNiBcdTA0MzBcdTA0M0FcdTA0NDJcdTA0MzhcdTA0MzJcdTA0MzVcdTA0M0QgLSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDNGXHUwNDNFXHUwNDM0IFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzRVx1MDQzOVwiLFxuICAgIGxhc3RDaGVjazogXCJcdTA0MUZcdTA0M0VcdTA0NDFcdTA0M0JcdTA0MzVcdTA0MzRcdTA0M0RcdTA0NEZcdTA0NEYgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwOiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiXHUwNDIxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDQzXHUwNDRFXHUwNDQ5XHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0Mzc6IHt0aW1lfVx1MDQ0MVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzQ1x1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0N1x1MDQzNVx1MDQ0MVx1MDQzQVx1MDQzMFx1MDQ0RiBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEYuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDlcdTA0MzVcdTA0M0QgXHUwNDMwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDNDXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQ3XHUwNDM1XHUwNDQxXHUwNDNBXHUwNDM4XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1MDQxRFx1MDQzNSBcdTA0NDNcdTA0MzRcdTA0MzBcdTA0M0JcdTA0M0VcdTA0NDFcdTA0NEMgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzQ1x1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0N1x1MDQzNVx1MDQ0MVx1MDQzQVx1MDQzOC4gXHUwNDE4XHUwNDQxXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQ0MyBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBXHUwNDMwLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHUwNDIyXHUwNDQwXHUwNDM1XHUwNDMxXHUwNDQzXHUwNDM1XHUwNDQyXHUwNDQxXHUwNDRGIFx1MDQ0MFx1MDQ0M1x1MDQ0N1x1MDQzRFx1MDQzMFx1MDQ0RiBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEZcIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFx1MDQyNlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0MzAgXHUwNDNFXHUwNDMxXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTA0MUZcdTA0M0VcdTA0MzhcdTA0NDFcdTA0M0EgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXHUwNDNFXHUwNDM5IFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQ0Qi4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1MDQxRFx1MDQzMFx1MDQzNlx1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQzNSBcdTA0M0FcdTA0M0RcdTA0M0VcdTA0M0ZcdTA0M0FcdTA0MzggXHUwMEFCUGFpbnRcdTAwQkIuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTA0MUFcdTA0M0RcdTA0M0VcdTA0M0ZcdTA0M0FcdTA0MzAgXHUwMEFCUGFpbnRcdTAwQkIgXHUwNDNEXHUwNDM1IFx1MDQzRFx1MDQzMFx1MDQzOVx1MDQzNFx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDEyXHUwNDE1XHUwNDIwXHUwNDI1XHUwNDFEXHUwNDE1XHUwNDFDIFx1MDQxQlx1MDQxNVx1MDQxMlx1MDQxRVx1MDQxQyBcdTA0NDNcdTA0MzNcdTA0M0JcdTA0NDMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4IFx1MDQzNFx1MDQzQlx1MDQ0RiBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NEJcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBcdTA0MjJcdTA0MzVcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0NEMgXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDFEXHUwNDE4XHUwNDE2XHUwNDFEXHUwNDE1XHUwNDFDIFx1MDQxRlx1MDQyMFx1MDQxMFx1MDQxMlx1MDQxRVx1MDQxQyBcdTA0NDNcdTA0MzNcdTA0M0JcdTA0NDMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4XCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NDVcdTA0M0RcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNCXHUwNDM1XHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQ0M1x1MDQzM1x1MDQzQlx1MDQzMC4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwIFx1MDQzRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzNVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDMwLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDQxMlx1MDQzNVx1MDQ0MFx1MDQ0NVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0JcdTA0MzVcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDQzXHUwNDMzXHUwNDNFXHUwNDNCIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0N1x1MDQzNVx1MDQzRDogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgXHUwNDFEXHUwNDM4XHUwNDM2XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzRlx1MDQ0MFx1MDQzMFx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0NDNcdTA0MzNcdTA0M0VcdTA0M0IgXHUwNDM3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQ3XHUwNDM1XHUwNDNEOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgXHUwNDIyXHUwNDMwXHUwNDM5XHUwNDNDLVx1MDQzMFx1MDQ0M1x1MDQ0MiBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzBcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCwgXHUwNDNGXHUwNDNFXHUwNDM2XHUwNDMwXHUwNDNCXHUwNDQzXHUwNDM5XHUwNDQxXHUwNDQyXHUwNDMwLCBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDQxXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDMwXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgemhIYW5zID0ge1xuICAvLyBcdTU0MkZcdTUyQThcdTU2NjhcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBcdTgxRUFcdTUyQThcdTY3M0FcdTU2NjhcdTRFQkEnLFxuICAgIGF1dG9GYXJtOiAnXHVEODNDXHVERjNFIFx1ODFFQVx1NTJBOFx1NTE5Q1x1NTczQScsXG4gICAgYXV0b0ltYWdlOiAnXHVEODNDXHVERkE4IFx1ODFFQVx1NTJBOFx1N0VEOFx1NTZGRScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIFx1ODFFQVx1NTJBOFx1NUI4OFx1NjJBNCcsXG4gICAgc2VsZWN0aW9uOiAnXHU5MDA5XHU2MkU5JyxcbiAgICB1c2VyOiAnXHU3NTI4XHU2MjM3JyxcbiAgICBjaGFyZ2VzOiAnXHU2QjIxXHU2NTcwJyxcbiAgICBiYWNrZW5kOiAnXHU1NDBFXHU3QUVGJyxcbiAgICBkYXRhYmFzZTogJ1x1NjU3MFx1NjM2RVx1NUU5MycsXG4gICAgdXB0aW1lOiAnXHU4RkQwXHU4ODRDXHU2NUY2XHU5NUY0JyxcbiAgICBjbG9zZTogJ1x1NTE3M1x1OTVFRCcsXG4gICAgbGF1bmNoOiAnXHU1NDJGXHU1MkE4JyxcbiAgICBsb2FkaW5nOiAnXHU1MkEwXHU4RjdEXHU0RTJEXHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdcdTYyNjdcdTg4NENcdTRFMkRcdTIwMjYnLFxuICAgIGRvd25sb2FkaW5nOiAnXHU2QjYzXHU1NzI4XHU0RTBCXHU4RjdEXHU4MTFBXHU2NzJDXHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdcdTkwMDlcdTYyRTlcdTRFMDBcdTRFMkFcdTY3M0FcdTU2NjhcdTRFQkFcdTVFNzZcdTcwQjlcdTUxRkJcdTU0MkZcdTUyQTgnLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdcdTUxQzZcdTU5MDdcdTU0MkZcdTUyQTgnLFxuICAgIGxvYWRFcnJvcjogJ1x1NTJBMFx1OEY3RFx1OTUxOVx1OEJFRicsXG4gICAgbG9hZEVycm9yTXNnOiAnXHU2NUUwXHU2Q0Q1XHU1MkEwXHU4RjdEXHU2MjQwXHU5MDA5XHU2NzNBXHU1NjY4XHU0RUJBXHUzMDAyXHU4QkY3XHU2OEMwXHU2N0U1XHU3RjUxXHU3RURDXHU4RkRFXHU2M0E1XHU2MjE2XHU5MUNEXHU4QkQ1XHUzMDAyJyxcbiAgICBjaGVja2luZzogJ1x1RDgzRFx1REQwNCBcdTY4QzBcdTY3RTVcdTRFMkQuLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBcdTU3MjhcdTdFQkYnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgXHU3OUJCXHU3RUJGJyxcbiAgICBvazogJ1x1RDgzRFx1REZFMiBcdTZCNjNcdTVFMzgnLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IFx1OTUxOVx1OEJFRicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gXHU3RUQ4XHU1NkZFXHU2QTIxXHU1NzU3XG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1ODFFQVx1NTJBOFx1N0VEOFx1NTZGRVwiLFxuICAgIGluaXRCb3Q6IFwiXHU1MjFEXHU1OUNCXHU1MzE2XHU4MUVBXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBXCIsXG4gICAgdXBsb2FkSW1hZ2U6IFwiXHU0RTBBXHU0RjIwXHU1NkZFXHU3MjQ3XCIsXG4gICAgcmVzaXplSW1hZ2U6IFwiXHU4QzAzXHU2NTc0XHU1NkZFXHU3MjQ3XHU1OTI3XHU1QzBGXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHU5MDA5XHU2MkU5XHU0RjREXHU3RjZFXCIsXG4gICAgc3RhcnRQYWludGluZzogXCJcdTVGMDBcdTU5Q0JcdTdFRDhcdTUyMzZcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiXHU1MDVDXHU2QjYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgc2F2ZVByb2dyZXNzOiBcIlx1NEZERFx1NUI1OFx1OEZEQlx1NUVBNlwiLFxuICAgIGxvYWRQcm9ncmVzczogXCJcdTUyQTBcdThGN0RcdThGREJcdTVFQTZcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgXHU2OEMwXHU2N0U1XHU1M0VGXHU3NTI4XHU5ODlDXHU4MjcyLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHU4QkY3XHU1NzI4XHU3RjUxXHU3QUQ5XHU0RTBBXHU2MjUzXHU1RjAwXHU4QzAzXHU4MjcyXHU2NzdGXHU1NDBFXHU5MUNEXHU4QkQ1XHVGRjAxXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IFx1NjI3RVx1NTIzMCB7Y291bnR9IFx1NzlDRFx1NTNFRlx1NzUyOFx1OTg5Q1x1ODI3MlwiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgXHU2QjYzXHU1NzI4XHU1MkEwXHU4RjdEXHU1NkZFXHU3MjQ3Li4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IFx1NTZGRVx1NzI0N1x1NURGMlx1NTJBMFx1OEY3RFx1RkYwQ1x1NjcwOVx1NjU0OFx1NTBDRlx1N0QyMCB7Y291bnR9IFx1NEUyQVwiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIFx1NTZGRVx1NzI0N1x1NTJBMFx1OEY3RFx1NTkzMVx1OEQyNVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHU4QkY3XHU1NzI4XHU0RjYwXHU2MEYzXHU1RjAwXHU1OUNCXHU3RUQ4XHU1MjM2XHU3Njg0XHU1NzMwXHU2NUI5XHU2RDgyXHU3QjJDXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXHVGRjAxXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTRGNjBcdTZEODJcdTUzQzJcdTgwMDNcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHU0RjREXHU3RjZFXHU4QkJFXHU3RjZFXHU2MjEwXHU1MjlGXHVGRjAxXCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTRGNERcdTdGNkVcdTkwMDlcdTYyRTlcdThEODVcdTY1RjZcIixcbiAgICBwb3NpdGlvbkRldGVjdGVkOiBcIlx1RDgzQ1x1REZBRiBcdTVERjJcdTY4QzBcdTZENEJcdTUyMzBcdTRGNERcdTdGNkVcdUZGMENcdTU5MDRcdTc0MDZcdTRFMkQuLi5cIixcbiAgICBwb3NpdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTRGNERcdTdGNkVcdTY4QzBcdTZENEJcdTU5MzFcdThEMjVcdUZGMENcdThCRjdcdTkxQ0RcdThCRDVcIixcbiAgICBzdGFydFBhaW50aW5nTXNnOiBcIlx1RDgzQ1x1REZBOCBcdTVGMDBcdTU5Q0JcdTdFRDhcdTUyMzYuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBcdThGREJcdTVFQTY6IHtwYWludGVkfS97dG90YWx9IFx1NTBDRlx1N0QyMC4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgXHU2Q0ExXHU2NzA5XHU2QjIxXHU2NTcwXHUzMDAyXHU3QjQ5XHU1Rjg1IHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHU3NTI4XHU2MjM3XHU1REYyXHU1MDVDXHU2QjYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgXHU3RUQ4XHU1MjM2XHU1QjhDXHU2MjEwXHVGRjAxXHU1MTcxXHU3RUQ4XHU1MjM2IHtjb3VudH0gXHU0RTJBXHU1MENGXHU3RDIwXHUzMDAyXCIsXG4gICAgcGFpbnRpbmdFcnJvcjogXCJcdTI3NEMgXHU3RUQ4XHU1MjM2XHU4RkM3XHU3QTBCXHU0RTJEXHU1MUZBXHU5NTE5XCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgXHU4QkY3XHU1MTQ4XHU1MkEwXHU4RjdEXHU1NkZFXHU3MjQ3XHU1RTc2XHU5MDA5XHU2MkU5XHU0RjREXHU3RjZFXCIsXG4gICAgcHJvZ3Jlc3M6IFwiXHU4RkRCXHU1RUE2XCIsXG4gICAgdXNlck5hbWU6IFwiXHU3NTI4XHU2MjM3XCIsXG4gICAgcGl4ZWxzOiBcIlx1NTBDRlx1N0QyMFwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTcwXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJcdTk4ODRcdThCQTFcdTY1RjZcdTk1RjRcIixcbiAgICBpbml0TWVzc2FnZTogXCJcdTcwQjlcdTUxRkJcdTIwMUNcdTUyMURcdTU5Q0JcdTUzMTZcdTgxRUFcdTUyQThcdTY3M0FcdTU2NjhcdTRFQkFcdTIwMURcdTVGMDBcdTU5Q0JcIixcbiAgICB3YWl0aW5nSW5pdDogXCJcdTdCNDlcdTVGODVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBcdTU2RkVcdTcyNDdcdTVERjJcdThDMDNcdTY1NzRcdTRFM0Ege3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBcdTdFRDhcdTUyMzZcdTY2ODJcdTUwNUNcdTRFOEVcdTRGNERcdTdGNkUgWDoge3h9LCBZOiB7eX1cIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTZCQ0ZcdTYyNzlcdTUwQ0ZcdTdEMjBcdTY1NzBcIixcbiAgICBiYXRjaFNpemU6IFwiXHU2Mjc5XHU2QjIxXHU1OTI3XHU1QzBGXCIsXG4gICAgbmV4dEJhdGNoVGltZTogXCJcdTRFMEJcdTZCMjFcdTYyNzlcdTZCMjFcdTY1RjZcdTk1RjRcIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlx1NEY3Rlx1NzUyOFx1NjI0MFx1NjcwOVx1NTNFRlx1NzUyOFx1NkIyMVx1NjU3MFwiLFxuICAgIHNob3dPdmVybGF5OiBcIlx1NjYzRVx1NzkzQVx1ODk4Nlx1NzZENlx1NUM0MlwiLFxuICAgIG1heENoYXJnZXM6IFwiXHU2QkNGXHU2Mjc5XHU2NzAwXHU1OTI3XHU2QjIxXHU2NTcwXCIsXG4gICAgd2FpdGluZ0ZvckNoYXJnZXM6IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3MDoge2N1cnJlbnR9L3tuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJcdTUyNjlcdTRGNTlcdTY1RjZcdTk1RjRcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIFx1N0I0OVx1NUY4NSB7dGltZX0gXHU1NDBFXHU3RUU3XHU3RUVELi4uXCIsXG4gICAgcHJvZ3Jlc3NTYXZlZDogXCJcdTI3MDUgXHU4RkRCXHU1RUE2XHU1REYyXHU0RkREXHU1QjU4XHU0RTNBIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgXHU1REYyXHU1MkEwXHU4RjdEXHU4RkRCXHU1RUE2OiB7cGFpbnRlZH0ve3RvdGFsfSBcdTUwQ0ZcdTdEMjBcdTVERjJcdTdFRDhcdTUyMzZcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgXHU1MkEwXHU4RjdEXHU4RkRCXHU1RUE2XHU1OTMxXHU4RDI1OiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIFx1NEZERFx1NUI1OFx1OEZEQlx1NUVBNlx1NTkzMVx1OEQyNToge2Vycm9yfVwiLFxuICAgIGNvbmZpcm1TYXZlUHJvZ3Jlc3M6IFwiXHU1NzI4XHU1MDVDXHU2QjYyXHU0RTRCXHU1MjREXHU4OTgxXHU0RkREXHU1QjU4XHU1RjUzXHU1MjREXHU4RkRCXHU1RUE2XHU1NDE3XHVGRjFGXCIsXG4gICAgc2F2ZVByb2dyZXNzVGl0bGU6IFwiXHU0RkREXHU1QjU4XHU4RkRCXHU1RUE2XCIsXG4gICAgZGlzY2FyZFByb2dyZXNzOiBcIlx1NjUzRVx1NUYwM1wiLFxuICAgIGNhbmNlbDogXCJcdTUzRDZcdTZEODhcIixcbiAgICBtaW5pbWl6ZTogXCJcdTY3MDBcdTVDMEZcdTUzMTZcIixcbiAgICB3aWR0aDogXCJcdTVCQkRcdTVFQTZcIixcbiAgICBoZWlnaHQ6IFwiXHU5QUQ4XHU1RUE2XCIsXG4gICAga2VlcEFzcGVjdDogXCJcdTRGRERcdTYzMDFcdTdFQjVcdTZBMkFcdTZCRDRcIixcbiAgICBhcHBseTogXCJcdTVFOTRcdTc1MjhcIixcbiAgICBvdmVybGF5T246IFwiXHU4OTg2XHU3NkQ2XHU1QzQyOiBcdTVGMDBcdTU0MkZcIixcbiAgICBvdmVybGF5T2ZmOiBcIlx1ODk4Nlx1NzZENlx1NUM0MjogXHU1MTczXHU5NUVEXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgXHU2Mjc5XHU2QjIxXHU1QjhDXHU2MjEwOiBcdTVERjJcdTdFRDhcdTUyMzYge3BhaW50ZWR9IFx1NTBDRlx1N0QyMCB8IFx1OEZEQlx1NUVBNjoge3BlcmNlbnR9JSAoe2N1cnJlbnR9L3t0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTcwXHU2MDYyXHU1OTBEOiB7Y3VycmVudH0ve25lZWRlZH0gLSBcdTY1RjZcdTk1RjQ6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1NzA6IHtjdXJyZW50fS97bmVlZGVkfSAtIFx1NTI2OVx1NEY1OToge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgXHU2QjYzXHU1NzI4XHU4MUVBXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTgxRUFcdTUyQThcdTU0MkZcdTUyQThcdTYyMTBcdTUyOUZcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgXHU2NUUwXHU2Q0Q1XHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHVGRjBDXHU4QkY3XHU2MjRCXHU1MkE4XHU2NENEXHU0RjVDXHUzMDAyXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTVERjJcdTY4QzBcdTZENEJcdTUyMzBcdThDMDNcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjQxQ1x1N0QyMlx1OEMwM1x1ODI3Mlx1Njc3Ri4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1NkI2M1x1NTcyOFx1NzBCOVx1NTFGQlx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRS4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRVwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHU5NzAwXHU4OTgxXHU2MjRCXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2XCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBcdTkxQ0RcdThCRDUge2F0dGVtcHR9L3ttYXhBdHRlbXB0c31cdUZGMENcdTdCNDlcdTVGODUge2RlbGF5fSBcdTc5RDIuLi5cIixcbiAgICByZXRyeUVycm9yOiBcIlx1RDgzRFx1RENBNSBcdTdCMkMge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30gXHU2QjIxXHU1QzFEXHU4QkQ1XHU1MUZBXHU5NTE5XHVGRjBDXHU1QzA2XHU1NzI4IHtkZWxheX0gXHU3OUQyXHU1NDBFXHU5MUNEXHU4QkQ1Li4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIFx1OEQ4NVx1OEZDNyB7bWF4QXR0ZW1wdHN9IFx1NkIyMVx1NUMxRFx1OEJENVx1NTkzMVx1OEQyNVx1MzAwMlx1N0VFN1x1N0VFRFx1NEUwQlx1NEUwMFx1NjI3OS4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgXHU3RjUxXHU3RURDXHU5NTE5XHU4QkVGXHVGRjBDXHU2QjYzXHU1NzI4XHU5MUNEXHU4QkQ1Li4uXCIsXG4gICAgc2VydmVyRXJyb3I6IFwiXHVEODNEXHVERDI1IFx1NjcwRFx1NTJBMVx1NTY2OFx1OTUxOVx1OEJFRlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEJENS4uLlwiLFxuICAgIHRpbWVvdXRFcnJvcjogXCJcdTIzRjAgXHU2NzBEXHU1MkExXHU1NjY4XHU4RDg1XHU2NUY2XHVGRjBDXHU2QjYzXHU1NzI4XHU5MUNEXHU4QkQ1Li4uXCJcbiAgfSxcblxuICAvLyBcdTUxOUNcdTU3M0FcdTZBMjFcdTU3NTdcdUZGMDhcdTVGODVcdTVCOUVcdTczQjBcdUZGMDlcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTUxOUNcdTU3M0FcdTY3M0FcdTU2NjhcdTRFQkFcIixcbiAgICBzdGFydDogXCJcdTVGMDBcdTU5Q0JcIixcbiAgICBzdG9wOiBcIlx1NTA1Q1x1NkI2MlwiLFxuICAgIHN0b3BwZWQ6IFwiXHU2NzNBXHU1NjY4XHU0RUJBXHU1REYyXHU1MDVDXHU2QjYyXCIsXG4gICAgY2FsaWJyYXRlOiBcIlx1NjgyMVx1NTFDNlwiLFxuICAgIHBhaW50T25jZTogXCJcdTRFMDBcdTZCMjFcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJcdTY4QzBcdTY3RTVcdTcyQjZcdTYwMDFcdTRFMkQuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIlx1OTE0RFx1N0Y2RVwiLFxuICAgIGRlbGF5OiBcIlx1NUVGNlx1OEZERiAoXHU2QkVCXHU3OUQyKVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1NkJDRlx1NjI3OVx1NTBDRlx1N0QyMFwiLFxuICAgIG1pbkNoYXJnZXM6IFwiXHU2NzAwXHU1QzExXHU2QjIxXHU2NTcwXCIsXG4gICAgY29sb3JNb2RlOiBcIlx1OTg5Q1x1ODI3Mlx1NkEyMVx1NUYwRlwiLFxuICAgIHJhbmRvbTogXCJcdTk2OEZcdTY3M0FcIixcbiAgICBmaXhlZDogXCJcdTU2RkFcdTVCOUFcIixcbiAgICByYW5nZTogXCJcdTgzMDNcdTU2RjRcIixcbiAgICBmaXhlZENvbG9yOiBcIlx1NTZGQVx1NUI5QVx1OTg5Q1x1ODI3MlwiLFxuICAgIGFkdmFuY2VkOiBcIlx1OUFEOFx1N0VBN1wiLFxuICAgIHRpbGVYOiBcIlx1NzRFNlx1NzI0NyBYXCIsXG4gICAgdGlsZVk6IFwiXHU3NEU2XHU3MjQ3IFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlx1ODFFQVx1NUI5QVx1NEU0OVx1OEMwM1x1ODI3Mlx1Njc3RlwiLFxuICAgIHBhbGV0dGVFeGFtcGxlOiBcIlx1NEY4Qlx1NTk4MjogI0ZGMDAwMCwjMDBGRjAwLCMwMDAwRkZcIixcbiAgICBjYXB0dXJlOiBcIlx1NjM1NVx1ODNCN1wiLFxuICAgIHBhaW50ZWQ6IFwiXHU1REYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgY2hhcmdlczogXCJcdTZCMjFcdTY1NzBcIixcbiAgICByZXRyaWVzOiBcIlx1OTFDRFx1OEJENVwiLFxuICAgIHRpbGU6IFwiXHU3NEU2XHU3MjQ3XCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiXHU5MTREXHU3RjZFXHU1REYyXHU0RkREXHU1QjU4XCIsXG4gICAgY29uZmlnTG9hZGVkOiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1NTJBMFx1OEY3RFwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1OTFDRFx1N0Y2RVwiLFxuICAgIGNhcHR1cmVJbnN0cnVjdGlvbnM6IFwiXHU4QkY3XHU2MjRCXHU1MkE4XHU3RUQ4XHU1MjM2XHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXHU0RUU1XHU2MzU1XHU4M0I3XHU1NzUwXHU2ODA3Li4uXCIsXG4gICAgYmFja2VuZE9ubGluZTogXCJcdTU0MEVcdTdBRUZcdTU3MjhcdTdFQkZcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJcdTU0MEVcdTdBRUZcdTc5QkJcdTdFQkZcIixcbiAgICBzdGFydGluZ0JvdDogXCJcdTZCNjNcdTU3MjhcdTU0MkZcdTUyQThcdTY3M0FcdTU2NjhcdTRFQkEuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJcdTZCNjNcdTU3MjhcdTUwNUNcdTZCNjJcdTY3M0FcdTU2NjhcdTRFQkEuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJcdTY4MjFcdTUxQzZcdTRFMkQuLi5cIixcbiAgICBhbHJlYWR5UnVubmluZzogXCJcdTgxRUFcdTUyQThcdTUxOUNcdTU3M0FcdTVERjJcdTU3MjhcdThGRDBcdTg4NENcdTMwMDJcIixcbiAgICBpbWFnZVJ1bm5pbmdXYXJuaW5nOiBcIlx1ODFFQVx1NTJBOFx1N0VEOFx1NTZGRVx1NkI2M1x1NTcyOFx1OEZEMFx1ODg0Q1x1RkYwQ1x1OEJGN1x1NTE0OFx1NTE3M1x1OTVFRFx1NTE4RFx1NTQyRlx1NTJBOFx1ODFFQVx1NTJBOFx1NTE5Q1x1NTczQVx1MzAwMlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFx1NTcyOFx1NTczMFx1NTZGRVx1NzY4NFx1N0E3QVx1NzY3RFx1NTMzQVx1NTdERlx1NkQ4Mlx1NEUwMFx1NEUyQVx1NTBDRlx1N0QyMFx1NEVFNVx1OEJCRVx1N0Y2RVx1NTE5Q1x1NTczQVx1NTMzQVx1NTdERlwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU0RjYwXHU2RDgyXHU1M0MyXHU4MDAzXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1NTMzQVx1NTdERlx1OEJCRVx1N0Y2RVx1NjIxMFx1NTI5Rlx1RkYwMVx1NTM0QVx1NUY4NDogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1NTMzQVx1NTdERlx1OTAwOVx1NjJFOVx1OEQ4NVx1NjVGNlwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgXHU4QkY3XHU1MTQ4XHU5MDA5XHU2MkU5XHU1MzNBXHU1N0RGXHVGRjA4XHU0RjdGXHU3NTI4XHUyMDFDXHU5MDA5XHU2MkU5XHU1MzNBXHU1N0RGXHUyMDFEXHU2MzA5XHU5NEFFXHVGRjA5XCIsXG4gICAgZmFybVJhZGl1czogXCJcdTUxOUNcdTU3M0FcdTUzNEFcdTVGODRcIixcbiAgICBwb3NpdGlvbkluZm86IFwiXHU1RjUzXHU1MjREXHU1MzNBXHU1N0RGXCIsXG4gICAgZmFybWluZ0luUmFkaXVzOiBcIlx1RDgzQ1x1REYzRSBcdTZCNjNcdTU3MjhcdTRFRTVcdTUzNEFcdTVGODQge3JhZGl1c31weCBcdTU3MjggKHt4fSx7eX0pIFx1NTE5Q1x1NTczQVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgXHU5MUNEXHU4OTgxOiBcdThCRjdcdTkwMDlcdTYyRTlcdTdBN0FcdTc2N0RcdTUzM0FcdTU3REZcdTRFRTVcdTkwN0ZcdTUxNERcdTUxQjJcdTdBODFcIixcbiAgICBub1Bvc2l0aW9uOiBcIlx1NjcyQVx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlwiLFxuICAgIGN1cnJlbnRab25lOiBcIlx1NTMzQVx1NTdERjogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBcdThCRjdcdTUxNDhcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcdUZGMENcdTU3MjhcdTU3MzBcdTU2RkVcdTRFMEFcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcdTRFRTVcdThCQkVcdTdGNkVcdTUxOUNcdTU3M0FcdTUzM0FcdTU3REZcIlxuICB9LFxuXG4gIC8vIFx1NTE2Q1x1NTE3MVxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiXHU2NjJGXCIsXG4gICAgbm86IFwiXHU1NDI2XCIsXG4gICAgb2s6IFwiXHU3ODZFXHU4QkE0XCIsXG4gICAgY2FuY2VsOiBcIlx1NTNENlx1NkQ4OFwiLFxuICAgIGNsb3NlOiBcIlx1NTE3M1x1OTVFRFwiLFxuICAgIHNhdmU6IFwiXHU0RkREXHU1QjU4XCIsXG4gICAgbG9hZDogXCJcdTUyQTBcdThGN0RcIixcbiAgICBkZWxldGU6IFwiXHU1MjIwXHU5NjY0XCIsXG4gICAgZWRpdDogXCJcdTdGMTZcdThGOTFcIixcbiAgICBzdGFydDogXCJcdTVGMDBcdTU5Q0JcIixcbiAgICBzdG9wOiBcIlx1NTA1Q1x1NkI2MlwiLFxuICAgIHBhdXNlOiBcIlx1NjY4Mlx1NTA1Q1wiLFxuICAgIHJlc3VtZTogXCJcdTdFRTdcdTdFRURcIixcbiAgICByZXNldDogXCJcdTkxQ0RcdTdGNkVcIixcbiAgICBzZXR0aW5nczogXCJcdThCQkVcdTdGNkVcIixcbiAgICBoZWxwOiBcIlx1NUUyRVx1NTJBOVwiLFxuICAgIGFib3V0OiBcIlx1NTE3M1x1NEU4RVwiLFxuICAgIGxhbmd1YWdlOiBcIlx1OEJFRFx1OEEwMFwiLFxuICAgIGxvYWRpbmc6IFwiXHU1MkEwXHU4RjdEXHU0RTJELi4uXCIsXG4gICAgZXJyb3I6IFwiXHU5NTE5XHU4QkVGXCIsXG4gICAgc3VjY2VzczogXCJcdTYyMTBcdTUyOUZcIixcbiAgICB3YXJuaW5nOiBcIlx1OEI2Nlx1NTQ0QVwiLFxuICAgIGluZm86IFwiXHU0RkUxXHU2MDZGXCIsXG4gICAgbGFuZ3VhZ2VDaGFuZ2VkOiBcIlx1OEJFRFx1OEEwMFx1NURGMlx1NTIwN1x1NjM2Mlx1NEUzQSB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBcdTVCODhcdTYyQTRcdTZBMjFcdTU3NTdcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU4MUVBXHU1MkE4XHU1Qjg4XHU2MkE0XCIsXG4gICAgaW5pdEJvdDogXCJcdTUyMURcdTU5Q0JcdTUzMTZcdTVCODhcdTYyQTRcdTY3M0FcdTU2NjhcdTRFQkFcIixcbiAgICBzZWxlY3RBcmVhOiBcIlx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlwiLFxuICAgIGNhcHR1cmVBcmVhOiBcIlx1NjM1NVx1ODNCN1x1NTMzQVx1NTdERlwiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJcdTVGMDBcdTU5Q0JcdTVCODhcdTYyQTRcIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJcdTUwNUNcdTZCNjJcdTVCODhcdTYyQTRcIixcbiAgICB1cHBlckxlZnQ6IFwiXHU1REU2XHU0RTBBXHU4OUQyXCIsXG4gICAgbG93ZXJSaWdodDogXCJcdTUzRjNcdTRFMEJcdTg5RDJcIixcbiAgICBwcm90ZWN0ZWRQaXhlbHM6IFwiXHU1M0Q3XHU0RkREXHU2MkE0XHU1MENGXHU3RDIwXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIlx1NjhDMFx1NkQ0Qlx1NTIzMFx1NzY4NFx1NTNEOFx1NTMxNlwiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlx1NEZFRVx1NTkwRFx1NzY4NFx1NTBDRlx1N0QyMFwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTcwXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHU3QjQ5XHU1Rjg1XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNDXHVERkE4IFx1NjhDMFx1NjdFNVx1NTNFRlx1NzUyOFx1OTg5Q1x1ODI3Mi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1OTg5Q1x1ODI3Mlx1RkYwQ1x1OEJGN1x1NTcyOFx1N0Y1MVx1N0FEOVx1NEUwQVx1NjI1M1x1NUYwMFx1OEMwM1x1ODI3Mlx1Njc3Rlx1MzAwMlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTYyN0VcdTUyMzAge2NvdW50fSBcdTc5Q0RcdTUzRUZcdTc1MjhcdTk4OUNcdTgyNzJcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgXHU1Qjg4XHU2MkE0XHU2NzNBXHU1NjY4XHU0RUJBXHU1MjFEXHU1OUNCXHU1MzE2XHU2MjEwXHU1MjlGXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBcdTVCODhcdTYyQTRcdTY3M0FcdTU2NjhcdTRFQkFcdTUyMURcdTU5Q0JcdTUzMTZcdTU5MzFcdThEMjVcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBcdTU3NTBcdTY4MDdcdTY1RTBcdTY1NDhcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgXHU1MzNBXHU1N0RGXHU2NUUwXHU2NTQ4XHVGRjBDXHU1REU2XHU0RTBBXHU4OUQyXHU1RkM1XHU5ODdCXHU1QzBGXHU0RThFXHU1M0YzXHU0RTBCXHU4OUQyXCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBcdTUzM0FcdTU3REZcdThGQzdcdTU5Mjc6IHtzaXplfSBcdTUwQ0ZcdTdEMjAgKFx1NjcwMFx1NTkyNzoge21heH0pXCIsXG4gICAgY2FwdHVyaW5nQXJlYTogXCJcdUQ4M0RcdURDRjggXHU2MzU1XHU4M0I3XHU1Qjg4XHU2MkE0XHU1MzNBXHU1N0RGXHU0RTJELi4uXCIsXG4gICAgYXJlYUNhcHR1cmVkOiBcIlx1MjcwNSBcdTUzM0FcdTU3REZcdTYzNTVcdTgzQjdcdTYyMTBcdTUyOUY6IHtjb3VudH0gXHU1MENGXHU3RDIwXHU1M0Q3XHU0RkREXHU2MkE0XCIsXG4gICAgY2FwdHVyZUVycm9yOiBcIlx1Mjc0QyBcdTYzNTVcdTgzQjdcdTUzM0FcdTU3REZcdTUxRkFcdTk1MTk6IHtlcnJvcn1cIixcbiAgICBjYXB0dXJlRmlyc3Q6IFwiXHUyNzRDIFx1OEJGN1x1NTE0OFx1NjM1NVx1ODNCN1x1NEUwMFx1NEUyQVx1NUI4OFx1NjJBNFx1NTMzQVx1NTdERlwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTVCODhcdTYyQTRcdTVERjJcdTU0MkZcdTUyQTggLSBcdTUzM0FcdTU3REZcdTc2RDFcdTYzQTdcdTRFMkRcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHU1Qjg4XHU2MkE0XHU1REYyXHU1MDVDXHU2QjYyXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBcdTUzM0FcdTU3REZcdTVCODlcdTUxNjggLSBcdTY3MkFcdTY4QzBcdTZENEJcdTUyMzBcdTUzRDhcdTUzMTZcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IFx1NjhDMFx1NkQ0Qlx1NTIzMCB7Y291bnR9IFx1NEUyQVx1NTNEOFx1NTMxNlwiLFxuICAgIHJlcGFpcmluZzogXCJcdUQ4M0RcdURFRTBcdUZFMEYgXHU2QjYzXHU1NzI4XHU0RkVFXHU1OTBEIHtjb3VudH0gXHU0RTJBXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcmVwYWlyZWRTdWNjZXNzOiBcIlx1MjcwNSBcdTVERjJcdTYyMTBcdTUyOUZcdTRGRUVcdTU5MEQge2NvdW50fSBcdTRFMkFcdTUwQ0ZcdTdEMjBcIixcbiAgICByZXBhaXJFcnJvcjogXCJcdTI3NEMgXHU0RkVFXHU1OTBEXHU1MUZBXHU5NTE5OiB7ZXJyb3J9XCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjZBMFx1RkUwRiBcdTZCMjFcdTY1NzBcdTRFMERcdThEQjNcdUZGMENcdTY1RTBcdTZDRDVcdTRGRUVcdTU5MERcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjhDMFx1NjdFNVx1NTMzQVx1NTdERlx1NTNEOFx1NTMxNi4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIFx1NjhDMFx1NjdFNVx1NTFGQVx1OTUxOToge2Vycm9yfVwiLFxuICAgIGd1YXJkQWN0aXZlOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTVCODhcdTYyQTRcdTRFMkQgLSBcdTUzM0FcdTU3REZcdTUzRDdcdTRGRERcdTYyQTRcIixcbiAgICBsYXN0Q2hlY2s6IFwiXHU0RTBBXHU2QjIxXHU2OEMwXHU2N0U1OiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiXHU0RTBCXHU2QjIxXHU2OEMwXHU2N0U1OiB7dGltZX0gXHU3OUQyXHU1NDBFXCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgXHU2QjYzXHU1NzI4XHU4MUVBXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTgxRUFcdTUyQThcdTU0MkZcdTUyQThcdTYyMTBcdTUyOUZcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgXHU2NUUwXHU2Q0Q1XHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHVGRjBDXHU4QkY3XHU2MjRCXHU1MkE4XHU2NENEXHU0RjVDXHUzMDAyXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBcdTk3MDBcdTg5ODFcdTYyNEJcdTUyQThcdTUyMURcdTU5Q0JcdTUzMTZcIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFx1NURGMlx1NjhDMFx1NkQ0Qlx1NTIzMFx1OEMwM1x1ODI3Mlx1Njc3RlwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHU2QjYzXHU1NzI4XHU2NDFDXHU3RDIyXHU4QzAzXHU4MjcyXHU2NzdGLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgXHU2QjYzXHU1NzI4XHU3MEI5XHU1MUZCXHU3RUQ4XHU1MjM2XHU2MzA5XHU5NEFFLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHU2NzJBXHU2MjdFXHU1MjMwXHU3RUQ4XHU1MjM2XHU2MzA5XHU5NEFFXCIsXG4gICAgc2VsZWN0VXBwZXJMZWZ0OiBcIlx1RDgzQ1x1REZBRiBcdTU3MjhcdTk3MDBcdTg5ODFcdTRGRERcdTYyQTRcdTUzM0FcdTU3REZcdTc2ODRcdTVERTZcdTRFMEFcdTg5RDJcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBcdTczQjBcdTU3MjhcdTU3MjhcdTUzRjNcdTRFMEJcdTg5RDJcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcIixcbiAgICB3YWl0aW5nVXBwZXJMZWZ0OiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTkwMDlcdTYyRTlcdTVERTZcdTRFMEFcdTg5RDIuLi5cIixcbiAgICB3YWl0aW5nTG93ZXJSaWdodDogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU5MDA5XHU2MkU5XHU1M0YzXHU0RTBCXHU4OUQyLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1NURGMlx1NjM1NVx1ODNCN1x1NURFNlx1NEUwQVx1ODlEMjogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgXHU1REYyXHU2MzU1XHU4M0I3XHU1M0YzXHU0RTBCXHU4OUQyOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgXHU5MDA5XHU2MkU5XHU4RDg1XHU2NUY2XCIsXG4gICAgc2VsZWN0aW9uRXJyb3I6IFwiXHUyNzRDIFx1OTAwOVx1NjJFOVx1NTFGQVx1OTUxOVx1RkYwQ1x1OEJGN1x1OTFDRFx1OEJENVwiXG4gIH1cbn07XG4iLCAiZXhwb3J0IGNvbnN0IHpoSGFudCA9IHtcbiAgLy8gXHU1NTUzXHU1MkQ1XHU1NjY4XG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgXHU4MUVBXHU1MkQ1XHU2QTVGXHU1NjY4XHU0RUJBJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBcdTgxRUFcdTUyRDVcdThGQjJcdTU4MzQnLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBcdTgxRUFcdTUyRDVcdTdFNkFcdTU3MTYnLFxuICAgIGF1dG9HdWFyZDogJ1x1RDgzRFx1REVFMVx1RkUwRiBcdTgxRUFcdTUyRDVcdTVCODhcdThCNzcnLFxuICAgIHNlbGVjdGlvbjogJ1x1OTA3OFx1NjRDNycsXG4gICAgdXNlcjogJ1x1NzUyOFx1NjIzNycsXG4gICAgY2hhcmdlczogJ1x1NkIyMVx1NjU3OCcsXG4gICAgYmFja2VuZDogJ1x1NUY4Q1x1N0FFRicsXG4gICAgZGF0YWJhc2U6ICdcdTY1NzhcdTY0REFcdTVFQUInLFxuICAgIHVwdGltZTogJ1x1OTA0Qlx1ODg0Q1x1NjY0Mlx1OTU5MycsXG4gICAgY2xvc2U6ICdcdTk1RENcdTk1ODknLFxuICAgIGxhdW5jaDogJ1x1NTU1M1x1NTJENScsXG4gICAgbG9hZGluZzogJ1x1NTJBMFx1OEYwOVx1NEUyRFx1MjAyNicsXG4gICAgZXhlY3V0aW5nOiAnXHU1N0Y3XHU4ODRDXHU0RTJEXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ1x1NkI2M1x1NTcyOFx1NEUwQlx1OEYwOVx1ODE3M1x1NjcyQ1x1MjAyNicsXG4gICAgY2hvb3NlQm90OiAnXHU5MDc4XHU2NEM3XHU0RTAwXHU1MDBCXHU2QTVGXHU1NjY4XHU0RUJBXHU0RTI2XHU5RURFXHU2NENBXHU1NTUzXHU1MkQ1JyxcbiAgICByZWFkeVRvTGF1bmNoOiAnXHU2RTk2XHU1MDk5XHU1NTUzXHU1MkQ1JyxcbiAgICBsb2FkRXJyb3I6ICdcdTUyQTBcdThGMDlcdTkzMkZcdThBQTQnLFxuICAgIGxvYWRFcnJvck1zZzogJ1x1NzEyMVx1NkNENVx1NTJBMFx1OEYwOVx1NjI0MFx1OTA3OFx1NkE1Rlx1NTY2OFx1NEVCQVx1MzAwMlx1OEFDQlx1NkFBMlx1NjdFNVx1N0RCMlx1N0Q2MVx1OTAyM1x1NjNBNVx1NjIxNlx1OTFDRFx1OEE2Nlx1MzAwMicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgXHU2QUEyXHU2N0U1XHU0RTJELi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgXHU1NzI4XHU3RERBJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IFx1OTZFMlx1N0REQScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgXHU2QjYzXHU1RTM4JyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBcdTkzMkZcdThBQTQnLFxuICAgIHVua25vd246ICctJ1xuICB9LFxuXG4gIC8vIFx1N0U2QVx1NTcxNlx1NkEyMVx1NTg0QVxuICBpbWFnZToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTgxRUFcdTUyRDVcdTdFNkFcdTU3MTZcIixcbiAgICBpbml0Qm90OiBcIlx1NTIxRFx1NTlDQlx1NTMxNlx1ODFFQVx1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQVwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlx1NEUwQVx1NTBCM1x1NTcxNlx1NzI0N1wiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlx1OEFCRlx1NjU3NFx1NTcxNlx1NzI0N1x1NTkyN1x1NUMwRlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1OTA3OFx1NjRDN1x1NEY0RFx1N0Y2RVwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiXHU5NThCXHU1OUNCXHU3RTZBXHU4OEZEXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlx1NTA1Q1x1NkI2Mlx1N0U2QVx1ODhGRFwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJcdTRGRERcdTVCNThcdTkwMzJcdTVFQTZcIixcbiAgICBsb2FkUHJvZ3Jlc3M6IFwiXHU1MkEwXHU4RjA5XHU5MDMyXHU1RUE2XCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIFx1NkFBMlx1NjdFNVx1NTNFRlx1NzUyOFx1OTg0Rlx1ODI3Mi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1OEFDQlx1NTcyOFx1N0RCMlx1N0FEOVx1NEUwQVx1NjI1M1x1OTU4Qlx1OEFCRlx1ODI3Mlx1Njc3Rlx1NUY4Q1x1OTFDRFx1OEE2Nlx1RkYwMVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTYyN0VcdTUyMzAge2NvdW50fSBcdTdBMkVcdTUzRUZcdTc1MjhcdTk4NEZcdTgyNzJcIixcbiAgICBsb2FkaW5nSW1hZ2U6IFwiXHVEODNEXHVEREJDXHVGRTBGIFx1NkI2M1x1NTcyOFx1NTJBMFx1OEYwOVx1NTcxNlx1NzI0Ny4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBcdTU3MTZcdTcyNDdcdTVERjJcdTUyQTBcdThGMDlcdUZGMENcdTY3MDlcdTY1NDhcdTUwQ0ZcdTdEMjAge2NvdW50fSBcdTUwMEJcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBcdTU3MTZcdTcyNDdcdTUyQTBcdThGMDlcdTU5MzFcdTY1NTdcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1OEFDQlx1NTcyOFx1NEY2MFx1NjBGM1x1OTU4Qlx1NTlDQlx1N0U2QVx1ODhGRFx1NzY4NFx1NTczMFx1NjVCOVx1NTg1N1x1N0IyQ1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFx1RkYwMVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU0RjYwXHU1ODU3XHU1M0MzXHU4MDAzXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1NEY0RFx1N0Y2RVx1OEEyRFx1N0Y2RVx1NjIxMFx1NTI5Rlx1RkYwMVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU5MDc4XHU2NEM3XHU4RDg1XHU2NjQyXCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgXHU1REYyXHU2QUEyXHU2RTJDXHU1MjMwXHU0RjREXHU3RjZFXHVGRjBDXHU4NjU1XHU3NDA2XHU0RTJELi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU2QUEyXHU2RTJDXHU1OTMxXHU2NTU3XHVGRjBDXHU4QUNCXHU5MUNEXHU4QTY2XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggXHU5NThCXHU1OUNCXHU3RTZBXHU4OEZELi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgXHU5MDMyXHU1RUE2OiB7cGFpbnRlZH0ve3RvdGFsfSBcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyMzFCIFx1NkM5Mlx1NjcwOVx1NkIyMVx1NjU3OFx1MzAwMlx1N0I0OVx1NUY4NSB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NzUyOFx1NjIzN1x1NURGMlx1NTA1Q1x1NkI2Mlx1N0U2QVx1ODhGRFwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1N0U2QVx1ODhGRFx1NUI4Q1x1NjIxMFx1RkYwMVx1NTE3MVx1N0U2QVx1ODhGRCB7Y291bnR9IFx1NTAwQlx1NTBDRlx1N0QyMFx1MzAwMlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIFx1N0U2QVx1ODhGRFx1OTA0RVx1N0EwQlx1NEUyRFx1NTFGQVx1OTMyRlwiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIFx1OEFDQlx1NTE0OFx1NTJBMFx1OEYwOVx1NTcxNlx1NzI0N1x1NEUyNlx1OTA3OFx1NjRDN1x1NEY0RFx1N0Y2RVwiLFxuICAgIHByb2dyZXNzOiBcIlx1OTAzMlx1NUVBNlwiLFxuICAgIHVzZXJOYW1lOiBcIlx1NzUyOFx1NjIzN1wiLFxuICAgIHBpeGVsczogXCJcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3OFwiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiXHU5ODEwXHU4QTA4XHU2NjQyXHU5NTkzXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiXHU5RURFXHU2NENBXHUyMDFDXHU1MjFEXHU1OUNCXHU1MzE2XHU4MUVBXHU1MkQ1XHU2QTVGXHU1NjY4XHU0RUJBXHUyMDFEXHU5NThCXHU1OUNCXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHU3QjQ5XHU1Rjg1XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgXHU1NzE2XHU3MjQ3XHU1REYyXHU4QUJGXHU2NTc0XHU3MEJBIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgXHU3RTZBXHU4OEZEXHU2NkFCXHU1MDVDXHU2NUJDXHU0RjREXHU3RjZFIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHU2QkNGXHU2Mjc5XHU1MENGXHU3RDIwXHU2NTc4XCIsXG4gICAgYmF0Y2hTaXplOiBcIlx1NjI3OVx1NkIyMVx1NTkyN1x1NUMwRlwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiXHU0RTBCXHU2QjIxXHU2Mjc5XHU2QjIxXHU2NjQyXHU5NTkzXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJcdTRGN0ZcdTc1MjhcdTYyNDBcdTY3MDlcdTUzRUZcdTc1MjhcdTZCMjFcdTY1NzhcIixcbiAgICBzaG93T3ZlcmxheTogXCJcdTk4NkZcdTc5M0FcdTg5ODZcdTg0Q0JcdTVDNjRcIixcbiAgICBtYXhDaGFyZ2VzOiBcIlx1NkJDRlx1NjI3OVx1NjcwMFx1NTkyN1x1NkIyMVx1NjU3OFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1Nzg6IHtjdXJyZW50fS97bmVlZGVkfVwiLFxuICAgIHRpbWVSZW1haW5pbmc6IFwiXHU1MjY5XHU5OTE4XHU2NjQyXHU5NTkzXCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBcdTdCNDlcdTVGODUge3RpbWV9IFx1NUY4Q1x1N0U3Q1x1N0U4Qy4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFx1OTAzMlx1NUVBNlx1NURGMlx1NEZERFx1NUI1OFx1NzBCQSB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFx1NURGMlx1NTJBMFx1OEYwOVx1OTAzMlx1NUVBNjoge3BhaW50ZWR9L3t0b3RhbH0gXHU1MENGXHU3RDIwXHU1REYyXHU3RTZBXHU4OEZEXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIFx1NTJBMFx1OEYwOVx1OTAzMlx1NUVBNlx1NTkzMVx1NjU1Nzoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBcdTRGRERcdTVCNThcdTkwMzJcdTVFQTZcdTU5MzFcdTY1NTc6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1NTcyOFx1NTA1Q1x1NkI2Mlx1NEU0Qlx1NTI0RFx1ODk4MVx1NEZERFx1NUI1OFx1NzU3Nlx1NTI0RFx1OTAzMlx1NUVBNlx1NTVDRVx1RkYxRlwiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlx1NEZERFx1NUI1OFx1OTAzMlx1NUVBNlwiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJcdTY1M0VcdTY4QzRcIixcbiAgICBjYW5jZWw6IFwiXHU1M0Q2XHU2RDg4XCIsXG4gICAgbWluaW1pemU6IFwiXHU2NzAwXHU1QzBGXHU1MzE2XCIsXG4gICAgd2lkdGg6IFwiXHU1QkVDXHU1RUE2XCIsXG4gICAgaGVpZ2h0OiBcIlx1OUFEOFx1NUVBNlwiLFxuICAgIGtlZXBBc3BlY3Q6IFwiXHU0RkREXHU2MzAxXHU3RTMxXHU2QTZCXHU2QkQ0XCIsXG4gICAgYXBwbHk6IFwiXHU2MUM5XHU3NTI4XCIsXG4gICAgb3ZlcmxheU9uOiBcIlx1ODk4Nlx1ODRDQlx1NUM2NDogXHU5NThCXHU1NTUzXCIsXG4gICAgb3ZlcmxheU9mZjogXCJcdTg5ODZcdTg0Q0JcdTVDNjQ6IFx1OTVEQ1x1OTU4OVwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFx1NjI3OVx1NkIyMVx1NUI4Q1x1NjIxMDogXHU1REYyXHU3RTZBXHU4OEZEIHtwYWludGVkfSBcdTUwQ0ZcdTdEMjAgfCBcdTkwMzJcdTVFQTY6IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3OFx1NjA2Mlx1NUZBOToge2N1cnJlbnR9L3tuZWVkZWR9IC0gXHU2NjQyXHU5NTkzOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTc4OiB7Y3VycmVudH0ve25lZWRlZH0gLSBcdTUyNjlcdTk5MTg6IHt0aW1lfVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkQ1XHU1NTUzXHU1MkQ1XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NzEyMVx1NkNENVx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1RkYwQ1x1OEFDQlx1NjI0Qlx1NTJENVx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHU1REYyXHU2QUEyXHU2RTJDXHU1MjMwXHU4QUJGXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY0MUNcdTdEMjJcdThBQkZcdTgyNzJcdTY3N0YuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTZCNjNcdTU3MjhcdTlFREVcdTY0Q0FcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTUuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTVcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1OTcwMFx1ODk4MVx1NjI0Qlx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNlwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgXHU5MUNEXHU4QTY2IHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9XHVGRjBDXHU3QjQ5XHU1Rjg1IHtkZWxheX0gXHU3OUQyLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgXHU3QjJDIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IFx1NkIyMVx1NTYxN1x1OEE2Nlx1NTFGQVx1OTMyRlx1RkYwQ1x1NUMwN1x1NTcyOCB7ZGVsYXl9IFx1NzlEMlx1NUY4Q1x1OTFDRFx1OEE2Ni4uLlwiLFxuICAgIHJldHJ5RmFpbGVkOiBcIlx1Mjc0QyBcdThEODVcdTkwNEUge21heEF0dGVtcHRzfSBcdTZCMjFcdTU2MTdcdThBNjZcdTU5MzFcdTY1NTdcdTMwMDJcdTdFN0NcdTdFOENcdTRFMEJcdTRFMDBcdTYyNzkuLi5cIixcbiAgICBuZXR3b3JrRXJyb3I6IFwiXHVEODNDXHVERjEwIFx1N0RCMlx1N0Q2MVx1OTMyRlx1OEFBNFx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEE2Ni4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBcdTY3MERcdTUyRDlcdTU2NjhcdTkzMkZcdThBQTRcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThBNjYuLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFx1NjcwRFx1NTJEOVx1NTY2OFx1OEQ4NVx1NjY0Mlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEE2Ni4uLlwiXG4gIH0sXG5cbiAgLy8gXHU4RkIyXHU1ODM0XHU2QTIxXHU1ODRBXHVGRjA4XHU1Rjg1XHU1QkU2XHU3M0ZFXHVGRjA5XG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU4RkIyXHU1ODM0XHU2QTVGXHU1NjY4XHU0RUJBXCIsXG4gICAgc3RhcnQ6IFwiXHU5NThCXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBzdG9wcGVkOiBcIlx1NkE1Rlx1NTY2OFx1NEVCQVx1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIGNhbGlicmF0ZTogXCJcdTY4MjFcdTZFOTZcIixcbiAgICBwYWludE9uY2U6IFwiXHU0RTAwXHU2QjIxXCIsXG4gICAgY2hlY2tpbmdTdGF0dXM6IFwiXHU2QUEyXHU2N0U1XHU3MkMwXHU2MTRCXHU0RTJELi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJcdTkxNERcdTdGNkVcIixcbiAgICBkZWxheTogXCJcdTVFRjZcdTkwNzIgKFx1NkJFQlx1NzlEMilcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTZCQ0ZcdTYyNzlcdTUwQ0ZcdTdEMjBcIixcbiAgICBtaW5DaGFyZ2VzOiBcIlx1NjcwMFx1NUMxMVx1NkIyMVx1NjU3OFwiLFxuICAgIGNvbG9yTW9kZTogXCJcdTk4NEZcdTgyNzJcdTZBMjFcdTVGMEZcIixcbiAgICByYW5kb206IFwiXHU5NkE4XHU2QTVGXCIsXG4gICAgZml4ZWQ6IFwiXHU1NkZBXHU1QjlBXCIsXG4gICAgcmFuZ2U6IFwiXHU3QkM0XHU1NzBEXCIsXG4gICAgZml4ZWRDb2xvcjogXCJcdTU2RkFcdTVCOUFcdTk4NEZcdTgyNzJcIixcbiAgICBhZHZhbmNlZDogXCJcdTlBRDhcdTdEMUFcIixcbiAgICB0aWxlWDogXCJcdTc0RTZcdTcyNDcgWFwiLFxuICAgIHRpbGVZOiBcIlx1NzRFNlx1NzI0NyBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJcdTgxRUFcdTVCOUFcdTdGQTlcdThBQkZcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJcdTRGOEJcdTU5ODI6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJcdTYzNTVcdTczNzJcIixcbiAgICBwYWludGVkOiBcIlx1NURGMlx1N0U2QVx1ODhGRFwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTc4XCIsXG4gICAgcmV0cmllczogXCJcdTkxQ0RcdThBNjZcIixcbiAgICB0aWxlOiBcIlx1NzRFNlx1NzI0N1wiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1NEZERFx1NUI1OFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTUyQTBcdThGMDlcIixcbiAgICBjb25maWdSZXNldDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTkxQ0RcdTdGNkVcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlx1OEFDQlx1NjI0Qlx1NTJENVx1N0U2QVx1ODhGRFx1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFx1NEVFNVx1NjM1NVx1NzM3Mlx1NUVBN1x1NkExOS4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiXHU1RjhDXHU3QUVGXHU1NzI4XHU3RERBXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiXHU1RjhDXHU3QUVGXHU5NkUyXHU3RERBXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1NTUzXHU1MkQ1XHU2QTVGXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1MDVDXHU2QjYyXHU2QTVGXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiXHU2ODIxXHU2RTk2XHU0RTJELi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiXHU4MUVBXHU1MkQ1XHU4RkIyXHU1ODM0XHU1REYyXHU1NzI4XHU5MDRCXHU4ODRDXHUzMDAyXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJcdTgxRUFcdTUyRDVcdTdFNkFcdTU3MTZcdTZCNjNcdTU3MjhcdTkwNEJcdTg4NENcdUZGMENcdThBQ0JcdTUxNDhcdTk1RENcdTk1ODlcdTUxOERcdTU1NTNcdTUyRDVcdTgxRUFcdTUyRDVcdThGQjJcdTU4MzRcdTMwMDJcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1RDgzQ1x1REZBRiBcdTU3MjhcdTU3MzBcdTU3MTZcdTc2ODRcdTdBN0FcdTc2N0RcdTUzNDBcdTU3REZcdTU4NTdcdTRFMDBcdTUwMEJcdTUwQ0ZcdTdEMjBcdTRFRTVcdThBMkRcdTdGNkVcdThGQjJcdTU4MzRcdTUzNDBcdTU3REZcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1NEY2MFx1NTg1N1x1NTNDM1x1ODAwM1x1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTUzNDBcdTU3REZcdThBMkRcdTdGNkVcdTYyMTBcdTUyOUZcdUZGMDFcdTUzNEFcdTVGOTE6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTUzNDBcdTU3REZcdTkwNzhcdTY0QzdcdThEODVcdTY2NDJcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFx1OEFDQlx1NTE0OFx1OTA3OFx1NjRDN1x1NTM0MFx1NTdERlx1RkYwOFx1NEY3Rlx1NzUyOFx1MjAxQ1x1OTA3OFx1NjRDN1x1NTM0MFx1NTdERlx1MjAxRFx1NjMwOVx1OTIxNVx1RkYwOVwiLFxuICAgIGZhcm1SYWRpdXM6IFwiXHU4RkIyXHU1ODM0XHU1MzRBXHU1RjkxXCIsXG4gICAgcG9zaXRpb25JbmZvOiBcIlx1NzU3Nlx1NTI0RFx1NTM0MFx1NTdERlwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgXHU2QjYzXHU1NzI4XHU0RUU1XHU1MzRBXHU1RjkxIHtyYWRpdXN9cHggXHU1NzI4ICh7eH0se3l9KSBcdThGQjJcdTU4MzRcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIFx1OTFDRFx1ODk4MTogXHU4QUNCXHU5MDc4XHU2NEM3XHU3QTdBXHU3NjdEXHU1MzQwXHU1N0RGXHU0RUU1XHU5MDdGXHU1MTREXHU4ODVEXHU3QTgxXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJcdTY3MkFcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcIixcbiAgICBjdXJyZW50Wm9uZTogXCJcdTUzNDBcdTU3REY6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgXHU4QUNCXHU1MTQ4XHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXHVGRjBDXHU1NzI4XHU1NzMwXHU1NzE2XHU0RTBBXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXHU0RUU1XHU4QTJEXHU3RjZFXHU4RkIyXHU1ODM0XHU1MzQwXHU1N0RGXCJcbiAgfSxcblxuICAvLyBcdTUxNkNcdTUxNzFcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIlx1NjYyRlwiLFxuICAgIG5vOiBcIlx1NTQyNlwiLFxuICAgIG9rOiBcIlx1NzhCQVx1OEE4RFwiLFxuICAgIGNhbmNlbDogXCJcdTUzRDZcdTZEODhcIixcbiAgICBjbG9zZTogXCJcdTk1RENcdTk1ODlcIixcbiAgICBzYXZlOiBcIlx1NEZERFx1NUI1OFwiLFxuICAgIGxvYWQ6IFwiXHU1MkEwXHU4RjA5XCIsXG4gICAgZGVsZXRlOiBcIlx1NTIyQVx1OTY2NFwiLFxuICAgIGVkaXQ6IFwiXHU3REU4XHU4RjJGXCIsXG4gICAgc3RhcnQ6IFwiXHU5NThCXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBwYXVzZTogXCJcdTY2QUJcdTUwNUNcIixcbiAgICByZXN1bWU6IFwiXHU3RTdDXHU3RThDXCIsXG4gICAgcmVzZXQ6IFwiXHU5MUNEXHU3RjZFXCIsXG4gICAgc2V0dGluZ3M6IFwiXHU4QTJEXHU3RjZFXCIsXG4gICAgaGVscDogXCJcdTVFNkJcdTUyQTlcIixcbiAgICBhYm91dDogXCJcdTk1RENcdTY1QkNcIixcbiAgICBsYW5ndWFnZTogXCJcdThBOUVcdThBMDBcIixcbiAgICBsb2FkaW5nOiBcIlx1NTJBMFx1OEYwOVx1NEUyRC4uLlwiLFxuICAgIGVycm9yOiBcIlx1OTMyRlx1OEFBNFwiLFxuICAgIHN1Y2Nlc3M6IFwiXHU2MjEwXHU1MjlGXCIsXG4gICAgd2FybmluZzogXCJcdThCNjZcdTU0NEFcIixcbiAgICBpbmZvOiBcIlx1NEZFMVx1NjA2RlwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJcdThBOUVcdThBMDBcdTVERjJcdTUyMDdcdTYzREJcdTcwQkEge2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gXHU1Qjg4XHU4Qjc3XHU2QTIxXHU1ODRBXG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1ODFFQVx1NTJENVx1NUI4OFx1OEI3N1wiLFxuICAgIGluaXRCb3Q6IFwiXHU1MjFEXHU1OUNCXHU1MzE2XHU1Qjg4XHU4Qjc3XHU2QTVGXHU1NjY4XHU0RUJBXCIsXG4gICAgc2VsZWN0QXJlYTogXCJcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcIixcbiAgICBjYXB0dXJlQXJlYTogXCJcdTYzNTVcdTczNzJcdTUzNDBcdTU3REZcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiXHU5NThCXHU1OUNCXHU1Qjg4XHU4Qjc3XCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiXHU1MDVDXHU2QjYyXHU1Qjg4XHU4Qjc3XCIsXG4gICAgdXBwZXJMZWZ0OiBcIlx1NURFNlx1NEUwQVx1ODlEMlwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiXHU1M0YzXHU0RTBCXHU4OUQyXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlx1NTNEN1x1NEZERFx1OEI3N1x1NTBDRlx1N0QyMFwiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJcdTZBQTJcdTZFMkNcdTUyMzBcdTc2ODRcdThCOEFcdTUzMTZcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJcdTRGRUVcdTVGQTlcdTc2ODRcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3OFwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1N0I0OVx1NUY4NVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBcdTZBQTJcdTY3RTVcdTUzRUZcdTc1MjhcdTk4NEZcdTgyNzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTk4NEZcdTgyNzJcdUZGMENcdThBQ0JcdTU3MjhcdTdEQjJcdTdBRDlcdTRFMEFcdTYyNTNcdTk1OEJcdThBQkZcdTgyNzJcdTY3N0ZcdTMwMDJcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHU2MjdFXHU1MjMwIHtjb3VudH0gXHU3QTJFXHU1M0VGXHU3NTI4XHU5ODRGXHU4MjcyXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1NUI4OFx1OEI3N1x1NkE1Rlx1NTY2OFx1NEVCQVx1NTIxRFx1NTlDQlx1NTMxNlx1NjIxMFx1NTI5RlwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgXHU1Qjg4XHU4Qjc3XHU2QTVGXHU1NjY4XHU0RUJBXHU1MjFEXHU1OUNCXHU1MzE2XHU1OTMxXHU2NTU3XCIsXG4gICAgaW52YWxpZENvb3JkczogXCJcdTI3NEMgXHU1RUE3XHU2QTE5XHU3MTIxXHU2NTQ4XCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIFx1NTM0MFx1NTdERlx1NzEyMVx1NjU0OFx1RkYwQ1x1NURFNlx1NEUwQVx1ODlEMlx1NUZDNVx1OTgwOFx1NUMwRlx1NjVCQ1x1NTNGM1x1NEUwQlx1ODlEMlwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHU1MzQwXHU1N0RGXHU5MDRFXHU1OTI3OiB7c2l6ZX0gXHU1MENGXHU3RDIwIChcdTY3MDBcdTU5Mjc6IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IFx1NjM1NVx1NzM3Mlx1NUI4OFx1OEI3N1x1NTM0MFx1NTdERlx1NEUyRC4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHU1MzQwXHU1N0RGXHU2MzU1XHU3MzcyXHU2MjEwXHU1MjlGOiB7Y291bnR9IFx1NTBDRlx1N0QyMFx1NTNEN1x1NEZERFx1OEI3N1wiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgXHU2MzU1XHU3MzcyXHU1MzQwXHU1N0RGXHU1MUZBXHU5MzJGOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBcdThBQ0JcdTUxNDhcdTYzNTVcdTczNzJcdTRFMDBcdTUwMEJcdTVCODhcdThCNzdcdTUzNDBcdTU3REZcIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU4Qjc3XHU1REYyXHU1NTUzXHU1MkQ1IC0gXHU1MzQwXHU1N0RGXHU3NkUzXHU2M0E3XHU0RTJEXCIsXG4gICAgcHJvdGVjdGlvblN0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NUI4OFx1OEI3N1x1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHU1MzQwXHU1N0RGXHU1Qjg5XHU1MTY4IC0gXHU2NzJBXHU2QUEyXHU2RTJDXHU1MjMwXHU4QjhBXHU1MzE2XCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCBcdTZBQTJcdTZFMkNcdTUyMzAge2NvdW50fSBcdTUwMEJcdThCOEFcdTUzMTZcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFx1NkI2M1x1NTcyOFx1NEZFRVx1NUZBOSB7Y291bnR9IFx1NTAwQlx1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgXHU1REYyXHU2MjEwXHU1MjlGXHU0RkVFXHU1RkE5IHtjb3VudH0gXHU1MDBCXHU1MENGXHU3RDIwXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIFx1NEZFRVx1NUZBOVx1NTFGQVx1OTMyRjoge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgXHU2QjIxXHU2NTc4XHU0RTBEXHU4REIzXHVGRjBDXHU3MTIxXHU2Q0Q1XHU0RkVFXHU1RkE5XCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTZBQTJcdTY3RTVcdTUzNDBcdTU3REZcdThCOEFcdTUzMTYuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBcdTZBQTJcdTY3RTVcdTUxRkFcdTkzMkY6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU4Qjc3XHU0RTJEIC0gXHU1MzQwXHU1N0RGXHU1M0Q3XHU0RkREXHU4Qjc3XCIsXG4gICAgbGFzdENoZWNrOiBcIlx1NEUwQVx1NkIyMVx1NkFBMlx1NjdFNToge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIlx1NEUwQlx1NkIyMVx1NkFBMlx1NjdFNToge3RpbWV9IFx1NzlEMlx1NUY4Q1wiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkQ1XHU1NTUzXHU1MkQ1XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NzEyMVx1NkNENVx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1RkYwQ1x1OEFDQlx1NjI0Qlx1NTJENVx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHU5NzAwXHU4OTgxXHU2MjRCXHU1MkQ1XHU1MjFEXHU1OUNCXHU1MzE2XCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTVERjJcdTZBQTJcdTZFMkNcdTUyMzBcdThBQkZcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjQxQ1x1N0QyMlx1OEFCRlx1ODI3Mlx1Njc3Ri4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1NkI2M1x1NTcyOFx1OUVERVx1NjRDQVx1N0U2QVx1ODhGRFx1NjMwOVx1OTIxNS4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1N0U2QVx1ODhGRFx1NjMwOVx1OTIxNVwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgXHU1NzI4XHU5NzAwXHU4OTgxXHU0RkREXHU4Qjc3XHU1MzQwXHU1N0RGXHU3Njg0XHU1REU2XHU0RTBBXHU4OUQyXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgXHU3M0ZFXHU1NzI4XHU1NzI4XHU1M0YzXHU0RTBCXHU4OUQyXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU5MDc4XHU2NEM3XHU1REU2XHU0RTBBXHU4OUQyLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1OTA3OFx1NjRDN1x1NTNGM1x1NEUwQlx1ODlEMi4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBcdTVERjJcdTYzNTVcdTczNzJcdTVERTZcdTRFMEFcdTg5RDI6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1NURGMlx1NjM1NVx1NzM3Mlx1NTNGM1x1NEUwQlx1ODlEMjogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1OTA3OFx1NjRDN1x1OEQ4NVx1NjY0MlwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTkwNzhcdTY0QzdcdTUxRkFcdTkzMkZcdUZGMENcdThBQ0JcdTkxQ0RcdThBNjZcIlxuICB9XG59OyIsICJpbXBvcnQgeyBlcyB9IGZyb20gJy4vZXMuanMnO1xuaW1wb3J0IHsgZW4gfSBmcm9tICcuL2VuLmpzJztcbmltcG9ydCB7IGZyIH0gZnJvbSAnLi9mci5qcyc7XG5pbXBvcnQgeyBydSB9IGZyb20gJy4vcnUuanMnO1xuaW1wb3J0IHsgemhIYW5zIH0gZnJvbSAnLi96aC1IYW5zLmpzJztcbmltcG9ydCB7IHpoSGFudCB9IGZyb20gJy4vemgtSGFudC5qcyc7XG5cbi8vIElkaW9tYXMgZGlzcG9uaWJsZXNcbmV4cG9ydCBjb25zdCBBVkFJTEFCTEVfTEFOR1VBR0VTID0ge1xuICBlczogeyBuYW1lOiAnRXNwYVx1MDBGMW9sJywgZmxhZzogJ1x1RDgzQ1x1RERFQVx1RDgzQ1x1RERGOCcsIGNvZGU6ICdlcycgfSxcbiAgZW46IHsgbmFtZTogJ0VuZ2xpc2gnLCBmbGFnOiAnXHVEODNDXHVEREZBXHVEODNDXHVEREY4JywgY29kZTogJ2VuJyB9LFxuICBmcjogeyBuYW1lOiAnRnJhblx1MDBFN2FpcycsIGZsYWc6ICdcdUQ4M0NcdURERUJcdUQ4M0NcdURERjcnLCBjb2RlOiAnZnInIH0sXG4gIHJ1OiB7IG5hbWU6ICdcdTA0MjBcdTA0NDNcdTA0NDFcdTA0NDFcdTA0M0FcdTA0MzhcdTA0MzknLCBmbGFnOiAnXHVEODNDXHVEREY3XHVEODNDXHVEREZBJywgY29kZTogJ3J1JyB9LFxuICB6aEhhbnM6IHsgbmFtZTogJ1x1N0I4MFx1NEY1M1x1NEUyRFx1NjU4NycsIGZsYWc6ICdcdUQ4M0NcdURERThcdUQ4M0NcdURERjMnLCBjb2RlOiAnemgtSGFucycgfSxcbiAgemhIYW50OiB7IG5hbWU6ICdcdTdFNDFcdTlBRDRcdTRFMkRcdTY1ODcnLCBmbGFnOiAnXHVEODNDXHVEREU4XHVEODNDXHVEREYzJywgY29kZTogJ3poLUhhbnQnIH1cbn07XG5cbi8vIFRvZGFzIGxhcyB0cmFkdWNjaW9uZXNcbmNvbnN0IHRyYW5zbGF0aW9ucyA9IHtcbiAgZXMsXG4gIGVuLFxuICBmcixcbiAgcnUsXG4gIHpoSGFucyxcbiAgemhIYW50XG59O1xuXG4vLyBFc3RhZG8gZGVsIGlkaW9tYSBhY3R1YWxcbmxldCBjdXJyZW50TGFuZ3VhZ2UgPSAnZXMnO1xubGV0IGN1cnJlbnRUcmFuc2xhdGlvbnMgPSB0cmFuc2xhdGlvbnNbY3VycmVudExhbmd1YWdlXTtcblxuLyoqXG4gKiBEZXRlY3RhIGVsIGlkaW9tYSBkZWwgbmF2ZWdhZG9yXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hIGRldGVjdGFkb1xuICovXG5leHBvcnQgZnVuY3Rpb24gZGV0ZWN0QnJvd3Nlckxhbmd1YWdlKCkge1xuICBjb25zdCBicm93c2VyTGFuZyA9IHdpbmRvdy5uYXZpZ2F0b3IubGFuZ3VhZ2UgfHwgd2luZG93Lm5hdmlnYXRvci51c2VyTGFuZ3VhZ2UgfHwgJ2VzJztcblxuICAvLyBFeHRyYWVyIHNvbG8gZWwgY1x1MDBGM2RpZ28gZGVsIGlkaW9tYSAoZWo6ICdlcy1FUycgLT4gJ2VzJylcbiAgY29uc3QgbGFuZ0NvZGUgPSBicm93c2VyTGFuZy5zcGxpdCgnLScpWzBdLnRvTG93ZXJDYXNlKCk7XG5cbiAgLy8gVmVyaWZpY2FyIHNpIHRlbmVtb3Mgc29wb3J0ZSBwYXJhIGVzdGUgaWRpb21hXG4gIGlmICh0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdKSB7XG4gICAgcmV0dXJuIGxhbmdDb2RlO1xuICB9XG5cbiAgLy8gRmFsbGJhY2sgYSBlc3BhXHUwMEYxb2wgcG9yIGRlZmVjdG9cbiAgcmV0dXJuICdlcyc7XG59XG5cbi8qKlxuICogT2J0aWVuZSBlbCBpZGlvbWEgZ3VhcmRhZG8gKGRlc2hhYmlsaXRhZG8gLSBubyB1c2FyIGxvY2FsU3RvcmFnZSlcbiAqIEByZXR1cm5zIHtzdHJpbmd9IFNpZW1wcmUgcmV0b3JuYSBudWxsXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRTYXZlZExhbmd1YWdlKCkge1xuICAvLyBObyB1c2FyIGxvY2FsU3RvcmFnZSAtIHNpZW1wcmUgcmV0b3JuYXIgbnVsbFxuICByZXR1cm4gbnVsbDtcbn1cblxuLyoqXG4gKiBHdWFyZGEgZWwgaWRpb21hIChkZXNoYWJpbGl0YWRvIC0gbm8gdXNhciBsb2NhbFN0b3JhZ2UpXG4gKiBAcGFyYW0ge3N0cmluZ30gbGFuZ0NvZGUgLSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBzYXZlTGFuZ3VhZ2UobGFuZ0NvZGUpIHtcbiAgLy8gTm8gZ3VhcmRhciBlbiBsb2NhbFN0b3JhZ2UgLSBmdW5jaVx1MDBGM24gZGVzaGFiaWxpdGFkYVxuICByZXR1cm47XG59XG5cbi8qKlxuICogSW5pY2lhbGl6YSBlbCBzaXN0ZW1hIGRlIGlkaW9tYXNcbiAqIEByZXR1cm5zIHtzdHJpbmd9IENcdTAwRjNkaWdvIGRlbCBpZGlvbWEgaW5pY2lhbGl6YWRvXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBpbml0aWFsaXplTGFuZ3VhZ2UoKSB7XG4gIC8vIFByaW9yaWRhZDogZ3VhcmRhZG8gPiBuYXZlZ2Fkb3IgPiBlc3BhXHUwMEYxb2xcbiAgY29uc3Qgc2F2ZWRMYW5nID0gZ2V0U2F2ZWRMYW5ndWFnZSgpO1xuICBjb25zdCBicm93c2VyTGFuZyA9IGRldGVjdEJyb3dzZXJMYW5ndWFnZSgpO1xuXG4gIGxldCBzZWxlY3RlZExhbmcgPSAnZXMnOyAvLyBmYWxsYmFjayBwb3IgZGVmZWN0b1xuXG4gIGlmIChzYXZlZExhbmcgJiYgdHJhbnNsYXRpb25zW3NhdmVkTGFuZ10pIHtcbiAgICBzZWxlY3RlZExhbmcgPSBzYXZlZExhbmc7XG4gIH0gZWxzZSBpZiAoYnJvd3NlckxhbmcgJiYgdHJhbnNsYXRpb25zW2Jyb3dzZXJMYW5nXSkge1xuICAgIHNlbGVjdGVkTGFuZyA9IGJyb3dzZXJMYW5nO1xuICB9XG5cbiAgc2V0TGFuZ3VhZ2Uoc2VsZWN0ZWRMYW5nKTtcbiAgcmV0dXJuIHNlbGVjdGVkTGFuZztcbn1cblxuLyoqXG4gKiBDYW1iaWEgZWwgaWRpb21hIGFjdHVhbFxuICogQHBhcmFtIHtzdHJpbmd9IGxhbmdDb2RlIC0gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYVxuICovXG5leHBvcnQgZnVuY3Rpb24gc2V0TGFuZ3VhZ2UobGFuZ0NvZGUpIHtcbiAgaWYgKCF0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdKSB7XG4gICAgY29uc29sZS53YXJuKGBJZGlvbWEgJyR7bGFuZ0NvZGV9JyBubyBkaXNwb25pYmxlLiBVc2FuZG8gJyR7Y3VycmVudExhbmd1YWdlfSdgKTtcbiAgICByZXR1cm47XG4gIH1cblxuICBjdXJyZW50TGFuZ3VhZ2UgPSBsYW5nQ29kZTtcbiAgY3VycmVudFRyYW5zbGF0aW9ucyA9IHRyYW5zbGF0aW9uc1tsYW5nQ29kZV07XG4gIHNhdmVMYW5ndWFnZShsYW5nQ29kZSk7XG5cbiAgLy8gRW1pdGlyIGV2ZW50byBwZXJzb25hbGl6YWRvIHBhcmEgcXVlIGxvcyBtXHUwMEYzZHVsb3MgcHVlZGFuIHJlYWNjaW9uYXJcbiAgaWYgKHR5cGVvZiB3aW5kb3cgIT09ICd1bmRlZmluZWQnICYmIHdpbmRvdy5DdXN0b21FdmVudCkge1xuICAgIHdpbmRvdy5kaXNwYXRjaEV2ZW50KG5ldyB3aW5kb3cuQ3VzdG9tRXZlbnQoJ2xhbmd1YWdlQ2hhbmdlZCcsIHtcbiAgICAgIGRldGFpbDogeyBsYW5ndWFnZTogbGFuZ0NvZGUsIHRyYW5zbGF0aW9uczogY3VycmVudFRyYW5zbGF0aW9ucyB9XG4gICAgfSkpO1xuICB9XG59XG5cbi8qKlxuICogT2J0aWVuZSBlbCBpZGlvbWEgYWN0dWFsXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hIGFjdHVhbFxuICovXG5leHBvcnQgZnVuY3Rpb24gZ2V0Q3VycmVudExhbmd1YWdlKCkge1xuICByZXR1cm4gY3VycmVudExhbmd1YWdlO1xufVxuXG4vKipcbiAqIE9idGllbmUgbGFzIHRyYWR1Y2Npb25lcyBhY3R1YWxlc1xuICogQHJldHVybnMge29iamVjdH0gT2JqZXRvIGNvbiB0b2RhcyBsYXMgdHJhZHVjY2lvbmVzIGRlbCBpZGlvbWEgYWN0dWFsXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRDdXJyZW50VHJhbnNsYXRpb25zKCkge1xuICByZXR1cm4gY3VycmVudFRyYW5zbGF0aW9ucztcbn1cblxuLyoqXG4gKiBPYnRpZW5lIHVuIHRleHRvIHRyYWR1Y2lkbyB1c2FuZG8gbm90YWNpXHUwMEYzbiBkZSBwdW50b1xuICogQHBhcmFtIHtzdHJpbmd9IGtleSAtIENsYXZlIGRlbCB0ZXh0byAoZWo6ICdpbWFnZS50aXRsZScsICdjb21tb24uY2FuY2VsJylcbiAqIEBwYXJhbSB7b2JqZWN0fSBwYXJhbXMgLSBQYXJcdTAwRTFtZXRyb3MgcGFyYSBpbnRlcnBvbGFjaVx1MDBGM24gKGVqOiB7Y291bnQ6IDV9KVxuICogQHJldHVybnMge3N0cmluZ30gVGV4dG8gdHJhZHVjaWRvXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiB0KGtleSwgcGFyYW1zID0ge30pIHtcbiAgY29uc3Qga2V5cyA9IGtleS5zcGxpdCgnLicpO1xuICBsZXQgdmFsdWUgPSBjdXJyZW50VHJhbnNsYXRpb25zO1xuXG4gIC8vIE5hdmVnYXIgcG9yIGxhIGVzdHJ1Y3R1cmEgZGUgb2JqZXRvc1xuICBmb3IgKGNvbnN0IGsgb2Yga2V5cykge1xuICAgIGlmICh2YWx1ZSAmJiB0eXBlb2YgdmFsdWUgPT09ICdvYmplY3QnICYmIGsgaW4gdmFsdWUpIHtcbiAgICAgIHZhbHVlID0gdmFsdWVba107XG4gICAgfSBlbHNlIHtcbiAgICAgIGNvbnNvbGUud2FybihgQ2xhdmUgZGUgdHJhZHVjY2lcdTAwRjNuIG5vIGVuY29udHJhZGE6ICcke2tleX0nYCk7XG4gICAgICByZXR1cm4ga2V5OyAvLyBSZXRvcm5hciBsYSBjbGF2ZSBjb21vIGZhbGxiYWNrXG4gICAgfVxuICB9XG5cbiAgaWYgKHR5cGVvZiB2YWx1ZSAhPT0gJ3N0cmluZycpIHtcbiAgICBjb25zb2xlLndhcm4oYENsYXZlIGRlIHRyYWR1Y2NpXHUwMEYzbiBubyBlcyBzdHJpbmc6ICcke2tleX0nYCk7XG4gICAgcmV0dXJuIGtleTtcbiAgfVxuXG4gIC8vIEludGVycG9sYXIgcGFyXHUwMEUxbWV0cm9zXG4gIHJldHVybiBpbnRlcnBvbGF0ZSh2YWx1ZSwgcGFyYW1zKTtcbn1cblxuLyoqXG4gKiBJbnRlcnBvbGEgcGFyXHUwMEUxbWV0cm9zIGVuIHVuIHN0cmluZ1xuICogQHBhcmFtIHtzdHJpbmd9IHRleHQgLSBUZXh0byBjb24gbWFyY2Fkb3JlcyB7a2V5fVxuICogQHBhcmFtIHtvYmplY3R9IHBhcmFtcyAtIFBhclx1MDBFMW1ldHJvcyBhIGludGVycG9sYXJcbiAqIEByZXR1cm5zIHtzdHJpbmd9IFRleHRvIGNvbiBwYXJcdTAwRTFtZXRyb3MgaW50ZXJwb2xhZG9zXG4gKi9cbmZ1bmN0aW9uIGludGVycG9sYXRlKHRleHQsIHBhcmFtcykge1xuICBpZiAoIXBhcmFtcyB8fCBPYmplY3Qua2V5cyhwYXJhbXMpLmxlbmd0aCA9PT0gMCkge1xuICAgIHJldHVybiB0ZXh0O1xuICB9XG5cbiAgcmV0dXJuIHRleHQucmVwbGFjZSgvXFx7KFxcdyspXFx9L2csIChtYXRjaCwga2V5KSA9PiB7XG4gICAgcmV0dXJuIHBhcmFtc1trZXldICE9PSB1bmRlZmluZWQgPyBwYXJhbXNba2V5XSA6IG1hdGNoO1xuICB9KTtcbn1cblxuLyoqXG4gKiBPYnRpZW5lIHRyYWR1Y2Npb25lcyBkZSB1bmEgc2VjY2lcdTAwRjNuIGVzcGVjXHUwMEVEZmljYVxuICogQHBhcmFtIHtzdHJpbmd9IHNlY3Rpb24gLSBTZWNjaVx1MDBGM24gKGVqOiAnaW1hZ2UnLCAnbGF1bmNoZXInLCAnY29tbW9uJylcbiAqIEByZXR1cm5zIHtvYmplY3R9IE9iamV0byBjb24gbGFzIHRyYWR1Y2Npb25lcyBkZSBsYSBzZWNjaVx1MDBGM25cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGdldFNlY3Rpb24oc2VjdGlvbikge1xuICBpZiAoY3VycmVudFRyYW5zbGF0aW9uc1tzZWN0aW9uXSkge1xuICAgIHJldHVybiBjdXJyZW50VHJhbnNsYXRpb25zW3NlY3Rpb25dO1xuICB9XG5cbiAgY29uc29sZS53YXJuKGBTZWNjaVx1MDBGM24gZGUgdHJhZHVjY2lcdTAwRjNuIG5vIGVuY29udHJhZGE6ICcke3NlY3Rpb259J2ApO1xuICByZXR1cm4ge307XG59XG5cbi8qKlxuICogVmVyaWZpY2Egc2kgdW4gaWRpb21hIGVzdFx1MDBFMSBkaXNwb25pYmxlXG4gKiBAcGFyYW0ge3N0cmluZ30gbGFuZ0NvZGUgLSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hXG4gKiBAcmV0dXJucyB7Ym9vbGVhbn0gVHJ1ZSBzaSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICovXG5leHBvcnQgZnVuY3Rpb24gaXNMYW5ndWFnZUF2YWlsYWJsZShsYW5nQ29kZSkge1xuICByZXR1cm4gISF0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdO1xufVxuXG4vLyBJbmljaWFsaXphciBhdXRvbVx1MDBFMXRpY2FtZW50ZSBhbCBjYXJnYXIgZWwgbVx1MDBGM2R1bG9cbmluaXRpYWxpemVMYW5ndWFnZSgpO1xuIiwgImltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuaW1wb3J0IHsgRkFSTV9ERUZBVUxUUywgZmFybVN0YXRlIH0gZnJvbSBcIi4vY29uZmlnLmpzXCI7XG5pbXBvcnQgeyBzYXZlRmFybUNmZywgbG9hZEZhcm1DZmcsIHJlc2V0RmFybUNmZyB9IGZyb20gXCIuLi9jb3JlL3N0b3JhZ2UuanNcIjtcbmltcG9ydCB7IGRyYWdIZWFkZXIsIGNsYW1wIH0gZnJvbSBcIi4uL2NvcmUvdXRpbHMuanNcIjtcbmltcG9ydCB7IHQgfSBmcm9tIFwiLi4vbG9jYWxlcy9pbmRleC5qc1wiO1xuXG5leHBvcnQgZnVuY3Rpb24gY3JlYXRlRmFybVVJKGNvbmZpZywgb25TdGFydCwgb25TdG9wKSB7XG4gIGNvbnN0IHNoYWRvd0hvc3QgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdkaXYnKTtcbiAgc2hhZG93SG9zdC5pZCA9ICd3cGxhY2UtZmFybS11aSc7XG4gIHNoYWRvd0hvc3Quc3R5bGUuY3NzVGV4dCA9IGBcbiAgICBwb3NpdGlvbjogZml4ZWQ7XG4gICAgdG9wOiAxMHB4O1xuICAgIHJpZ2h0OiAxMHB4O1xuICAgIHotaW5kZXg6IDIxNDc0ODM2NDc7XG4gICAgZm9udC1mYW1pbHk6IC1hcHBsZS1zeXN0ZW0sIEJsaW5rTWFjU3lzdGVtRm9udCwgJ1NlZ29lIFVJJywgJ1JvYm90bycsIHNhbnMtc2VyaWY7XG4gIGA7XG4gIFxuICBjb25zdCBzaGFkb3cgPSBzaGFkb3dIb3N0LmF0dGFjaFNoYWRvdyh7IG1vZGU6ICdvcGVuJyB9KTtcbiAgXG4gIGNvbnN0IHN0eWxlID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc3R5bGUnKTtcbiAgc3R5bGUudGV4dENvbnRlbnQgPSBgXG4gICAgLndwbGFjZS1jb250YWluZXIge1xuICAgICAgYmFja2dyb3VuZDogbGluZWFyLWdyYWRpZW50KDEzNWRlZywgIzY2N2VlYSAwJSwgIzc2NGJhMiAxMDAlKTtcbiAgICAgIGJvcmRlcjogMnB4IHNvbGlkICM0YTU1Njg7XG4gICAgICBib3JkZXItcmFkaXVzOiAxMnB4O1xuICAgICAgcGFkZGluZzogMTZweDtcbiAgICAgIG1pbi13aWR0aDogMzIwcHg7XG4gICAgICBtYXgtd2lkdGg6IDQwMHB4O1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgICAgYm94LXNoYWRvdzogMCAxMHB4IDI1cHggcmdiYSgwLDAsMCwwLjMpO1xuICAgICAgZm9udC1zaXplOiAxNHB4O1xuICAgICAgYmFja2Ryb3AtZmlsdGVyOiBibHVyKDEwcHgpO1xuICAgICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWhlYWRlciB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIG1hcmdpbi1ib3R0b206IDEycHg7XG4gICAgICBwYWRkaW5nLWJvdHRvbTogOHB4O1xuICAgICAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkIHJnYmEoMjU1LDI1NSwyNTUsMC4yKTtcbiAgICAgIGN1cnNvcjogbW92ZTtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS10aXRsZSB7XG4gICAgICBmb250LXdlaWdodDogYm9sZDtcbiAgICAgIGZvbnQtc2l6ZTogMTZweDtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgZ2FwOiA4cHg7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtbWluaW1pemUge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgyNTUsMjU1LDI1NSwwLjIpO1xuICAgICAgYm9yZGVyOiBub25lO1xuICAgICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgICAgcGFkZGluZzogNHB4IDhweDtcbiAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICAgIGZvbnQtc2l6ZTogMTJweDtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1taW5pbWl6ZTpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwyNTUsMjU1LDAuMyk7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtY29udGVudCB7XG4gICAgICBkaXNwbGF5OiBibG9jaztcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1jb250ZW50Lm1pbmltaXplZCB7XG4gICAgICBkaXNwbGF5OiBub25lO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLXNlY3Rpb24ge1xuICAgICAgbWFyZ2luLWJvdHRvbTogMTJweDtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1zZWN0aW9uLXRpdGxlIHtcbiAgICAgIGZvbnQtd2VpZ2h0OiBib2xkO1xuICAgICAgbWFyZ2luLWJvdHRvbTogOHB4O1xuICAgICAgZm9udC1zaXplOiAxM3B4O1xuICAgICAgY29sb3I6ICNlMmU4ZjA7XG4gICAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1yb3cge1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICBtYXJnaW4tYm90dG9tOiA4cHg7XG4gICAgICBnYXA6IDhweDtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1sYWJlbCB7XG4gICAgICBmbGV4OiAxO1xuICAgICAgZm9udC1zaXplOiAxMnB4O1xuICAgICAgY29sb3I6ICNjYmQ1ZTA7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtaW5wdXQge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgyNTUsMjU1LDI1NSwwLjEpO1xuICAgICAgYm9yZGVyOiAxcHggc29saWQgcmdiYSgyNTUsMjU1LDI1NSwwLjIpO1xuICAgICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgICAgcGFkZGluZzogNHB4IDhweDtcbiAgICAgIGZvbnQtc2l6ZTogMTJweDtcbiAgICAgIHdpZHRoOiA4MHB4O1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWlucHV0OmZvY3VzIHtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICBib3JkZXItY29sb3I6ICM5MGNkZjQ7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwyNTUsMjU1LDAuMTUpO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWlucHV0LndpZGUge1xuICAgICAgd2lkdGg6IDEwMCU7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2Utc2VsZWN0IHtcbiAgICAgIGJhY2tncm91bmQ6IHJnYmEoMjU1LDI1NSwyNTUsMC4xKTtcbiAgICAgIGJvcmRlcjogMXB4IHNvbGlkIHJnYmEoMjU1LDI1NSwyNTUsMC4yKTtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgICAgIGNvbG9yOiB3aGl0ZTtcbiAgICAgIHBhZGRpbmc6IDRweCA4cHg7XG4gICAgICBmb250LXNpemU6IDEycHg7XG4gICAgICB3aWR0aDogMTAwcHg7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtYnV0dG9uIHtcbiAgICAgIGJhY2tncm91bmQ6IGxpbmVhci1ncmFkaWVudCgxMzVkZWcsICM0Mjk5ZTEgMCUsICMzMTgyY2UgMTAwJSk7XG4gICAgICBib3JkZXI6IG5vbmU7XG4gICAgICBib3JkZXItcmFkaXVzOiA2cHg7XG4gICAgICBjb2xvcjogd2hpdGU7XG4gICAgICBwYWRkaW5nOiA4cHggMTZweDtcbiAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICAgIGZvbnQtc2l6ZTogMTJweDtcbiAgICAgIGZvbnQtd2VpZ2h0OiA1MDA7XG4gICAgICBtYXJnaW46IDJweDtcbiAgICAgIHRyYW5zaXRpb246IGFsbCAwLjJzO1xuICAgICAgbWluLXdpZHRoOiA2MHB4O1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWJ1dHRvbjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kOiBsaW5lYXItZ3JhZGllbnQoMTM1ZGVnLCAjMzE4MmNlIDAlLCAjMmM1MjgyIDEwMCUpO1xuICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC0xcHgpO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWJ1dHRvbjphY3RpdmUge1xuICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDApO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWJ1dHRvbjpkaXNhYmxlZCB7XG4gICAgICBvcGFjaXR5OiAwLjU7XG4gICAgICBjdXJzb3I6IG5vdC1hbGxvd2VkO1xuICAgICAgdHJhbnNmb3JtOiBub25lO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWJ1dHRvbi5zdGFydCB7XG4gICAgICBiYWNrZ3JvdW5kOiBsaW5lYXItZ3JhZGllbnQoMTM1ZGVnLCAjNDhiYjc4IDAlLCAjMzhhMTY5IDEwMCUpO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWJ1dHRvbi5zdGFydDpob3Zlcjpub3QoOmRpc2FibGVkKSB7XG4gICAgICBiYWNrZ3JvdW5kOiBsaW5lYXItZ3JhZGllbnQoMTM1ZGVnLCAjMzhhMTY5IDAlLCAjMmY4NTVhIDEwMCUpO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWJ1dHRvbi5zdG9wIHtcbiAgICAgIGJhY2tncm91bmQ6IGxpbmVhci1ncmFkaWVudCgxMzVkZWcsICNmNTY1NjUgMCUsICNlNTNlM2UgMTAwJSk7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtYnV0dG9uLnN0b3A6aG92ZXI6bm90KDpkaXNhYmxlZCkge1xuICAgICAgYmFja2dyb3VuZDogbGluZWFyLWdyYWRpZW50KDEzNWRlZywgI2U1M2UzZSAwJSwgI2M1MzAzMCAxMDAlKTtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1idXR0b24uc21hbGwge1xuICAgICAgcGFkZGluZzogNHB4IDhweDtcbiAgICAgIGZvbnQtc2l6ZTogMTFweDtcbiAgICAgIG1pbi13aWR0aDogNDBweDtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1zdGF0dXMge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjMpO1xuICAgICAgYm9yZGVyLXJhZGl1czogNnB4O1xuICAgICAgcGFkZGluZzogOHB4O1xuICAgICAgbWFyZ2luOiA4cHggMDtcbiAgICAgIGZvbnQtc2l6ZTogMTJweDtcbiAgICAgIG1pbi1oZWlnaHQ6IDIwcHg7XG4gICAgICB3b3JkLXdyYXA6IGJyZWFrLXdvcmQ7XG4gICAgICB0cmFuc2l0aW9uOiBhbGwgMC4zcyBlYXNlO1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLXN0YXR1cy5zdWNjZXNzIHtcbiAgICAgIGJhY2tncm91bmQ6IHJnYmEoNzIsIDE4NywgMTIwLCAwLjIpO1xuICAgICAgYm9yZGVyLWxlZnQ6IDNweCBzb2xpZCAjNDhiYjc4O1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLXN0YXR1cy5lcnJvciB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDI0NSwgMTAxLCAxMDEsIDAuMik7XG4gICAgICBib3JkZXItbGVmdDogM3B4IHNvbGlkICNmNTY1NjU7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2Utc3RhdHVzLnN0YXR1cyB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDY2LCAxNTMsIDIyNSwgMC4yKTtcbiAgICAgIGJvcmRlci1sZWZ0OiAzcHggc29saWQgIzQyOTllMTtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1zdGF0cyB7XG4gICAgICBkaXNwbGF5OiBncmlkO1xuICAgICAgZ3JpZC10ZW1wbGF0ZS1jb2x1bW5zOiAxZnIgMWZyIDFmciAxZnI7XG4gICAgICBnYXA6IDhweDtcbiAgICAgIG1hcmdpbi10b3A6IDhweDtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1zdGF0IHtcbiAgICAgIGJhY2tncm91bmQ6IHJnYmEoMCwwLDAsMC4yKTtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgICAgIHBhZGRpbmc6IDZweDtcbiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1zdGF0LXZhbHVlIHtcbiAgICAgIGZvbnQtd2VpZ2h0OiBib2xkO1xuICAgICAgZm9udC1zaXplOiAxNHB4O1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLXN0YXQtbGFiZWwge1xuICAgICAgZm9udC1zaXplOiAxMHB4O1xuICAgICAgY29sb3I6ICNhMGFlYzA7XG4gICAgICBtYXJnaW4tdG9wOiAycHg7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtYnV0dG9ucyB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgZmxleC13cmFwOiB3cmFwO1xuICAgICAgZ2FwOiA0cHg7XG4gICAgICBtYXJnaW4tdG9wOiA4cHg7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtYWR2YW5jZWQge1xuICAgICAgbWFyZ2luLXRvcDogOHB4O1xuICAgICAgcGFkZGluZy10b3A6IDhweDtcbiAgICAgIGJvcmRlci10b3A6IDFweCBzb2xpZCByZ2JhKDI1NSwyNTUsMjU1LDAuMSk7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtdGhlbWUtcHJldmlldyB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgZ2FwOiAycHg7XG4gICAgICBmbGV4LXdyYXA6IHdyYXA7XG4gICAgICBtYXJnaW4tdG9wOiA0cHg7XG4gICAgICBtaW4taGVpZ2h0OiAxNnB4O1xuICAgIH1cbiAgICBcbiAgICAud3BsYWNlLWNvbG9yLWRvdCB7XG4gICAgICB3aWR0aDogMTJweDtcbiAgICAgIGhlaWdodDogMTJweDtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDJweDtcbiAgICAgIGJvcmRlcjogMXB4IHNvbGlkIHJnYmEoMjU1LDI1NSwyNTUsMC4zKTtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1oZWFsdGgge1xuICAgICAgZm9udC1zaXplOiAxMHB4O1xuICAgICAgY29sb3I6ICNhMGFlYzA7XG4gICAgICBtYXJnaW4tdG9wOiA0cHg7XG4gICAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2UtaGVhbHRoLm9ubGluZSB7XG4gICAgICBjb2xvcjogIzQ4YmI3ODtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS1oZWFsdGgub2ZmbGluZSB7XG4gICAgICBjb2xvcjogI2Y1NjU2NTtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS16b25lLWluZm8ge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjIpO1xuICAgICAgYm9yZGVyLXJhZGl1czogNnB4O1xuICAgICAgcGFkZGluZzogOHB4O1xuICAgICAgbWFyZ2luOiA4cHggMDtcbiAgICAgIGZvbnQtc2l6ZTogMTFweDtcbiAgICB9XG4gICAgXG4gICAgLndwbGFjZS16b25lLXRleHQge1xuICAgICAgY29sb3I6ICNlMmU4ZjA7XG4gICAgICBtYXJnaW4tYm90dG9tOiA0cHg7XG4gICAgfVxuICAgIFxuICAgIC53cGxhY2Utem9uZS13YXJuaW5nIHtcbiAgICAgIGNvbG9yOiAjZmZkNzAwO1xuICAgICAgZm9udC1zaXplOiAxMHB4O1xuICAgICAgZm9udC1zdHlsZTogaXRhbGljO1xuICAgIH1cbiAgICBcbiAgICAjem9uZS1kaXNwbGF5IHtcbiAgICAgIGZvbnQtd2VpZ2h0OiBib2xkO1xuICAgICAgY29sb3I6ICM5MGNkZjQ7XG4gICAgfVxuICBgO1xuICBcbiAgc2hhZG93LmFwcGVuZENoaWxkKHN0eWxlKTtcbiAgXG4gIGNvbnN0IGNvbnRhaW5lciA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICBjb250YWluZXIuY2xhc3NOYW1lID0gJ3dwbGFjZS1jb250YWluZXInO1xuICBcbiAgLy8gRXN0YWRvIGludGVybm8gZGUgbGEgVUlcbiAgY29uc3QgdWlTdGF0ZSA9IHtcbiAgICBtaW5pbWl6ZWQ6IGZhbHNlLFxuICAgIHNob3dBZHZhbmNlZDogZmFsc2VcbiAgfTtcbiAgXG4gIGNvbnRhaW5lci5pbm5lckhUTUwgPSBgXG4gICAgPGRpdiBjbGFzcz1cIndwbGFjZS1oZWFkZXJcIj5cbiAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2UtdGl0bGVcIj5cbiAgICAgICAgXHVEODNFXHVERDE2ICR7dCgnZmFybS50aXRsZScpfVxuICAgICAgPC9kaXY+XG4gICAgICA8YnV0dG9uIGNsYXNzPVwid3BsYWNlLW1pbmltaXplXCI+XHUyMjEyPC9idXR0b24+XG4gICAgPC9kaXY+XG4gICAgXG4gICAgPGRpdiBjbGFzcz1cIndwbGFjZS1jb250ZW50XCI+XG4gICAgICA8IS0tIEVzdGFkbyB5IGNvbnRyb2xlcyBwcmluY2lwYWxlcyAtLT5cbiAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utc2VjdGlvblwiPlxuICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXN0YXR1c1wiIGlkPVwic3RhdHVzXCI+XHVEODNEXHVEQ0E0ICR7dCgnZmFybS5zdG9wcGVkJyl9PC9kaXY+XG4gICAgICAgIFxuICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXN0YXRzXCI+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1zdGF0XCI+XG4gICAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXN0YXQtdmFsdWVcIiBpZD1cInBhaW50ZWQtY291bnRcIj4wPC9kaXY+XG4gICAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXN0YXQtbGFiZWxcIj4ke3QoJ2Zhcm0ucGFpbnRlZCcpfTwvZGl2PlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utc3RhdFwiPlxuICAgICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1zdGF0LXZhbHVlXCIgaWQ9XCJjaGFyZ2VzLWNvdW50XCI+MDwvZGl2PlxuICAgICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1zdGF0LWxhYmVsXCI+JHt0KCdmYXJtLmNoYXJnZXMnKX08L2Rpdj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXN0YXRcIj5cbiAgICAgICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utc3RhdC12YWx1ZVwiIGlkPVwicmV0cnktY291bnRcIj4wPC9kaXY+XG4gICAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXN0YXQtbGFiZWxcIj4ke3QoJ2Zhcm0ucmV0cmllcycpfTwvZGl2PlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utc3RhdFwiPlxuICAgICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1zdGF0LXZhbHVlXCIgaWQ9XCJ0aWxlLXBvc1wiPjAsMDwvZGl2PlxuICAgICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1zdGF0LWxhYmVsXCI+JHt0KCdmYXJtLnRpbGUnKX08L2Rpdj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIFxuICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLWJ1dHRvbnNcIj5cbiAgICAgICAgICA8YnV0dG9uIGNsYXNzPVwid3BsYWNlLWJ1dHRvbiBzdGFydFwiIGlkPVwic3RhcnQtYnRuXCI+XHUyNUI2XHVGRTBGICR7dCgnZmFybS5zdGFydCcpfTwvYnV0dG9uPlxuICAgICAgICAgIDxidXR0b24gY2xhc3M9XCJ3cGxhY2UtYnV0dG9uIHN0b3BcIiBpZD1cInN0b3AtYnRuXCIgZGlzYWJsZWQ+XHUyM0Y5XHVGRTBGICR7dCgnZmFybS5zdG9wJyl9PC9idXR0b24+XG4gICAgICAgICAgPGJ1dHRvbiBjbGFzcz1cIndwbGFjZS1idXR0b24gc21hbGxcIiBpZD1cInNlbGVjdC1wb3NpdGlvbi1idG5cIj5cdUQ4M0NcdURGMEQgJHt0KCdmYXJtLnNlbGVjdFBvc2l0aW9uJyl9PC9idXR0b24+XG4gICAgICAgICAgPGJ1dHRvbiBjbGFzcz1cIndwbGFjZS1idXR0b24gc21hbGxcIiBpZD1cIm9uY2UtYnRuXCI+XHVEODNDXHVERkE4ICR7dCgnZmFybS5wYWludE9uY2UnKX08L2J1dHRvbj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIFxuICAgICAgICA8IS0tIEluZm9ybWFjaVx1MDBGM24gZGUgbGEgem9uYSBzZWxlY2Npb25hZGEgLS0+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utem9uZS1pbmZvXCIgaWQ9XCJ6b25lLWluZm9cIj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXpvbmUtdGV4dFwiPlx1RDgzRFx1RENDRCAke3QoJ2Zhcm0ucG9zaXRpb25JbmZvJyl9OiA8c3BhbiBpZD1cInpvbmUtZGlzcGxheVwiPiR7dCgnZmFybS5ub1Bvc2l0aW9uJyl9PC9zcGFuPjwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utem9uZS13YXJuaW5nXCI+XHUyNkEwXHVGRTBGICR7dCgnZmFybS5zZWxlY3RFbXB0eUFyZWEnKX08L2Rpdj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIFxuICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLWhlYWx0aFwiIGlkPVwiaGVhbHRoLXN0YXR1c1wiPlx1RDgzRFx1REQwRCAke3QoJ2Zhcm0uY2hlY2tpbmdTdGF0dXMnKX08L2Rpdj5cbiAgICAgIDwvZGl2PlxuICAgICAgXG4gICAgICA8IS0tIENvbmZpZ3VyYWNpXHUwMEYzbiBiXHUwMEUxc2ljYSAtLT5cbiAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utc2VjdGlvblwiPlxuICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXNlY3Rpb24tdGl0bGVcIj5cdTI2OTlcdUZFMEYgJHt0KCdmYXJtLmNvbmZpZ3VyYXRpb24nKX08L2Rpdj5cbiAgICAgICAgXG4gICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utcm93XCI+XG4gICAgICAgICAgPHNwYW4gY2xhc3M9XCJ3cGxhY2UtbGFiZWxcIj4ke3QoJ2Zhcm0uZGVsYXknKX06PC9zcGFuPlxuICAgICAgICAgIDxpbnB1dCB0eXBlPVwibnVtYmVyXCIgY2xhc3M9XCJ3cGxhY2UtaW5wdXRcIiBpZD1cImRlbGF5LWlucHV0XCIgbWluPVwiMTAwMFwiIG1heD1cIjMwMDAwMFwiIHN0ZXA9XCIxMDAwXCI+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICBcbiAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1yb3dcIj5cbiAgICAgICAgICA8c3BhbiBjbGFzcz1cIndwbGFjZS1sYWJlbFwiPiR7dCgnZmFybS5waXhlbHNQZXJCYXRjaCcpfTo8L3NwYW4+XG4gICAgICAgICAgPGlucHV0IHR5cGU9XCJudW1iZXJcIiBjbGFzcz1cIndwbGFjZS1pbnB1dFwiIGlkPVwicGl4ZWxzLWlucHV0XCIgbWluPVwiMVwiIG1heD1cIjUwXCI+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICBcbiAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1yb3dcIj5cbiAgICAgICAgICA8c3BhbiBjbGFzcz1cIndwbGFjZS1sYWJlbFwiPiR7dCgnZmFybS5taW5DaGFyZ2VzJyl9Ojwvc3Bhbj5cbiAgICAgICAgICA8aW5wdXQgdHlwZT1cIm51bWJlclwiIGNsYXNzPVwid3BsYWNlLWlucHV0XCIgaWQ9XCJtaW4tY2hhcmdlcy1pbnB1dFwiIG1pbj1cIjBcIiBtYXg9XCI1MFwiIHN0ZXA9XCIwLjFcIj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIFxuICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXJvd1wiPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwid3BsYWNlLWxhYmVsXCI+JHt0KCdmYXJtLmNvbG9yTW9kZScpfTo8L3NwYW4+XG4gICAgICAgICAgPHNlbGVjdCBjbGFzcz1cIndwbGFjZS1zZWxlY3RcIiBpZD1cImNvbG9yLW1vZGUtc2VsZWN0XCI+XG4gICAgICAgICAgICA8b3B0aW9uIHZhbHVlPVwicmFuZG9tXCI+JHt0KCdmYXJtLnJhbmRvbScpfTwvb3B0aW9uPlxuICAgICAgICAgICAgPG9wdGlvbiB2YWx1ZT1cImZpeGVkXCI+JHt0KCdmYXJtLmZpeGVkJyl9PC9vcHRpb24+XG4gICAgICAgICAgPC9zZWxlY3Q+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICBcbiAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1yb3dcIiBpZD1cImNvbG9yLXJhbmdlLXJvd1wiPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwid3BsYWNlLWxhYmVsXCI+JHt0KCdmYXJtLnJhbmdlJyl9Ojwvc3Bhbj5cbiAgICAgICAgICA8aW5wdXQgdHlwZT1cIm51bWJlclwiIGNsYXNzPVwid3BsYWNlLWlucHV0XCIgaWQ9XCJjb2xvci1taW4taW5wdXRcIiBtaW49XCIxXCIgbWF4PVwiMzJcIiBzdHlsZT1cIndpZHRoOiAzNXB4O1wiPlxuICAgICAgICAgIDxzcGFuIHN0eWxlPVwiY29sb3I6ICNjYmQ1ZTA7XCI+LTwvc3Bhbj5cbiAgICAgICAgICA8aW5wdXQgdHlwZT1cIm51bWJlclwiIGNsYXNzPVwid3BsYWNlLWlucHV0XCIgaWQ9XCJjb2xvci1tYXgtaW5wdXRcIiBtaW49XCIxXCIgbWF4PVwiMzJcIiBzdHlsZT1cIndpZHRoOiAzNXB4O1wiPlxuICAgICAgICA8L2Rpdj5cbiAgICAgICAgXG4gICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utcm93XCIgaWQ9XCJjb2xvci1maXhlZC1yb3dcIiBzdHlsZT1cImRpc3BsYXk6IG5vbmU7XCI+XG4gICAgICAgICAgPHNwYW4gY2xhc3M9XCJ3cGxhY2UtbGFiZWxcIj4ke3QoJ2Zhcm0uZml4ZWRDb2xvcicpfTo8L3NwYW4+XG4gICAgICAgICAgPGlucHV0IHR5cGU9XCJudW1iZXJcIiBjbGFzcz1cIndwbGFjZS1pbnB1dFwiIGlkPVwiY29sb3ItZml4ZWQtaW5wdXRcIiBtaW49XCIxXCIgbWF4PVwiMzJcIj5cbiAgICAgICAgPC9kaXY+XG4gICAgICA8L2Rpdj5cbiAgICAgIFxuICAgICAgPCEtLSBDb25maWd1cmFjaVx1MDBGM24gYXZhbnphZGEgKGNvbGFwc2FibGUpIC0tPlxuICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1zZWN0aW9uXCI+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utc2VjdGlvbi10aXRsZVwiIGlkPVwiYWR2YW5jZWQtdG9nZ2xlXCI+XG4gICAgICAgICAgXHVEODNEXHVERDI3ICR7dCgnZmFybS5hZHZhbmNlZCcpfSA8c3BhbiBpZD1cImFkdmFuY2VkLWFycm93XCI+XHUyNUI2PC9zcGFuPlxuICAgICAgICA8L2Rpdj5cbiAgICAgICAgXG4gICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2UtYWR2YW5jZWRcIiBpZD1cImFkdmFuY2VkLXNlY3Rpb25cIiBzdHlsZT1cImRpc3BsYXk6IG5vbmU7XCI+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1yb3dcIj5cbiAgICAgICAgICAgIDxzcGFuIGNsYXNzPVwid3BsYWNlLWxhYmVsXCI+JHt0KCdmYXJtLnRpbGVYJyl9Ojwvc3Bhbj5cbiAgICAgICAgICAgIDxpbnB1dCB0eXBlPVwibnVtYmVyXCIgY2xhc3M9XCJ3cGxhY2UtaW5wdXRcIiBpZD1cInRpbGUteC1pbnB1dFwiPlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIFxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJ3cGxhY2Utcm93XCI+XG4gICAgICAgICAgICA8c3BhbiBjbGFzcz1cIndwbGFjZS1sYWJlbFwiPiR7dCgnZmFybS50aWxlWScpfTo8L3NwYW4+XG4gICAgICAgICAgICA8aW5wdXQgdHlwZT1cIm51bWJlclwiIGNsYXNzPVwid3BsYWNlLWlucHV0XCIgaWQ9XCJ0aWxlLXktaW5wdXRcIj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICBcbiAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLXJvd1wiPlxuICAgICAgICAgICAgPHNwYW4gY2xhc3M9XCJ3cGxhY2UtbGFiZWxcIj4ke3QoJ2Zhcm0uY3VzdG9tUGFsZXR0ZScpfTo8L3NwYW4+XG4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIndwbGFjZS1yb3dcIj5cbiAgICAgICAgICAgIDxpbnB1dCB0eXBlPVwidGV4dFwiIGNsYXNzPVwid3BsYWNlLWlucHV0IHdpZGVcIiBpZD1cImN1c3RvbS1wYWxldHRlLWlucHV0XCIgXG4gICAgICAgICAgICAgICAgICAgcGxhY2Vob2xkZXI9XCIke3QoJ2Zhcm0ucGFsZXR0ZUV4YW1wbGUnKX1cIj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICBcbiAgICAgICAgICA8ZGl2IGNsYXNzPVwid3BsYWNlLWJ1dHRvbnNcIj5cbiAgICAgICAgICAgIDxidXR0b24gY2xhc3M9XCJ3cGxhY2UtYnV0dG9uIHNtYWxsXCIgaWQ9XCJzYXZlLWJ0blwiPlx1RDgzRFx1RENCRSAke3QoJ2NvbW1vbi5zYXZlJyl9PC9idXR0b24+XG4gICAgICAgICAgICA8YnV0dG9uIGNsYXNzPVwid3BsYWNlLWJ1dHRvbiBzbWFsbFwiIGlkPVwibG9hZC1idG5cIj5cdUQ4M0RcdURDQzEgJHt0KCdjb21tb24ubG9hZCcpfTwvYnV0dG9uPlxuICAgICAgICAgICAgPGJ1dHRvbiBjbGFzcz1cIndwbGFjZS1idXR0b24gc21hbGxcIiBpZD1cInJlc2V0LWJ0blwiPlx1RDgzRFx1REQwNCAke3QoJ2NvbW1vbi5yZXNldCcpfTwvYnV0dG9uPlxuICAgICAgICAgICAgPGJ1dHRvbiBjbGFzcz1cIndwbGFjZS1idXR0b24gc21hbGxcIiBpZD1cImNhcHR1cmUtYnRuXCI+XHVEODNEXHVEQ0Y4ICR7dCgnZmFybS5jYXB0dXJlJyl9PC9idXR0b24+XG4gICAgICAgICAgPC9kaXY+XG4gICAgICAgIDwvZGl2PlxuICAgICAgPC9kaXY+XG4gICAgPC9kaXY+XG4gIGA7XG4gIFxuICBzaGFkb3cuYXBwZW5kQ2hpbGQoY29udGFpbmVyKTtcbiAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChzaGFkb3dIb3N0KTtcbiAgXG4gIC8vIEhhY2VyIGVsIHBhbmVsIGFycmFzdHJhYmxlXG4gIGNvbnN0IGhlYWRlciA9IHNoYWRvdy5xdWVyeVNlbGVjdG9yKCcud3BsYWNlLWhlYWRlcicpO1xuICBkcmFnSGVhZGVyKGhlYWRlciwgc2hhZG93SG9zdCk7XG4gIFxuICAvLyBSZWZlcmVuY2lhcyBhIGVsZW1lbnRvc1xuICBjb25zdCBlbGVtZW50cyA9IHtcbiAgICBtaW5pbWl6ZUJ0bjogc2hhZG93LnF1ZXJ5U2VsZWN0b3IoJy53cGxhY2UtbWluaW1pemUnKSxcbiAgICBjb250ZW50OiBzaGFkb3cucXVlcnlTZWxlY3RvcignLndwbGFjZS1jb250ZW50JyksXG4gICAgc3RhdHVzOiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3N0YXR1cycpLFxuICAgIHBhaW50ZWRDb3VudDogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdwYWludGVkLWNvdW50JyksXG4gICAgY2hhcmdlc0NvdW50OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ2NoYXJnZXMtY291bnQnKSxcbiAgICByZXRyeUNvdW50OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3JldHJ5LWNvdW50JyksXG4gICAgdGlsZVBvczogc2hhZG93LmdldEVsZW1lbnRCeUlkKCd0aWxlLXBvcycpLFxuICAgIHN0YXJ0QnRuOiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3N0YXJ0LWJ0bicpLFxuICAgIHN0b3BCdG46IHNoYWRvdy5nZXRFbGVtZW50QnlJZCgnc3RvcC1idG4nKSxcbiAgICBzZWxlY3RQb3NpdGlvbkJ0bjogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdzZWxlY3QtcG9zaXRpb24tYnRuJyksXG4gICAgb25jZUJ0bjogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdvbmNlLWJ0bicpLFxuICAgIHpvbmVJbmZvOiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3pvbmUtaW5mbycpLFxuICAgIHpvbmVEaXNwbGF5OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3pvbmUtZGlzcGxheScpLFxuICAgIGhlYWx0aFN0YXR1czogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdoZWFsdGgtc3RhdHVzJyksXG4gICAgZGVsYXlJbnB1dDogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdkZWxheS1pbnB1dCcpLFxuICAgIHBpeGVsc0lucHV0OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3BpeGVscy1pbnB1dCcpLFxuICAgIG1pbkNoYXJnZXNJbnB1dDogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdtaW4tY2hhcmdlcy1pbnB1dCcpLFxuICAgIGNvbG9yTW9kZVNlbGVjdDogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdjb2xvci1tb2RlLXNlbGVjdCcpLFxuICAgIGNvbG9yUmFuZ2VSb3c6IHNoYWRvdy5nZXRFbGVtZW50QnlJZCgnY29sb3ItcmFuZ2Utcm93JyksXG4gICAgY29sb3JGaXhlZFJvdzogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdjb2xvci1maXhlZC1yb3cnKSxcbiAgICBjb2xvck1pbklucHV0OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ2NvbG9yLW1pbi1pbnB1dCcpLFxuICAgIGNvbG9yTWF4SW5wdXQ6IHNoYWRvdy5nZXRFbGVtZW50QnlJZCgnY29sb3ItbWF4LWlucHV0JyksXG4gICAgY29sb3JGaXhlZElucHV0OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ2NvbG9yLWZpeGVkLWlucHV0JyksXG4gICAgYWR2YW5jZWRUb2dnbGU6IHNoYWRvdy5nZXRFbGVtZW50QnlJZCgnYWR2YW5jZWQtdG9nZ2xlJyksXG4gICAgYWR2YW5jZWRTZWN0aW9uOiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ2FkdmFuY2VkLXNlY3Rpb24nKSxcbiAgICBhZHZhbmNlZEFycm93OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ2FkdmFuY2VkLWFycm93JyksXG4gICAgdGlsZVhJbnB1dDogc2hhZG93LmdldEVsZW1lbnRCeUlkKCd0aWxlLXgtaW5wdXQnKSxcbiAgICB0aWxlWUlucHV0OiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ3RpbGUteS1pbnB1dCcpLFxuICAgIGN1c3RvbVBhbGV0dGVJbnB1dDogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdjdXN0b20tcGFsZXR0ZS1pbnB1dCcpLFxuICAgIHNhdmVCdG46IHNoYWRvdy5nZXRFbGVtZW50QnlJZCgnc2F2ZS1idG4nKSxcbiAgICBsb2FkQnRuOiBzaGFkb3cuZ2V0RWxlbWVudEJ5SWQoJ2xvYWQtYnRuJyksXG4gICAgcmVzZXRCdG46IHNoYWRvdy5nZXRFbGVtZW50QnlJZCgncmVzZXQtYnRuJyksXG4gICAgY2FwdHVyZUJ0bjogc2hhZG93LmdldEVsZW1lbnRCeUlkKCdjYXB0dXJlLWJ0bicpXG4gIH07XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBhY3R1YWxpemFyIGxvcyB2YWxvcmVzIGRlIGxvcyBpbnB1dHMgZGVzZGUgbGEgY29uZmlndXJhY2lcdTAwRjNuXG4gIGZ1bmN0aW9uIHVwZGF0ZUlucHV0c0Zyb21Db25maWcoKSB7XG4gICAgZWxlbWVudHMuZGVsYXlJbnB1dC52YWx1ZSA9IGNvbmZpZy5ERUxBWV9NUztcbiAgICBlbGVtZW50cy5waXhlbHNJbnB1dC52YWx1ZSA9IGNvbmZpZy5QSVhFTFNfUEVSX0JBVENIO1xuICAgIGVsZW1lbnRzLm1pbkNoYXJnZXNJbnB1dC52YWx1ZSA9IGNvbmZpZy5NSU5fQ0hBUkdFUztcbiAgICBlbGVtZW50cy5jb2xvck1vZGVTZWxlY3QudmFsdWUgPSBjb25maWcuQ09MT1JfTU9ERTtcbiAgICBlbGVtZW50cy5jb2xvck1pbklucHV0LnZhbHVlID0gY29uZmlnLkNPTE9SX01JTjtcbiAgICBlbGVtZW50cy5jb2xvck1heElucHV0LnZhbHVlID0gY29uZmlnLkNPTE9SX01BWDtcbiAgICBlbGVtZW50cy5jb2xvckZpeGVkSW5wdXQudmFsdWUgPSBjb25maWcuQ09MT1JfRklYRUQ7XG4gICAgZWxlbWVudHMudGlsZVhJbnB1dC52YWx1ZSA9IGNvbmZpZy5USUxFX1ggfHwgJyc7XG4gICAgZWxlbWVudHMudGlsZVlJbnB1dC52YWx1ZSA9IGNvbmZpZy5USUxFX1kgfHwgJyc7XG4gICAgZWxlbWVudHMuY3VzdG9tUGFsZXR0ZUlucHV0LnZhbHVlID0gKGNvbmZpZy5DVVNUT01fUEFMRVRURSB8fCBbXSkuam9pbignLCcpO1xuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgdmlzaWJpbGlkYWQgZGUgY29udHJvbGVzIGRlIGNvbG9yXG4gICAgdXBkYXRlQ29sb3JNb2RlVmlzaWJpbGl0eSgpO1xuICAgIHVwZGF0ZVRpbGVEaXNwbGF5KCk7XG4gICAgdXBkYXRlWm9uZURpc3BsYXkoKTtcbiAgICB1cGRhdGVCdXR0b25TdGF0ZXMoZmFybVN0YXRlPy5ydW5uaW5nIHx8IGZhbHNlKTtcbiAgfVxuICBcbiAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgYWN0dWFsaXphciBsYSBjb25maWd1cmFjaVx1MDBGM24gZGVzZGUgbG9zIGlucHV0c1xuICBmdW5jdGlvbiB1cGRhdGVDb25maWdGcm9tSW5wdXRzKCkge1xuICAgIGNvbmZpZy5ERUxBWV9NUyA9IHBhcnNlSW50KGVsZW1lbnRzLmRlbGF5SW5wdXQudmFsdWUpIHx8IEZBUk1fREVGQVVMVFMuREVMQVlfTVM7XG4gICAgY29uZmlnLlBJWEVMU19QRVJfQkFUQ0ggPSBjbGFtcChwYXJzZUludChlbGVtZW50cy5waXhlbHNJbnB1dC52YWx1ZSkgfHwgRkFSTV9ERUZBVUxUUy5QSVhFTFNfUEVSX0JBVENILCAxLCA1MCk7XG4gICAgY29uZmlnLk1JTl9DSEFSR0VTID0gcGFyc2VGbG9hdChlbGVtZW50cy5taW5DaGFyZ2VzSW5wdXQudmFsdWUpIHx8IEZBUk1fREVGQVVMVFMuTUlOX0NIQVJHRVM7XG4gICAgY29uZmlnLkNPTE9SX01PREUgPSBlbGVtZW50cy5jb2xvck1vZGVTZWxlY3QudmFsdWU7XG4gICAgY29uZmlnLkNPTE9SX01JTiA9IGNsYW1wKHBhcnNlSW50KGVsZW1lbnRzLmNvbG9yTWluSW5wdXQudmFsdWUpIHx8IEZBUk1fREVGQVVMVFMuQ09MT1JfTUlOLCAxLCAzMik7XG4gICAgY29uZmlnLkNPTE9SX01BWCA9IGNsYW1wKHBhcnNlSW50KGVsZW1lbnRzLmNvbG9yTWF4SW5wdXQudmFsdWUpIHx8IEZBUk1fREVGQVVMVFMuQ09MT1JfTUFYLCAxLCAzMik7XG4gICAgY29uZmlnLkNPTE9SX0ZJWEVEID0gY2xhbXAocGFyc2VJbnQoZWxlbWVudHMuY29sb3JGaXhlZElucHV0LnZhbHVlKSB8fCBGQVJNX0RFRkFVTFRTLkNPTE9SX0ZJWEVELCAxLCAzMik7XG4gICAgXG4gICAgLy8gQXNlZ3VyYXIgcXVlIE1JTiA8PSBNQVhcbiAgICBpZiAoY29uZmlnLkNPTE9SX01JTiA+IGNvbmZpZy5DT0xPUl9NQVgpIHtcbiAgICAgIGNvbmZpZy5DT0xPUl9NQVggPSBjb25maWcuQ09MT1JfTUlOO1xuICAgICAgZWxlbWVudHMuY29sb3JNYXhJbnB1dC52YWx1ZSA9IGNvbmZpZy5DT0xPUl9NQVg7XG4gICAgfVxuICAgIFxuICAgIGNvbnN0IHRpbGVYID0gcGFyc2VJbnQoZWxlbWVudHMudGlsZVhJbnB1dC52YWx1ZSk7XG4gICAgY29uc3QgdGlsZVkgPSBwYXJzZUludChlbGVtZW50cy50aWxlWUlucHV0LnZhbHVlKTtcbiAgICBpZiAoTnVtYmVyLmlzRmluaXRlKHRpbGVYKSkgY29uZmlnLlRJTEVfWCA9IHRpbGVYO1xuICAgIGlmIChOdW1iZXIuaXNGaW5pdGUodGlsZVkpKSBjb25maWcuVElMRV9ZID0gdGlsZVk7XG4gICAgXG4gICAgdXBkYXRlVGlsZURpc3BsYXkoKTtcbiAgICB1cGRhdGVab25lRGlzcGxheSgpO1xuICB9XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBhY3R1YWxpemFyIHZpc2liaWxpZGFkIGRlIGNvbnRyb2xlcyBkZSBtb2RvIGRlIGNvbG9yXG4gIGZ1bmN0aW9uIHVwZGF0ZUNvbG9yTW9kZVZpc2liaWxpdHkoKSB7XG4gICAgY29uc3QgbW9kZSA9IGVsZW1lbnRzLmNvbG9yTW9kZVNlbGVjdC52YWx1ZTtcbiAgICBlbGVtZW50cy5jb2xvclJhbmdlUm93LnN0eWxlLmRpc3BsYXkgPSBtb2RlID09PSAncmFuZG9tJyA/ICdmbGV4JyA6ICdub25lJztcbiAgICBlbGVtZW50cy5jb2xvckZpeGVkUm93LnN0eWxlLmRpc3BsYXkgPSBtb2RlID09PSAnZml4ZWQnID8gJ2ZsZXgnIDogJ25vbmUnO1xuICB9XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBhY3R1YWxpemFyIGRpc3BsYXkgZGVsIHRpbGVcbiAgZnVuY3Rpb24gdXBkYXRlVGlsZURpc3BsYXkoKSB7XG4gICAgaWYgKGVsZW1lbnRzLnRpbGVQb3MpIHtcbiAgICAgIGVsZW1lbnRzLnRpbGVQb3MudGV4dENvbnRlbnQgPSBgJHtjb25maWcuVElMRV9YIHx8IDB9LCR7Y29uZmlnLlRJTEVfWSB8fCAwfWA7XG4gICAgfVxuICB9XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBhY3R1YWxpemFyIGVsIGRpc3BsYXkgZGUgbGEgem9uYSBzZWxlY2Npb25hZGFcbiAgZnVuY3Rpb24gdXBkYXRlWm9uZURpc3BsYXkoKSB7XG4gICAgaWYgKGVsZW1lbnRzLnpvbmVEaXNwbGF5KSB7XG4gICAgICBpZiAoY29uZmlnLlBPU0lUSU9OX1NFTEVDVEVEICYmIGNvbmZpZy5CQVNFX1ggIT09IG51bGwgJiYgY29uZmlnLkJBU0VfWSAhPT0gbnVsbCkge1xuICAgICAgICBlbGVtZW50cy56b25lRGlzcGxheS50ZXh0Q29udGVudCA9IHQoJ2Zhcm0uY3VycmVudFpvbmUnLCB7IHg6IGNvbmZpZy5CQVNFX1gsIHk6IGNvbmZpZy5CQVNFX1kgfSk7XG4gICAgICAgIGVsZW1lbnRzLnpvbmVEaXNwbGF5LnN0eWxlLmNvbG9yID0gJyM0OGJiNzgnOyAvLyBWZXJkZSBwYXJhIGluZGljYXIgYWN0aXZhXG4gICAgICB9IGVsc2Uge1xuICAgICAgICBlbGVtZW50cy56b25lRGlzcGxheS50ZXh0Q29udGVudCA9IHQoJ2Zhcm0ubm9Qb3NpdGlvbicpO1xuICAgICAgICBlbGVtZW50cy56b25lRGlzcGxheS5zdHlsZS5jb2xvciA9ICcjZjU2NTY1JzsgLy8gUm9qbyBwYXJhIGluZGljYXIgbm8gc2VsZWNjaW9uYWRhXG4gICAgICB9XG4gICAgfVxuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgZXN0YWRvIGRlIGJvdG9uZXMgY3VhbmRvIGNhbWJpZSBsYSB6b25hXG4gICAgdXBkYXRlQnV0dG9uU3RhdGVzKGZhcm1TdGF0ZT8ucnVubmluZyB8fCBmYWxzZSk7XG4gIH1cbiAgXG4gIC8vIEV2ZW50IGxpc3RlbmVyc1xuICBlbGVtZW50cy5taW5pbWl6ZUJ0bj8uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgdWlTdGF0ZS5taW5pbWl6ZWQgPSAhdWlTdGF0ZS5taW5pbWl6ZWQ7XG4gICAgZWxlbWVudHMuY29udGVudC5jbGFzc0xpc3QudG9nZ2xlKCdtaW5pbWl6ZWQnLCB1aVN0YXRlLm1pbmltaXplZCk7XG4gICAgZWxlbWVudHMubWluaW1pemVCdG4udGV4dENvbnRlbnQgPSB1aVN0YXRlLm1pbmltaXplZCA/ICcrJyA6ICdcdTIyMTInO1xuICB9KTtcbiAgXG4gIGVsZW1lbnRzLnN0YXJ0QnRuPy5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsICgpID0+IHtcbiAgICB1cGRhdGVDb25maWdGcm9tSW5wdXRzKCk7XG4gICAgb25TdGFydCgpO1xuICAgIHVwZGF0ZUJ1dHRvblN0YXRlcyh0cnVlKTtcbiAgfSk7XG4gIFxuICBlbGVtZW50cy5zdG9wQnRuPy5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsICgpID0+IHtcbiAgICBvblN0b3AoKTtcbiAgICB1cGRhdGVCdXR0b25TdGF0ZXMoZmFsc2UpO1xuICB9KTtcbiAgXG4gIGVsZW1lbnRzLm9uY2VCdG4/LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIC8vIEFzZWd1cmFyIHF1ZSBpbnB1dHMgcmVmbGVqYW4gbGEgXHUwMEZBbHRpbWEgY2FwdHVyYS9jYWxpYnJhY2lcdTAwRjNuXG4gICAgdXBkYXRlSW5wdXRzRnJvbUNvbmZpZygpO1xuICAgIHVwZGF0ZUNvbmZpZ0Zyb21JbnB1dHMoKTtcbiAgICAvLyBMbGFtYXIgYSBsYSBmdW5jaVx1MDBGM24gZGUgcGludGFyIHVuYSB2ZXogc2kgZXhpc3RlXG4gICAgaWYgKHdpbmRvdy5XUEFVSSAmJiB3aW5kb3cuV1BBVUkub25jZSkge1xuICAgICAgd2luZG93LldQQVVJLm9uY2UoKTtcbiAgICB9XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuc2VsZWN0UG9zaXRpb25CdG4/LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIHNlbGVjdEZhcm1Qb3NpdGlvbihjb25maWcsIHNldFN0YXR1cywgdXBkYXRlWm9uZURpc3BsYXkpO1xuICB9KTtcbiAgXG4gIGVsZW1lbnRzLmNvbG9yTW9kZVNlbGVjdD8uYWRkRXZlbnRMaXN0ZW5lcignY2hhbmdlJywgKCkgPT4ge1xuICAgIHVwZGF0ZUNvbG9yTW9kZVZpc2liaWxpdHkoKTtcbiAgICB1cGRhdGVDb25maWdGcm9tSW5wdXRzKCk7XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuY3VzdG9tUGFsZXR0ZUlucHV0Py5hZGRFdmVudExpc3RlbmVyKCdpbnB1dCcsICgpID0+IHtcbiAgICB1cGRhdGVDb25maWdGcm9tSW5wdXRzKCk7XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuYWR2YW5jZWRUb2dnbGU/LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIHVpU3RhdGUuc2hvd0FkdmFuY2VkID0gIXVpU3RhdGUuc2hvd0FkdmFuY2VkO1xuICAgIGVsZW1lbnRzLmFkdmFuY2VkU2VjdGlvbi5zdHlsZS5kaXNwbGF5ID0gdWlTdGF0ZS5zaG93QWR2YW5jZWQgPyAnYmxvY2snIDogJ25vbmUnO1xuICAgIGVsZW1lbnRzLmFkdmFuY2VkQXJyb3cudGV4dENvbnRlbnQgPSB1aVN0YXRlLnNob3dBZHZhbmNlZCA/ICdcdTI1QkMnIDogJ1x1MjVCNic7XG4gIH0pO1xuICBcbiAgLy8gTGlzdGVuZXJzIHBhcmEgaW5wdXRzIChhY3R1YWxpemFjaVx1MDBGM24gYXV0b21cdTAwRTF0aWNhKVxuICBbJ2RlbGF5SW5wdXQnLCAncGl4ZWxzSW5wdXQnLCAnbWluQ2hhcmdlc0lucHV0JywgJ2NvbG9yTWluSW5wdXQnLCAnY29sb3JNYXhJbnB1dCcsICdjb2xvckZpeGVkSW5wdXQnLCAndGlsZVhJbnB1dCcsICd0aWxlWUlucHV0J10uZm9yRWFjaChpbnB1dE5hbWUgPT4ge1xuICAgIGVsZW1lbnRzW2lucHV0TmFtZV0/LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIHVwZGF0ZUNvbmZpZ0Zyb21JbnB1dHMpO1xuICB9KTtcbiAgXG4gIGVsZW1lbnRzLnNhdmVCdG4/LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIHVwZGF0ZUNvbmZpZ0Zyb21JbnB1dHMoKTtcbiAgICBzYXZlRmFybUNmZyhjb25maWcpO1xuICAgIHNldFN0YXR1cyhgXHVEODNEXHVEQ0JFICR7dCgnZmFybS5jb25maWdTYXZlZCcpfWAsICdzdWNjZXNzJyk7XG4gIH0pO1xuICBcbiAgZWxlbWVudHMubG9hZEJ0bj8uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgY29uc3QgbG9hZGVkID0gbG9hZEZhcm1DZmcoRkFSTV9ERUZBVUxUUyk7XG4gICAgT2JqZWN0LmFzc2lnbihjb25maWcsIGxvYWRlZCk7XG4gICAgdXBkYXRlSW5wdXRzRnJvbUNvbmZpZygpO1xuICAgIHNldFN0YXR1cyhgXHVEODNEXHVEQ0MxICR7dCgnZmFybS5jb25maWdMb2FkZWQnKX1gLCAnc3VjY2VzcycpO1xuICB9KTtcbiAgXG4gIGVsZW1lbnRzLnJlc2V0QnRuPy5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsICgpID0+IHtcbiAgICByZXNldEZhcm1DZmcoKTtcbiAgICBPYmplY3QuYXNzaWduKGNvbmZpZywgRkFSTV9ERUZBVUxUUyk7XG4gICAgdXBkYXRlSW5wdXRzRnJvbUNvbmZpZygpO1xuICAgIHNldFN0YXR1cyhgXHVEODNEXHVERDA0ICR7dCgnZmFybS5jb25maWdSZXNldCcpfWAsICdzdWNjZXNzJyk7XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuY2FwdHVyZUJ0bj8uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgLy8gRnVuY2lcdTAwRjNuIGRlIGNhcHR1cmEgLSBzZXJcdTAwRTEgaW1wbGVtZW50YWRhXG4gICAgc2V0U3RhdHVzKGBcdUQ4M0RcdURDRjggJHt0KCdmYXJtLmNhcHR1cmVJbnN0cnVjdGlvbnMnKX1gLCAnc3RhdHVzJyk7XG4gICAgLy8gQXF1XHUwMEVEIGlyXHUwMEVEYSBsYSBsXHUwMEYzZ2ljYSBkZSBjYXB0dXJhXG4gIH0pO1xuICBcbiAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgYWN0dWFsaXphciBlc3RhZG8gZGUgYm90b25lc1xuICBmdW5jdGlvbiB1cGRhdGVCdXR0b25TdGF0ZXMocnVubmluZykge1xuICAgIGlmIChlbGVtZW50cy5zdGFydEJ0bikge1xuICAgICAgLy8gRWwgYm90XHUwMEYzbiBkZSBpbmljaW8gZXN0XHUwMEUxIGRlc2hhYmlsaXRhZG8gc2k6XG4gICAgICAvLyAxLiBFbCBib3QgZXN0XHUwMEUxIGNvcnJpZW5kbywgT1xuICAgICAgLy8gMi4gTm8gc2UgaGEgc2VsZWNjaW9uYWRvIHVuYSB6b25hXG4gICAgICBjb25zdCBub1pvbmVTZWxlY3RlZCA9ICFjb25maWcuUE9TSVRJT05fU0VMRUNURUQgfHwgY29uZmlnLkJBU0VfWCA9PT0gbnVsbCB8fCBjb25maWcuQkFTRV9ZID09PSBudWxsO1xuICAgICAgZWxlbWVudHMuc3RhcnRCdG4uZGlzYWJsZWQgPSBydW5uaW5nIHx8IG5vWm9uZVNlbGVjdGVkO1xuICAgICAgXG4gICAgICAvLyBDYW1iaWFyIHRleHRvIGRlbCBib3RcdTAwRjNuIHNlZ1x1MDBGQW4gZWwgZXN0YWRvXG4gICAgICBpZiAobm9ab25lU2VsZWN0ZWQpIHtcbiAgICAgICAgZWxlbWVudHMuc3RhcnRCdG4udGV4dENvbnRlbnQgPSBgXHVEODNEXHVERUFCICR7dCgnZmFybS5zZWxlY3RQb3NpdGlvbicpfSBcdTI2QTBcdUZFMEZgO1xuICAgICAgICBlbGVtZW50cy5zdGFydEJ0bi50aXRsZSA9IHQoJ2Zhcm0ubWlzc2luZ1Bvc2l0aW9uJyk7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBlbGVtZW50cy5zdGFydEJ0bi50ZXh0Q29udGVudCA9IGBcdTI1QjZcdUZFMEYgJHt0KCdmYXJtLnN0YXJ0Jyl9YDtcbiAgICAgICAgZWxlbWVudHMuc3RhcnRCdG4udGl0bGUgPSAnJztcbiAgICAgIH1cbiAgICB9XG4gICAgaWYgKGVsZW1lbnRzLnN0b3BCdG4pIGVsZW1lbnRzLnN0b3BCdG4uZGlzYWJsZWQgPSAhcnVubmluZztcbiAgfVxuICBcbiAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgYWN0dWFsaXphciBlbCBlc3RhZG8gdmlzdWFsXG4gIGZ1bmN0aW9uIHNldFN0YXR1cyhtZXNzYWdlLCB0eXBlID0gJ3N0YXR1cycpIHtcbiAgICBpZiAoZWxlbWVudHMuc3RhdHVzKSB7XG4gICAgICBlbGVtZW50cy5zdGF0dXMudGV4dENvbnRlbnQgPSBtZXNzYWdlO1xuICAgICAgZWxlbWVudHMuc3RhdHVzLmNsYXNzTmFtZSA9IGB3cGxhY2Utc3RhdHVzICR7dHlwZX1gO1xuICAgICAgbG9nKGBTdGF0dXM6ICR7bWVzc2FnZX1gKTtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIGFjdHVhbGl6YXIgZXN0YWRcdTAwRURzdGljYXNcbiAgZnVuY3Rpb24gdXBkYXRlU3RhdHMocGFpbnRlZCwgY2hhcmdlcywgcmV0cmllcyA9IDAsIGhlYWx0aCA9IG51bGwpIHtcbiAgICBpZiAoZWxlbWVudHMucGFpbnRlZENvdW50KSB7XG4gICAgICBlbGVtZW50cy5wYWludGVkQ291bnQudGV4dENvbnRlbnQgPSBwYWludGVkIHx8IDA7XG4gICAgfVxuICAgIGlmIChlbGVtZW50cy5jaGFyZ2VzQ291bnQpIHtcbiAgICAgIGVsZW1lbnRzLmNoYXJnZXNDb3VudC50ZXh0Q29udGVudCA9IHR5cGVvZiBjaGFyZ2VzID09PSAnbnVtYmVyJyA/IGNoYXJnZXMudG9GaXhlZCgxKSA6ICcwJztcbiAgICB9XG4gICAgaWYgKGVsZW1lbnRzLnJldHJ5Q291bnQpIHtcbiAgICAgIGVsZW1lbnRzLnJldHJ5Q291bnQudGV4dENvbnRlbnQgPSByZXRyaWVzIHx8IDA7XG4gICAgfVxuICAgIGlmIChlbGVtZW50cy5oZWFsdGhTdGF0dXMgJiYgaGVhbHRoKSB7XG4gICAgICBlbGVtZW50cy5oZWFsdGhTdGF0dXMudGV4dENvbnRlbnQgPSBoZWFsdGgudXAgPyBgXHVEODNEXHVERkUyICR7dCgnZmFybS5iYWNrZW5kT25saW5lJyl9YCA6IGBcdUQ4M0RcdUREMzQgJHt0KCdmYXJtLmJhY2tlbmRPZmZsaW5lJyl9YDtcbiAgICAgIGVsZW1lbnRzLmhlYWx0aFN0YXR1cy5jbGFzc05hbWUgPSBgd3BsYWNlLWhlYWx0aCAke2hlYWx0aC51cCA/ICdvbmxpbmUnIDogJ29mZmxpbmUnfWA7XG4gICAgfVxuICB9XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBlZmVjdG8gdmlzdWFsIGRlIGZsYXNoXG4gIGZ1bmN0aW9uIGZsYXNoRWZmZWN0KCkge1xuICAgIGNvbnRhaW5lci5zdHlsZS5ib3hTaGFkb3cgPSAnMCAwIDIwcHggIzQ4YmI3OCc7XG4gICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICBjb250YWluZXIuc3R5bGUuYm94U2hhZG93ID0gJzAgMTBweCAyNXB4IHJnYmEoMCwwLDAsMC4zKSc7XG4gICAgfSwgMjAwKTtcbiAgfVxuICBcbiAgLy8gSW5pY2lhbGl6YXIgdmFsb3Jlc1xuICB1cGRhdGVJbnB1dHNGcm9tQ29uZmlnKCk7XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBhY3R1YWxpemFyIHRleHRvcyBjdWFuZG8gY2FtYmllIGVsIGlkaW9tYVxuICBmdW5jdGlvbiB1cGRhdGVUZXh0cygpIHtcbiAgICAvLyBBY3R1YWxpemFyIHRcdTAwRUR0dWxvXG4gICAgY29uc3QgdGl0bGUgPSBzaGFkb3cucXVlcnlTZWxlY3RvcignLndwbGFjZS10aXRsZScpO1xuICAgIGlmICh0aXRsZSkge1xuICAgICAgdGl0bGUuaW5uZXJIVE1MID0gYFx1RDgzRVx1REQxNiAke3QoJ2Zhcm0udGl0bGUnKX1gO1xuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIGJvdG9uZXNcbiAgICBpZiAoZWxlbWVudHMuc3RhcnRCdG4pIGVsZW1lbnRzLnN0YXJ0QnRuLmlubmVySFRNTCA9IGBcdTI1QjZcdUZFMEYgJHt0KCdmYXJtLnN0YXJ0Jyl9YDtcbiAgICBpZiAoZWxlbWVudHMuc3RvcEJ0bikgZWxlbWVudHMuc3RvcEJ0bi5pbm5lckhUTUwgPSBgXHUyM0Y5XHVGRTBGICR7dCgnZmFybS5zdG9wJyl9YDtcbiAgICBpZiAoZWxlbWVudHMuc2VsZWN0UG9zaXRpb25CdG4pIGVsZW1lbnRzLnNlbGVjdFBvc2l0aW9uQnRuLmlubmVySFRNTCA9IGBcdUQ4M0NcdURGMEQgJHt0KCdmYXJtLnNlbGVjdFBvc2l0aW9uJyl9YDtcbiAgICBpZiAoZWxlbWVudHMub25jZUJ0bikgZWxlbWVudHMub25jZUJ0bi5pbm5lckhUTUwgPSBgXHVEODNDXHVERkE4ICR7dCgnZmFybS5wYWludE9uY2UnKX1gO1xuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgZXRpcXVldGFzIGRlIGVzdGFkXHUwMEVEc3RpY2FzXG4gICAgY29uc3QgcGFpbnRlZExhYmVsID0gc2hhZG93LnF1ZXJ5U2VsZWN0b3IoJyNwYWludGVkLWNvdW50JykucGFyZW50RWxlbWVudC5xdWVyeVNlbGVjdG9yKCcud3BsYWNlLXN0YXQtbGFiZWwnKTtcbiAgICBjb25zdCBjaGFyZ2VzTGFiZWwgPSBzaGFkb3cucXVlcnlTZWxlY3RvcignI2NoYXJnZXMtY291bnQnKS5wYXJlbnRFbGVtZW50LnF1ZXJ5U2VsZWN0b3IoJy53cGxhY2Utc3RhdC1sYWJlbCcpO1xuICAgIGNvbnN0IHJldHJ5TGFiZWwgPSBzaGFkb3cucXVlcnlTZWxlY3RvcignI3JldHJ5LWNvdW50JykucGFyZW50RWxlbWVudC5xdWVyeVNlbGVjdG9yKCcud3BsYWNlLXN0YXQtbGFiZWwnKTtcbiAgICBjb25zdCB0aWxlTGFiZWwgPSBzaGFkb3cucXVlcnlTZWxlY3RvcignI3RpbGUtcG9zJykucGFyZW50RWxlbWVudC5xdWVyeVNlbGVjdG9yKCcud3BsYWNlLXN0YXQtbGFiZWwnKTtcbiAgICBcbiAgICBpZiAocGFpbnRlZExhYmVsKSBwYWludGVkTGFiZWwudGV4dENvbnRlbnQgPSB0KCdmYXJtLnBhaW50ZWQnKTtcbiAgICBpZiAoY2hhcmdlc0xhYmVsKSBjaGFyZ2VzTGFiZWwudGV4dENvbnRlbnQgPSB0KCdmYXJtLmNoYXJnZXMnKTtcbiAgICBpZiAocmV0cnlMYWJlbCkgcmV0cnlMYWJlbC50ZXh0Q29udGVudCA9IHQoJ2Zhcm0ucmV0cmllcycpO1xuICAgIGlmICh0aWxlTGFiZWwpIHRpbGVMYWJlbC50ZXh0Q29udGVudCA9IHQoJ2Zhcm0udGlsZScpO1xuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgc2VjY2lvbmVzXG4gICAgY29uc3QgY29uZmlnVGl0bGUgPSBzaGFkb3cucXVlcnlTZWxlY3RvcignLndwbGFjZS1zZWN0aW9uLXRpdGxlJyk7XG4gICAgaWYgKGNvbmZpZ1RpdGxlKSBjb25maWdUaXRsZS5pbm5lckhUTUwgPSBgXHUyNjk5XHVGRTBGICR7dCgnZmFybS5jb25maWd1cmF0aW9uJyl9YDtcbiAgICBcbiAgICBjb25zdCBhZHZhbmNlZFRpdGxlID0gc2hhZG93LmdldEVsZW1lbnRCeUlkKCdhZHZhbmNlZC10b2dnbGUnKTtcbiAgICBpZiAoYWR2YW5jZWRUaXRsZSkge1xuICAgICAgY29uc3QgYXJyb3cgPSBhZHZhbmNlZFRpdGxlLnF1ZXJ5U2VsZWN0b3IoJyNhZHZhbmNlZC1hcnJvdycpO1xuICAgICAgY29uc3QgYXJyb3dUZXh0ID0gYXJyb3cgPyBhcnJvdy50ZXh0Q29udGVudCA6ICdcdTI1QjYnO1xuICAgICAgYWR2YW5jZWRUaXRsZS5pbm5lckhUTUwgPSBgXHVEODNEXHVERDI3ICR7dCgnZmFybS5hZHZhbmNlZCcpfSA8c3BhbiBpZD1cImFkdmFuY2VkLWFycm93XCI+JHthcnJvd1RleHR9PC9zcGFuPmA7XG4gICAgfVxuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgZXRpcXVldGFzIGRlIGNvbmZpZ3VyYWNpXHUwMEYzblxuICAgIC8vIExhcyBldGlxdWV0YXMgc2UgYWN0dWFsaXphbiBhdXRvbVx1MDBFMXRpY2FtZW50ZSBkZXNkZSBlbCBpbm5lckhUTUwgaW5pY2lhbFxuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgb3BjaW9uZXMgZGVsIHNlbGVjdG9yIGRlIG1vZG8gZGUgY29sb3JcbiAgICBjb25zdCBjb2xvck1vZGVTZWxlY3QgPSBlbGVtZW50cy5jb2xvck1vZGVTZWxlY3Q7XG4gICAgaWYgKGNvbG9yTW9kZVNlbGVjdCkge1xuICAgICAgY29uc3QgcmFuZG9tT3B0aW9uID0gY29sb3JNb2RlU2VsZWN0LnF1ZXJ5U2VsZWN0b3IoJ29wdGlvblt2YWx1ZT1cInJhbmRvbVwiXScpO1xuICAgICAgY29uc3QgZml4ZWRPcHRpb24gPSBjb2xvck1vZGVTZWxlY3QucXVlcnlTZWxlY3Rvcignb3B0aW9uW3ZhbHVlPVwiZml4ZWRcIl0nKTtcbiAgICAgIGlmIChyYW5kb21PcHRpb24pIHJhbmRvbU9wdGlvbi50ZXh0Q29udGVudCA9IHQoJ2Zhcm0ucmFuZG9tJyk7XG4gICAgICBpZiAoZml4ZWRPcHRpb24pIGZpeGVkT3B0aW9uLnRleHRDb250ZW50ID0gdCgnZmFybS5maXhlZCcpO1xuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIHBsYWNlaG9sZGVyXG4gICAgaWYgKGVsZW1lbnRzLmN1c3RvbVBhbGV0dGVJbnB1dCkge1xuICAgICAgZWxlbWVudHMuY3VzdG9tUGFsZXR0ZUlucHV0LnBsYWNlaG9sZGVyID0gdCgnZmFybS5wYWxldHRlRXhhbXBsZScpO1xuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIGJvdG9uZXMgZGUgY29uZmlndXJhY2lcdTAwRjNuXG4gICAgaWYgKGVsZW1lbnRzLnNhdmVCdG4pIGVsZW1lbnRzLnNhdmVCdG4uaW5uZXJIVE1MID0gYFx1RDgzRFx1RENCRSAke3QoJ2NvbW1vbi5zYXZlJyl9YDtcbiAgICBpZiAoZWxlbWVudHMubG9hZEJ0bikgZWxlbWVudHMubG9hZEJ0bi5pbm5lckhUTUwgPSBgXHVEODNEXHVEQ0MxICR7dCgnY29tbW9uLmxvYWQnKX1gO1xuICAgIGlmIChlbGVtZW50cy5yZXNldEJ0bikgZWxlbWVudHMucmVzZXRCdG4uaW5uZXJIVE1MID0gYFx1RDgzRFx1REQwNCAke3QoJ2NvbW1vbi5yZXNldCcpfWA7XG4gICAgaWYgKGVsZW1lbnRzLmNhcHR1cmVCdG4pIGVsZW1lbnRzLmNhcHR1cmVCdG4uaW5uZXJIVE1MID0gYFx1RDgzRFx1RENGOCAke3QoJ2Zhcm0uY2FwdHVyZScpfWA7XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBpbmZvcm1hY2lcdTAwRjNuIGRlIHpvbmFcbiAgICB1cGRhdGVab25lRGlzcGxheSgpO1xuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgZXN0YWRvIGRlIGJvdG9uZXMgKHBhcmEgYWN0dWFsaXphciB0ZXh0b3MpXG4gICAgdXBkYXRlQnV0dG9uU3RhdGVzKGZhcm1TdGF0ZT8ucnVubmluZyB8fCBmYWxzZSk7XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBlc3RhZG8gZGUgc2FsdWQgc2kgZXhpc3RlXG4gICAgY29uc3QgaGVhbHRoU3RhdHVzID0gZWxlbWVudHMuaGVhbHRoU3RhdHVzO1xuICAgIGlmIChoZWFsdGhTdGF0dXMgJiYgaGVhbHRoU3RhdHVzLnRleHRDb250ZW50LmluY2x1ZGVzKCdcdUQ4M0RcdUREMEQnKSkge1xuICAgICAgaGVhbHRoU3RhdHVzLnRleHRDb250ZW50ID0gYFx1RDgzRFx1REQwRCAke3QoJ2Zhcm0uY2hlY2tpbmdTdGF0dXMnKX1gO1xuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIGVzdGFkbyBzaSBlc3RcdTAwRTEgZGV0ZW5pZG9cbiAgICBjb25zdCBzdGF0dXMgPSBlbGVtZW50cy5zdGF0dXM7XG4gICAgaWYgKHN0YXR1cyAmJiBzdGF0dXMudGV4dENvbnRlbnQuaW5jbHVkZXMoJ1x1RDgzRFx1RENBNCcpKSB7XG4gICAgICBzdGF0dXMudGV4dENvbnRlbnQgPSBgXHVEODNEXHVEQ0E0ICR7dCgnZmFybS5zdG9wcGVkJyl9YDtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIHNlbGVjY2lvbmFyIHBvc2ljaVx1MDBGM24gZGUgZmFybWluZ1xuICBhc3luYyBmdW5jdGlvbiBzZWxlY3RGYXJtUG9zaXRpb24oY29uZmlnLCBzZXRTdGF0dXMsIHVwZGF0ZVpvbmVEaXNwbGF5KSB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlKSA9PiB7XG4gICAgICBzZXRTdGF0dXModCgnZmFybS5zZWxlY3RQb3NpdGlvbkFsZXJ0JyksICdpbmZvJyk7XG4gICAgICBcbiAgICAgIC8vIEFjdGl2YXIgbW9kbyBkZSBzZWxlY2NpXHUwMEYzbiBkZSBwb3NpY2lcdTAwRjNuXG4gICAgICBjb25maWcuc2VsZWN0aW5nUG9zaXRpb24gPSB0cnVlO1xuICAgICAgXG4gICAgICAvLyBJbnRlcmNlcHRhciByZXF1ZXN0cyBwYXJhIGNhcHR1cmFyIHBvc2ljaVx1MDBGM25cbiAgICAgIGNvbnN0IG9yaWdpbmFsRmV0Y2ggPSB3aW5kb3cuZmV0Y2g7XG4gICAgICB3aW5kb3cuZmV0Y2ggPSBhc3luYyAodXJsLCBvcHRpb25zKSA9PiB7XG4gICAgICAgIGlmIChjb25maWcuc2VsZWN0aW5nUG9zaXRpb24gJiYgdXJsLmluY2x1ZGVzKCcvczAvcGl4ZWwvJykpIHtcbiAgICAgICAgICB0cnkge1xuICAgICAgICAgICAgY29uc3QgcmVzcG9uc2UgPSBhd2FpdCBvcmlnaW5hbEZldGNoKHVybCwgb3B0aW9ucyk7XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIGlmIChyZXNwb25zZS5vayAmJiBvcHRpb25zICYmIG9wdGlvbnMuYm9keSkge1xuICAgICAgICAgICAgICBjb25zdCBib2R5RGF0YSA9IEpTT04ucGFyc2Uob3B0aW9ucy5ib2R5KTtcbiAgICAgICAgICAgICAgaWYgKGJvZHlEYXRhLmNvb3JkcyAmJiBib2R5RGF0YS5jb29yZHMubGVuZ3RoID49IDIpIHtcbiAgICAgICAgICAgICAgICBjb25zdCBsb2NhbFggPSBib2R5RGF0YS5jb29yZHNbMF07XG4gICAgICAgICAgICAgICAgY29uc3QgbG9jYWxZID0gYm9keURhdGEuY29vcmRzWzFdO1xuICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgIC8vIEV4dHJhZXIgdGlsZSBkZSBsYSBVUkxcbiAgICAgICAgICAgICAgICBjb25zdCB0aWxlTWF0Y2ggPSB1cmwubWF0Y2goL1xcL3MwXFwvcGl4ZWxcXC8oLT9cXGQrKVxcLygtP1xcZCspLyk7XG4gICAgICAgICAgICAgICAgaWYgKHRpbGVNYXRjaCkge1xuICAgICAgICAgICAgICAgICAgY29uZmlnLlRJTEVfWCA9IHBhcnNlSW50KHRpbGVNYXRjaFsxXSk7XG4gICAgICAgICAgICAgICAgICBjb25maWcuVElMRV9ZID0gcGFyc2VJbnQodGlsZU1hdGNoWzJdKTtcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgLy8gRXN0YWJsZWNlciBwb3NpY2lcdTAwRjNuIGJhc2UgeSBhY3RpdmFyIHNpc3RlbWEgZGUgcmFkaW9cbiAgICAgICAgICAgICAgICBjb25maWcuQkFTRV9YID0gbG9jYWxYO1xuICAgICAgICAgICAgICAgIGNvbmZpZy5CQVNFX1kgPSBsb2NhbFk7XG4gICAgICAgICAgICAgICAgY29uZmlnLlBPU0lUSU9OX1NFTEVDVEVEID0gdHJ1ZTtcbiAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICBjb25maWcuc2VsZWN0aW5nUG9zaXRpb24gPSBmYWxzZTtcbiAgICAgICAgICAgICAgICB3aW5kb3cuZmV0Y2ggPSBvcmlnaW5hbEZldGNoO1xuICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgIC8vIEFjdHVhbGl6YXIgZGlzcGxheXMgeSBzaW5jcm9uaXphciBpbnB1dHMgY29uIGxhIG51ZXZhIGNvbmZpZ1xuICAgICAgICAgICAgICAgIHVwZGF0ZVpvbmVEaXNwbGF5KCk7XG4gICAgICAgICAgICAgICAgdXBkYXRlVGlsZURpc3BsYXkoKTtcbiAgICAgICAgICAgICAgICAvLyBNVVkgSU1QT1JUQU5URTogc2luY3Jvbml6YXIgbG9zIGlucHV0cyBwYXJhIHF1ZSAndXBkYXRlQ29uZmlnRnJvbUlucHV0cygpJ1xuICAgICAgICAgICAgICAgIC8vIG5vIHNvYnJlZXNjcmliYSBlbCBUSUxFX1gvVElMRV9ZIGNvbiB2YWxvcmVzIGFudGlndW9zIGFsIHB1bHNhciBcIlVuYSB2ZXpcIi9cIkluaWNpYXJcIlxuICAgICAgICAgICAgICAgIHVwZGF0ZUlucHV0c0Zyb21Db25maWcoKTtcbiAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICBzZXRTdGF0dXModCgnZmFybS5wb3NpdGlvblNldCcpLCAnc3VjY2VzcycpO1xuICAgICAgICAgICAgICAgIGxvZyhgXHUyNzA1IFpvbmEgZGUgZmFybWluZyBlc3RhYmxlY2lkYTogdGlsZSgke2NvbmZpZy5USUxFX1h9LCR7Y29uZmlnLlRJTEVfWX0pIGJhc2UoJHtsb2NhbFh9LCR7bG9jYWxZfSkgcmFkaW8oJHtjb25maWcuRkFSTV9SQURJVVN9cHgpYCk7XG4gICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgLy8gR3VhcmRhciBjb25maWd1cmFjaVx1MDBGM25cbiAgICAgICAgICAgICAgICBzYXZlRmFybUNmZyhjb25maWcpO1xuICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgIHJlc29sdmUodHJ1ZSk7XG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIFxuICAgICAgICAgICAgcmV0dXJuIHJlc3BvbnNlO1xuICAgICAgICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICAgICAgICBsb2coJ0Vycm9yIGludGVyY2VwdGFuZG8gcGl4ZWw6JywgZXJyb3IpO1xuICAgICAgICAgICAgcmV0dXJuIG9yaWdpbmFsRmV0Y2godXJsLCBvcHRpb25zKTtcbiAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgcmV0dXJuIG9yaWdpbmFsRmV0Y2godXJsLCBvcHRpb25zKTtcbiAgICAgIH07XG4gICAgICBcbiAgICAgIC8vIFRpbWVvdXQgcGFyYSBzZWxlY2NpXHUwMEYzbiBkZSBwb3NpY2lcdTAwRjNuXG4gICAgICBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgaWYgKGNvbmZpZy5zZWxlY3RpbmdQb3NpdGlvbikge1xuICAgICAgICAgIHdpbmRvdy5mZXRjaCA9IG9yaWdpbmFsRmV0Y2g7XG4gICAgICAgICAgY29uZmlnLnNlbGVjdGluZ1Bvc2l0aW9uID0gZmFsc2U7XG4gICAgICAgICAgc2V0U3RhdHVzKHQoJ2Zhcm0ucG9zaXRpb25UaW1lb3V0JyksICdlcnJvcicpO1xuICAgICAgICAgIHJlc29sdmUoZmFsc2UpO1xuICAgICAgICB9XG4gICAgICB9LCAxMjAwMDApOyAvLyAyIG1pbnV0b3NcbiAgICB9KTtcbiAgfVxuICBcbiAgLy8gRXNjdWNoYXIgY2FtYmlvcyBkZSBpZGlvbWFcbiAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsIHVwZGF0ZVRleHRzKTtcbiAgXG4gIC8vIEFQSSBwXHUwMEZBYmxpY2EgZGUgbGEgVUlcbiAgcmV0dXJuIHtcbiAgICBzZXRTdGF0dXMsXG4gICAgdXBkYXRlU3RhdHMsXG4gICAgZmxhc2hFZmZlY3QsXG4gICAgdXBkYXRlQnV0dG9uU3RhdGVzLFxuICAgIHVwZGF0ZVRleHRzLFxuICAgIGRlc3Ryb3k6ICgpID0+IHtcbiAgICAgIHdpbmRvdy5yZW1vdmVFdmVudExpc3RlbmVyKCdsYW5ndWFnZUNoYW5nZWQnLCB1cGRhdGVUZXh0cyk7XG4gICAgICBkb2N1bWVudC5ib2R5LnJlbW92ZUNoaWxkKHNoYWRvd0hvc3QpO1xuICAgIH0sXG4gICAgdXBkYXRlQ29uZmlnOiB1cGRhdGVJbnB1dHNGcm9tQ29uZmlnLFxuICAgIGdldEVsZW1lbnQ6ICgpID0+IHNoYWRvd0hvc3RcbiAgfTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgYXV0by1jYWxpYnJhciBsYXMgY29vcmRlbmFkYXMgZGVsIHRpbGUgYmFzXHUwMEUxbmRvc2UgZW4gbGEgcG9zaWNpXHUwMEYzbiBkZWwgdmlld3BvcnRcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBhdXRvQ2FsaWJyYXRlVGlsZShjb25maWcpIHtcbiAgdHJ5IHtcbiAgICBsb2coJ1x1RDgzQ1x1REZBRiBJbmljaWFuZG8gYXV0by1jYWxpYnJhY2lcdTAwRjNuIGRlbCB0aWxlLi4uJyk7XG4gICAgLy8gU2kgeWEgaGF5IHVuYSB6b25hIHNlbGVjY2lvbmFkYSB5IHVuIHRpbGUgZGVmaW5pZG8sIG5vIGZvcnphciBudWV2YSBjYWxpYnJhY2lcdTAwRjNuXG4gICAgaWYgKGNvbmZpZy5QT1NJVElPTl9TRUxFQ1RFRCAmJiBjb25maWcuQkFTRV9YICE9IG51bGwgJiYgY29uZmlnLkJBU0VfWSAhPSBudWxsICYmIE51bWJlci5pc0Zpbml0ZShjb25maWcuVElMRV9YKSAmJiBOdW1iZXIuaXNGaW5pdGUoY29uZmlnLlRJTEVfWSkpIHtcbiAgICAgIGxvZyhgXHUyMTM5XHVGRTBGIFlhIGV4aXN0ZSB6b25hIHNlbGVjY2lvbmFkYS4gU2UgbWFudGllbmUgdGlsZSBhY3R1YWw6ICgke2NvbmZpZy5USUxFX1h9LCAke2NvbmZpZy5USUxFX1l9KWApO1xuICAgICAgc2F2ZUZhcm1DZmcoY29uZmlnKTtcbiAgICAgIHJldHVybiB7IHRpbGVYOiBjb25maWcuVElMRV9YLCB0aWxlWTogY29uZmlnLlRJTEVfWSwgc3VjY2VzczogdHJ1ZSB9O1xuICAgIH1cbiAgICBcbiAgICAvLyBCdXNjYXIgZWxlbWVudG9zIHF1ZSBpbmRpcXVlbiBsYSBwb3NpY2lcdTAwRjNuIGFjdHVhbFxuICAgIGNvbnN0IHVybFBhcmFtcyA9IG5ldyB3aW5kb3cuVVJMU2VhcmNoUGFyYW1zKHdpbmRvdy5sb2NhdGlvbi5zZWFyY2gpO1xuICAgIGNvbnN0IGhhc2hQYXJhbXMgPSB3aW5kb3cubG9jYXRpb24uaGFzaDtcbiAgICBcbiAgICAvLyBJbnRlbnRhciBleHRyYWVyIGNvb3JkZW5hZGFzIGRlIGxhIFVSTFxuICAgIGxldCB0aWxlWCwgdGlsZVk7XG4gICAgXG4gICAgLy8gQnVzY2FyIGVuIHF1ZXJ5IHBhcmFtc1xuICAgIGlmICh1cmxQYXJhbXMuaGFzKCd4JykgJiYgdXJsUGFyYW1zLmhhcygneScpKSB7XG4gICAgICB0aWxlWCA9IHBhcnNlSW50KHVybFBhcmFtcy5nZXQoJ3gnKSk7XG4gICAgICB0aWxlWSA9IHBhcnNlSW50KHVybFBhcmFtcy5nZXQoJ3knKSk7XG4gICAgfVxuICAgIFxuICAgIC8vIEJ1c2NhciBlbiBoYXNoIChmb3JtYXRvICN4LHkgbyBzaW1pbGFyKVxuICAgIGlmICghdGlsZVggJiYgIXRpbGVZICYmIGhhc2hQYXJhbXMpIHtcbiAgICAgIGNvbnN0IGhhc2hNYXRjaCA9IGhhc2hQYXJhbXMubWF0Y2goLyMoLT9cXGQrKSwoLT9cXGQrKS8pO1xuICAgICAgaWYgKGhhc2hNYXRjaCkge1xuICAgICAgICB0aWxlWCA9IHBhcnNlSW50KGhhc2hNYXRjaFsxXSk7XG4gICAgICAgIHRpbGVZID0gcGFyc2VJbnQoaGFzaE1hdGNoWzJdKTtcbiAgICAgIH1cbiAgICB9XG4gICAgXG4gICAgLy8gQnVzY2FyIGVsZW1lbnRvcyBET00gcXVlIGluZGlxdWVuIHBvc2ljaVx1MDBGM25cbiAgICBpZiAoIXRpbGVYICYmICF0aWxlWSkge1xuICAgICAgY29uc3QgcG9zaXRpb25FbGVtZW50cyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ1tkYXRhLXhdLCBbZGF0YS15XSwgLmNvb3JkaW5hdGVzLCAucG9zaXRpb24nKTtcbiAgICAgIGZvciAoY29uc3QgZWwgb2YgcG9zaXRpb25FbGVtZW50cykge1xuICAgICAgICBjb25zdCB4ID0gZWwuZ2V0QXR0cmlidXRlKCdkYXRhLXgnKSB8fCBlbC5nZXRBdHRyaWJ1dGUoJ3gnKTtcbiAgICAgICAgY29uc3QgeSA9IGVsLmdldEF0dHJpYnV0ZSgnZGF0YS15JykgfHwgZWwuZ2V0QXR0cmlidXRlKCd5Jyk7XG4gICAgICAgIGlmICh4ICYmIHkpIHtcbiAgICAgICAgICB0aWxlWCA9IHBhcnNlSW50KHgpO1xuICAgICAgICAgIHRpbGVZID0gcGFyc2VJbnQoeSk7XG4gICAgICAgICAgYnJlYWs7XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gICAgXG4gICAgLy8gQnVzY2FyIGVuIGVsIHRleHRvIHZpc2libGUgZGUgbGEgcFx1MDBFMWdpbmFcbiAgICBpZiAoIXRpbGVYICYmICF0aWxlWSkge1xuICAgICAgY29uc3QgdGV4dENvbnRlbnQgPSBkb2N1bWVudC5ib2R5LnRleHRDb250ZW50IHx8ICcnO1xuICAgICAgY29uc3QgY29vcmRNYXRjaCA9IHRleHRDb250ZW50Lm1hdGNoKC8oPzp0aWxlfHBvc3xwb3NpdGlvbik/XFxzKlsoW10/XFxzKigtP1xcZCspXFxzKlssO11cXHMqKC0/XFxkKylcXHMqWylcXF1dPy9pKTtcbiAgICAgIGlmIChjb29yZE1hdGNoKSB7XG4gICAgICAgIHRpbGVYID0gcGFyc2VJbnQoY29vcmRNYXRjaFsxXSk7XG4gICAgICAgIHRpbGVZID0gcGFyc2VJbnQoY29vcmRNYXRjaFsyXSk7XG4gICAgICB9XG4gICAgfVxuICAgIFxuICAgIC8vIFZhbG9yZXMgcG9yIGRlZmVjdG8gc2kgbm8gc2UgZW5jdWVudHJhIG5hZGFcbiAgICBpZiAoIU51bWJlci5pc0Zpbml0ZSh0aWxlWCkgfHwgIU51bWJlci5pc0Zpbml0ZSh0aWxlWSkpIHtcbiAgICAgIHRpbGVYID0gMDtcbiAgICAgIHRpbGVZID0gMDtcbiAgICAgIGxvZygnXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZGllcm9uIGRldGVjdGFyIGNvb3JkZW5hZGFzIGF1dG9tXHUwMEUxdGljYW1lbnRlLCB1c2FuZG8gKDAsMCknKTtcbiAgICB9XG4gICAgXG4gICAgLy8gVmFsaWRhciBxdWUgbGFzIGNvb3JkZW5hZGFzIHNlYW4gcmF6b25hYmxlc1xuICAgIGlmIChNYXRoLmFicyh0aWxlWCkgPiAxMDAwMDAwIHx8IE1hdGguYWJzKHRpbGVZKSA+IDEwMDAwMDApIHtcbiAgICAgIGxvZygnXHUyNkEwXHVGRTBGIENvb3JkZW5hZGFzIGRldGVjdGFkYXMgcGFyZWNlbiBpbmNvcnJlY3RhcywgbGltaXRhbmRvIGEgcmFuZ28gdlx1MDBFMWxpZG8nKTtcbiAgICAgIHRpbGVYID0gTWF0aC5tYXgoLTEwMDAwMDAsIE1hdGgubWluKDEwMDAwMDAsIHRpbGVYKSk7XG4gICAgICB0aWxlWSA9IE1hdGgubWF4KC0xMDAwMDAwLCBNYXRoLm1pbigxMDAwMDAwLCB0aWxlWSkpO1xuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIGNvbmZpZ3VyYWNpXHUwMEYzblxuICAgIGNvbmZpZy5USUxFX1ggPSB0aWxlWDtcbiAgICBjb25maWcuVElMRV9ZID0gdGlsZVk7XG4gICAgXG4gICAgbG9nKGBcdTI3MDUgVGlsZSBjYWxpYnJhZG8gYXV0b21cdTAwRTF0aWNhbWVudGU6ICgke3RpbGVYfSwgJHt0aWxlWX0pYCk7XG4gICAgXG4gICAgLy8gR3VhcmRhciBsYSBjb25maWd1cmFjaVx1MDBGM24gY2FsaWJyYWRhXG4gICAgc2F2ZUZhcm1DZmcoY29uZmlnKTtcbiAgICBcbiAgICByZXR1cm4geyB0aWxlWCwgdGlsZVksIHN1Y2Nlc3M6IHRydWUgfTtcbiAgICBcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1Mjc0QyBFcnJvciBlbiBhdXRvLWNhbGlicmFjaVx1MDBGM246JywgZXJyb3IpO1xuICAgIHJldHVybiB7IHRpbGVYOiAwLCB0aWxlWTogMCwgc3VjY2VzczogZmFsc2UsIGVycm9yOiBlcnJvci5tZXNzYWdlIH07XG4gIH1cbn1cblxuZXhwb3J0IGZ1bmN0aW9uIG1vdW50RmFybVVJKCkge1xuICAvLyBFc3RhIGZ1bmNpXHUwMEYzbiBzZXJcdTAwRTEgbGxhbWFkYSBkZXNkZSBmYXJtL2luZGV4LmpzXG4gIGxvZygnXHVEODNEXHVEQ0YxIE1vbnRhbmRvIFVJIGRlbCBmYXJtLi4uJyk7XG4gIFxuICAvLyBDcmVhciB1bmEgVUkgYlx1MDBFMXNpY2EgcGFyYSBlbCBmYXJtXG4gIGNvbnN0IHVpID0gY3JlYXRlRmFybVVJKFxuICAgIEZBUk1fREVGQVVMVFMsXG4gICAgKCkgPT4gbG9nKHQoJ2Zhcm0uc3RhcnRpbmdCb3QnKSksXG4gICAgKCkgPT4gbG9nKHQoJ2Zhcm0uc3RvcHBpbmdCb3QnKSksXG4gICAgKCkgPT4gbG9nKHQoJ2Zhcm0uY2FsaWJyYXRpbmcnKSlcbiAgKTtcbiAgXG4gIHJldHVybiB7XG4gICAgc2V0U3RhdHVzOiAobXNnKSA9PiB7XG4gICAgICBsb2cobXNnKTtcbiAgICAgIHVpLnNldFN0YXR1cyhtc2cpO1xuICAgIH0sXG4gICAgdXBkYXRlU3RhdHM6IHVpLnVwZGF0ZVN0YXRzLFxuICAgIGZsYXNoRWZmZWN0OiB1aS5mbGFzaEVmZmVjdCxcbiAgICB1cGRhdGVUZXh0czogdWkudXBkYXRlVGV4dHMsXG4gICAgZGVzdHJveTogdWkuZGVzdHJveVxuICB9O1xufVxuIiwgImxldCBsb2FkZWQgPSBmYWxzZTtcblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGxvYWRUdXJuc3RpbGUoKSB7XG4gIGlmIChsb2FkZWQgfHwgd2luZG93LnR1cm5zdGlsZSkgcmV0dXJuO1xuICBcbiAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICBjb25zdCBzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7XG4gICAgcy5zcmMgPSAnaHR0cHM6Ly9jaGFsbGVuZ2VzLmNsb3VkZmxhcmUuY29tL3R1cm5zdGlsZS92MC9hcGkuanM/cmVuZGVyPWV4cGxpY2l0JztcbiAgICBzLmFzeW5jID0gdHJ1ZTsgXG4gICAgcy5kZWZlciA9IHRydWU7XG4gICAgcy5vbmxvYWQgPSAoKSA9PiB7XG4gICAgICBsb2FkZWQgPSB0cnVlO1xuICAgICAgcmVzb2x2ZSgpO1xuICAgIH07XG4gICAgcy5vbmVycm9yID0gKCkgPT4gcmVqZWN0KG5ldyBFcnJvcignTm8gc2UgcHVkbyBjYXJnYXIgVHVybnN0aWxlJykpO1xuICAgIGRvY3VtZW50LmhlYWQuYXBwZW5kQ2hpbGQocyk7XG4gIH0pO1xufVxuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gZXhlY3V0ZVR1cm5zdGlsZShzaXRlS2V5LCBhY3Rpb24gPSBcInBhaW50XCIpIHtcbiAgYXdhaXQgbG9hZFR1cm5zdGlsZSgpO1xuICBcbiAgaWYgKHR5cGVvZiB3aW5kb3cudHVybnN0aWxlPy5leGVjdXRlID09PSAnZnVuY3Rpb24nKSB7XG4gICAgdHJ5IHtcbiAgICAgIGNvbnN0IHRva2VuID0gYXdhaXQgd2luZG93LnR1cm5zdGlsZS5leGVjdXRlKHNpdGVLZXksIHsgYWN0aW9uIH0pO1xuICAgICAgaWYgKHRva2VuICYmIHRva2VuLmxlbmd0aCA+IDIwKSByZXR1cm4gdG9rZW47XG4gICAgfSBjYXRjaCB7IFxuICAgICAgLyogZmFsbGJhY2sgYWJham8gKi8gXG4gICAgfVxuICB9XG4gIFxuICAvLyBGYWxsYmFjazogcmVuZGVyIG9jdWx0b1xuICByZXR1cm4gYXdhaXQgbmV3IFByb21pc2UoKHJlc29sdmUpID0+IHtcbiAgICBjb25zdCBob3N0ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnZGl2Jyk7XG4gICAgaG9zdC5zdHlsZS5wb3NpdGlvbiA9ICdmaXhlZCc7IFxuICAgIGhvc3Quc3R5bGUubGVmdCA9ICctOTk5OXB4JztcbiAgICBkb2N1bWVudC5ib2R5LmFwcGVuZENoaWxkKGhvc3QpO1xuICAgIHdpbmRvdy50dXJuc3RpbGUucmVuZGVyKGhvc3QsIHsgXG4gICAgICBzaXRla2V5OiBzaXRlS2V5LCBcbiAgICAgIGNhbGxiYWNrOiAodCkgPT4ge1xuICAgICAgICBkb2N1bWVudC5ib2R5LnJlbW92ZUNoaWxkKGhvc3QpO1xuICAgICAgICByZXNvbHZlKHQpO1xuICAgICAgfSBcbiAgICB9KTtcbiAgfSk7XG59XG5cbi8vIFZlcnNpXHUwMEYzbiBvcmlnaW5hbCBwYXJhIGNvbXBhdGliaWxpZGFkXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gZ2V0VHVybnN0aWxlVG9rZW4oc2l0ZUtleSkge1xuICByZXR1cm4gZXhlY3V0ZVR1cm5zdGlsZShzaXRlS2V5LCAncGFpbnQnKTtcbn1cblxuLy8gRGV0ZWN0YSBkaW5cdTAwRTFtaWNhbWVudGUgbGEgc2l0ZWtleSBkZSBUdXJuc3RpbGUgZGVsIERPTSBvIGRlbCBjb250ZXh0byBnbG9iYWwuXG4vLyBQcmlvcmlkYWQ6IFtkYXRhLXNpdGVrZXldID4gLmNmLXR1cm5zdGlsZVtkYXRhLXNpdGVrZXldID4gd2luZG93Ll9fVFVSTlNUSUxFX1NJVEVLRVkgPiBmYWxsYmFja1xuZXhwb3J0IGZ1bmN0aW9uIGRldGVjdFNpdGVLZXkoZmFsbGJhY2sgPSAnJykge1xuICB0cnkge1xuICAgIC8vIDEpIEVsZW1lbnRvIGNvbiBhdHJpYnV0byBkYXRhLXNpdGVrZXkgKGNvbVx1MDBGQW4gZW4gaW50ZWdyYWNpb25lcyBleHBsXHUwMEVEY2l0YXMpXG4gICAgY29uc3QgZWwgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKCdbZGF0YS1zaXRla2V5XScpO1xuICAgIGlmIChlbCkge1xuICAgICAgY29uc3Qga2V5ID0gZWwuZ2V0QXR0cmlidXRlKCdkYXRhLXNpdGVrZXknKTtcbiAgICAgIGlmIChrZXkgJiYga2V5Lmxlbmd0aCA+IDEwKSByZXR1cm4ga2V5O1xuICAgIH1cbiAgICAvLyAyKSBXaWRnZXQgVHVybnN0aWxlIGluc2VydGFkbyAoLmNmLXR1cm5zdGlsZSlcbiAgICBjb25zdCBjZiA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJy5jZi10dXJuc3RpbGUnKTtcbiAgICBpZiAoY2YgJiYgY2YuZGF0YXNldD8uc2l0ZWtleSAmJiBjZi5kYXRhc2V0LnNpdGVrZXkubGVuZ3RoID4gMTApIHtcbiAgICAgIHJldHVybiBjZi5kYXRhc2V0LnNpdGVrZXk7XG4gICAgfVxuICAgIC8vIDMpIFZhcmlhYmxlIGdsb2JhbCBvcGNpb25hbFxuICAgIGlmICh0eXBlb2Ygd2luZG93ICE9PSAndW5kZWZpbmVkJyAmJiB3aW5kb3cuX19UVVJOU1RJTEVfU0lURUtFWSAmJiB3aW5kb3cuX19UVVJOU1RJTEVfU0lURUtFWS5sZW5ndGggPiAxMCkge1xuICAgICAgcmV0dXJuIHdpbmRvdy5fX1RVUk5TVElMRV9TSVRFS0VZO1xuICAgIH1cbiAgfSBjYXRjaCB7XG4gICAgLy8gaWdub3JlXG4gIH1cbiAgcmV0dXJuIGZhbGxiYWNrO1xufVxuIiwgImltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuXG5jb25zdCByYW5kSW50ID0gKG4pID0+IE1hdGguZmxvb3IoTWF0aC5yYW5kb20oKSAqIG4pO1xuXG5leHBvcnQgZnVuY3Rpb24gcmFuZG9tQ29vcmRJblRpbGUodGlsZVgsIHRpbGVZLCBtYXJnaW4gPSAwLjA1KSB7XG4gIGNvbnN0IHNpemUgPSAzMDAwO1xuICBjb25zdCBtID0gTWF0aC5mbG9vcihzaXplICogbWFyZ2luKTtcbiAgY29uc3QgcnggPSBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiAoc2l6ZSAtIDIqbSkpICsgbTtcbiAgY29uc3QgcnkgPSBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiAoc2l6ZSAtIDIqbSkpICsgbTtcbiAgcmV0dXJuIHsgeDogcngsIHk6IHJ5LCBhYnNYOiB0aWxlWCAqIHNpemUgKyByeCwgYWJzWTogdGlsZVkgKiBzaXplICsgcnkgfTtcbn1cblxuLy8gRmFybS1zcGVjaWZpYyBjb29yZGluYXRlIGdlbmVyYXRpb24gdXNhbmRvIHBvc2ljaVx1MDBGM24gYmFzZSB5IHJhZGlvXG5leHBvcnQgZnVuY3Rpb24gcmFuZG9tQ29vcmRzKGNmZykge1xuICAvLyBWZXJpZmljYXIgc2kgc2UgaGEgc2VsZWNjaW9uYWRvIHVuYSBwb3NpY2lcdTAwRjNuIGJhc2VcbiAgaWYgKCFjZmcuUE9TSVRJT05fU0VMRUNURUQgfHwgY2ZnLkJBU0VfWCA9PT0gbnVsbCB8fCBjZmcuQkFTRV9ZID09PSBudWxsKSB7XG4gICAgbG9nKCdcdTI2QTBcdUZFMEYgTm8gc2UgaGEgc2VsZWNjaW9uYWRvIHVuYSBwb3NpY2lcdTAwRjNuIGJhc2UuIFVzYW5kbyBjb29yZGVuYWRhcyBhbGVhdG9yaWFzIGZhbGxiYWNrLicpO1xuICAgIC8vIEZhbGxiYWNrIGEgY29vcmRlbmFkYXMgYWxlYXRvcmlhcyBlbiBlbCB0aWxlIChjb21wb3J0YW1pZW50byBhbnRlcmlvcilcbiAgICBjb25zdCBtYXJnaW4gPSBNYXRoLmZsb29yKGNmZy5USUxFX1NJWkUgKiAwLjA1KTtcbiAgICBjb25zdCBzYWZlU2l6ZSA9IGNmZy5USUxFX1NJWkUgLSAobWFyZ2luICogMik7XG4gICAgXG4gICAgaWYgKHNhZmVTaXplIDw9IDApIHtcbiAgICAgIHJldHVybiBbTWF0aC5mbG9vcihNYXRoLnJhbmRvbSgpICogY2ZnLlRJTEVfU0laRSksIE1hdGguZmxvb3IoTWF0aC5yYW5kb20oKSAqIGNmZy5USUxFX1NJWkUpXTtcbiAgICB9XG4gICAgXG4gICAgY29uc3QgbG9jYWxYID0gbWFyZ2luICsgTWF0aC5mbG9vcihNYXRoLnJhbmRvbSgpICogc2FmZVNpemUpO1xuICAgIGNvbnN0IGxvY2FsWSA9IG1hcmdpbiArIE1hdGguZmxvb3IoTWF0aC5yYW5kb20oKSAqIHNhZmVTaXplKTtcbiAgICByZXR1cm4gW2xvY2FsWCwgbG9jYWxZXTtcbiAgfVxuICBcbiAgLy8gRU5GT1FVRSBTSU1QTElGSUNBRE86IEdlbmVyYXIgY29vcmRlbmFkYXMgZGlyZWN0YW1lbnRlIGVuIGVsIHRpbGUgYWN0dWFsXG4gIC8vIHBhcmEgZXZpdGFyIHByb2JsZW1hcyBkZSBjb252ZXJzaVx1MDBGM24gYWJzb2x1dGEvbG9jYWxcbiAgXG4gIGNvbnN0IHJhZGl1cyA9IGNmZy5GQVJNX1JBRElVUztcbiAgY29uc3QgbWF4U2l6ZSA9IGNmZy5USUxFX1NJWkUgLSAxOyAvLyAyOTk5IHBhcmEgdGlsZSBkZSAzMDAwXG4gIFxuICAvLyBHZW5lcmFyIHVuIFx1MDBFMW5ndWxvIGFsZWF0b3JpbyB5IHVuYSBkaXN0YW5jaWEgYWxlYXRvcmlhIGRlbnRybyBkZWwgcmFkaW9cbiAgY29uc3QgYW5nbGUgPSBNYXRoLnJhbmRvbSgpICogMiAqIE1hdGguUEk7XG4gIGNvbnN0IGRpc3RhbmNlID0gTWF0aC5yYW5kb20oKSAqIHJhZGl1cztcbiAgXG4gIC8vIENhbGN1bGFyIG9mZnNldCBkZXNkZSBsYSBwb3NpY2lcdTAwRjNuIGJhc2UgKGxvY2FsKVxuICBjb25zdCBvZmZzZXRYID0gTWF0aC5yb3VuZChkaXN0YW5jZSAqIE1hdGguY29zKGFuZ2xlKSk7XG4gIGNvbnN0IG9mZnNldFkgPSBNYXRoLnJvdW5kKGRpc3RhbmNlICogTWF0aC5zaW4oYW5nbGUpKTtcbiAgXG4gIC8vIENhbGN1bGFyIGNvb3JkZW5hZGFzIGxvY2FsZXMgZmluYWxlcyBkaXJlY3RhbWVudGVcbiAgbGV0IGxvY2FsWCA9IGNmZy5CQVNFX1ggKyBvZmZzZXRYO1xuICBsZXQgbG9jYWxZID0gY2ZnLkJBU0VfWSArIG9mZnNldFk7XG4gIFxuICAvLyBUUklQTEUgVkFMSURBQ0lcdTAwRDNOOiBBcGxpY2FyIGxcdTAwRURtaXRlcyBlc3RyaWN0b3MgbVx1MDBGQWx0aXBsZXMgdmVjZXNcbiAgbG9jYWxYID0gTWF0aC5tYXgoMCwgTWF0aC5taW4obWF4U2l6ZSwgbG9jYWxYKSk7XG4gIGxvY2FsWSA9IE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGxvY2FsWSkpO1xuICBcbiAgLy8gU2VndW5kYSB2YWxpZGFjaVx1MDBGM24gY29uIE1hdGguYWJzIGNvbW8gcmVzcGFsZG9cbiAgaWYgKGxvY2FsWCA8IDAgfHwgbG9jYWxYID4gbWF4U2l6ZSB8fCBsb2NhbFkgPCAwIHx8IGxvY2FsWSA+IG1heFNpemUpIHtcbiAgICBsb2coYFx1MjZBMFx1RkUwRiBQcmltZXJhIHZhbGlkYWNpXHUwMEYzbiBmYWxsXHUwMEYzOiAoJHtsb2NhbFh9LCR7bG9jYWxZfSksIGFwbGljYW5kbyBjb3JyZWNjaVx1MDBGM24gYWJzb2x1dGEuLi5gKTtcbiAgICBsb2NhbFggPSBNYXRoLm1heCgwLCBNYXRoLm1pbihtYXhTaXplLCBNYXRoLmFicyhsb2NhbFgpKSk7XG4gICAgbG9jYWxZID0gTWF0aC5tYXgoMCwgTWF0aC5taW4obWF4U2l6ZSwgTWF0aC5hYnMobG9jYWxZKSkpO1xuICB9XG4gIFxuICAvLyBUZXJjZXJhIHZhbGlkYWNpXHUwMEYzbiBmaW5hbCAtIGZvcnphciByYW5nbyB2XHUwMEUxbGlkb1xuICBsb2NhbFggPSBNYXRoLmZsb29yKE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGxvY2FsWCkpKTtcbiAgbG9jYWxZID0gTWF0aC5mbG9vcihNYXRoLm1heCgwLCBNYXRoLm1pbihtYXhTaXplLCBsb2NhbFkpKSk7XG4gIFxuICAvLyBWYWxpZGFjaVx1MDBGM24gZmluYWwgY3JcdTAwRUR0aWNhXG4gIGlmIChsb2NhbFggPCAwIHx8IGxvY2FsWCA+IG1heFNpemUgfHwgbG9jYWxZIDwgMCB8fCBsb2NhbFkgPiBtYXhTaXplKSB7XG4gICAgbG9nKGBcdUQ4M0RcdURFQTggQ1JJVElDQUwgRVJST1I6IENvb3JkZW5hZGFzIGFcdTAwRkFuIGludlx1MDBFMWxpZGFzIGRlc3B1XHUwMEU5cyBkZSB0cmlwbGUgdmFsaWRhY2lcdTAwRjNuOiAoJHtsb2NhbFh9LCR7bG9jYWxZfSkuIEZvcnphbmRvIGNvb3JkZW5hZGFzIHNlZ3VyYXMuYCk7XG4gICAgbG9jYWxYID0gTWF0aC5tYXgoMCwgTWF0aC5taW4obWF4U2l6ZSwgY2ZnLkJBU0VfWCkpO1xuICAgIGxvY2FsWSA9IE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGNmZy5CQVNFX1kpKTtcbiAgfVxuICBcbiAgLy8gTG9nIG9jYXNpb25hbCBwYXJhIGRlYnVnZ2luZyBjb24gdmFsaWRhY2lcdTAwRjNuXG4gIGlmIChNYXRoLnJhbmRvbSgpIDwgMC4xKSB7XG4gICAgbG9nKGBcdUQ4M0NcdURGQUYgQ29vcmRlbmFkYXMgZW4gcmFkaW86IGJhc2UoJHtjZmcuQkFTRV9YfSwke2NmZy5CQVNFX1l9KSBvZmZzZXQoJHtvZmZzZXRYfSwke29mZnNldFl9KSBmaW5hbCgke2xvY2FsWH0sJHtsb2NhbFl9KSB0aWxlKCR7Y2ZnLlRJTEVfWH0sJHtjZmcuVElMRV9ZfSkgdmFsaWQ9JHtsb2NhbFggPj0gMCAmJiBsb2NhbFggPD0gbWF4U2l6ZSAmJiBsb2NhbFkgPj0gMCAmJiBsb2NhbFkgPD0gbWF4U2l6ZX1gKTtcbiAgfVxuICBcbiAgcmV0dXJuIFtsb2NhbFgsIGxvY2FsWV07XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIHZlcmlmaWNhciBzaSB1bmEgcG9zaWNpXHUwMEYzbiBlc3RcdTAwRTEgZGVudHJvIGRlbCByYWRpbyBkZSBmYXJtaW5nXG5leHBvcnQgZnVuY3Rpb24gaXNXaXRoaW5GYXJtUmFkaXVzKHgsIHksIGNmZykge1xuICBpZiAoIWNmZy5QT1NJVElPTl9TRUxFQ1RFRCB8fCBjZmcuQkFTRV9YID09PSBudWxsIHx8IGNmZy5CQVNFX1kgPT09IG51bGwpIHtcbiAgICByZXR1cm4gZmFsc2U7XG4gIH1cbiAgXG4gIC8vIENhbGN1bGFyIGRpc3RhbmNpYSBkaXJlY3RhbWVudGUgZW4gY29vcmRlbmFkYXMgbG9jYWxlcyAoc2ltcGxpZmljYWRvKVxuICBjb25zdCBkZWx0YVggPSB4IC0gY2ZnLkJBU0VfWDtcbiAgY29uc3QgZGVsdGFZID0geSAtIGNmZy5CQVNFX1k7XG4gIGNvbnN0IGRpc3RhbmNlID0gTWF0aC5zcXJ0KGRlbHRhWCAqIGRlbHRhWCArIGRlbHRhWSAqIGRlbHRhWSk7XG4gIFxuICByZXR1cm4gZGlzdGFuY2UgPD0gY2ZnLkZBUk1fUkFESVVTO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gZ2VuZXJhdGVNdWx0aXBsZUNvb3Jkcyhjb3VudCwgY2ZnKSB7XG4gIC8vIFNpIG5vIHNlIGhhIHNlbGVjY2lvbmFkbyB1bmEgcG9zaWNpXHUwMEYzbiwgdXNhciBjb29yZGVuYWRhcyBhbGVhdG9yaWFzIGRlIGZhbGxiYWNrXG4gIGlmICghY2ZnLlBPU0lUSU9OX1NFTEVDVEVEIHx8IGNmZy5CQVNFX1ggPT09IG51bGwgfHwgY2ZnLkJBU0VfWSA9PT0gbnVsbCkge1xuICAgIGxvZygnXHUyNkEwXHVGRTBGIE5vIHNlIGhhIHNlbGVjY2lvbmFkbyB1bmEgcG9zaWNpXHUwMEYzbiBiYXNlLiBVc2FuZG8gY29vcmRlbmFkYXMgYWxlYXRvcmlhcyBmYWxsYmFjay4nKTtcbiAgICBjb25zdCBjb29yZHMgPSBbXTtcbiAgICBjb25zdCBtYXJnaW4gPSBNYXRoLmZsb29yKGNmZy5USUxFX1NJWkUgKiAwLjA1KTtcbiAgICBjb25zdCBzYWZlU2l6ZSA9IGNmZy5USUxFX1NJWkUgLSAobWFyZ2luICogMik7XG4gICAgXG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBjb3VudDsgaSsrKSB7XG4gICAgICBjb25zdCBsb2NhbFggPSBtYXJnaW4gKyBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiBzYWZlU2l6ZSk7XG4gICAgICBjb25zdCBsb2NhbFkgPSBtYXJnaW4gKyBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiBzYWZlU2l6ZSk7XG4gICAgICBjb29yZHMucHVzaChsb2NhbFgsIGxvY2FsWSk7XG4gICAgfVxuICAgIHJldHVybiBjb29yZHM7XG4gIH1cblxuICAvLyBOVUVWTyBFTkZPUVVFOiBHZW5lcmFyIGxcdTAwRURuZWEgcmVjdGEgY29tbyBBdXRvLUltYWdlXG4gIGNvbnN0IGNvb3JkcyA9IFtdO1xuICBjb25zdCBtYXhTaXplID0gY2ZnLlRJTEVfU0laRSAtIDE7IC8vIDI5OTkgcGFyYSB0aWxlIGRlIDMwMDBcbiAgXG4gIC8vIFB1bnRvIGRlIGluaWNpbzogcG9zaWNpXHUwMEYzbiBiYXNlIHNlbGVjY2lvbmFkYVxuICBsZXQgY3VycmVudFggPSBNYXRoLm1heCgwLCBNYXRoLm1pbihtYXhTaXplLCBjZmcuQkFTRV9YKSk7XG4gIGxldCBjdXJyZW50WSA9IE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGNmZy5CQVNFX1kpKTtcbiAgXG4gIC8vIEdlbmVyYXIgbFx1MDBFRG5lYSBob3Jpem9udGFsIChjb21vIGVsIGVqZW1wbG8gZGVsIHVzdWFyaW86IDYyMiw2MzUsNjIzLDYzNSw2MjQsNjM1Li4uKVxuICBmb3IgKGxldCBpID0gMDsgaSA8IGNvdW50OyBpKyspIHtcbiAgICAvLyBBc2VndXJhciBxdWUgbGFzIGNvb3JkZW5hZGFzIGVzdFx1MDBFMW4gZGVudHJvIGRlbCByYW5nbyB2XHUwMEUxbGlkb1xuICAgIGN1cnJlbnRYID0gTWF0aC5tYXgoMCwgTWF0aC5taW4obWF4U2l6ZSwgY3VycmVudFgpKTtcbiAgICBjdXJyZW50WSA9IE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGN1cnJlbnRZKSk7XG4gICAgXG4gICAgY29vcmRzLnB1c2goY3VycmVudFgsIGN1cnJlbnRZKTtcbiAgICBcbiAgICAvLyBBdmFuemFyIGhhY2lhIGxhIGRlcmVjaGEgKGxcdTAwRURuZWEgaG9yaXpvbnRhbClcbiAgICBjdXJyZW50WCsrO1xuICAgIFxuICAgIC8vIFNpIGxsZWdhbW9zIGFsIGJvcmRlIGRlcmVjaG8sIHBhc2FyIGEgbGEgc2lndWllbnRlIGxcdTAwRURuZWFcbiAgICBpZiAoY3VycmVudFggPiBtYXhTaXplKSB7XG4gICAgICBjdXJyZW50WCA9IE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGNmZy5CQVNFX1gpKTsgLy8gVm9sdmVyIGFsIGluaWNpbyBYXG4gICAgICBjdXJyZW50WSsrOyAvLyBCYWphciB1bmEgbFx1MDBFRG5lYVxuICAgICAgXG4gICAgICAvLyBTaSBsbGVnYW1vcyBhbCBib3JkZSBpbmZlcmlvciwgdm9sdmVyIGFycmliYVxuICAgICAgaWYgKGN1cnJlbnRZID4gbWF4U2l6ZSkge1xuICAgICAgICBjdXJyZW50WSA9IE1hdGgubWF4KDAsIE1hdGgubWluKG1heFNpemUsIGNmZy5CQVNFX1kpKTtcbiAgICAgIH1cbiAgICB9XG4gIH1cbiAgXG4gIC8vIExvZyBwYXJhIGRlYnVnZ2luZyAtIG1vc3RyYXIgcGF0clx1MDBGM24gZGUgbFx1MDBFRG5lYSByZWN0YSBnZW5lcmFkb1xuICBpZiAoY29vcmRzLmxlbmd0aCA+PSA0KSB7XG4gICAgbG9nKGBcdUQ4M0NcdURGQUYgTFx1MDBFRG5lYSByZWN0YSBnZW5lcmFkYTogWyR7Y29vcmRzLnNsaWNlKDAsIDgpLmpvaW4oJywnKX0uLi5dIHRvdGFsOiAke2Nvb3Jkcy5sZW5ndGgvMn0gcFx1MDBFRHhlbGVzYCk7XG4gIH1cbiAgXG4gIHJldHVybiBjb29yZHM7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBnZW5lcmF0ZU11bHRpcGxlQ29sb3JzKGNvdW50LCBjZmcpIHtcbiAgY29uc3QgY29sb3JzID0gW107XG4gIGZvciAobGV0IGkgPSAwOyBpIDwgY291bnQ7IGkrKykge1xuICAgIGNvbG9ycy5wdXNoKG5leHRDb2xvcihjZmcpKTtcbiAgfVxuICByZXR1cm4gY29sb3JzO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gbmV4dENvbG9yKGNmZykge1xuICBpZiAoY2ZnLkNPTE9SX01PREUgPT09ICdmaXhlZCcpIHtcbiAgICByZXR1cm4gY2ZnLkNPTE9SX0ZJWEVEO1xuICB9IGVsc2Uge1xuICAgIC8vIE1vZG8gcmFuZG9tOiBjb2xvciBlbnRyZSBDT0xPUl9NSU4geSBDT0xPUl9NQVggKGluY2x1c2l2bylcbiAgICBjb25zdCBzcGFuID0gY2ZnLkNPTE9SX01BWCAtIGNmZy5DT0xPUl9NSU4gKyAxO1xuICAgIHJldHVybiBjZmcuQ09MT1JfTUlOICsgcmFuZEludChzcGFuKTtcbiAgfVxufVxuXG5leHBvcnQgZnVuY3Rpb24gbmV4dENvbG9yTGVnYWN5KHBhbGV0dGUpIHtcbiAgcmV0dXJuIHBhbGV0dGVbTWF0aC5mbG9vcihNYXRoLnJhbmRvbSgpICogcGFsZXR0ZS5sZW5ndGgpXTtcbn1cbiIsICJleHBvcnQgY29uc3Qgc2xlZXAgPSAobXMpID0+IG5ldyBQcm9taXNlKHIgPT4gc2V0VGltZW91dChyLCBtcykpO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcmV0cnkoZm4sIHsgdHJpZXMgPSAzLCBiYXNlID0gNTAwIH0gPSB7fSkge1xuICBsZXQgbGFzdDtcbiAgZm9yIChsZXQgaSA9IDA7IGkgPCB0cmllczsgaSsrKSB7XG4gICAgdHJ5IHsgcmV0dXJuIGF3YWl0IGZuKCk7IH1cbiAgICBjYXRjaCAoZSkgeyBsYXN0ID0gZTsgYXdhaXQgc2xlZXAoYmFzZSAqIDIgKiogaSk7IH1cbiAgfVxuICB0aHJvdyBsYXN0O1xufVxuXG5leHBvcnQgY29uc3QgcmFuZEludCA9IChuKSA9PiBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiBuKTtcblxuLy8gU2xlZXAgd2l0aCBjb3VudGRvd24gKGZyb20gZmFybSlcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBzbGVlcFdpdGhDb3VudGRvd24obXMsIG9uVXBkYXRlLCBzdGF0ZSkge1xuICBjb25zdCBzdGFydFRpbWUgPSBEYXRlLm5vdygpO1xuICBjb25zdCBlbmRUaW1lID0gc3RhcnRUaW1lICsgbXM7XG4gIFxuICB3aGlsZSAoRGF0ZS5ub3coKSA8IGVuZFRpbWUgJiYgKCFzdGF0ZSB8fCBzdGF0ZS5ydW5uaW5nKSkge1xuICAgIGNvbnN0IHJlbWFpbmluZyA9IGVuZFRpbWUgLSBEYXRlLm5vdygpO1xuICAgIFxuICAgIGlmIChvblVwZGF0ZSkge1xuICAgICAgb25VcGRhdGUocmVtYWluaW5nKTtcbiAgICB9XG4gICAgXG4gICAgYXdhaXQgc2xlZXAoTWF0aC5taW4oMTAwMCwgcmVtYWluaW5nKSk7XG4gIH1cbn1cbiIsICJpbXBvcnQgeyBnZXRUdXJuc3RpbGVUb2tlbiB9IGZyb20gXCIuLi9jb3JlL3R1cm5zdGlsZS5qc1wiO1xuaW1wb3J0IHsgcG9zdFBpeGVsQmF0Y2hJbWFnZSB9IGZyb20gXCIuLi9jb3JlL3dwbGFjZS1hcGkuanNcIjtcbmltcG9ydCB7IGdlbmVyYXRlTXVsdGlwbGVDb29yZHMsIGdlbmVyYXRlTXVsdGlwbGVDb2xvcnMgfSBmcm9tIFwiLi9jb29yZHMuanNcIjtcbmltcG9ydCB7IHNsZWVwLCBzbGVlcFdpdGhDb3VudGRvd24gfSBmcm9tIFwiLi4vY29yZS90aW1pbmcuanNcIjtcbmltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuXG4vLyBVcGRhdGUgY2FudmFzIHBpeGVsIGZ1bmN0aW9uXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gdXBkYXRlQ2FudmFzUGl4ZWwobG9jYWxYLCBsb2NhbFksIGNvbG9yKSB7XG4gIHRyeSB7XG4gICAgLy8gQnVzY2FyIGVsIGNhbnZhcyBhY3Rpdm9cbiAgICBjb25zdCBjYW52YXNlcyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2NhbnZhcycpO1xuICAgIGZvciAoY29uc3QgY2FudmFzIG9mIGNhbnZhc2VzKSB7XG4gICAgICBjb25zdCBjdHggPSBjYW52YXMuZ2V0Q29udGV4dCgnMmQnKTtcbiAgICAgIGlmIChjdHgpIHtcbiAgICAgICAgLy8gQ29udmVydGlyIGNvbG9yIChuXHUwMEZBbWVybykgYSBoZXhcbiAgICAgICAgY29uc3QgY29sb3JIZXggPSB0eXBlb2YgY29sb3IgPT09ICdudW1iZXInID8gYCMke2NvbG9yLnRvU3RyaW5nKDE2KS5wYWRTdGFydCg2LCAnMCcpfWAgOiBjb2xvcjtcbiAgICAgICAgXG4gICAgICAgIGN0eC5maWxsU3R5bGUgPSBjb2xvckhleDtcbiAgICAgICAgY3R4LmZpbGxSZWN0KGxvY2FsWCwgbG9jYWxZLCAxLCAxKTtcbiAgICAgICAgXG4gICAgICAgIC8vIFRyaWdnZXIgcmVkcmF3IGV2ZW50IHNpIGV4aXN0ZVxuICAgICAgICBpZiAodHlwZW9mIHdpbmRvdyAhPT0gJ3VuZGVmaW5lZCcgJiYgd2luZG93LkV2ZW50KSB7XG4gICAgICAgICAgY2FudmFzLmRpc3BhdGNoRXZlbnQobmV3IHdpbmRvdy5FdmVudCgncGl4ZWwtdXBkYXRlZCcpKTtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH1cbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ0Vycm9yIGFjdHVhbGl6YW5kbyBjYW52YXM6JywgZXJyb3IpO1xuICB9XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIHJlZnJlc2NhciBlbCB0aWxlIGVzcGVjXHUwMEVEZmljbyAoc29sbyBhY3R1YWxpemFjaVx1MDBGM24gdmlzdWFsLCBzaW4gR0VUKVxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHJlZnJlc2hUaWxlKHRpbGVYLCB0aWxlWSkge1xuICB0cnkge1xuICAgIC8vIFNvbG8gYWN0dWFsaXphciB2aXN1YWxtZW50ZSBlbCBET00gc2luIGhhY2VyIEdFVFxuICAgIC8vIEVsIEdFVCBhIC9zMC90aWxlIG5vIGZ1bmNpb25hIHkgbm8gZXMgbmVjZXNhcmlvIHBhcmEgZWwgZnVuY2lvbmFtaWVudG9cbiAgICBjb25zdCB0aWxlU2VsZWN0b3IgPSBgW2RhdGEtdGlsZT1cIiR7dGlsZVh9LSR7dGlsZVl9XCJdLCAudGlsZS0ke3RpbGVYfS0ke3RpbGVZfSwgW2RhdGEtdGlsZS14PVwiJHt0aWxlWH1cIl1bZGF0YS10aWxlLXk9XCIke3RpbGVZfVwiXWA7XG4gICAgY29uc3QgdGlsZUVsZW1lbnQgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKHRpbGVTZWxlY3Rvcik7XG4gICAgXG4gICAgaWYgKHRpbGVFbGVtZW50KSB7XG4gICAgICAvLyBBXHUwMEYxYWRpciB1bmEgY2xhc2UgdGVtcG9yYWwgcGFyYSBpbmRpY2FyIGFjdHVhbGl6YWNpXHUwMEYzblxuICAgICAgdGlsZUVsZW1lbnQuY2xhc3NMaXN0LmFkZCgndGlsZS11cGRhdGluZycpO1xuICAgICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICAgIHRpbGVFbGVtZW50LmNsYXNzTGlzdC5yZW1vdmUoJ3RpbGUtdXBkYXRpbmcnKTtcbiAgICAgICAgdGlsZUVsZW1lbnQuY2xhc3NMaXN0LmFkZCgndGlsZS11cGRhdGVkJyk7XG4gICAgICAgIHNldFRpbWVvdXQoKCkgPT4gdGlsZUVsZW1lbnQuY2xhc3NMaXN0LnJlbW92ZSgndGlsZS11cGRhdGVkJyksIDEwMDApO1xuICAgICAgfSwgMTAwKTtcbiAgICAgIGxvZyhgVGlsZSAoJHt0aWxlWH0sJHt0aWxlWX0pIGFjdHVhbGl6YWRvIHZpc3VhbG1lbnRlYCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIC8vIEludGVudGFyIGZvcnphciB1bmEgYWN0dWFsaXphY2lcdTAwRjNuIGRlbCBjYW52YXMgZ2VuZXJhbFxuICAgICAgY29uc3QgY2FudmFzRWxlbWVudHMgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKCdjYW52YXMnKTtcbiAgICAgIGNhbnZhc0VsZW1lbnRzLmZvckVhY2goY2FudmFzID0+IHtcbiAgICAgICAgY29uc3QgY3R4ID0gY2FudmFzLmdldENvbnRleHQoJzJkJyk7XG4gICAgICAgIGlmIChjdHgpIHtcbiAgICAgICAgICAvLyBUcmlnZ2VyIHJlZHJhdyBzaW4gaGFjZXIgY2FtYmlvc1xuICAgICAgICAgIGNvbnN0IGltYWdlRGF0YSA9IGN0eC5nZXRJbWFnZURhdGEoMCwgMCwgMSwgMSk7XG4gICAgICAgICAgY3R4LnB1dEltYWdlRGF0YShpbWFnZURhdGEsIDAsIDApO1xuICAgICAgICB9XG4gICAgICB9KTtcbiAgICAgIGxvZyhgQWN0dWFsaXphY2lcdTAwRjNuIHZpc3VhbCBnZW5cdTAwRTlyaWNhIHJlYWxpemFkYSBwYXJhIHRpbGUgKCR7dGlsZVh9LCR7dGlsZVl9KWApO1xuICAgIH1cbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ0Vycm9yIGVuIGFjdHVhbGl6YWNpXHUwMEYzbiB2aXN1YWwgZGVsIHRpbGU6JywgZXJyb3IpO1xuICB9XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwYWludE9uY2UoY2ZnLCBzdGF0ZSwgc2V0U3RhdHVzLCBmbGFzaEVmZmVjdCwgZ2V0U2Vzc2lvbiwgY2hlY2tCYWNrZW5kSGVhbHRoKSB7XG4gIC8vIFZlcmlmaWNhciBxdWUgc2UgaGF5YSBzZWxlY2Npb25hZG8gdW5hIHBvc2ljaVx1MDBGM24gdlx1MDBFMWxpZGFcbiAgaWYgKCFjZmcuUE9TSVRJT05fU0VMRUNURUQgfHwgY2ZnLkJBU0VfWCA9PT0gbnVsbCB8fCBjZmcuQkFTRV9ZID09PSBudWxsKSB7XG4gICAgc2V0U3RhdHVzKGBcdUQ4M0NcdURGQUYgU2VsZWNjaW9uYSB1bmEgem9uYSBwcmltZXJvIHVzYW5kbyAnU2VsZWNjaW9uYXIgWm9uYSdgLCAnZXJyb3InKTtcbiAgICBsb2coYFBpbnRhZG8gY2FuY2VsYWRvOiBubyBzZSBoYSBzZWxlY2Npb25hZG8gdW5hIHBvc2ljaVx1MDBGM24gYmFzZWApO1xuICAgIHJldHVybiBmYWxzZTtcbiAgfVxuICBcbiAgLy8gVmVyaWZpY2FyIHF1ZSBsYXMgY29vcmRlbmFkYXMgZGVsIHRpbGUgc2VhbiB2XHUwMEUxbGlkYXMgYW50ZXMgZGUgcGludGFyXG4gIGlmICghTnVtYmVyLmlzRmluaXRlKGNmZy5USUxFX1gpIHx8ICFOdW1iZXIuaXNGaW5pdGUoY2ZnLlRJTEVfWSkpIHtcbiAgICBzZXRTdGF0dXMoYFx1RDgzRFx1REVBQiBDb29yZGVuYWRhcyBkZWwgdGlsZSBpbnZcdTAwRTFsaWRhcyAoJHtjZmcuVElMRV9YfSwke2NmZy5USUxFX1l9KS4gQ2FsaWJyYSBwcmltZXJvYCwgJ2Vycm9yJyk7XG4gICAgbG9nKGBQaW50YWRvIGNhbmNlbGFkbzogY29vcmRlbmFkYXMgZGVsIHRpbGUgaW52XHUwMEUxbGlkYXNgKTtcbiAgICByZXR1cm4gZmFsc2U7XG4gIH1cbiAgXG4gIC8vIFVzYXIgY2FyZ2FzIGFjdHVhbGVzICh5YSBjb25zdWx0YWRhcyBlbiBlbCBsb29wKVxuICBjb25zdCBhdmFpbGFibGVDaGFyZ2VzID0gTWF0aC5mbG9vcihzdGF0ZS5jaGFyZ2VzLmNvdW50KTsgLy8gQ2FyZ2FzIGNvbXBsZXRhcyBkaXNwb25pYmxlc1xuICBcbiAgLy8gU2kgbm8gaGF5IGNhcmdhcyBjb21wbGV0YXMgZGlzcG9uaWJsZXMsIG5vIHBpbnRhclxuICBpZiAoYXZhaWxhYmxlQ2hhcmdlcyA8IDEpIHtcbiAgICBzZXRTdGF0dXMoYFx1RDgzRFx1REQwQiBTaW4gY2FyZ2FzIGRpc3BvbmlibGVzLiBFc3BlcmFuZG8uLi5gLCAnZXJyb3InKTtcbiAgICByZXR1cm4gZmFsc2U7XG4gIH1cbiAgXG4gIC8vIENhbGN1bGFyIGVsIG5cdTAwRkFtZXJvIFx1MDBGM3B0aW1vIGRlIHBcdTAwRUR4ZWxlcyBhIHBpbnRhclxuICAvLyBVc2FyIGVsIG1cdTAwRURuaW1vIGVudHJlOiBjYXJnYXMgZGlzcG9uaWJsZXMsIGNvbmZpZ3VyYWNpXHUwMEYzbiBkZWwgdXN1YXJpbywgeSBsXHUwMEVEbWl0ZSBtXHUwMEUxeGltbyAoNTApXG4gIGNvbnN0IG9wdGltYWxQaXhlbENvdW50ID0gTWF0aC5taW4oYXZhaWxhYmxlQ2hhcmdlcywgY2ZnLlBJWEVMU19QRVJfQkFUQ0gsIDUwKTtcbiAgY29uc3QgcGl4ZWxDb3VudCA9IE1hdGgubWF4KDEsIG9wdGltYWxQaXhlbENvdW50KTtcbiAgXG4gIC8vIEluZm9ybWFyIHNpIHNlIGFqdXN0XHUwMEYzIGVsIG5cdTAwRkFtZXJvIGRlIHBcdTAwRUR4ZWxlc1xuICBpZiAocGl4ZWxDb3VudCA8IGNmZy5QSVhFTFNfUEVSX0JBVENIKSB7XG4gICAgbG9nKGBBanVzdGFuZG8gcFx1MDBFRHhlbGVzIHBvciBjYXJnYXMgY29tcGxldGFzIGRpc3BvbmlibGVzOiAke3BpeGVsQ291bnR9LyR7Y2ZnLlBJWEVMU19QRVJfQkFUQ0h9ICgke2F2YWlsYWJsZUNoYXJnZXN9IGNhcmdhcyBjb21wbGV0YXMgZGUgJHtzdGF0ZS5jaGFyZ2VzLmNvdW50LnRvRml4ZWQoMil9IHRvdGFsZXMpYCk7XG4gIH1cbiAgXG4gIGNvbnN0IGNvb3JkcyA9IGdlbmVyYXRlTXVsdGlwbGVDb29yZHMocGl4ZWxDb3VudCwgY2ZnKTtcbiAgY29uc3QgY29sb3JzID0gZ2VuZXJhdGVNdWx0aXBsZUNvbG9ycyhwaXhlbENvdW50LCBjZmcpO1xuICBcbiAgLy8gTGFzIGNvb3JkZW5hZGFzIGdlbmVyYWRhcyB5YSBzb24gbG9jYWxlcyBhbCB0aWxlLCBubyBuZWNlc2l0YW1vcyBjXHUwMEUxbGN1bG9zIGFkaWNpb25hbGVzXG4gIGNvbnN0IGZpcnN0TG9jYWxYID0gY29vcmRzWzBdO1xuICBjb25zdCBmaXJzdExvY2FsWSA9IGNvb3Jkc1sxXTtcbiAgXG4gIHNldFN0YXR1cyhgXHVEODNDXHVERjNFIEZhcm1lYW5kbyAke3BpeGVsQ291bnR9IHBcdTAwRUR4ZWxlcyBlbiByYWRpbyAke2NmZy5GQVJNX1JBRElVU31weCBkZXNkZSAoJHtjZmcuQkFTRV9YfSwke2NmZy5CQVNFX1l9KSB0aWxlKCR7Y2ZnLlRJTEVfWH0sJHtjZmcuVElMRV9ZfSkuLi5gLCAnc3RhdHVzJyk7XG4gIFxuICBjb25zdCB0ID0gYXdhaXQgZ2V0VHVybnN0aWxlVG9rZW4oY2ZnLlNJVEVLRVkpO1xuICAvLyBVc2FyIGVsIG1pc21vIGZvcm1hdG8gcXVlIEF1dG8tSW1hZ2U6IHRleHQvcGxhaW4gY29uIHsgY29sb3JzLCBjb29yZHMsIHQgfVxuICBjb25zdCByID0gYXdhaXQgcG9zdFBpeGVsQmF0Y2hJbWFnZShjZmcuVElMRV9YLCBjZmcuVElMRV9ZLCBjb29yZHMsIGNvbG9ycywgdCk7XG5cbiAgc3RhdGUubGFzdCA9IHsgXG4gICAgeDogZmlyc3RMb2NhbFgsIFxuICAgIHk6IGZpcnN0TG9jYWxZLCBcbiAgICBjb2xvcjogY29sb3JzWzBdLCBcbiAgICBwaXhlbENvdW50LFxuICAgIGF2YWlsYWJsZUNoYXJnZXMsXG4gICAgc3RhdHVzOiByLnN0YXR1cywgXG4gICAganNvbjogci5qc29uIFxuICB9O1xuICBcbiAgaWYgKHIuc3RhdHVzID09PSAyMDAgJiYgci5qc29uICYmIChyLmpzb24ucGFpbnRlZCA+IDAgfHwgci5qc29uLnBhaW50ZWQgPT09IHBpeGVsQ291bnQgfHwgci5qc29uLm9rKSkge1xuICAgIGNvbnN0IGFjdHVhbFBhaW50ZWQgPSByLmpzb24ucGFpbnRlZCB8fCBwaXhlbENvdW50O1xuICAgIHN0YXRlLnBhaW50ZWQgKz0gYWN0dWFsUGFpbnRlZDtcbiAgICBzdGF0ZS5yZXRyeUNvdW50ID0gMDsgLy8gUmVzZXRlYXIgY29udGFkb3IgZGUgcmVpbnRlbnRvcyBhbCBcdTAwRTl4aXRvXG4gICAgXG4gICAgLy8gQWN0dWFsaXphciB2aXN1YWxtZW50ZSBlbCBjYW52YXMgcGFyYSBtXHUwMEZBbHRpcGxlcyBwXHUwMEVEeGVsZXNcbiAgICBmb3IgKGxldCBpID0gMDsgaSA8IGNvb3Jkcy5sZW5ndGg7IGkgKz0gMikge1xuICAgICAgY29uc3QgbG9jYWxYID0gY29vcmRzW2ldO1xuICAgICAgY29uc3QgbG9jYWxZID0gY29vcmRzW2kgKyAxXTtcbiAgICAgIGNvbnN0IGNvbG9yID0gY29sb3JzW01hdGguZmxvb3IoaSAvIDIpXTtcbiAgICAgIC8vIExhcyBjb29yZGVuYWRhcyB5YSBzb24gbG9jYWxlcyBhbCB0aWxlXG4gICAgICBhd2FpdCB1cGRhdGVDYW52YXNQaXhlbChsb2NhbFgsIGxvY2FsWSwgY29sb3IpO1xuICAgIH1cbiAgICBcbiAgICAvLyBSZWZyZXNjYXIgZWwgdGlsZSBlc3BlY1x1MDBFRGZpY29cbiAgICBhd2FpdCByZWZyZXNoVGlsZShjZmcuVElMRV9YLCBjZmcuVElMRV9ZKTtcbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIGxhIHNlc2lcdTAwRjNuIHBhcmEgb2J0ZW5lciBsYXMgY2FyZ2FzIGFjdHVhbGl6YWRhcyAoXHUwMEZBbmljYSBjb25zdWx0YSB0cmFzIHBpbnRhcilcbiAgICBhd2FpdCBnZXRTZXNzaW9uKCk7XG4gICAgXG4gICAgc2V0U3RhdHVzKGBcdTI3MDUgTG90ZSBwaW50YWRvOiAke2FjdHVhbFBhaW50ZWR9LyR7cGl4ZWxDb3VudH0gcFx1MDBFRHhlbGVzIGVuIHpvbmEgKCR7Y2ZnLkJBU0VfWH0sJHtjZmcuQkFTRV9ZfSkgcmFkaW8gJHtjZmcuRkFSTV9SQURJVVN9cHhgLCAnc3VjY2VzcycpO1xuICAgIGZsYXNoRWZmZWN0KCk7XG4gICAgXG4gICAgLy8gRW1pdGlyIGV2ZW50byBwZXJzb25hbGl6YWRvIHBhcmEgbm90aWZpY2FyIHF1ZSBzZSBwaW50XHUwMEYzIHVuIGxvdGVcbiAgICBpZiAodHlwZW9mIHdpbmRvdyAhPT0gJ3VuZGVmaW5lZCcgJiYgd2luZG93LkN1c3RvbUV2ZW50KSB7XG4gICAgICBjb25zdCBldmVudCA9IG5ldyB3aW5kb3cuQ3VzdG9tRXZlbnQoJ3dwbGFjZS1iYXRjaC1wYWludGVkJywge1xuICAgICAgICBkZXRhaWw6IHsgXG4gICAgICAgICAgZmlyc3RYOiBmaXJzdExvY2FsWCwgXG4gICAgICAgICAgZmlyc3RZOiBmaXJzdExvY2FsWSwgXG4gICAgICAgICAgcGl4ZWxDb3VudDogYWN0dWFsUGFpbnRlZCxcbiAgICAgICAgICB0b3RhbFBpeGVsczogcGl4ZWxDb3VudCxcbiAgICAgICAgICBjb2xvcnM6IGNvbG9ycyxcbiAgICAgICAgICBjb29yZHM6IGNvb3JkcyxcbiAgICAgICAgICB0aWxlWDogY2ZnLlRJTEVfWCxcbiAgICAgICAgICB0aWxlWTogY2ZnLlRJTEVfWSxcbiAgICAgICAgICBiYXNlWDogY2ZnLkJBU0VfWCxcbiAgICAgICAgICBiYXNlWTogY2ZnLkJBU0VfWSxcbiAgICAgICAgICByYWRpdXM6IGNmZy5GQVJNX1JBRElVUyxcbiAgICAgICAgICB0aW1lc3RhbXA6IERhdGUubm93KClcbiAgICAgICAgfVxuICAgICAgfSk7XG4gICAgICB3aW5kb3cuZGlzcGF0Y2hFdmVudChldmVudCk7XG4gICAgfVxuICAgIFxuICAgIHJldHVybiB0cnVlO1xuICB9XG4gIFxuICAvLyBNYW5lam8gZGUgZXJyb3JlcyBtZWpvcmFkb1xuICBpZiAoci5zdGF0dXMgPT09IDQwMykge1xuICAgIHNldFN0YXR1cygnXHUyNkEwXHVGRTBGIDQwMyAodG9rZW4gZXhwaXJhZG8gbyBDbG91ZGZsYXJlKS4gUmVpbnRlbnRhclx1MDBFMS4uLicsICdlcnJvcicpO1xuICB9IGVsc2UgaWYgKHIuc3RhdHVzID09PSA0MDEpIHtcbiAgICBzZXRTdGF0dXMoJ1x1RDgzRFx1REQxMiA0MDEgKG5vIGF1dG9yaXphZG8pLiBWZXJpZmljYSB0dSBzZXNpXHUwMEYzbi4nLCAnZXJyb3InKTtcbiAgfSBlbHNlIGlmIChyLnN0YXR1cyA9PT0gNDI5KSB7XG4gICAgc2V0U3RhdHVzKCdcdTIzRjMgNDI5IChsXHUwMEVEbWl0ZSBkZSB0YXNhKS4gRXNwZXJhbmRvLi4uJywgJ2Vycm9yJyk7XG4gIH0gZWxzZSBpZiAoci5zdGF0dXMgPT09IDQwOCkge1xuICAgIHNldFN0YXR1cygnXHUyM0YwIFRpbWVvdXQgZGVsIHNlcnZpZG9yLiBDb29yZGVuYWRhcyBwcm9ibGVtXHUwMEUxdGljYXMgbyBzZXJ2aWRvciBzb2JyZWNhcmdhZG8nLCAnZXJyb3InKTtcbiAgfSBlbHNlIGlmIChyLnN0YXR1cyA9PT0gMCkge1xuICAgIHNldFN0YXR1cygnXHVEODNDXHVERjEwIEVycm9yIGRlIHJlZC4gVmVyaWZpY2FuZG8gY29uZWN0aXZpZGFkLi4uJywgJ2Vycm9yJyk7XG4gIH0gZWxzZSBpZiAoci5zdGF0dXMgPT09IDUwMCkge1xuICAgIHNldFN0YXR1cygnXHVEODNEXHVERDI1IDUwMCAoZXJyb3IgaW50ZXJubyBkZWwgc2Vydmlkb3IpLiBSZWludGVudGFyXHUwMEUxLi4uJywgJ2Vycm9yJyk7XG4gIH0gZWxzZSBpZiAoci5zdGF0dXMgPT09IDUwMiB8fCByLnN0YXR1cyA9PT0gNTAzIHx8IHIuc3RhdHVzID09PSA1MDQpIHtcbiAgICBzZXRTdGF0dXMoYFx1RDgzRFx1REVBQiAke3Iuc3RhdHVzfSAoc2Vydmlkb3Igbm8gZGlzcG9uaWJsZSkuIFJlaW50ZW50YXJcdTAwRTEuLi5gLCAnZXJyb3InKTtcbiAgfSBlbHNlIGlmIChyLnN0YXR1cyA9PT0gNDA0KSB7XG4gICAgc2V0U3RhdHVzKGBcdUQ4M0RcdURERkFcdUZFMEYgNDA0ICh0aWxlIG5vIGVuY29udHJhZG8pLiBWZXJpZmljYW5kbyBjb29yZGVuYWRhcyB0aWxlKCR7Y2ZnLlRJTEVfWH0sJHtjZmcuVElMRV9ZfSlgLCAnZXJyb3InKTtcbiAgfSBlbHNlIHtcbiAgICAvLyBQYXJhIG90cm9zIGVycm9yZXMsIHZlcmlmaWNhciBlbCBoZWFsdGggZGVsIGJhY2tlbmRcbiAgICB0cnkge1xuICAgICAgY29uc3QgaGVhbHRoID0gYXdhaXQgY2hlY2tCYWNrZW5kSGVhbHRoKCk7XG4gICAgICBjb25zdCBoZWFsdGhTdGF0dXMgPSBoZWFsdGg/LnVwID8gJ1x1RDgzRFx1REZFMiBPbmxpbmUnIDogJ1x1RDgzRFx1REQzNCBPZmZsaW5lJztcbiAgICAgIHNldFN0YXR1cyhgXHUyNzRDIEVycm9yICR7ci5zdGF0dXN9OiAke3IuanNvbj8ubWVzc2FnZSB8fCByLmpzb24/LmVycm9yIHx8ICdGYWxsbyBhbCBwaW50YXInfSAoQmFja2VuZDogJHtoZWFsdGhTdGF0dXN9KWAsICdlcnJvcicpO1xuICAgIH0gY2F0Y2gge1xuICAgICAgc2V0U3RhdHVzKGBcdTI3NEMgRXJyb3IgJHtyLnN0YXR1c306ICR7ci5qc29uPy5tZXNzYWdlIHx8IHIuanNvbj8uZXJyb3IgfHwgJ0ZhbGxvIGFsIHBpbnRhcid9IChIZWFsdGggY2hlY2sgZmFsbFx1MDBGMylgLCAnZXJyb3InKTtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIExvZyBkZXRhbGxhZG8gcGFyYSBkZWJ1Z2dpbmdcbiAgbG9nKGBGYWxsbyBlbiBwaW50YWRvOiBzdGF0dXM9JHtyLnN0YXR1c30sIGpzb249YCwgci5qc29uLCAnY29vcmRzPScsIGNvb3JkcywgJ2NvbG9ycz0nLCBjb2xvcnMpO1xuICBcbiAgcmV0dXJuIGZhbHNlO1xufVxuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcGFpbnRXaXRoUmV0cnkoY2ZnLCBzdGF0ZSwgc2V0U3RhdHVzLCBmbGFzaEVmZmVjdCwgZ2V0U2Vzc2lvbiwgY2hlY2tCYWNrZW5kSGVhbHRoKSB7XG4gIGNvbnN0IG1heEF0dGVtcHRzID0gNTsgLy8gQXVtZW50YXIgYSA1IGludGVudG9zXG4gIGNvbnN0IGJhc2VEZWxheSA9IDMwMDA7IC8vIERlbGF5IGJhc2UgZGUgMyBzZWd1bmRvc1xuICBcbiAgZm9yIChsZXQgYXR0ZW1wdCA9IDE7IGF0dGVtcHQgPD0gbWF4QXR0ZW1wdHM7IGF0dGVtcHQrKykge1xuICAgIHRyeSB7XG4gICAgICBjb25zdCBzdWNjZXNzID0gYXdhaXQgcGFpbnRPbmNlKGNmZywgc3RhdGUsIHNldFN0YXR1cywgZmxhc2hFZmZlY3QsIGdldFNlc3Npb24sIGNoZWNrQmFja2VuZEhlYWx0aCk7XG4gICAgICBpZiAoc3VjY2Vzcykge1xuICAgICAgICBzdGF0ZS5yZXRyeUNvdW50ID0gMDsgLy8gUmVzZXQgZW4gXHUwMEU5eGl0b1xuICAgICAgICByZXR1cm4gdHJ1ZTtcbiAgICAgIH1cbiAgICAgIFxuICAgICAgc3RhdGUucmV0cnlDb3VudCA9IGF0dGVtcHQ7XG4gICAgICBcbiAgICAgIGlmIChhdHRlbXB0IDwgbWF4QXR0ZW1wdHMpIHtcbiAgICAgICAgY29uc3QgZGVsYXkgPSBiYXNlRGVsYXkgKiBNYXRoLnBvdygyLCBhdHRlbXB0IC0gMSk7IC8vIEJhY2tvZmYgZXhwb25lbmNpYWxcbiAgICAgICAgc2V0U3RhdHVzKGBcdUQ4M0RcdUREMDQgUmVpbnRlbnRvICR7YXR0ZW1wdH0vJHttYXhBdHRlbXB0c30gZW4gJHtkZWxheS8xMDAwfXMuLi5gLCAnZXJyb3InKTtcbiAgICAgICAgYXdhaXQgc2xlZXAoZGVsYXkpO1xuICAgICAgfVxuICAgICAgXG4gICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgIGxvZyhgRXJyb3IgZW4gaW50ZW50byAke2F0dGVtcHR9OmAsIGVycm9yKTtcbiAgICAgIHN0YXRlLnJldHJ5Q291bnQgPSBhdHRlbXB0O1xuICAgICAgXG4gICAgICBpZiAoYXR0ZW1wdCA8IG1heEF0dGVtcHRzKSB7XG4gICAgICAgIGNvbnN0IGRlbGF5ID0gYmFzZURlbGF5ICogTWF0aC5wb3coMiwgYXR0ZW1wdCAtIDEpO1xuICAgICAgICBzZXRTdGF0dXMoYFx1RDgzRFx1RENBNSBFcnJvciBlbiBpbnRlbnRvICR7YXR0ZW1wdH0vJHttYXhBdHRlbXB0c30sIHJlaW50ZW50YW5kbyBlbiAke2RlbGF5LzEwMDB9cy4uLmAsICdlcnJvcicpO1xuICAgICAgICBhd2FpdCBzbGVlcChkZWxheSk7XG4gICAgICB9XG4gICAgfVxuICB9XG4gIFxuICBzdGF0ZS5yZXRyeUNvdW50ID0gbWF4QXR0ZW1wdHM7XG4gIHNldFN0YXR1cyhgXHUyNzRDIEZhbGxcdTAwRjMgZGVzcHVcdTAwRTlzIGRlICR7bWF4QXR0ZW1wdHN9IGludGVudG9zLiBTZSByZXF1aWVyZSBpbnRlcnZlbmNpXHUwMEYzbiBtYW51YWwuYCwgJ2Vycm9yJyk7XG4gIHJldHVybiBmYWxzZTtcbn1cblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGxvb3AoY2ZnLCBzdGF0ZSwgc2V0U3RhdHVzLCBmbGFzaEVmZmVjdCwgZ2V0U2Vzc2lvbiwgY2hlY2tCYWNrZW5kSGVhbHRoLCB1cGRhdGVTdGF0cykge1xuICBsb2coJ1x1RDgzRFx1REU4MCBMb29wIGluaWNpYWRvJyk7XG4gIHN0YXRlLnJ1bm5pbmcgPSB0cnVlO1xuICBcbiAgd2hpbGUgKHN0YXRlLnJ1bm5pbmcpIHtcbiAgICB0cnkge1xuICAgICAgLy8gQWN0dWFsaXphciBlc3RhZFx1MDBFRHN0aWNhcyBhbnRlcyBkZSBjYWRhIGNpY2xvXG4gICAgICBhd2FpdCB1cGRhdGVTdGF0cygpO1xuICAgICAgXG4gICAgICAvLyBWZXJpZmljYXIgc2kgaGF5IGNhcmdhcyBzdWZpY2llbnRlcyBwYXJhIHBpbnRhclxuICAgICAgaWYgKHN0YXRlLmNoYXJnZXMuY291bnQgPCBjZmcuTUlOX0NIQVJHRVMpIHtcbiAgICAgICAgY29uc3Qgd2FpdFRpbWUgPSBNYXRoLm1heCgwLCAoY2ZnLk1JTl9DSEFSR0VTIC0gc3RhdGUuY2hhcmdlcy5jb3VudCkgKiBjZmcuQ0hBUkdFX1JFR0VOX01TKTtcbiAgICAgICAgc2V0U3RhdHVzKGBcdTIzRjMgRXNwZXJhbmRvIGNhcmdhczogJHtzdGF0ZS5jaGFyZ2VzLmNvdW50LnRvRml4ZWQoMSl9LyR7Y2ZnLk1JTl9DSEFSR0VTfSAoJHtNYXRoLnJvdW5kKHdhaXRUaW1lLzEwMDApfXMpYCwgJ3N0YXR1cycpO1xuICAgICAgICBcbiAgICAgICAgYXdhaXQgc2xlZXBXaXRoQ291bnRkb3duKE1hdGgubWluKHdhaXRUaW1lLCBjZmcuREVMQVlfTVMpLCAocmVtYWluaW5nKSA9PiB7XG4gICAgICAgICAgc2V0U3RhdHVzKGBcdTIzRjMgRXNwZXJhbmRvIGNhcmdhczogJHtzdGF0ZS5jaGFyZ2VzLmNvdW50LnRvRml4ZWQoMSl9LyR7Y2ZnLk1JTl9DSEFSR0VTfSAofiR7TWF0aC5yb3VuZChyZW1haW5pbmcvMTAwMCl9cylgLCAnc3RhdHVzJyk7XG4gICAgICAgIH0sIHN0YXRlKTtcbiAgICAgICAgXG4gICAgICAgIGNvbnRpbnVlO1xuICAgICAgfVxuICAgICAgXG4gICAgICAvLyBJbnRlbnRhciBwaW50YXJcbiAgICAgIGNvbnN0IHN1Y2Nlc3MgPSBhd2FpdCBwYWludFdpdGhSZXRyeShjZmcsIHN0YXRlLCBzZXRTdGF0dXMsIGZsYXNoRWZmZWN0LCBnZXRTZXNzaW9uLCBjaGVja0JhY2tlbmRIZWFsdGgpO1xuICAgICAgXG4gICAgICBpZiAoIXN1Y2Nlc3MpIHtcbiAgICAgICAgLy8gU2kgZmFsbFx1MDBGMyBkZXNwdVx1MDBFOXMgZGUgdG9kb3MgbG9zIHJlaW50ZW50b3MsIGVzcGVyYXIgbVx1MDBFMXMgdGllbXBvXG4gICAgICAgIHNldFN0YXR1cygnXHVEODNEXHVERTM0IEVzcGVyYW5kbyBhbnRlcyBkZWwgc2lndWllbnRlIGludGVudG8uLi4nLCAnZXJyb3InKTtcbiAgICAgICAgYXdhaXQgc2xlZXBXaXRoQ291bnRkb3duKGNmZy5ERUxBWV9NUyAqIDIsIChyZW1haW5pbmcpID0+IHtcbiAgICAgICAgICBzZXRTdGF0dXMoYFx1RDgzRFx1REUzNCBDb29sZG93biBleHRlbmRpZG86ICR7TWF0aC5yb3VuZChyZW1haW5pbmcvMTAwMCl9c2AsICdlcnJvcicpO1xuICAgICAgICB9KTtcbiAgICAgICAgY29udGludWU7XG4gICAgICB9XG4gICAgICBcbiAgICAgIC8vIERlbGF5IG5vcm1hbCBlbnRyZSBwaW50YWRhcyBleGl0b3Nhc1xuICAgICAgaWYgKHN0YXRlLnJ1bm5pbmcpIHtcbiAgICAgICAgYXdhaXQgc2xlZXBXaXRoQ291bnRkb3duKGNmZy5ERUxBWV9NUywgKHJlbWFpbmluZykgPT4ge1xuICAgICAgICAgIHNldFN0YXR1cyhgXHVEODNEXHVEQ0E0IEVzcGVyYW5kbyAke01hdGgucm91bmQocmVtYWluaW5nLzEwMDApfXMgaGFzdGEgc2lndWllbnRlIHBpbnRhZGEuLi5gLCAnc3RhdHVzJyk7XG4gICAgICAgIH0pO1xuICAgICAgfVxuICAgICAgXG4gICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgIGxvZygnRXJyb3IgY3JcdTAwRUR0aWNvIGVuIGxvb3A6JywgZXJyb3IpO1xuICAgICAgc2V0U3RhdHVzKGBcdUQ4M0RcdURDQTUgRXJyb3IgY3JcdTAwRUR0aWNvOiAke2Vycm9yLm1lc3NhZ2V9YCwgJ2Vycm9yJyk7XG4gICAgICBcbiAgICAgIC8vIEVzcGVyYXIgbVx1MDBFMXMgdGllbXBvIGFudGVzIGRlIGNvbnRpbnVhciB0cmFzIGVycm9yIGNyXHUwMEVEdGljb1xuICAgICAgaWYgKHN0YXRlLnJ1bm5pbmcpIHtcbiAgICAgICAgYXdhaXQgc2xlZXBXaXRoQ291bnRkb3duKGNmZy5ERUxBWV9NUyAqIDMsIChyZW1haW5pbmcpID0+IHtcbiAgICAgICAgICBzZXRTdGF0dXMoYFx1RDgzRFx1REVBOCBSZWN1cGVyXHUwMEUxbmRvc2UgZGUgZXJyb3IgY3JcdTAwRUR0aWNvOiAke01hdGgucm91bmQocmVtYWluaW5nLzEwMDApfXNgLCAnZXJyb3InKTtcbiAgICAgICAgfSk7XG4gICAgICB9XG4gICAgfVxuICB9XG4gIFxuICBsb2coJ1x1MjNGOVx1RkUwRiBMb29wIGRldGVuaWRvJyk7XG4gIHNldFN0YXR1cygnXHUyM0Y5XHVGRTBGIEJvdCBkZXRlbmlkbycsICdzdGF0dXMnKTtcbn1cbiIsICJpbXBvcnQgeyBsb2cgfSBmcm9tIFwiLi9sb2dnZXIuanNcIjtcblxuLy8gU2lzdGVtYSBkZSBjYXB0dXJhIHBhcmEgY29vcmRlbmFkYXMgZGVsIHRpbGVcbmV4cG9ydCBjbGFzcyBDb29yZGluYXRlQ2FwdHVyZSB7XG4gIGNvbnN0cnVjdG9yKCkge1xuICAgIHRoaXMuYWN0aXZlID0gZmFsc2U7XG4gICAgdGhpcy5vcmlnaW5hbEZldGNoID0gd2luZG93LmZldGNoO1xuICAgIHRoaXMuY2FsbGJhY2sgPSBudWxsO1xuICB9XG5cbiAgLy8gSGFiaWxpdGFyIGNhcHR1cmEgZGUgY29vcmRlbmFkYXMgcG9yIHVuYSB2ZXpcbiAgZW5hYmxlKGNhbGxiYWNrKSB7XG4gICAgaWYgKHRoaXMuYWN0aXZlKSB7XG4gICAgICBsb2coJ1x1MjZBMFx1RkUwRiBDYXB0dXJhIHlhIGVzdFx1MDBFMSBhY3RpdmEnKTtcbiAgICAgIHJldHVybjtcbiAgICB9XG5cbiAgICB0aGlzLmFjdGl2ZSA9IHRydWU7XG4gICAgdGhpcy5jYWxsYmFjayA9IGNhbGxiYWNrO1xuICAgIFxuICAgIGxvZygnXHVEODNEXHVERDc1XHVGRTBGIENhcHR1cmEgZGUgY29vcmRlbmFkYXMgYWN0aXZhZGEuIFBpbnRhIHVuIHBcdTAwRUR4ZWwgbWFudWFsbWVudGUuLi4nKTtcbiAgICBcbiAgICAvLyBJbnRlcmNlcHRhciBmZXRjaFxuICAgIHdpbmRvdy5mZXRjaCA9IGFzeW5jICguLi5hcmdzKSA9PiB7XG4gICAgICBjb25zdCByZXN1bHQgPSBhd2FpdCB0aGlzLm9yaWdpbmFsRmV0Y2guYXBwbHkod2luZG93LCBhcmdzKTtcbiAgICAgIFxuICAgICAgaWYgKHRoaXMuYWN0aXZlICYmIHRoaXMuc2hvdWxkQ2FwdHVyZShhcmdzWzBdLCBhcmdzWzFdKSkge1xuICAgICAgICBhd2FpdCB0aGlzLmhhbmRsZUNhcHR1cmUoYXJnc1swXSwgYXJnc1sxXSwgcmVzdWx0LmNsb25lKCkpO1xuICAgICAgfVxuICAgICAgXG4gICAgICByZXR1cm4gcmVzdWx0O1xuICAgIH07XG5cbiAgICAvLyBBdXRvLWRlc2FjdGl2YXIgZGVzcHVcdTAwRTlzIGRlIDMwIHNlZ3VuZG9zXG4gICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICBpZiAodGhpcy5hY3RpdmUpIHtcbiAgICAgICAgdGhpcy5kaXNhYmxlKCk7XG4gICAgICAgIGxvZygnXHUyM0YwIENhcHR1cmEgZGUgY29vcmRlbmFkYXMgZXhwaXJhZGEnKTtcbiAgICAgIH1cbiAgICB9LCAzMDAwMCk7XG4gIH1cblxuICAvLyBWZXJpZmljYXIgc2kgZGViZW1vcyBjYXB0dXJhciBlc3RhIHBldGljaVx1MDBGM25cbiAgc2hvdWxkQ2FwdHVyZSh1cmwsIG9wdGlvbnMpIHtcbiAgICBpZiAoIXVybCB8fCAhb3B0aW9ucykgcmV0dXJuIGZhbHNlO1xuICAgIFxuICAgIC8vIEJ1c2NhciBwYXRyb25lcyBkZSBVUkwgcmVsYWNpb25hZG9zIGNvbiBwaW50YXJcbiAgICBjb25zdCB1cmxTdHIgPSB1cmwudG9TdHJpbmcoKTtcbiAgICBpZiAoIXVybFN0ci5pbmNsdWRlcygncGFpbnQnKSAmJiAhdXJsU3RyLmluY2x1ZGVzKCdwaXhlbCcpICYmICF1cmxTdHIuaW5jbHVkZXMoJ3BsYWNlJykpIHtcbiAgICAgIHJldHVybiBmYWxzZTtcbiAgICB9XG5cbiAgICAvLyBWZXJpZmljYXIgcXVlIHNlYSB1biBQT1NUIGNvbiBkYXRvc1xuICAgIGlmICghb3B0aW9ucy5tZXRob2QgfHwgb3B0aW9ucy5tZXRob2QudG9VcHBlckNhc2UoKSAhPT0gJ1BPU1QnKSB7XG4gICAgICByZXR1cm4gZmFsc2U7XG4gICAgfVxuXG4gICAgcmV0dXJuIHRydWU7XG4gIH1cblxuICAvLyBNYW5lamFyIGxhIGNhcHR1cmEgZGUgY29vcmRlbmFkYXNcbiAgYXN5bmMgaGFuZGxlQ2FwdHVyZSh1cmwsIG9wdGlvbnMsIHJlc3BvbnNlKSB7XG4gICAgdHJ5IHtcbiAgICAgIGxldCBjb29yZHMgPSBudWxsO1xuICAgICAgbGV0IHRpbGVYID0gbnVsbCwgdGlsZVkgPSBudWxsO1xuXG4gICAgICAvLyBJbnRlbnRhciBleHRyYWVyIGNvb3JkZW5hZGFzIGRlbCBjdWVycG8gZGUgbGEgcGV0aWNpXHUwMEYzblxuICAgICAgaWYgKG9wdGlvbnMuYm9keSkge1xuICAgICAgICBsZXQgYm9keTtcbiAgICAgICAgXG4gICAgICAgIGlmICh0eXBlb2Ygb3B0aW9ucy5ib2R5ID09PSAnc3RyaW5nJykge1xuICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICBib2R5ID0gSlNPTi5wYXJzZShvcHRpb25zLmJvZHkpO1xuICAgICAgICAgIH0gY2F0Y2gge1xuICAgICAgICAgICAgYm9keSA9IG9wdGlvbnMuYm9keTtcbiAgICAgICAgICB9XG4gICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgYm9keSA9IG9wdGlvbnMuYm9keTtcbiAgICAgICAgfVxuXG4gICAgICAgIC8vIEJ1c2NhciBjb29yZGVuYWRhcyBlbiBkaWZlcmVudGVzIGZvcm1hdG9zXG4gICAgICAgIGlmIChib2R5LmNvb3JkcyAmJiBBcnJheS5pc0FycmF5KGJvZHkuY29vcmRzKSkge1xuICAgICAgICAgIGNvb3JkcyA9IGJvZHkuY29vcmRzO1xuICAgICAgICB9IGVsc2UgaWYgKGJvZHkueCAhPT0gdW5kZWZpbmVkICYmIGJvZHkueSAhPT0gdW5kZWZpbmVkKSB7XG4gICAgICAgICAgY29vcmRzID0gW2JvZHkueCwgYm9keS55XTtcbiAgICAgICAgfSBlbHNlIGlmIChib2R5LmNvb3JkaW5hdGVzKSB7XG4gICAgICAgICAgY29vcmRzID0gYm9keS5jb29yZGluYXRlcztcbiAgICAgICAgfVxuICAgICAgfVxuXG4gICAgICAvLyBFeHRyYWVyIHRpbGUgZGVzZGUgbGEgVVJMIHNpIGVzdFx1MDBFMSBwcmVzZW50ZVxuICAgICAgY29uc3QgdXJsU3RyID0gdXJsLnRvU3RyaW5nKCk7XG4gICAgICBjb25zdCB0aWxlTWF0Y2ggPSB1cmxTdHIubWF0Y2goL1xcL3MwXFwvcGl4ZWxcXC8oLT9cXGQrKVxcLygtP1xcZCspLyk7XG4gICAgICBpZiAodGlsZU1hdGNoKSB7XG4gICAgICAgIHRpbGVYID0gcGFyc2VJbnQodGlsZU1hdGNoWzFdKTtcbiAgICAgICAgdGlsZVkgPSBwYXJzZUludCh0aWxlTWF0Y2hbMl0pO1xuICAgICAgfVxuXG4gICAgICAvLyBJbnRlbnRhciBleHRyYWVyIGNvb3JkcyBkZSBsYSBVUkwgc2kgbm8gdmluaWVyb24gZW4gZWwgYm9keVxuICAgICAgaWYgKCFjb29yZHMpIHtcbiAgICAgICAgY29uc3QgdXJsQ29vcmRNYXRjaCA9IHVybFN0ci5tYXRjaCgvWz8mXSg/Onh8Y29vcmRzPyk9KFteJl0rKS8pO1xuICAgICAgICBpZiAodXJsQ29vcmRNYXRjaCkge1xuICAgICAgICAgIGNvbnN0IGNvb3JkU3RyID0gZGVjb2RlVVJJQ29tcG9uZW50KHVybENvb3JkTWF0Y2hbMV0pO1xuICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICBjb29yZHMgPSBKU09OLnBhcnNlKGNvb3JkU3RyKTtcbiAgICAgICAgICB9IGNhdGNoIHtcbiAgICAgICAgICAgIGNvbnN0IHBhcnRzID0gY29vcmRTdHIuc3BsaXQoJywnKTtcbiAgICAgICAgICAgIGlmIChwYXJ0cy5sZW5ndGggPj0gMikge1xuICAgICAgICAgICAgICBjb29yZHMgPSBbcGFyc2VJbnQocGFydHNbMF0pLCBwYXJzZUludChwYXJ0c1sxXSldO1xuICAgICAgICAgICAgfVxuICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgfVxuXG4gICAgICAvLyBTaSBlbmNvbnRyYW1vcyBjb29yZGVuYWRhcywgY2FsY3VsYXIgZWwgdGlsZVxuICAgICAgaWYgKGNvb3JkcyAmJiBjb29yZHMubGVuZ3RoID49IDIpIHtcbiAgICAgICAgbGV0IGdsb2JhbFgsIGdsb2JhbFksIGxvY2FsWCwgbG9jYWxZO1xuXG4gICAgICAgIGlmIChOdW1iZXIuaXNJbnRlZ2VyKHRpbGVYKSAmJiBOdW1iZXIuaXNJbnRlZ2VyKHRpbGVZKSkge1xuICAgICAgICAgIC8vIFRyYXRhbW9zIGNvb3JkcyBjb21vIGxvY2FsZXMgYWwgdGlsZSBleHRyYVx1MDBFRGRvIGRlIGxhIFVSTFxuICAgICAgICAgIGxvY2FsWCA9IGNvb3Jkc1swXTtcbiAgICAgICAgICBsb2NhbFkgPSBjb29yZHNbMV07XG4gICAgICAgICAgZ2xvYmFsWCA9IHRpbGVYICogMzAwMCArIGxvY2FsWDtcbiAgICAgICAgICBnbG9iYWxZID0gdGlsZVkgKiAzMDAwICsgbG9jYWxZO1xuICAgICAgICAgIGxvZyhgXHVEODNDXHVERkFGIENvb3JkZW5hZGFzIGNhcHR1cmFkYXMgKGxvY2FsZXMpOiB0aWxlKCR7dGlsZVh9LCR7dGlsZVl9KSBsb2NhbCgke2xvY2FsWH0sJHtsb2NhbFl9KSAtPiBnbG9iYWwoJHtnbG9iYWxYfSwke2dsb2JhbFl9KWApO1xuICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgIC8vIFNpbiB0aWxlIGVuIFVSTCwgaW50ZXJwcmV0YW1vcyBjb29yZHMgY29tbyBnbG9iYWxlcyB5IGRlcml2YW1vcyB0aWxlXG4gICAgICAgICAgZ2xvYmFsWCA9IGNvb3Jkc1swXTtcbiAgICAgICAgICBnbG9iYWxZID0gY29vcmRzWzFdO1xuICAgICAgICAgIHRpbGVYID0gTWF0aC5mbG9vcihnbG9iYWxYIC8gMzAwMCk7XG4gICAgICAgICAgdGlsZVkgPSBNYXRoLmZsb29yKGdsb2JhbFkgLyAzMDAwKTtcbiAgICAgICAgICBsb2NhbFggPSBnbG9iYWxYICUgMzAwMDtcbiAgICAgICAgICBsb2NhbFkgPSBnbG9iYWxZICUgMzAwMDtcbiAgICAgICAgICBsb2coYFx1RDgzQ1x1REZBRiBDb29yZGVuYWRhcyBjYXB0dXJhZGFzIChnbG9iYWxlcyk6IGdsb2JhbCgke2dsb2JhbFh9LCR7Z2xvYmFsWX0pIC0+IHRpbGUoJHt0aWxlWH0sJHt0aWxlWX0pIGxvY2FsKCR7bG9jYWxYfSwke2xvY2FsWX0pYCk7XG4gICAgICAgIH1cblxuICAgICAgICAvLyBWZXJpZmljYXIgcXVlIGxhIHJlc3B1ZXN0YSBzZWEgZXhpdG9zYVxuICAgICAgICBpZiAocmVzcG9uc2Uub2spIHtcbiAgICAgICAgICB0aGlzLmRpc2FibGUoKTtcbiAgICAgICAgICBcbiAgICAgICAgICBpZiAodGhpcy5jYWxsYmFjaykge1xuICAgICAgICAgICAgdGhpcy5jYWxsYmFjayh7XG4gICAgICAgICAgICAgIHN1Y2Nlc3M6IHRydWUsXG4gICAgICAgICAgICAgIHRpbGVYLFxuICAgICAgICAgICAgICB0aWxlWSxcbiAgICAgICAgICAgICAgZ2xvYmFsWCxcbiAgICAgICAgICAgICAgZ2xvYmFsWSxcbiAgICAgICAgICAgICAgbG9jYWxYLFxuICAgICAgICAgICAgICBsb2NhbFlcbiAgICAgICAgICAgIH0pO1xuICAgICAgICAgIH1cbiAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICBsb2coJ1x1MjZBMFx1RkUwRiBDYXB0dXJhIHJlYWxpemFkYSBwZXJvIGxhIHJlc3B1ZXN0YSBubyBmdWUgZXhpdG9zYScpO1xuICAgICAgICB9XG4gICAgICB9XG5cbiAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgbG9nKCdFcnJvciBwcm9jZXNhbmRvIGNhcHR1cmE6JywgZXJyb3IpO1xuICAgIH1cbiAgfVxuXG4gIC8vIERlc2FjdGl2YXIgY2FwdHVyYVxuICBkaXNhYmxlKCkge1xuICAgIGlmICghdGhpcy5hY3RpdmUpIHJldHVybjtcbiAgICBcbiAgICB0aGlzLmFjdGl2ZSA9IGZhbHNlO1xuICAgIHdpbmRvdy5mZXRjaCA9IHRoaXMub3JpZ2luYWxGZXRjaDtcbiAgICB0aGlzLmNhbGxiYWNrID0gbnVsbDtcbiAgICBcbiAgICBsb2coJ1x1RDgzRFx1REQxMiBDYXB0dXJhIGRlIGNvb3JkZW5hZGFzIGRlc2FjdGl2YWRhJyk7XG4gIH1cbn1cblxuLy8gSW5zdGFuY2lhIGdsb2JhbFxuZXhwb3J0IGNvbnN0IGNvb3JkaW5hdGVDYXB0dXJlID0gbmV3IENvb3JkaW5hdGVDYXB0dXJlKCk7XG4iLCAiZXhwb3J0IGNvbnN0ICQgPSAoc2VsLCByb290ID0gZG9jdW1lbnQpID0+IHJvb3QucXVlcnlTZWxlY3RvcihzZWwpO1xuXG5leHBvcnQgZnVuY3Rpb24gY3JlYXRlU3R5bGUoY3NzKSB7XG4gIGNvbnN0IHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KFwic3R5bGVcIik7XG4gIHMudGV4dENvbnRlbnQgPSBjc3M7IGRvY3VtZW50LmhlYWQuYXBwZW5kQ2hpbGQocyk7IHJldHVybiBzO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gbW91bnRTaGFkb3coY29udGFpbmVyID0gZG9jdW1lbnQuYm9keSkge1xuICBjb25zdCBob3N0ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudChcImRpdlwiKTtcbiAgaG9zdC5pZCA9IFwid3BsYWNlLWJvdC1yb290XCI7XG4gIGNvbnRhaW5lci5hcHBlbmRDaGlsZChob3N0KTtcbiAgY29uc3Qgcm9vdCA9IGhvc3QuYXR0YWNoU2hhZG93ID8gaG9zdC5hdHRhY2hTaGFkb3coeyBtb2RlOiBcIm9wZW5cIiB9KSA6IGhvc3Q7XG4gIHJldHVybiB7IGhvc3QsIHJvb3QgfTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgZGV0ZWN0YXIgc2kgbGEgcGFsZXRhIGRlIGNvbG9yZXMgZXN0XHUwMEUxIGFiaWVydGFcbmV4cG9ydCBmdW5jdGlvbiBpc1BhbGV0dGVPcGVuKGRlYnVnID0gZmFsc2UpIHtcbiAgLy8gQnVzY2FyIGVsZW1lbnRvcyBjb211bmVzIGRlIGxhIHBhbGV0YSBkZSBjb2xvcmVzIChtXHUwMEU5dG9kbyBvcmlnaW5hbClcbiAgY29uc3QgcGFsZXR0ZVNlbGVjdG9ycyA9IFtcbiAgICAnW2RhdGEtdGVzdGlkPVwiY29sb3ItcGlja2VyXCJdJyxcbiAgICAnLmNvbG9yLXBpY2tlcicsXG4gICAgJy5wYWxldHRlJyxcbiAgICAnW2NsYXNzKj1cImNvbG9yXCJdW2NsYXNzKj1cInBpY2tlclwiXScsXG4gICAgJ1tjbGFzcyo9XCJwYWxldHRlXCJdJ1xuICBdO1xuICBcbiAgZm9yIChjb25zdCBzZWxlY3RvciBvZiBwYWxldHRlU2VsZWN0b3JzKSB7XG4gICAgY29uc3QgZWxlbWVudCA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3Ioc2VsZWN0b3IpO1xuICAgIGlmIChlbGVtZW50ICYmIGVsZW1lbnQub2Zmc2V0UGFyZW50ICE9PSBudWxsKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQTggUGFsZXRhIGRldGVjdGFkYSBwb3Igc2VsZWN0b3I6ICR7c2VsZWN0b3J9YCk7XG4gICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIEJ1c2NhciBwb3IgY29sb3JlcyBlbiB1biBncmlkIG8gbGlzdGEgKG1cdTAwRTl0b2RvIG9yaWdpbmFsKVxuICBjb25zdCBjb2xvckVsZW1lbnRzID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbCgnW3N0eWxlKj1cImJhY2tncm91bmQtY29sb3JcIl0sIFtzdHlsZSo9XCJiYWNrZ3JvdW5kOlwiXSwgLmNvbG9yLCBbY2xhc3MqPVwiY29sb3JcIl0nKTtcbiAgbGV0IHZpc2libGVDb2xvcnMgPSAwO1xuICBmb3IgKGNvbnN0IGVsIG9mIGNvbG9yRWxlbWVudHMpIHtcbiAgICBpZiAoZWwub2Zmc2V0UGFyZW50ICE9PSBudWxsICYmIGVsLm9mZnNldFdpZHRoID4gMTAgJiYgZWwub2Zmc2V0SGVpZ2h0ID4gMTApIHtcbiAgICAgIHZpc2libGVDb2xvcnMrKztcbiAgICAgIGlmICh2aXNpYmxlQ29sb3JzID49IDUpIHtcbiAgICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkE4IFBhbGV0YSBkZXRlY3RhZGEgcG9yIGNvbG9yZXMgdmlzaWJsZXM6ICR7dmlzaWJsZUNvbG9yc31gKTtcbiAgICAgICAgcmV0dXJuIHRydWU7IC8vIFNpIGhheSA1KyBlbGVtZW50b3MgZGUgY29sb3IgdmlzaWJsZXNcbiAgICAgIH1cbiAgICB9XG4gIH1cbiAgXG4gIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzRFx1REQwRCBQYWxldGEgbm8gZGV0ZWN0YWRhLiBDb2xvcmVzIHZpc2libGVzOiAke3Zpc2libGVDb2xvcnN9YCk7XG4gIHJldHVybiBmYWxzZTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgZW5jb250cmFyIHkgaGFjZXIgY2xpYyBlbiBlbCBib3RcdTAwRjNuIGRlIFBhaW50XG5leHBvcnQgZnVuY3Rpb24gZmluZEFuZENsaWNrUGFpbnRCdXR0b24oZGVidWcgPSBmYWxzZSwgZG91YmxlQ2xpY2sgPSBmYWxzZSkge1xuICAvLyBNXHUwMEU5dG9kbyAxOiBCXHUwMEZBc3F1ZWRhIGVzcGVjXHUwMEVEZmljYSBwb3IgY2xhc2VzIChtXHUwMEU5dG9kbyBvcmlnaW5hbCwgbVx1MDBFMXMgY29uZmlhYmxlKVxuICBjb25zdCBzcGVjaWZpY0J1dHRvbiA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJ2J1dHRvbi5idG4uYnRuLXByaW1hcnkuYnRuLWxnLCBidXR0b24uYnRuLmJ0bi1wcmltYXJ5LnNtXFxcXDpidG4teGwnKTtcbiAgXG4gIGlmIChzcGVjaWZpY0J1dHRvbikge1xuICAgIGNvbnN0IGJ1dHRvblRleHQgPSBzcGVjaWZpY0J1dHRvbi50ZXh0Q29udGVudC50b0xvd2VyQ2FzZSgpO1xuICAgIGNvbnN0IGhhc1BhaW50VGV4dCA9IGJ1dHRvblRleHQuaW5jbHVkZXMoJ3BhaW50JykgfHwgYnV0dG9uVGV4dC5pbmNsdWRlcygncGludGFyJyk7XG4gICAgY29uc3QgaGFzUGFpbnRJY29uID0gc3BlY2lmaWNCdXR0b24ucXVlcnlTZWxlY3Rvcignc3ZnIHBhdGhbZCo9XCIyNDAtMTIwXCJdJykgfHwgXG4gICAgICAgICAgICAgICAgICAgICAgICBzcGVjaWZpY0J1dHRvbi5xdWVyeVNlbGVjdG9yKCdzdmcgcGF0aFtkKj1cIk0xNVwiXScpO1xuICAgIFxuICAgIGlmIChoYXNQYWludFRleHQgfHwgaGFzUGFpbnRJY29uKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQUYgQm90XHUwMEYzbiBQYWludCBlbmNvbnRyYWRvIHBvciBzZWxlY3RvciBlc3BlY1x1MDBFRGZpY286IFwiJHtidXR0b25UZXh0fVwiYCk7XG4gICAgICBzcGVjaWZpY0J1dHRvbi5jbGljaygpO1xuICAgICAgXG4gICAgICAvLyBTaSBzZSByZXF1aWVyZSBkb2JsZSBjbGljLCBoYWNlciBzZWd1bmRvIGNsaWMgZGVzcHVcdTAwRTlzIGRlIHVuIGRlbGF5XG4gICAgICBpZiAoZG91YmxlQ2xpY2spIHtcbiAgICAgICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkFGIFNlZ3VuZG8gY2xpYyBlbiBib3RcdTAwRjNuIFBhaW50YCk7XG4gICAgICAgICAgc3BlY2lmaWNCdXR0b24uY2xpY2soKTtcbiAgICAgICAgfSwgNTAwKTtcbiAgICAgIH1cbiAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbiAgfVxuICBcbiAgLy8gTVx1MDBFOXRvZG8gMjogQlx1MDBGQXNxdWVkYSBzaW1wbGUgcG9yIHRleHRvIChtXHUwMEU5dG9kbyBvcmlnaW5hbClcbiAgY29uc3QgYnV0dG9ucyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2J1dHRvbicpO1xuICBmb3IgKGNvbnN0IGJ1dHRvbiBvZiBidXR0b25zKSB7XG4gICAgY29uc3QgYnV0dG9uVGV4dCA9IGJ1dHRvbi50ZXh0Q29udGVudC50b0xvd2VyQ2FzZSgpO1xuICAgIGlmICgoYnV0dG9uVGV4dC5pbmNsdWRlcygncGFpbnQnKSB8fCBidXR0b25UZXh0LmluY2x1ZGVzKCdwaW50YXInKSkgJiYgXG4gICAgICAgIGJ1dHRvbi5vZmZzZXRQYXJlbnQgIT09IG51bGwgJiZcbiAgICAgICAgIWJ1dHRvbi5kaXNhYmxlZCkge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkFGIEJvdFx1MDBGM24gUGFpbnQgZW5jb250cmFkbyBwb3IgdGV4dG86IFwiJHtidXR0b24udGV4dENvbnRlbnQudHJpbSgpfVwiYCk7XG4gICAgICBidXR0b24uY2xpY2soKTtcbiAgICAgIFxuICAgICAgLy8gU2kgc2UgcmVxdWllcmUgZG9ibGUgY2xpYywgaGFjZXIgc2VndW5kbyBjbGljIGRlc3B1XHUwMEU5cyBkZSB1biBkZWxheVxuICAgICAgaWYgKGRvdWJsZUNsaWNrKSB7XG4gICAgICAgIHNldFRpbWVvdXQoKCkgPT4ge1xuICAgICAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzQ1x1REZBRiBTZWd1bmRvIGNsaWMgZW4gYm90XHUwMEYzbiBQYWludGApO1xuICAgICAgICAgIGJ1dHRvbi5jbGljaygpO1xuICAgICAgICB9LCA1MDApO1xuICAgICAgfVxuICAgICAgcmV0dXJuIHRydWU7XG4gICAgfVxuICB9XG4gIFxuICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3NEMgQm90XHUwMEYzbiBQYWludCBubyBlbmNvbnRyYWRvYCk7XG4gIHJldHVybiBmYWxzZTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgcmVhbGl6YXIgYXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludCBjb24gc2VjdWVuY2lhIGNvcnJlY3RhXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gYXV0b0NsaWNrUGFpbnRCdXR0b24obWF4QXR0ZW1wdHMgPSAzLCBkZWJ1ZyA9IHRydWUpIHtcbiAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNFXHVERDE2IEluaWNpYW5kbyBhdXRvLWNsaWNrIGRlbCBib3RcdTAwRjNuIFBhaW50IChtXHUwMEUxeGltbyAke21heEF0dGVtcHRzfSBpbnRlbnRvcylgKTtcbiAgXG4gIGZvciAobGV0IGF0dGVtcHQgPSAxOyBhdHRlbXB0IDw9IG1heEF0dGVtcHRzOyBhdHRlbXB0KyspIHtcbiAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQUYgSW50ZW50byAke2F0dGVtcHR9LyR7bWF4QXR0ZW1wdHN9IC0gQnVzY2FuZG8gYm90XHUwMEYzbiBQYWludC4uLmApO1xuICAgIFxuICAgIC8vIFZlcmlmaWNhciBzaSBsYSBwYWxldGEgeWEgZXN0XHUwMEUxIGFiaWVydGFcbiAgICBpZiAoaXNQYWxldHRlT3BlbigpKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3MDUgUGFsZXRhIHlhIGVzdFx1MDBFMSBhYmllcnRhLCBhdXRvLWNsaWNrIGNvbXBsZXRhZG9gKTtcbiAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbiAgICBcbiAgICAvLyBDTElDIFx1MDBEQU5JQ086IFByZXNpb25hciBQYWludCB1bmEgc29sYSB2ZXogKHNvbG8gcGFyYSBtb3N0cmFyIHBhbGV0YS9kZXRlY3RhciBjb2xvcmVzKVxuICAgIGlmIChmaW5kQW5kQ2xpY2tQYWludEJ1dHRvbihkZWJ1ZywgZmFsc2UpKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0RcdURDNDYgQ2xpYyBlbiBib3RcdTAwRjNuIFBhaW50IHJlYWxpemFkbyAoc2luIHNlZ3VuZG8gY2xpYylgKTtcbiAgICAgIFxuICAgICAgLy8gRXNwZXJhciB1biBwb2NvIHBhcmEgcXVlIGxhIFVJL3BhbGV0YSBhcGFyZXpjYSBlbiBwYW50YWxsYVxuICAgICAgYXdhaXQgbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIDE1MDApKTtcbiAgICAgIFxuICAgICAgLy8gVmVyaWZpY2FyIHNpIGxhIHBhbGV0YSBzZSBhYnJpXHUwMEYzXG4gICAgICBpZiAoaXNQYWxldHRlT3BlbigpKSB7XG4gICAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1MjcwNSBQYWxldGEgYWJpZXJ0YSBleGl0b3NhbWVudGUgZGVzcHVcdTAwRTlzIGRlbCBpbnRlbnRvICR7YXR0ZW1wdH1gKTtcbiAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI2QTBcdUZFMEYgUGFsZXRhIG5vIGRldGVjdGFkYSB0cmFzIGVsIGNsaWMgZW4gaW50ZW50byAke2F0dGVtcHR9LiBSZWludGVudGFyXHUwMEUxLmApO1xuICAgICAgfVxuICAgIH0gZWxzZSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3NEMgQm90XHUwMEYzbiBQYWludCBubyBlbmNvbnRyYWRvIHBhcmEgY2xpYyBlbiBpbnRlbnRvICR7YXR0ZW1wdH1gKTtcbiAgICB9XG4gICAgXG4gICAgLy8gRXNwZXJhciBhbnRlcyBkZWwgc2lndWllbnRlIGludGVudG9cbiAgICBpZiAoYXR0ZW1wdCA8IG1heEF0dGVtcHRzKSB7XG4gICAgICBhd2FpdCBuZXcgUHJvbWlzZShyZXNvbHZlID0+IHNldFRpbWVvdXQocmVzb2x2ZSwgMTAwMCkpO1xuICAgIH1cbiAgfVxuICBcbiAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHUyNzRDIEF1dG8tY2xpY2sgZmFsbFx1MDBGMyBkZXNwdVx1MDBFOXMgZGUgJHttYXhBdHRlbXB0c30gaW50ZW50b3NgKTtcbiAgcmV0dXJuIGZhbHNlO1xufVxuIiwgImltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuaW1wb3J0IHsgZmFybVN0YXRlLCBGQVJNX0RFRkFVTFRTIH0gZnJvbSBcIi4uL2Zhcm0vY29uZmlnLmpzXCI7XG5pbXBvcnQgeyBsb2FkRmFybUNmZywgc2F2ZUZhcm1DZmcsIHJlc2V0VG9TYWZlRGVmYXVsdHMgfSBmcm9tIFwiLi4vY29yZS9zdG9yYWdlLmpzXCI7XG5pbXBvcnQgeyBnZXRTZXNzaW9uLCBjaGVja0hlYWx0aCB9IGZyb20gXCIuLi9jb3JlL3dwbGFjZS1hcGkuanNcIjtcbmltcG9ydCB7IGNyZWF0ZUZhcm1VSSwgYXV0b0NhbGlicmF0ZVRpbGUgfSBmcm9tIFwiLi4vZmFybS91aS5qc1wiO1xuaW1wb3J0IHsgbG9vcCwgcGFpbnRXaXRoUmV0cnkgfSBmcm9tIFwiLi4vZmFybS9sb29wLmpzXCI7XG5pbXBvcnQgeyBjb29yZGluYXRlQ2FwdHVyZSB9IGZyb20gXCIuLi9jb3JlL2NhcHR1cmUuanNcIjtcbmltcG9ydCB7IGNsYW1wIH0gZnJvbSBcIi4uL2NvcmUvdXRpbHMuanNcIjtcbmltcG9ydCB7IGluaXRpYWxpemVMYW5ndWFnZSwgdCB9IGZyb20gXCIuLi9sb2NhbGVzL2luZGV4LmpzXCI7XG5pbXBvcnQgeyBhdXRvQ2xpY2tQYWludEJ1dHRvbiB9IGZyb20gXCIuLi9jb3JlL2RvbS5qc1wiO1xuXG4oYXN5bmMgZnVuY3Rpb24oKSB7XG4gICd1c2Ugc3RyaWN0JztcblxuICAvLyBJbml0aWFsaXplIGludGVybmF0aW9uYWxpemF0aW9uIGZpcnN0XG4gIGF3YWl0IGluaXRpYWxpemVMYW5ndWFnZSgpO1xuICBcbiAgLy8gQXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludCBhbCBpbmljaW9cbiAgdHJ5IHtcbiAgICBsb2coJ1x1RDgzRVx1REQxNiBbRkFSTV0gSW5pY2lhbmRvIGF1dG8tY2xpY2sgZGVsIGJvdFx1MDBGM24gUGFpbnQuLi4nKTtcbiAgICBhd2FpdCBhdXRvQ2xpY2tQYWludEJ1dHRvbigzLCB0cnVlKTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1MjZBMFx1RkUwRiBbRkFSTV0gRXJyb3IgZW4gYXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludDonLCBlcnJvcik7XG4gIH1cblxuICAvLyBWZXJpZmljYXIgc2kgZWwgYm90IGRlIGZhcm0geWEgZXN0XHUwMEUxIGVqZWN1dFx1MDBFMW5kb3NlXG4gIGlmICh3aW5kb3cuX193cGxhY2VCb3Q/LmZhcm1SdW5uaW5nKSB7XG4gICAgYWxlcnQodCgnZmFybS5hbHJlYWR5UnVubmluZycsIFwiQXV0by1GYXJtIHlhIGVzdFx1MDBFMSBjb3JyaWVuZG8uXCIpKTtcbiAgICByZXR1cm47XG4gIH1cbiAgXG4gIC8vIFZlcmlmaWNhciBzaSBoYXkgb3Ryb3MgYm90cyBlamVjdXRcdTAwRTFuZG9zZVxuICBpZiAod2luZG93Ll9fd3BsYWNlQm90Py5pbWFnZVJ1bm5pbmcpIHtcbiAgICBhbGVydCh0KCdmYXJtLmltYWdlUnVubmluZ1dhcm5pbmcnLCBcIkF1dG8tSW1hZ2UgZXN0XHUwMEUxIGVqZWN1dFx1MDBFMW5kb3NlLiBDaVx1MDBFOXJyYWxvIGFudGVzIGRlIGluaWNpYXIgQXV0by1GYXJtLlwiKSk7XG4gICAgcmV0dXJuO1xuICB9XG5cbiAgLy8gSW5pY2lhbGl6YXIgZWwgZXN0YWRvIGdsb2JhbCBzaSBubyBleGlzdGVcbiAgaWYgKCF3aW5kb3cuX193cGxhY2VCb3QpIHtcbiAgICB3aW5kb3cuX193cGxhY2VCb3QgPSB7fTtcbiAgfVxuICBcbiAgLy8gTWFyY2FyIHF1ZSBlbCBmYXJtIGJvdCBlc3RcdTAwRTEgZWplY3V0XHUwMEUxbmRvc2VcbiAgd2luZG93Ll9fd3BsYWNlQm90LmZhcm1SdW5uaW5nID0gdHJ1ZTtcblxuICAvLyBMaXN0ZW4gZm9yIGxhbmd1YWdlIGNoYW5nZXNcbiAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsICgpID0+IHtcbiAgICBpZiAod2luZG93Ll9fd3BsYWNlQm90Py51aT8udXBkYXRlVGV4dHMpIHtcbiAgICAgIHdpbmRvdy5fX3dwbGFjZUJvdC51aS51cGRhdGVUZXh0cygpO1xuICAgIH1cbiAgfSk7XG5cbiAgbG9nKCdcdUQ4M0RcdURFODAgSW5pY2lhbmRvIFdQbGFjZSBGYXJtIEJvdCAodmVyc2lcdTAwRjNuIG1vZHVsYXIpJyk7XG5cbiAgLy8gVmVyaWZpY2FyIHNpIG5lY2VzaXRhIGNhbGlicmFjaVx1MDBGM24gaW5pY2lhbFxuICBmdW5jdGlvbiBuZWVkc0NhbGlicmF0aW9uQ2hlY2soY2ZnKSB7XG4gIC8vIFNpIGVsIHVzdWFyaW8geWEgc2VsZWNjaW9uXHUwMEYzIHVuYSB6b25hIHZcdTAwRTFsaWRhLCBOTyByZWNhbGlicmFyXG4gIGNvbnN0IGhhc1NlbGVjdGVkWm9uZSA9ICEhY2ZnLlBPU0lUSU9OX1NFTEVDVEVEICYmIGNmZy5CQVNFX1ggIT0gbnVsbCAmJiBjZmcuQkFTRV9ZICE9IG51bGw7XG4gIC8vIFZlcmlmaWNhciBzaSBsYXMgY29vcmRlbmFkYXMgc29uIGxhcyBwb3IgZGVmZWN0b1xuICBjb25zdCBoYXNEZWZhdWx0Q29vcmRzID0gY2ZnLlRJTEVfWCA9PT0gRkFSTV9ERUZBVUxUUy5USUxFX1ggJiYgY2ZnLlRJTEVfWSA9PT0gRkFSTV9ERUZBVUxUUy5USUxFX1k7XG4gIC8vIFZlcmlmaWNhciBxdWUgbGFzIGNvb3JkZW5hZGFzIHNlYW4gblx1MDBGQW1lcm9zIHZcdTAwRTFsaWRvc1xuICBjb25zdCBoYXNJbnZhbGlkQ29vcmRzID0gIU51bWJlci5pc0Zpbml0ZShjZmcuVElMRV9YKSB8fCAhTnVtYmVyLmlzRmluaXRlKGNmZy5USUxFX1kpO1xuXG4gIC8vIFNvbG8gY2FsaWJyYXIgc2kgTk8gaGF5IHpvbmEgc2VsZWNjaW9uYWRhIGFcdTAwRkFuIHkgYWRlbVx1MDBFMXMgbGFzIGNvb3JkcyBzb24gZGVmYXVsdCBvIGludlx1MDBFMWxpZGFzXG4gIGNvbnN0IG5lZWRzQ2FsaWIgPSAhaGFzU2VsZWN0ZWRab25lICYmIChoYXNEZWZhdWx0Q29vcmRzIHx8IGhhc0ludmFsaWRDb29yZHMpO1xuICBsb2coYFZlcmlmaWNhY2lcdTAwRjNuIGNhbGlicmFjaVx1MDBGM246IGRlZmF1bHRzPSR7aGFzRGVmYXVsdENvb3Jkc30sIHNlbGVjdGVkPSR7aGFzU2VsZWN0ZWRab25lfSwgaW52YWxpZD0ke2hhc0ludmFsaWRDb29yZHN9LCBjb29yZHM9KCR7Y2ZnLlRJTEVfWH0sJHtjZmcuVElMRV9ZfSlgKTtcblxuICByZXR1cm4gbmVlZHNDYWxpYjtcbiAgfVxuXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIGhhYmlsaXRhciBjYXB0dXJhIGRlIGNvb3JkZW5hZGFzXG4gIGZ1bmN0aW9uIGVuYWJsZUNhcHR1cmVPbmNlKCkge1xuICAgIGxvZygnXHVEODNEXHVERDc1XHVGRTBGIEFjdGl2YW5kbyBjYXB0dXJhIGRlIGNvb3JkZW5hZGFzLi4uJyk7XG4gICAgXG4gICAgY29vcmRpbmF0ZUNhcHR1cmUuZW5hYmxlKChyZXN1bHQpID0+IHtcbiAgICAgIGlmIChyZXN1bHQuc3VjY2Vzcykge1xuICAgICAgICBjZmcuVElMRV9YID0gcmVzdWx0LnRpbGVYO1xuICAgICAgICBjZmcuVElMRV9ZID0gcmVzdWx0LnRpbGVZO1xuICAgICAgICBzYXZlRmFybUNmZyhjZmcpO1xuICAgICAgICB1aS51cGRhdGVDb25maWcoKTtcbiAgICAgICAgdWkuc2V0U3RhdHVzKGBcdUQ4M0NcdURGQUYgQ29vcmRlbmFkYXMgY2FwdHVyYWRhczogdGlsZSgke3Jlc3VsdC50aWxlWH0sJHtyZXN1bHQudGlsZVl9KWAsICdzdWNjZXNzJyk7XG4gICAgICAgIGxvZyhgXHUyNzA1IENvb3JkZW5hZGFzIGNhcHR1cmFkYXMgYXV0b21cdTAwRTF0aWNhbWVudGU6IHRpbGUoJHtyZXN1bHQudGlsZVh9LCR7cmVzdWx0LnRpbGVZfSlgKTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIHVpLnNldFN0YXR1cyhgXHUyNzRDICR7dCgnY29tbW9uLmVycm9yJywgJ05vIHNlIHB1ZGllcm9uIGNhcHR1cmFyIGNvb3JkZW5hZGFzJyl9YCwgJ2Vycm9yJyk7XG4gICAgICB9XG4gICAgfSk7XG4gICAgXG4gICAgdWkuc2V0U3RhdHVzKGBcdUQ4M0RcdURDRjggJHt0KCdmYXJtLmNhcHR1cmVJbnN0cnVjdGlvbnMnKX1gLCAnc3RhdHVzJyk7XG4gIH1cblxuICAvLyBJbmljaWFsaXphciBjb25maWd1cmFjaVx1MDBGM25cbiAgbGV0IGNmZyA9IHsgLi4uRkFSTV9ERUZBVUxUUywgLi4ubG9hZEZhcm1DZmcoRkFSTV9ERUZBVUxUUykgfTtcbiAgXG4gIC8vIFZlcmlmaWNhciBzaXRla2V5XG4gIGlmICghY2ZnLlNJVEVLRVkpIHtcbiAgICBjb25zdCBzaXRlS2V5RWxlbWVudCA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJypbZGF0YS1zaXRla2V5XScpO1xuICAgIGlmIChzaXRlS2V5RWxlbWVudCkge1xuICAgICAgY2ZnLlNJVEVLRVkgPSBzaXRlS2V5RWxlbWVudC5nZXRBdHRyaWJ1dGUoJ2RhdGEtc2l0ZWtleScpO1xuICAgICAgbG9nKGBcdUQ4M0RcdURDREQgU2l0ZWtleSBlbmNvbnRyYWRhIGF1dG9tXHUwMEUxdGljYW1lbnRlOiAke2NmZy5TSVRFS0VZLnN1YnN0cmluZygwLCAyMCl9Li4uYCk7XG4gICAgICBzYXZlRmFybUNmZyhjZmcpO1xuICAgIH0gZWxzZSB7XG4gICAgICBsb2coJ1x1MjZBMFx1RkUwRiBObyBzZSBwdWRvIGVuY29udHJhciBsYSBzaXRla2V5IGF1dG9tXHUwMEUxdGljYW1lbnRlJyk7XG4gICAgfVxuICB9XG5cbiAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgYWN0dWFsaXphciBzZXNpXHUwMEYzbiB5IGVzdGFkXHUwMEVEc3RpY2FzXG4gIGFzeW5jIGZ1bmN0aW9uIHVwZGF0ZVN0YXRzKCkge1xuICAgIHRyeSB7XG4gICAgICBjb25zdCBzZXNzaW9uID0gYXdhaXQgZ2V0U2Vzc2lvbigpO1xuICAgICAgaWYgKHNlc3Npb24uc3VjY2VzcyAmJiBzZXNzaW9uLmRhdGEpIHtcbiAgICAgICAgZmFybVN0YXRlLmNoYXJnZXMuY291bnQgPSBzZXNzaW9uLmRhdGEuY2hhcmdlcyB8fCAwO1xuICAgICAgICBmYXJtU3RhdGUuY2hhcmdlcy5tYXggPSBzZXNzaW9uLmRhdGEubWF4Q2hhcmdlcyB8fCA1MDtcbiAgICAgICAgZmFybVN0YXRlLmNoYXJnZXMucmVnZW4gPSBzZXNzaW9uLmRhdGEuY2hhcmdlUmVnZW4gfHwgMzAwMDA7XG4gICAgICAgIGZhcm1TdGF0ZS51c2VyID0gc2Vzc2lvbi5kYXRhLnVzZXI7XG4gICAgICAgIFxuICAgICAgICAvLyBBY3R1YWxpemFyIGNvbmZpZ3VyYWNpXHUwMEYzbiBjb24gZGF0b3MgZGUgbGEgc2VzaVx1MDBGM25cbiAgICAgICAgY2ZnLkNIQVJHRV9SRUdFTl9NUyA9IGZhcm1TdGF0ZS5jaGFyZ2VzLnJlZ2VuO1xuICAgICAgICBcbiAgICAgICAgLy8gVmVyaWZpY2FyIGhlYWx0aFxuICAgICAgICBjb25zdCBoZWFsdGggPSBhd2FpdCBjaGVja0JhY2tlbmRIZWFsdGgoKTtcbiAgICAgICAgZmFybVN0YXRlLmhlYWx0aCA9IGhlYWx0aDtcbiAgICAgICAgXG4gICAgICAgIHVpLnVwZGF0ZVN0YXRzKGZhcm1TdGF0ZS5wYWludGVkLCBmYXJtU3RhdGUuY2hhcmdlcy5jb3VudCwgZmFybVN0YXRlLnJldHJ5Q291bnQsIGhlYWx0aCk7XG4gICAgICAgIHJldHVybiBzZXNzaW9uLmRhdGE7XG4gICAgICB9XG4gICAgICByZXR1cm4gbnVsbDtcbiAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgbG9nKCdFcnJvciBhY3R1YWxpemFuZG8gZXN0YWRcdTAwRURzdGljYXM6JywgZXJyb3IpO1xuICAgICAgcmV0dXJuIG51bGw7XG4gICAgfVxuICB9XG5cbiAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgdmVyaWZpY2FyIGhlYWx0aCBkZWwgYmFja2VuZFxuICBhc3luYyBmdW5jdGlvbiBjaGVja0JhY2tlbmRIZWFsdGgoKSB7XG4gICAgdHJ5IHtcbiAgICAgIHJldHVybiBhd2FpdCBjaGVja0hlYWx0aCgpO1xuICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICBsb2coJ0Vycm9yIHZlcmlmaWNhbmRvIGhlYWx0aDonLCBlcnJvcik7XG4gICAgICByZXR1cm4geyB1cDogZmFsc2UsIGVycm9yOiBlcnJvci5tZXNzYWdlIH07XG4gICAgfVxuICB9XG5cbiAgLy8gRnVuY2lcdTAwRjNuIGRlIHBpbnRhZG8gaW5kaXZpZHVhbFxuICBhc3luYyBmdW5jdGlvbiBwYWludE9uY2VXcmFwcGVyKCkge1xuICAgIHJldHVybiBhd2FpdCBwYWludFdpdGhSZXRyeShjZmcsIGZhcm1TdGF0ZSwgdWkuc2V0U3RhdHVzLCB1aS5mbGFzaEVmZmVjdCwgKCkgPT4gZ2V0U2Vzc2lvbigpLCBjaGVja0JhY2tlbmRIZWFsdGgpO1xuICB9XG5cbiAgLy8gQ3JlYXIgbGEgaW50ZXJmYXogZGUgdXN1YXJpb1xuICBjb25zdCB1aSA9IGNyZWF0ZUZhcm1VSShcbiAgICBjZmcsXG4gICAgLy8gb25TdGFydFxuICAgIGFzeW5jICgpID0+IHtcbiAgICAgIGlmIChmYXJtU3RhdGUucnVubmluZykge1xuICAgICAgICB1aS5zZXRTdGF0dXMoJ1x1MjZBMFx1RkUwRiBFbCBib3QgeWEgZXN0XHUwMEUxIGVqZWN1dFx1MDBFMW5kb3NlJywgJ2Vycm9yJyk7XG4gICAgICAgIHJldHVybjtcbiAgICAgIH1cbiAgICAgIFxuICAgICAgLy8gU2kgbm8gc2UgaGEgc2VsZWNjaW9uYWRvIHVuYSB6b25hLCBhY3RpdmFyIGF1dG9tXHUwMEUxdGljYW1lbnRlIGxhIHNlbGVjY2lcdTAwRjNuXG4gICAgICBpZiAoIWNmZy5QT1NJVElPTl9TRUxFQ1RFRCB8fCBjZmcuQkFTRV9YID09PSBudWxsIHx8IGNmZy5CQVNFX1kgPT09IG51bGwpIHtcbiAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2Zhcm0uYXV0b1NlbGVjdFBvc2l0aW9uJyksICdpbmZvJyk7XG4gICAgICAgIFxuICAgICAgICAvLyBBY3RpdmFyIHNlbGVjY2lcdTAwRjNuIGRlIHpvbmEgYXV0b21cdTAwRTF0aWNhbWVudGVcbiAgICAgICAgY29uc3Qgc2VsZWN0QnV0dG9uID0gdWkuZ2V0RWxlbWVudCgpLnNoYWRvd1Jvb3QuZ2V0RWxlbWVudEJ5SWQoJ3NlbGVjdC1wb3NpdGlvbi1idG4nKTtcbiAgICAgICAgaWYgKHNlbGVjdEJ1dHRvbikge1xuICAgICAgICAgIHNlbGVjdEJ1dHRvbi5jbGljaygpO1xuICAgICAgICB9XG4gICAgICAgIFxuICAgICAgICAvLyBSZXRvcm5hciBwYXJhIG5vIGluaWNpYXIgZWwgYm90IHRvZGF2XHUwMEVEYVxuICAgICAgICByZXR1cm47XG4gICAgICB9XG4gICAgICBcbiAgICAgIC8vIFZlcmlmaWNhciBzaSBuZWNlc2l0YSBjYWxpYnJhY2lcdTAwRjNuIChzb2xvIHNpIG5vIGhheSB6b25hIHNlbGVjY2lvbmFkYSlcbiAgICAgIGlmIChuZWVkc0NhbGlicmF0aW9uQ2hlY2soY2ZnKSkge1xuICAgICAgICB1aS5zZXRTdGF0dXMoJ1x1RDgzQ1x1REZBRiBDYWxpYnJhbmRvIGF1dG9tXHUwMEUxdGljYW1lbnRlLi4uJywgJ3N0YXR1cycpO1xuICAgICAgICBjb25zdCBjYWxpYnJhdGlvbiA9IGF3YWl0IGF1dG9DYWxpYnJhdGVUaWxlKGNmZyk7XG4gICAgICAgIGlmIChjYWxpYnJhdGlvbi5zdWNjZXNzKSB7XG4gICAgICAgICAgdWkuc2V0U3RhdHVzKGBcdTI3MDUgQ2FsaWJyYWRvOiB0aWxlKCR7Y2FsaWJyYXRpb24udGlsZVh9LCR7Y2FsaWJyYXRpb24udGlsZVl9KWAsICdzdWNjZXNzJyk7XG4gICAgICAgICAgdWkudXBkYXRlQ29uZmlnKCk7IC8vIEFjdHVhbGl6YXIgVUkgY29uIG51ZXZhcyBjb29yZGVuYWRhc1xuICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgIHVpLnNldFN0YXR1cygnXHUyNzRDIEVycm9yIGVuIGNhbGlicmFjaVx1MDBGM24uIENvbmZpZ3VyYSBtYW51YWxtZW50ZS4nLCAnZXJyb3InKTtcbiAgICAgICAgICByZXR1cm47XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICAgIFxuICAgICAgLy8gVmVyaWZpY2FyIGNvbmVjdGl2aWRhZFxuICAgICAgdWkuc2V0U3RhdHVzKCdcdUQ4M0RcdUREMEQgVmVyaWZpY2FuZG8gY29uZWN0aXZpZGFkLi4uJywgJ3N0YXR1cycpO1xuICAgICAgY29uc3QgaGVhbHRoID0gYXdhaXQgY2hlY2tCYWNrZW5kSGVhbHRoKCk7XG4gICAgICBpZiAoIWhlYWx0aC51cCkge1xuICAgICAgICB1aS5zZXRTdGF0dXMoJ1x1RDgzRFx1REQzNCBCYWNrZW5kIG5vIGRpc3BvbmlibGUuIFZlcmlmaWNhIHR1IGNvbmV4aVx1MDBGM24uJywgJ2Vycm9yJyk7XG4gICAgICAgIHJldHVybjtcbiAgICAgIH1cbiAgICAgIFxuICAgICAgLy8gT2J0ZW5lciBzZXNpXHUwMEYzbiBpbmljaWFsXG4gICAgICB1aS5zZXRTdGF0dXMoJ1x1RDgzRFx1REQwNCBPYnRlbmllbmRvIGluZm9ybWFjaVx1MDBGM24gZGUgc2VzaVx1MDBGM24uLi4nLCAnc3RhdHVzJyk7XG4gICAgICBjb25zdCBzZXNzaW9uRGF0YSA9IGF3YWl0IHVwZGF0ZVN0YXRzKCk7XG4gICAgICBpZiAoIXNlc3Npb25EYXRhKSB7XG4gICAgICAgIHVpLnNldFN0YXR1cygnXHUyNzRDIEVycm9yIG9idGVuaWVuZG8gc2VzaVx1MDBGM24uIFZlcmlmaWNhIHR1IGxvZ2luLicsICdlcnJvcicpO1xuICAgICAgICByZXR1cm47XG4gICAgICB9XG4gICAgICBcbiAgICAgIHVpLnNldFN0YXR1cygnXHVEODNEXHVERTgwIEluaWNpYW5kbyBib3QuLi4nLCAnc3RhdHVzJyk7XG4gICAgICB1aS51cGRhdGVCdXR0b25TdGF0ZXModHJ1ZSk7XG4gICAgICBcbiAgICAgIC8vIEluaWNpYXIgZWwgbG9vcCBwcmluY2lwYWxcbiAgICAgIGxvb3AoY2ZnLCBmYXJtU3RhdGUsIHVpLnNldFN0YXR1cywgdWkuZmxhc2hFZmZlY3QsIHVwZGF0ZVN0YXRzLCBjaGVja0JhY2tlbmRIZWFsdGgsIHVwZGF0ZVN0YXRzKTtcbiAgICB9LFxuICAgIFxuICAgIC8vIG9uU3RvcFxuICAgICgpID0+IHtcbiAgICAgIGZhcm1TdGF0ZS5ydW5uaW5nID0gZmFsc2U7XG4gICAgICBpZiAod2luZG93Ll9fd3BsYWNlQm90KSB7XG4gICAgICAgIHdpbmRvdy5fX3dwbGFjZUJvdC5mYXJtUnVubmluZyA9IGZhbHNlO1xuICAgICAgfVxuICAgICAgdWkuc2V0U3RhdHVzKCdcdTIzRjlcdUZFMEYgRGV0ZW5pZW5kbyBib3QuLi4nLCAnc3RhdHVzJyk7XG4gICAgICB1aS51cGRhdGVCdXR0b25TdGF0ZXMoZmFsc2UpO1xuICAgIH0sXG4gICAgXG4gICAgLy8gb25DYWxpYnJhdGVcbiAgICBhc3luYyAoKSA9PiB7XG4gICAgICB1aS5zZXRTdGF0dXMoJ1x1RDgzQ1x1REZBRiBDYWxpYnJhbmRvIHBvc2ljaVx1MDBGM24uLi4nLCAnc3RhdHVzJyk7XG4gICAgICBjb25zdCBjYWxpYnJhdGlvbiA9IGF3YWl0IGF1dG9DYWxpYnJhdGVUaWxlKGNmZyk7XG4gICAgICBpZiAoY2FsaWJyYXRpb24uc3VjY2Vzcykge1xuICAgICAgICB1aS5zZXRTdGF0dXMoYFx1MjcwNSBDYWxpYnJhZG86IHRpbGUoJHtjYWxpYnJhdGlvbi50aWxlWH0sJHtjYWxpYnJhdGlvbi50aWxlWX0pYCwgJ3N1Y2Nlc3MnKTtcbiAgICAgICAgdWkudXBkYXRlQ29uZmlnKCk7IC8vIEFjdHVhbGl6YXIgVUkgY29uIG51ZXZhcyBjb29yZGVuYWRhc1xuICAgICAgfSBlbHNlIHtcbiAgICAgICAgdWkuc2V0U3RhdHVzKGBcdTI3NEMgRXJyb3IgZW4gY2FsaWJyYWNpXHUwMEYzbjogJHtjYWxpYnJhdGlvbi5lcnJvciB8fCAnRGVzY29ub2NpZG8nfWAsICdlcnJvcicpO1xuICAgICAgfVxuICAgIH1cbiAgKTtcblxuICAvLyBDb25maWd1cmFyIGVsIGJvdFx1MDBGM24gZGUgY2FwdHVyYVxuICBjb25zdCBjYXB0dXJlQnRuID0gdWkuZ2V0RWxlbWVudCgpLnNoYWRvd1Jvb3QuZ2V0RWxlbWVudEJ5SWQoJ2NhcHR1cmUtYnRuJyk7XG4gIGlmIChjYXB0dXJlQnRuKSB7XG4gICAgY2FwdHVyZUJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIGVuYWJsZUNhcHR1cmVPbmNlKTtcbiAgfVxuXG4gIC8vIENvbmZpZ3VyYXIgZWwgYm90XHUwMEYzbiBcIlVuYSB2ZXpcIlxuICBjb25zdCBvbmNlQnRuID0gdWkuZ2V0RWxlbWVudCgpLnNoYWRvd1Jvb3QuZ2V0RWxlbWVudEJ5SWQoJ29uY2UtYnRuJyk7XG4gIGlmIChvbmNlQnRuKSB7XG4gICAgb25jZUJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIGFzeW5jICgpID0+IHtcbiAgICAgIGlmIChmYXJtU3RhdGUucnVubmluZykge1xuICAgICAgICB1aS5zZXRTdGF0dXMoJ1x1MjZBMFx1RkUwRiBEZXRcdTAwRTluIGVsIGJvdCBwcmltZXJvJywgJ2Vycm9yJyk7XG4gICAgICAgIHJldHVybjtcbiAgICAgIH1cbiAgICAgIFxuICAgICAgYXdhaXQgdXBkYXRlU3RhdHMoKTtcbiAgICAgIHVpLnNldFN0YXR1cygnXHVEODNDXHVERkE4IFBpbnRhbmRvIHVuYSB2ZXouLi4nLCAnc3RhdHVzJyk7XG4gICAgICBjb25zdCBzdWNjZXNzID0gYXdhaXQgcGFpbnRPbmNlV3JhcHBlcigpO1xuICAgICAgaWYgKHN1Y2Nlc3MpIHtcbiAgICAgICAgdWkuc2V0U3RhdHVzKCdcdTI3MDUgUFx1MDBFRHhlbCBwaW50YWRvIGV4aXRvc2FtZW50ZScsICdzdWNjZXNzJyk7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICB1aS5zZXRTdGF0dXMoJ1x1Mjc0QyBFcnJvciBhbCBwaW50YXIgcFx1MDBFRHhlbCcsICdlcnJvcicpO1xuICAgICAgfVxuICAgIH0pO1xuICB9XG5cbiAgLy8gQWN0dWFsaXphciBlc3RhZFx1MDBFRHN0aWNhcyBpbmljaWFsXG4gIGF3YWl0IHVwZGF0ZVN0YXRzKCk7XG5cbiAgLy8gU2V0dXAgZGUgZXZlbnRvcyBnbG9iYWxlc1xuICB3aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcignd3BsYWNlLWJhdGNoLXBhaW50ZWQnLCAoZXZlbnQpID0+IHtcbiAgICBsb2coYFx1RDgzQ1x1REZBOCBMb3RlIHBpbnRhZG86ICR7ZXZlbnQuZGV0YWlsLnBpeGVsQ291bnR9IHBcdTAwRUR4ZWxlcyBlbiB0aWxlKCR7ZXZlbnQuZGV0YWlsLnRpbGVYfSwke2V2ZW50LmRldGFpbC50aWxlWX0pYCk7XG4gIH0pO1xuXG4gIC8vIC0tLS0tLS0tLS0gRXhwb25lciBBUEkgcG9yIGNvbnNvbGEgKGNvbW8gZW4gZWwgb3JpZ2luYWwpIC0tLS0tLS0tLS1cbiAgd2luZG93LldQQVVJID0ge1xuICAgIG9uY2U6IHBhaW50T25jZVdyYXBwZXIsXG4gICAgZ2V0OiAoKSA9PiAoeyAuLi5jZmcgfSksXG4gICAgY2FwdHVyZTogZW5hYmxlQ2FwdHVyZU9uY2UsXG4gICAgcmVmcmVzaENhbnZhczogKCkgPT4ge1xuICAgICAgLy8gQWN0dWFsaXphciBjYW52YXMgc2kgaGF5IFx1MDBGQWx0aW1vIHBcdTAwRUR4ZWwgcGludGFkb1xuICAgICAgaWYgKGZhcm1TdGF0ZS5sYXN0KSB7XG4gICAgICAgIC8vIEVzdGEgZnVuY2lcdTAwRjNuIHNlIGltcGxlbWVudGFyXHUwMEVEYSBlbiBsb29wLmpzXG4gICAgICAgIGxvZyhgUmVmcmVzY2FuZG8gY2FudmFzIGVuIHBvc2ljaVx1MDBGM24gKCR7ZmFybVN0YXRlLmxhc3QueH0sJHtmYXJtU3RhdGUubGFzdC55fSlgKTtcbiAgICAgIH1cbiAgICB9LFxuICAgIHZlcmlmeVBpeGVsOiBhc3luYyAoeCwgeSkgPT4ge1xuICAgICAgbG9nKGBWZXJpZmljYW5kbyBwXHUwMEVEeGVsIGVuICgke3h9LCR7eX0pLi4uYCk7XG4gICAgICAvLyBFc3RhIGZ1bmNpXHUwMEYzbiB2ZXJpZmljYXJcdTAwRURhIHNpIHVuIHBcdTAwRUR4ZWwgZXNwZWNcdTAwRURmaWNvIGZ1ZSBwaW50YWRvIGNvcnJlY3RhbWVudGVcbiAgICAgIHJldHVybiB7IHZlcmlmaWVkOiB0cnVlLCB4LCB5IH07XG4gICAgfSxcbiAgICBcbiAgICBnZXRTdGF0czogKCkgPT4gKHtcbiAgICAgIHBhaW50ZWQ6IGZhcm1TdGF0ZS5wYWludGVkLFxuICAgICAgbGFzdDogZmFybVN0YXRlLmxhc3QsXG4gICAgICBjaGFyZ2VzOiBmYXJtU3RhdGUuY2hhcmdlcyxcbiAgICAgIHVzZXI6IGZhcm1TdGF0ZS51c2VyLFxuICAgICAgcnVubmluZzogZmFybVN0YXRlLnJ1bm5pbmcsXG4gICAgICBtaW5DaGFyZ2VzOiBjZmcuTUlOX0NIQVJHRVMsXG4gICAgICBkZWxheTogY2ZnLkRFTEFZX01TLFxuICAgICAgdGlsZUluZm86IHtcbiAgICAgICAgdGlsZVg6IGNmZy5USUxFX1gsXG4gICAgICAgIHRpbGVZOiBjZmcuVElMRV9ZLFxuICAgICAgICB0aWxlU2l6ZTogY2ZnLlRJTEVfU0laRSxcbiAgICAgICAgc2FmZU1hcmdpbjogTWF0aC5mbG9vcihjZmcuVElMRV9TSVpFICogMC4wNSksXG4gICAgICAgIHNhZmVBcmVhOiB7XG4gICAgICAgICAgbWluWDogTWF0aC5mbG9vcihjZmcuVElMRV9TSVpFICogMC4wNSksXG4gICAgICAgICAgbWF4WDogY2ZnLlRJTEVfU0laRSAtIE1hdGguZmxvb3IoY2ZnLlRJTEVfU0laRSAqIDAuMDUpIC0gMSxcbiAgICAgICAgICBtaW5ZOiBNYXRoLmZsb29yKGNmZy5USUxFX1NJWkUgKiAwLjA1KSxcbiAgICAgICAgICBtYXhZOiBjZmcuVElMRV9TSVpFIC0gTWF0aC5mbG9vcihjZmcuVElMRV9TSVpFICogMC4wNSkgLSAxXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9KSxcbiAgICBcbiAgICBzZXRQaXhlbHNQZXJCYXRjaDogKGNvdW50KSA9PiB7XG4gICAgICBjZmcuUElYRUxTX1BFUl9CQVRDSCA9IGNsYW1wKGNvdW50LCAxLCA1MCk7XG4gICAgICBzYXZlRmFybUNmZyhjZmcpO1xuICAgICAgdWkudXBkYXRlQ29uZmlnKCk7XG4gICAgICBsb2coYFBcdTAwRUR4ZWxlcyBwb3IgbG90ZSBjb25maWd1cmFkbyBhOiAke2NmZy5QSVhFTFNfUEVSX0JBVENIfWApO1xuICAgIH0sXG4gICAgXG4gICAgc2V0TWluQ2hhcmdlczogKG1pbikgPT4ge1xuICAgICAgY2ZnLk1JTl9DSEFSR0VTID0gTWF0aC5tYXgoMCwgbWluKTtcbiAgICAgIHNhdmVGYXJtQ2ZnKGNmZyk7XG4gICAgICB1aS51cGRhdGVDb25maWcoKTtcbiAgICAgIGxvZyhgQ2FyZ2FzIG1cdTAwRURuaW1hcyBjb25maWd1cmFkYXMgYTogJHtjZmcuTUlOX0NIQVJHRVN9YCk7XG4gICAgfSxcbiAgICBcbiAgICBzZXREZWxheTogKHNlY29uZHMpID0+IHtcbiAgICAgIGNmZy5ERUxBWV9NUyA9IE1hdGgubWF4KDEwMDAsIHNlY29uZHMgKiAxMDAwKTtcbiAgICAgIHNhdmVGYXJtQ2ZnKGNmZyk7XG4gICAgICB1aS51cGRhdGVDb25maWcoKTtcbiAgICAgIGxvZyhgRGVsYXkgY29uZmlndXJhZG8gYTogJHtjZmcuREVMQVlfTVN9bXNgKTtcbiAgICB9LFxuICAgIFxuICAgIGRpYWdub3NlOiAoKSA9PiB7XG4gICAgICBjb25zdCBzdGF0cyA9IHdpbmRvdy5XUEFVSS5nZXRTdGF0cygpO1xuICAgICAgY29uc3QgZGlhZ25vc2lzID0ge1xuICAgICAgICBjb25maWdWYWxpZDogTnVtYmVyLmlzRmluaXRlKGNmZy5USUxFX1gpICYmIE51bWJlci5pc0Zpbml0ZShjZmcuVElMRV9ZKSxcbiAgICAgICAgaGFzQ2hhcmdlczogZmFybVN0YXRlLmNoYXJnZXMuY291bnQgPiAwLFxuICAgICAgICBiYWNrZW5kSGVhbHRoeTogZmFybVN0YXRlLmhlYWx0aD8udXAgfHwgZmFsc2UsXG4gICAgICAgIHVzZXJMb2dnZWRJbjogISFmYXJtU3RhdGUudXNlcixcbiAgICAgICAgY29vcmRpbmF0ZXM6IGAoJHtjZmcuVElMRV9YfSwke2NmZy5USUxFX1l9KWAsXG4gICAgICAgIHNhZmVBcmVhOiBzdGF0cy50aWxlSW5mby5zYWZlQXJlYSxcbiAgICAgICAgcmVjb21tZW5kYXRpb25zOiBbXVxuICAgICAgfTtcbiAgICAgIFxuICAgICAgaWYgKCFkaWFnbm9zaXMuY29uZmlnVmFsaWQpIHtcbiAgICAgICAgZGlhZ25vc2lzLnJlY29tbWVuZGF0aW9ucy5wdXNoKCdDYWxpYnJhciBjb29yZGVuYWRhcyBkZWwgdGlsZScpO1xuICAgICAgfVxuICAgICAgaWYgKCFkaWFnbm9zaXMuaGFzQ2hhcmdlcykge1xuICAgICAgICBkaWFnbm9zaXMucmVjb21tZW5kYXRpb25zLnB1c2goJ0VzcGVyYXIgYSBxdWUgc2UgcmVnZW5lcmVuIGxhcyBjYXJnYXMnKTtcbiAgICAgIH1cbiAgICAgIGlmICghZGlhZ25vc2lzLmJhY2tlbmRIZWFsdGh5KSB7XG4gICAgICAgIGRpYWdub3Npcy5yZWNvbW1lbmRhdGlvbnMucHVzaCgnVmVyaWZpY2FyIGNvbmV4aVx1MDBGM24gYWwgYmFja2VuZCcpO1xuICAgICAgfVxuICAgICAgaWYgKCFkaWFnbm9zaXMudXNlckxvZ2dlZEluKSB7XG4gICAgICAgIGRpYWdub3Npcy5yZWNvbW1lbmRhdGlvbnMucHVzaCgnSW5pY2lhciBzZXNpXHUwMEYzbiBlbiBsYSBwbGF0YWZvcm1hJyk7XG4gICAgICB9XG4gICAgICBcbiAgICAgIGNvbnNvbGUudGFibGUoZGlhZ25vc2lzKTtcbiAgICAgIHJldHVybiBkaWFnbm9zaXM7XG4gICAgfSxcbiAgICBcbiAgICBjaGVja0hlYWx0aDogY2hlY2tCYWNrZW5kSGVhbHRoLFxuICAgIFxuICAgIHJlc2V0Q29uZmlnOiAoKSA9PiB7XG4gICAgICByZXNldFRvU2FmZURlZmF1bHRzKCk7XG4gICAgICBjZmcgPSB7IC4uLkZBUk1fREVGQVVMVFMgfTtcbiAgICAgIHVpLnVwZGF0ZUNvbmZpZygpO1xuICAgICAgbG9nKCdDb25maWd1cmFjaVx1MDBGM24gcmVzZXRlYWRhIGEgdmFsb3JlcyBwb3IgZGVmZWN0bycpO1xuICAgIH0sXG4gICAgXG4gICAgZGVidWdSZXRyaWVzOiAoKSA9PiB7XG4gICAgICByZXR1cm4ge1xuICAgICAgICBjdXJyZW50UmV0cmllczogZmFybVN0YXRlLnJldHJ5Q291bnQsXG4gICAgICAgIGluQ29vbGRvd246IGZhcm1TdGF0ZS5pbkNvb2xkb3duLFxuICAgICAgICBuZXh0UGFpbnRUaW1lOiBmYXJtU3RhdGUubmV4dFBhaW50VGltZSxcbiAgICAgICAgY29vbGRvd25FbmRUaW1lOiBmYXJtU3RhdGUuY29vbGRvd25FbmRUaW1lXG4gICAgICB9O1xuICAgIH0sXG4gICAgXG4gICAgZm9yY2VDbGVhckNvb2xkb3duOiAoKSA9PiB7XG4gICAgICBmYXJtU3RhdGUuaW5Db29sZG93biA9IGZhbHNlO1xuICAgICAgZmFybVN0YXRlLm5leHRQYWludFRpbWUgPSAwO1xuICAgICAgZmFybVN0YXRlLmNvb2xkb3duRW5kVGltZSA9IDA7XG4gICAgICBmYXJtU3RhdGUucmV0cnlDb3VudCA9IDA7XG4gICAgICBsb2coJ0Nvb2xkb3duIGZvcnphZG8gYSBsaW1waWFyJyk7XG4gICAgfSxcbiAgICBcbiAgICBzaW11bGF0ZUVycm9yOiAoc3RhdHVzQ29kZSA9IDUwMCkgPT4ge1xuICAgICAgbG9nKGBTaW11bGFuZG8gZXJyb3IgJHtzdGF0dXNDb2RlfSBwYXJhIHRlc3RpbmcuLi5gKTtcbiAgICAgIHVpLnNldFN0YXR1cyhgXHVEODNFXHVEREVBIFNpbXVsYW5kbyBlcnJvciAke3N0YXR1c0NvZGV9YCwgJ2Vycm9yJyk7XG4gICAgfVxuICB9O1xuXG4gIC8vIENsZWFudXAgYWwgY2VycmFyIGxhIHBcdTAwRTFnaW5hXG4gIHdpbmRvdy5hZGRFdmVudExpc3RlbmVyKCdiZWZvcmV1bmxvYWQnLCAoKSA9PiB7XG4gICAgZmFybVN0YXRlLnJ1bm5pbmcgPSBmYWxzZTtcbiAgICBpZiAod2luZG93Ll9fd3BsYWNlQm90KSB7XG4gICAgICB3aW5kb3cuX193cGxhY2VCb3QuZmFybVJ1bm5pbmcgPSBmYWxzZTtcbiAgICB9XG4gICAgY29vcmRpbmF0ZUNhcHR1cmUuZGlzYWJsZSgpO1xuICAgIHVpLmRlc3Ryb3koKTtcbiAgfSk7XG5cbiAgbG9nKCdcdTI3MDUgRmFybSBCb3QgaW5pY2lhbGl6YWRvIGNvcnJlY3RhbWVudGUnKTtcbiAgbG9nKCdcdUQ4M0RcdURDQTEgVXNhIGNvbnNvbGUubG9nKHdpbmRvdy5XUEFVSSkgcGFyYSB2ZXIgbGEgQVBJIGRpc3BvbmlibGUnKTtcblxufSkoKS5jYXRjaCgoZSkgPT4ge1xuICBjb25zb2xlLmVycm9yKFwiW0JPVF0gRXJyb3IgZW4gQXV0by1GYXJtOlwiLCBlKTtcbiAgaWYgKHdpbmRvdy5fX3dwbGFjZUJvdCkge1xuICAgIHdpbmRvdy5fX3dwbGFjZUJvdC5mYXJtUnVubmluZyA9IGZhbHNlO1xuICB9XG4gIGFsZXJ0KFwiQXV0by1GYXJtOiBlcnJvciBpbmVzcGVyYWRvLiBSZXZpc2EgY29uc29sYS5cIik7XG59KTtcbiJdLAogICJtYXBwaW5ncyI6ICI7OztBQVVPLE1BQU0sTUFBTSxJQUFJLE1BQU0sUUFBUSxJQUFJLFlBQVksR0FBRyxDQUFDOzs7QUNUbEQsTUFBTSxnQkFBZ0I7QUFBQSxJQUMzQixTQUFTO0FBQUE7QUFBQSxJQUNULFFBQVE7QUFBQSxJQUNSLFFBQVE7QUFBQSxJQUNSLFdBQVc7QUFBQTtBQUFBLElBQ1gsVUFBVTtBQUFBO0FBQUEsSUFDVixhQUFhO0FBQUE7QUFBQSxJQUNiLGlCQUFpQjtBQUFBO0FBQUEsSUFDakIsa0JBQWtCO0FBQUE7QUFBQSxJQUNsQixXQUFXO0FBQUEsSUFDWCxXQUFXO0FBQUEsSUFDWCxZQUFZO0FBQUE7QUFBQSxJQUNaLGFBQWE7QUFBQSxJQUNiLGdCQUFnQixDQUFDLFdBQVcsV0FBVyxXQUFXLFdBQVcsV0FBVyxTQUFTO0FBQUE7QUFBQSxJQUVqRixRQUFRO0FBQUE7QUFBQSxJQUNSLFFBQVE7QUFBQTtBQUFBLElBQ1IsYUFBYTtBQUFBO0FBQUEsSUFDYixtQkFBbUI7QUFBQTtBQUFBLElBQ25CLFVBQVU7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLFdBQVc7QUFBQSxNQUNYLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQTtBQUFBLElBQ1g7QUFBQSxFQUNGO0FBR08sTUFBTSxZQUFZO0FBQUEsSUFDdkIsU0FBUztBQUFBLElBQ1QsU0FBUztBQUFBLElBQ1QsTUFBTTtBQUFBO0FBQUEsSUFDTixTQUFTLEVBQUUsT0FBTyxHQUFHLEtBQUssR0FBRyxZQUFZLElBQU07QUFBQSxJQUMvQyxNQUFNO0FBQUEsSUFDTixPQUFPO0FBQUEsSUFDUCxhQUFhO0FBQUE7QUFBQSxJQUNiLG1CQUFtQjtBQUFBO0FBQUEsSUFDbkIsZUFBZSxPQUFPO0FBQUEsSUFDdEIsWUFBWTtBQUFBO0FBQUEsSUFDWixZQUFZO0FBQUE7QUFBQSxJQUNaLGVBQWU7QUFBQTtBQUFBLElBQ2YsaUJBQWlCO0FBQUE7QUFBQSxJQUNqQixRQUFRO0FBQUE7QUFBQSxFQUNWOzs7QUNyQ08sV0FBUyxZQUFZLEtBQUs7QUFFL0I7QUFBQSxFQUNGO0FBRU8sV0FBUyxZQUFZLFVBQVU7QUFFcEMsV0FBTyxFQUFFLEdBQUcsU0FBUztBQUFBLEVBQ3ZCO0FBR08sV0FBUyxlQUFlO0FBRTdCLFlBQVEsSUFBSSxZQUFZLGtFQUErRDtBQUFBLEVBQ3pGO0FBR08sV0FBUyxzQkFBc0I7QUFFcEMsWUFBUSxJQUFJLFlBQVksMkVBQXdFO0FBQUEsRUFDbEc7OztBQzdCQSxNQUFNLE9BQU87QUFFYixpQkFBc0IsYUFBYTtBQUpuQztBQUtFLFFBQUk7QUFDRixZQUFNLEtBQUssTUFBTSxNQUFNLEdBQUcsSUFBSSxPQUFPLEVBQUUsYUFBYSxVQUFVLENBQUMsRUFBRSxLQUFLLE9BQUssRUFBRSxLQUFLLENBQUM7QUFDbkYsWUFBTSxPQUFPLE1BQU07QUFDbkIsWUFBTSxLQUFJLHlCQUFJLFlBQVcsQ0FBQztBQUMxQixZQUFNLFVBQVU7QUFBQSxRQUNkLFFBQU8sT0FBRSxVQUFGLFlBQVc7QUFBQTtBQUFBLFFBQ2xCLE1BQUssT0FBRSxRQUFGLFlBQVM7QUFBQTtBQUFBLFFBQ2QsYUFBWSxPQUFFLGVBQUYsWUFBZ0I7QUFBQSxNQUM5QjtBQUVBLGFBQU87QUFBQSxRQUNMLFNBQVM7QUFBQSxRQUNULE1BQU07QUFBQSxVQUNKO0FBQUEsVUFDQSxTQUFTLFFBQVE7QUFBQSxVQUNqQixZQUFZLFFBQVE7QUFBQSxVQUNwQixhQUFhLFFBQVE7QUFBQSxRQUN2QjtBQUFBLE1BQ0Y7QUFBQSxJQUNGLFNBQVMsT0FBTztBQUNkLGFBQU87QUFBQSxRQUNMLFNBQVM7QUFBQSxRQUNULE9BQU8sTUFBTTtBQUFBLFFBQ2IsTUFBTTtBQUFBLFVBQ0osTUFBTTtBQUFBLFVBQ04sU0FBUztBQUFBLFVBQ1QsWUFBWTtBQUFBLFVBQ1osYUFBYTtBQUFBLFFBQ2Y7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUFBLEVBQ0Y7QUFFQSxpQkFBc0IsY0FBYztBQUNsQyxRQUFJO0FBQ0YsWUFBTSxXQUFXLE1BQU0sTUFBTSxHQUFHLElBQUksV0FBVztBQUFBLFFBQzdDLFFBQVE7QUFBQSxRQUNSLGFBQWE7QUFBQSxNQUNmLENBQUM7QUFFRCxVQUFJLFNBQVMsSUFBSTtBQUNmLGNBQU0sU0FBUyxNQUFNLFNBQVMsS0FBSztBQUNuQyxlQUFPO0FBQUEsVUFDTCxHQUFHO0FBQUEsVUFDSCxXQUFXLEtBQUssSUFBSTtBQUFBLFVBQ3BCLFFBQVE7QUFBQSxRQUNWO0FBQUEsTUFDRixPQUFPO0FBQ0wsZUFBTztBQUFBLFVBQ0wsVUFBVTtBQUFBLFVBQ1YsSUFBSTtBQUFBLFVBQ0osUUFBUTtBQUFBLFVBQ1IsV0FBVyxLQUFLLElBQUk7QUFBQSxVQUNwQixRQUFRO0FBQUEsVUFDUixZQUFZLFNBQVM7QUFBQSxRQUN2QjtBQUFBLE1BQ0Y7QUFBQSxJQUNGLFNBQVMsT0FBTztBQUNkLGFBQU87QUFBQSxRQUNMLFVBQVU7QUFBQSxRQUNWLElBQUk7QUFBQSxRQUNKLFFBQVE7QUFBQSxRQUNSLFdBQVcsS0FBSyxJQUFJO0FBQUEsUUFDcEIsUUFBUTtBQUFBLFFBQ1IsT0FBTyxNQUFNO0FBQUEsTUFDZjtBQUFBLElBQ0Y7QUFBQSxFQUNGO0FBOEZBLGlCQUFzQixvQkFBb0IsT0FBTyxPQUFPLFFBQVEsUUFBUSxnQkFBZ0I7QUFDdEYsUUFBSTtBQUNGLFlBQU0sT0FBTyxLQUFLLFVBQVU7QUFBQSxRQUMxQjtBQUFBLFFBQ0E7QUFBQSxRQUNBLEdBQUc7QUFBQSxNQUNMLENBQUM7QUFFRCxZQUFNLFdBQVcsTUFBTSxNQUFNLEdBQUcsSUFBSSxhQUFhLEtBQUssSUFBSSxLQUFLLElBQUk7QUFBQSxRQUNqRSxRQUFRO0FBQUEsUUFDUixhQUFhO0FBQUEsUUFDYixTQUFTLEVBQUUsZ0JBQWdCLDJCQUEyQjtBQUFBLFFBQ3REO0FBQUEsTUFDRixDQUFDO0FBRUQsVUFBSSxlQUFlO0FBQ25CLFVBQUk7QUFDRix1QkFBZSxNQUFNLFNBQVMsS0FBSztBQUFBLE1BQ3JDLFFBQVE7QUFDTix1QkFBZSxDQUFDO0FBQUEsTUFDbEI7QUFFQSxhQUFPO0FBQUEsUUFDTCxRQUFRLFNBQVM7QUFBQSxRQUNqQixNQUFNO0FBQUEsUUFDTixTQUFTLFNBQVM7QUFBQSxRQUNsQixVQUFTLDZDQUFjLFlBQVc7QUFBQSxNQUNwQztBQUFBLElBQ0YsU0FBUyxPQUFPO0FBQ2QsYUFBTztBQUFBLFFBQ0wsUUFBUTtBQUFBLFFBQ1IsTUFBTSxFQUFFLE9BQU8sTUFBTSxRQUFRO0FBQUEsUUFDN0IsU0FBUztBQUFBLFFBQ1QsU0FBUztBQUFBLE1BQ1g7QUFBQSxJQUNGO0FBQUEsRUFDRjs7O0FDck1PLFdBQVMsTUFBTSxHQUFHLEdBQUcsR0FBRztBQUM3QixXQUFPLEtBQUssSUFBSSxHQUFHLEtBQUssSUFBSSxHQUFHLENBQUMsQ0FBQztBQUFBLEVBQ25DO0FBUU8sV0FBUyxXQUFXLFVBQVUsU0FBUztBQUM1QyxRQUFJLFVBQVUsR0FBRyxVQUFVLEdBQUcsU0FBUyxHQUFHLFNBQVM7QUFFbkQsYUFBUyxNQUFNLFNBQVM7QUFDeEIsYUFBUyxpQkFBaUIsYUFBYSxTQUFTO0FBRWhELGFBQVMsVUFBVSxHQUFHO0FBQ3BCLFFBQUUsZUFBZTtBQUNqQixlQUFTLEVBQUU7QUFDWCxlQUFTLEVBQUU7QUFDWCxlQUFTLGlCQUFpQixXQUFXLFFBQVE7QUFDN0MsZUFBUyxpQkFBaUIsYUFBYSxNQUFNO0FBQUEsSUFDL0M7QUFFQSxhQUFTLE9BQU8sR0FBRztBQUNqQixRQUFFLGVBQWU7QUFDakIsZ0JBQVUsU0FBUyxFQUFFO0FBQ3JCLGdCQUFVLFNBQVMsRUFBRTtBQUNyQixlQUFTLEVBQUU7QUFDWCxlQUFTLEVBQUU7QUFFWCxZQUFNLFNBQVMsUUFBUSxZQUFZO0FBQ25DLFlBQU0sVUFBVSxRQUFRLGFBQWE7QUFFckMsY0FBUSxNQUFNLE1BQU0sS0FBSyxJQUFJLEdBQUcsTUFBTSxJQUFJO0FBQzFDLGNBQVEsTUFBTSxPQUFPLEtBQUssSUFBSSxHQUFHLE9BQU8sSUFBSTtBQUFBLElBQzlDO0FBRUEsYUFBUyxXQUFXO0FBQ2xCLGVBQVMsb0JBQW9CLFdBQVcsUUFBUTtBQUNoRCxlQUFTLG9CQUFvQixhQUFhLE1BQU07QUFBQSxJQUNsRDtBQUFBLEVBQ0Y7OztBQy9DTyxNQUFNLEtBQUs7QUFBQTtBQUFBLElBRWhCLFVBQVU7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxNQUNkLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULElBQUk7QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLFVBQVU7QUFBQSxNQUNWLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLG1CQUFtQjtBQUFBLE1BQ25CLGVBQWU7QUFBQSxNQUNmLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLHFCQUFxQjtBQUFBLE1BQ3JCLG1CQUFtQjtBQUFBLE1BQ25CLGlCQUFpQjtBQUFBLE1BQ2pCLFFBQVE7QUFBQSxNQUNSLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFlBQVk7QUFBQSxNQUNaLE9BQU87QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNWLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLHlCQUF5QjtBQUFBLE1BQ3pCLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLG9CQUFvQjtBQUFBLE1BQ3BCLGNBQWM7QUFBQSxNQUNkLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxJQUNoQjtBQUFBO0FBQUEsSUFHQSxNQUFNO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixPQUFPO0FBQUEsTUFDUCxnQkFBZ0I7QUFBQSxNQUNoQixZQUFZO0FBQUEsTUFDWixXQUFXO0FBQUEsTUFDWCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxZQUFZO0FBQUEsTUFDWixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixxQkFBcUI7QUFBQSxNQUNyQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixjQUFjO0FBQUEsTUFDZCxpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixvQkFBb0I7QUFBQSxJQUN0QjtBQUFBO0FBQUEsSUFHQSxRQUFRO0FBQUEsTUFDTixLQUFLO0FBQUEsTUFDTCxJQUFJO0FBQUEsTUFDSixJQUFJO0FBQUEsTUFDSixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixNQUFNO0FBQUEsTUFDTixRQUFRO0FBQUEsTUFDUixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixTQUFTO0FBQUEsTUFDVCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixpQkFBaUI7QUFBQSxJQUNuQjtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixvQkFBb0I7QUFBQSxNQUNwQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixvQkFBb0I7QUFBQSxNQUNwQixrQkFBa0I7QUFBQSxNQUNsQixnQkFBZ0I7QUFBQSxJQUNsQjtBQUFBLEVBQ0Y7OztBQzNQTyxNQUFNLEtBQUs7QUFBQTtBQUFBLElBRWhCLFVBQVU7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxNQUNkLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULElBQUk7QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLFVBQVU7QUFBQSxNQUNWLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLG1CQUFtQjtBQUFBLE1BQ25CLGVBQWU7QUFBQSxNQUNmLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLHFCQUFxQjtBQUFBLE1BQ3JCLG1CQUFtQjtBQUFBLE1BQ25CLGlCQUFpQjtBQUFBLE1BQ2pCLFFBQVE7QUFBQSxNQUNSLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFlBQVk7QUFBQSxNQUNaLE9BQU87QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNWLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLHlCQUF5QjtBQUFBLE1BQ3pCLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLG9CQUFvQjtBQUFBLE1BQ3BCLGNBQWM7QUFBQSxNQUNkLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxJQUNoQjtBQUFBO0FBQUEsSUFHQSxNQUFNO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixPQUFPO0FBQUEsTUFDUCxnQkFBZ0I7QUFBQSxNQUNoQixZQUFZO0FBQUEsTUFDWixXQUFXO0FBQUEsTUFDWCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxZQUFZO0FBQUEsTUFDWixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixxQkFBcUI7QUFBQSxNQUNyQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixjQUFjO0FBQUEsTUFDZCxpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixvQkFBb0I7QUFBQSxJQUN0QjtBQUFBO0FBQUEsSUFHQSxRQUFRO0FBQUEsTUFDTixLQUFLO0FBQUEsTUFDTCxJQUFJO0FBQUEsTUFDSixJQUFJO0FBQUEsTUFDSixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixNQUFNO0FBQUEsTUFDTixRQUFRO0FBQUEsTUFDUixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixTQUFTO0FBQUEsTUFDVCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixpQkFBaUI7QUFBQSxJQUNuQjtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixvQkFBb0I7QUFBQSxNQUNwQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixvQkFBb0I7QUFBQSxNQUNwQixrQkFBa0I7QUFBQSxNQUNsQixnQkFBZ0I7QUFBQSxJQUNsQjtBQUFBLEVBQ0Y7OztBQzNQTyxNQUFNLEtBQUs7QUFBQTtBQUFBLElBRWhCLFVBQVU7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxNQUNkLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULElBQUk7QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLFVBQVU7QUFBQSxNQUNWLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLG1CQUFtQjtBQUFBLE1BQ25CLGVBQWU7QUFBQSxNQUNmLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLHFCQUFxQjtBQUFBLE1BQ3JCLG1CQUFtQjtBQUFBLE1BQ25CLGlCQUFpQjtBQUFBLE1BQ2pCLFFBQVE7QUFBQSxNQUNSLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFlBQVk7QUFBQSxNQUNaLE9BQU87QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNWLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLHlCQUF5QjtBQUFBLE1BQ3pCLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLG9CQUFvQjtBQUFBLE1BQ3BCLGNBQWM7QUFBQSxNQUNkLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxJQUNoQjtBQUFBO0FBQUEsSUFHQSxNQUFNO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixPQUFPO0FBQUEsTUFDUCxnQkFBZ0I7QUFBQSxNQUNoQixZQUFZO0FBQUEsTUFDWixXQUFXO0FBQUEsTUFDWCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxZQUFZO0FBQUEsTUFDWixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixxQkFBcUI7QUFBQSxNQUNyQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixjQUFjO0FBQUEsTUFDZCxpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixvQkFBb0I7QUFBQSxJQUN0QjtBQUFBO0FBQUEsSUFHQSxRQUFRO0FBQUEsTUFDTixLQUFLO0FBQUEsTUFDTCxJQUFJO0FBQUEsTUFDSixJQUFJO0FBQUEsTUFDSixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixNQUFNO0FBQUEsTUFDTixRQUFRO0FBQUEsTUFDUixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixTQUFTO0FBQUEsTUFDVCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixpQkFBaUI7QUFBQSxJQUNuQjtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixvQkFBb0I7QUFBQSxNQUNwQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixvQkFBb0I7QUFBQSxNQUNwQixrQkFBa0I7QUFBQSxNQUNsQixnQkFBZ0I7QUFBQSxJQUNsQjtBQUFBLEVBQ0Y7OztBQzNQTyxNQUFNLEtBQUs7QUFBQTtBQUFBLElBRWhCLFVBQVU7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxNQUNkLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULElBQUk7QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLFVBQVU7QUFBQSxNQUNWLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLG1CQUFtQjtBQUFBLE1BQ25CLGVBQWU7QUFBQSxNQUNmLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLHFCQUFxQjtBQUFBLE1BQ3JCLG1CQUFtQjtBQUFBLE1BQ25CLGlCQUFpQjtBQUFBLE1BQ2pCLFFBQVE7QUFBQSxNQUNSLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFlBQVk7QUFBQSxNQUNaLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLHlCQUF5QjtBQUFBLE1BQ3pCLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLG9CQUFvQjtBQUFBLE1BQ3BCLGNBQWM7QUFBQSxNQUNkLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxJQUNoQjtBQUFBO0FBQUEsSUFHQSxNQUFNO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixPQUFPO0FBQUEsTUFDUCxnQkFBZ0I7QUFBQSxNQUNoQixZQUFZO0FBQUEsTUFDWixXQUFXO0FBQUEsTUFDWCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxZQUFZO0FBQUEsTUFDWixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixxQkFBcUI7QUFBQSxNQUNyQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixjQUFjO0FBQUEsTUFDZCxpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixvQkFBb0I7QUFBQSxJQUN0QjtBQUFBO0FBQUEsSUFHQSxRQUFRO0FBQUEsTUFDTixLQUFLO0FBQUEsTUFDTCxJQUFJO0FBQUEsTUFDSixJQUFJO0FBQUEsTUFDSixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixNQUFNO0FBQUEsTUFDTixRQUFRO0FBQUEsTUFDUixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixTQUFTO0FBQUEsTUFDVCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixpQkFBaUI7QUFBQSxJQUNuQjtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixvQkFBb0I7QUFBQSxNQUNwQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixvQkFBb0I7QUFBQSxNQUNwQixrQkFBa0I7QUFBQSxNQUNsQixnQkFBZ0I7QUFBQSxJQUNsQjtBQUFBLEVBQ0Y7OztBQ3pQTyxNQUFNLFNBQVM7QUFBQTtBQUFBLElBRXBCLFVBQVU7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxNQUNkLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULElBQUk7QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLFVBQVU7QUFBQSxNQUNWLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLG1CQUFtQjtBQUFBLE1BQ25CLGVBQWU7QUFBQSxNQUNmLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLHFCQUFxQjtBQUFBLE1BQ3JCLG1CQUFtQjtBQUFBLE1BQ25CLGlCQUFpQjtBQUFBLE1BQ2pCLFFBQVE7QUFBQSxNQUNSLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFlBQVk7QUFBQSxNQUNaLE9BQU87QUFBQSxNQUNQLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLHlCQUF5QjtBQUFBLE1BQ3pCLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLG9CQUFvQjtBQUFBLE1BQ3BCLGNBQWM7QUFBQSxNQUNkLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxJQUNoQjtBQUFBO0FBQUEsSUFHQSxNQUFNO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixPQUFPO0FBQUEsTUFDUCxnQkFBZ0I7QUFBQSxNQUNoQixZQUFZO0FBQUEsTUFDWixXQUFXO0FBQUEsTUFDWCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxZQUFZO0FBQUEsTUFDWixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixxQkFBcUI7QUFBQSxNQUNyQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixjQUFjO0FBQUEsTUFDZCxpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixvQkFBb0I7QUFBQSxJQUN0QjtBQUFBO0FBQUEsSUFHQSxRQUFRO0FBQUEsTUFDTixLQUFLO0FBQUEsTUFDTCxJQUFJO0FBQUEsTUFDSixJQUFJO0FBQUEsTUFDSixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixNQUFNO0FBQUEsTUFDTixRQUFRO0FBQUEsTUFDUixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixTQUFTO0FBQUEsTUFDVCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixpQkFBaUI7QUFBQSxJQUNuQjtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixvQkFBb0I7QUFBQSxNQUNwQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixvQkFBb0I7QUFBQSxNQUNwQixrQkFBa0I7QUFBQSxNQUNsQixnQkFBZ0I7QUFBQSxJQUNsQjtBQUFBLEVBQ0Y7OztBQzNQTyxNQUFNLFNBQVM7QUFBQTtBQUFBLElBRXBCLFVBQVU7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxNQUNkLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULElBQUk7QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLFVBQVU7QUFBQSxNQUNWLFVBQVU7QUFBQSxNQUNWLFFBQVE7QUFBQSxNQUNSLFNBQVM7QUFBQSxNQUNULGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFlBQVk7QUFBQSxNQUNaLG1CQUFtQjtBQUFBLE1BQ25CLGVBQWU7QUFBQSxNQUNmLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLHFCQUFxQjtBQUFBLE1BQ3JCLG1CQUFtQjtBQUFBLE1BQ25CLGlCQUFpQjtBQUFBLE1BQ2pCLFFBQVE7QUFBQSxNQUNSLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLFlBQVk7QUFBQSxNQUNaLE9BQU87QUFBQSxNQUNQLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGVBQWU7QUFBQSxNQUNmLHFCQUFxQjtBQUFBLE1BQ3JCLHlCQUF5QjtBQUFBLE1BQ3pCLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLG9CQUFvQjtBQUFBLE1BQ3BCLGNBQWM7QUFBQSxNQUNkLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxJQUNoQjtBQUFBO0FBQUEsSUFHQSxNQUFNO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixPQUFPO0FBQUEsTUFDUCxnQkFBZ0I7QUFBQSxNQUNoQixZQUFZO0FBQUEsTUFDWixXQUFXO0FBQUEsTUFDWCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxZQUFZO0FBQUEsTUFDWixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixxQkFBcUI7QUFBQSxNQUNyQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixnQkFBZ0I7QUFBQSxNQUNoQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixjQUFjO0FBQUEsTUFDZCxpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixvQkFBb0I7QUFBQSxJQUN0QjtBQUFBO0FBQUEsSUFHQSxRQUFRO0FBQUEsTUFDTixLQUFLO0FBQUEsTUFDTCxJQUFJO0FBQUEsTUFDSixJQUFJO0FBQUEsTUFDSixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixNQUFNO0FBQUEsTUFDTixRQUFRO0FBQUEsTUFDUixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixNQUFNO0FBQUEsTUFDTixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixTQUFTO0FBQUEsTUFDVCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxNQUFNO0FBQUEsTUFDTixpQkFBaUI7QUFBQSxJQUNuQjtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixvQkFBb0I7QUFBQSxNQUNwQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixvQkFBb0I7QUFBQSxNQUNwQixrQkFBa0I7QUFBQSxNQUNsQixnQkFBZ0I7QUFBQSxJQUNsQjtBQUFBLEVBQ0Y7OztBQ3pPQSxNQUFNLGVBQWU7QUFBQSxJQUNuQjtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsRUFDRjtBQUdBLE1BQUksa0JBQWtCO0FBQ3RCLE1BQUksc0JBQXNCLGFBQWEsZUFBZTtBQU0vQyxXQUFTLHdCQUF3QjtBQUN0QyxVQUFNLGNBQWMsT0FBTyxVQUFVLFlBQVksT0FBTyxVQUFVLGdCQUFnQjtBQUdsRixVQUFNLFdBQVcsWUFBWSxNQUFNLEdBQUcsRUFBRSxDQUFDLEVBQUUsWUFBWTtBQUd2RCxRQUFJLGFBQWEsUUFBUSxHQUFHO0FBQzFCLGFBQU87QUFBQSxJQUNUO0FBR0EsV0FBTztBQUFBLEVBQ1Q7QUFNTyxXQUFTLG1CQUFtQjtBQUVqQyxXQUFPO0FBQUEsRUFDVDtBQU1PLFdBQVMsYUFBYSxVQUFVO0FBRXJDO0FBQUEsRUFDRjtBQU1PLFdBQVMscUJBQXFCO0FBRW5DLFVBQU0sWUFBWSxpQkFBaUI7QUFDbkMsVUFBTSxjQUFjLHNCQUFzQjtBQUUxQyxRQUFJLGVBQWU7QUFFbkIsUUFBSSxhQUFhLGFBQWEsU0FBUyxHQUFHO0FBQ3hDLHFCQUFlO0FBQUEsSUFDakIsV0FBVyxlQUFlLGFBQWEsV0FBVyxHQUFHO0FBQ25ELHFCQUFlO0FBQUEsSUFDakI7QUFFQSxnQkFBWSxZQUFZO0FBQ3hCLFdBQU87QUFBQSxFQUNUO0FBTU8sV0FBUyxZQUFZLFVBQVU7QUFDcEMsUUFBSSxDQUFDLGFBQWEsUUFBUSxHQUFHO0FBQzNCLGNBQVEsS0FBSyxXQUFXLFFBQVEsNEJBQTRCLGVBQWUsR0FBRztBQUM5RTtBQUFBLElBQ0Y7QUFFQSxzQkFBa0I7QUFDbEIsMEJBQXNCLGFBQWEsUUFBUTtBQUMzQyxpQkFBYSxRQUFRO0FBR3JCLFFBQUksT0FBTyxXQUFXLGVBQWUsT0FBTyxhQUFhO0FBQ3ZELGFBQU8sY0FBYyxJQUFJLE9BQU8sWUFBWSxtQkFBbUI7QUFBQSxRQUM3RCxRQUFRLEVBQUUsVUFBVSxVQUFVLGNBQWMsb0JBQW9CO0FBQUEsTUFDbEUsQ0FBQyxDQUFDO0FBQUEsSUFDSjtBQUFBLEVBQ0Y7QUF3Qk8sV0FBUyxFQUFFLEtBQUssU0FBUyxDQUFDLEdBQUc7QUFDbEMsVUFBTSxPQUFPLElBQUksTUFBTSxHQUFHO0FBQzFCLFFBQUksUUFBUTtBQUdaLGVBQVcsS0FBSyxNQUFNO0FBQ3BCLFVBQUksU0FBUyxPQUFPLFVBQVUsWUFBWSxLQUFLLE9BQU87QUFDcEQsZ0JBQVEsTUFBTSxDQUFDO0FBQUEsTUFDakIsT0FBTztBQUNMLGdCQUFRLEtBQUssMENBQXVDLEdBQUcsR0FBRztBQUMxRCxlQUFPO0FBQUEsTUFDVDtBQUFBLElBQ0Y7QUFFQSxRQUFJLE9BQU8sVUFBVSxVQUFVO0FBQzdCLGNBQVEsS0FBSyx5Q0FBc0MsR0FBRyxHQUFHO0FBQ3pELGFBQU87QUFBQSxJQUNUO0FBR0EsV0FBTyxZQUFZLE9BQU8sTUFBTTtBQUFBLEVBQ2xDO0FBUUEsV0FBUyxZQUFZLE1BQU0sUUFBUTtBQUNqQyxRQUFJLENBQUMsVUFBVSxPQUFPLEtBQUssTUFBTSxFQUFFLFdBQVcsR0FBRztBQUMvQyxhQUFPO0FBQUEsSUFDVDtBQUVBLFdBQU8sS0FBSyxRQUFRLGNBQWMsQ0FBQyxPQUFPLFFBQVE7QUFDaEQsYUFBTyxPQUFPLEdBQUcsTUFBTSxTQUFZLE9BQU8sR0FBRyxJQUFJO0FBQUEsSUFDbkQsQ0FBQztBQUFBLEVBQ0g7QUEwQkEscUJBQW1COzs7QUM5TFosV0FBUyxhQUFhLFFBQVEsU0FBUyxRQUFRO0FBTnREO0FBT0UsVUFBTSxhQUFhLFNBQVMsY0FBYyxLQUFLO0FBQy9DLGVBQVcsS0FBSztBQUNoQixlQUFXLE1BQU0sVUFBVTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQVEzQixVQUFNLFNBQVMsV0FBVyxhQUFhLEVBQUUsTUFBTSxPQUFPLENBQUM7QUFFdkQsVUFBTSxRQUFRLFNBQVMsY0FBYyxPQUFPO0FBQzVDLFVBQU0sY0FBYztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQXlScEIsV0FBTyxZQUFZLEtBQUs7QUFFeEIsVUFBTSxZQUFZLFNBQVMsY0FBYyxLQUFLO0FBQzlDLGNBQVUsWUFBWTtBQUd0QixVQUFNLFVBQVU7QUFBQSxNQUNkLFdBQVc7QUFBQSxNQUNYLGNBQWM7QUFBQSxJQUNoQjtBQUVBLGNBQVUsWUFBWTtBQUFBO0FBQUE7QUFBQSxvQkFHWCxFQUFFLFlBQVksQ0FBQztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsMkRBUXdCLEVBQUUsY0FBYyxDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSw2Q0FLeEIsRUFBRSxjQUFjLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQSw2Q0FJakIsRUFBRSxjQUFjLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQSw2Q0FJakIsRUFBRSxjQUFjLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQSw2Q0FJakIsRUFBRSxXQUFXLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLDRFQUtPLEVBQUUsWUFBWSxDQUFDO0FBQUEsbUZBQ1IsRUFBRSxXQUFXLENBQUM7QUFBQSxtRkFDWCxFQUFFLHFCQUFxQixDQUFDO0FBQUEsd0VBQ25DLEVBQUUsZ0JBQWdCLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLG9EQUt2QyxFQUFFLG1CQUFtQixDQUFDLDZCQUE2QixFQUFFLGlCQUFpQixDQUFDO0FBQUEsMERBQ3BFLEVBQUUsc0JBQXNCLENBQUM7QUFBQTtBQUFBO0FBQUEsa0VBR2QsRUFBRSxxQkFBcUIsQ0FBQztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEseURBS3BDLEVBQUUsb0JBQW9CLENBQUM7QUFBQTtBQUFBO0FBQUEsdUNBRy9CLEVBQUUsWUFBWSxDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSx1Q0FLZixFQUFFLHFCQUFxQixDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSx1Q0FLeEIsRUFBRSxpQkFBaUIsQ0FBQztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsdUNBS3BCLEVBQUUsZ0JBQWdCLENBQUM7QUFBQTtBQUFBLHFDQUVyQixFQUFFLGFBQWEsQ0FBQztBQUFBLG9DQUNqQixFQUFFLFlBQVksQ0FBQztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsdUNBS1osRUFBRSxZQUFZLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSx1Q0FPZixFQUFFLGlCQUFpQixDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxzQkFRNUMsRUFBRSxlQUFlLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLHlDQUtRLEVBQUUsWUFBWSxDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSx5Q0FLZixFQUFFLFlBQVksQ0FBQztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEseUNBS2YsRUFBRSxvQkFBb0IsQ0FBQztBQUFBO0FBQUE7QUFBQTtBQUFBLGtDQUk5QixFQUFFLHFCQUFxQixDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUEsMEVBSVMsRUFBRSxhQUFhLENBQUM7QUFBQSwwRUFDaEIsRUFBRSxhQUFhLENBQUM7QUFBQSwyRUFDZixFQUFFLGNBQWMsQ0FBQztBQUFBLDZFQUNmLEVBQUUsY0FBYyxDQUFDO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQU9yRixXQUFPLFlBQVksU0FBUztBQUM1QixhQUFTLEtBQUssWUFBWSxVQUFVO0FBR3BDLFVBQU0sU0FBUyxPQUFPLGNBQWMsZ0JBQWdCO0FBQ3BELGVBQVcsUUFBUSxVQUFVO0FBRzdCLFVBQU0sV0FBVztBQUFBLE1BQ2YsYUFBYSxPQUFPLGNBQWMsa0JBQWtCO0FBQUEsTUFDcEQsU0FBUyxPQUFPLGNBQWMsaUJBQWlCO0FBQUEsTUFDL0MsUUFBUSxPQUFPLGVBQWUsUUFBUTtBQUFBLE1BQ3RDLGNBQWMsT0FBTyxlQUFlLGVBQWU7QUFBQSxNQUNuRCxjQUFjLE9BQU8sZUFBZSxlQUFlO0FBQUEsTUFDbkQsWUFBWSxPQUFPLGVBQWUsYUFBYTtBQUFBLE1BQy9DLFNBQVMsT0FBTyxlQUFlLFVBQVU7QUFBQSxNQUN6QyxVQUFVLE9BQU8sZUFBZSxXQUFXO0FBQUEsTUFDM0MsU0FBUyxPQUFPLGVBQWUsVUFBVTtBQUFBLE1BQ3pDLG1CQUFtQixPQUFPLGVBQWUscUJBQXFCO0FBQUEsTUFDOUQsU0FBUyxPQUFPLGVBQWUsVUFBVTtBQUFBLE1BQ3pDLFVBQVUsT0FBTyxlQUFlLFdBQVc7QUFBQSxNQUMzQyxhQUFhLE9BQU8sZUFBZSxjQUFjO0FBQUEsTUFDakQsY0FBYyxPQUFPLGVBQWUsZUFBZTtBQUFBLE1BQ25ELFlBQVksT0FBTyxlQUFlLGFBQWE7QUFBQSxNQUMvQyxhQUFhLE9BQU8sZUFBZSxjQUFjO0FBQUEsTUFDakQsaUJBQWlCLE9BQU8sZUFBZSxtQkFBbUI7QUFBQSxNQUMxRCxpQkFBaUIsT0FBTyxlQUFlLG1CQUFtQjtBQUFBLE1BQzFELGVBQWUsT0FBTyxlQUFlLGlCQUFpQjtBQUFBLE1BQ3RELGVBQWUsT0FBTyxlQUFlLGlCQUFpQjtBQUFBLE1BQ3RELGVBQWUsT0FBTyxlQUFlLGlCQUFpQjtBQUFBLE1BQ3RELGVBQWUsT0FBTyxlQUFlLGlCQUFpQjtBQUFBLE1BQ3RELGlCQUFpQixPQUFPLGVBQWUsbUJBQW1CO0FBQUEsTUFDMUQsZ0JBQWdCLE9BQU8sZUFBZSxpQkFBaUI7QUFBQSxNQUN2RCxpQkFBaUIsT0FBTyxlQUFlLGtCQUFrQjtBQUFBLE1BQ3pELGVBQWUsT0FBTyxlQUFlLGdCQUFnQjtBQUFBLE1BQ3JELFlBQVksT0FBTyxlQUFlLGNBQWM7QUFBQSxNQUNoRCxZQUFZLE9BQU8sZUFBZSxjQUFjO0FBQUEsTUFDaEQsb0JBQW9CLE9BQU8sZUFBZSxzQkFBc0I7QUFBQSxNQUNoRSxTQUFTLE9BQU8sZUFBZSxVQUFVO0FBQUEsTUFDekMsU0FBUyxPQUFPLGVBQWUsVUFBVTtBQUFBLE1BQ3pDLFVBQVUsT0FBTyxlQUFlLFdBQVc7QUFBQSxNQUMzQyxZQUFZLE9BQU8sZUFBZSxhQUFhO0FBQUEsSUFDakQ7QUFHQSxhQUFTLHlCQUF5QjtBQWplcEMsVUFBQUE7QUFrZUksZUFBUyxXQUFXLFFBQVEsT0FBTztBQUNuQyxlQUFTLFlBQVksUUFBUSxPQUFPO0FBQ3BDLGVBQVMsZ0JBQWdCLFFBQVEsT0FBTztBQUN4QyxlQUFTLGdCQUFnQixRQUFRLE9BQU87QUFDeEMsZUFBUyxjQUFjLFFBQVEsT0FBTztBQUN0QyxlQUFTLGNBQWMsUUFBUSxPQUFPO0FBQ3RDLGVBQVMsZ0JBQWdCLFFBQVEsT0FBTztBQUN4QyxlQUFTLFdBQVcsUUFBUSxPQUFPLFVBQVU7QUFDN0MsZUFBUyxXQUFXLFFBQVEsT0FBTyxVQUFVO0FBQzdDLGVBQVMsbUJBQW1CLFNBQVMsT0FBTyxrQkFBa0IsQ0FBQyxHQUFHLEtBQUssR0FBRztBQUcxRSxnQ0FBMEI7QUFDMUIsd0JBQWtCO0FBQ2xCLHdCQUFrQjtBQUNsQiwyQkFBbUJBLE1BQUEsOEJBQUFBLElBQVcsWUFBVyxLQUFLO0FBQUEsSUFDaEQ7QUFHQSxhQUFTLHlCQUF5QjtBQUNoQyxhQUFPLFdBQVcsU0FBUyxTQUFTLFdBQVcsS0FBSyxLQUFLLGNBQWM7QUFDdkUsYUFBTyxtQkFBbUIsTUFBTSxTQUFTLFNBQVMsWUFBWSxLQUFLLEtBQUssY0FBYyxrQkFBa0IsR0FBRyxFQUFFO0FBQzdHLGFBQU8sY0FBYyxXQUFXLFNBQVMsZ0JBQWdCLEtBQUssS0FBSyxjQUFjO0FBQ2pGLGFBQU8sYUFBYSxTQUFTLGdCQUFnQjtBQUM3QyxhQUFPLFlBQVksTUFBTSxTQUFTLFNBQVMsY0FBYyxLQUFLLEtBQUssY0FBYyxXQUFXLEdBQUcsRUFBRTtBQUNqRyxhQUFPLFlBQVksTUFBTSxTQUFTLFNBQVMsY0FBYyxLQUFLLEtBQUssY0FBYyxXQUFXLEdBQUcsRUFBRTtBQUNqRyxhQUFPLGNBQWMsTUFBTSxTQUFTLFNBQVMsZ0JBQWdCLEtBQUssS0FBSyxjQUFjLGFBQWEsR0FBRyxFQUFFO0FBR3ZHLFVBQUksT0FBTyxZQUFZLE9BQU8sV0FBVztBQUN2QyxlQUFPLFlBQVksT0FBTztBQUMxQixpQkFBUyxjQUFjLFFBQVEsT0FBTztBQUFBLE1BQ3hDO0FBRUEsWUFBTSxRQUFRLFNBQVMsU0FBUyxXQUFXLEtBQUs7QUFDaEQsWUFBTSxRQUFRLFNBQVMsU0FBUyxXQUFXLEtBQUs7QUFDaEQsVUFBSSxPQUFPLFNBQVMsS0FBSyxFQUFHLFFBQU8sU0FBUztBQUM1QyxVQUFJLE9BQU8sU0FBUyxLQUFLLEVBQUcsUUFBTyxTQUFTO0FBRTVDLHdCQUFrQjtBQUNsQix3QkFBa0I7QUFBQSxJQUNwQjtBQUdBLGFBQVMsNEJBQTRCO0FBQ25DLFlBQU0sT0FBTyxTQUFTLGdCQUFnQjtBQUN0QyxlQUFTLGNBQWMsTUFBTSxVQUFVLFNBQVMsV0FBVyxTQUFTO0FBQ3BFLGVBQVMsY0FBYyxNQUFNLFVBQVUsU0FBUyxVQUFVLFNBQVM7QUFBQSxJQUNyRTtBQUdBLGFBQVMsb0JBQW9CO0FBQzNCLFVBQUksU0FBUyxTQUFTO0FBQ3BCLGlCQUFTLFFBQVEsY0FBYyxHQUFHLE9BQU8sVUFBVSxDQUFDLElBQUksT0FBTyxVQUFVLENBQUM7QUFBQSxNQUM1RTtBQUFBLElBQ0Y7QUFHQSxhQUFTLG9CQUFvQjtBQTVoQi9CLFVBQUFBO0FBNmhCSSxVQUFJLFNBQVMsYUFBYTtBQUN4QixZQUFJLE9BQU8scUJBQXFCLE9BQU8sV0FBVyxRQUFRLE9BQU8sV0FBVyxNQUFNO0FBQ2hGLG1CQUFTLFlBQVksY0FBYyxFQUFFLG9CQUFvQixFQUFFLEdBQUcsT0FBTyxRQUFRLEdBQUcsT0FBTyxPQUFPLENBQUM7QUFDL0YsbUJBQVMsWUFBWSxNQUFNLFFBQVE7QUFBQSxRQUNyQyxPQUFPO0FBQ0wsbUJBQVMsWUFBWSxjQUFjLEVBQUUsaUJBQWlCO0FBQ3RELG1CQUFTLFlBQVksTUFBTSxRQUFRO0FBQUEsUUFDckM7QUFBQSxNQUNGO0FBR0EsMkJBQW1CQSxNQUFBLDhCQUFBQSxJQUFXLFlBQVcsS0FBSztBQUFBLElBQ2hEO0FBR0EsbUJBQVMsZ0JBQVQsbUJBQXNCLGlCQUFpQixTQUFTLE1BQU07QUFDcEQsY0FBUSxZQUFZLENBQUMsUUFBUTtBQUM3QixlQUFTLFFBQVEsVUFBVSxPQUFPLGFBQWEsUUFBUSxTQUFTO0FBQ2hFLGVBQVMsWUFBWSxjQUFjLFFBQVEsWUFBWSxNQUFNO0FBQUEsSUFDL0Q7QUFFQSxtQkFBUyxhQUFULG1CQUFtQixpQkFBaUIsU0FBUyxNQUFNO0FBQ2pELDZCQUF1QjtBQUN2QixjQUFRO0FBQ1IseUJBQW1CLElBQUk7QUFBQSxJQUN6QjtBQUVBLG1CQUFTLFlBQVQsbUJBQWtCLGlCQUFpQixTQUFTLE1BQU07QUFDaEQsYUFBTztBQUNQLHlCQUFtQixLQUFLO0FBQUEsSUFDMUI7QUFFQSxtQkFBUyxZQUFULG1CQUFrQixpQkFBaUIsU0FBUyxNQUFNO0FBRWhELDZCQUF1QjtBQUN2Qiw2QkFBdUI7QUFFdkIsVUFBSSxPQUFPLFNBQVMsT0FBTyxNQUFNLE1BQU07QUFDckMsZUFBTyxNQUFNLEtBQUs7QUFBQSxNQUNwQjtBQUFBLElBQ0Y7QUFFQSxtQkFBUyxzQkFBVCxtQkFBNEIsaUJBQWlCLFNBQVMsTUFBTTtBQUMxRCx5QkFBbUIsUUFBUSxXQUFXLGlCQUFpQjtBQUFBLElBQ3pEO0FBRUEsbUJBQVMsb0JBQVQsbUJBQTBCLGlCQUFpQixVQUFVLE1BQU07QUFDekQsZ0NBQTBCO0FBQzFCLDZCQUF1QjtBQUFBLElBQ3pCO0FBRUEsbUJBQVMsdUJBQVQsbUJBQTZCLGlCQUFpQixTQUFTLE1BQU07QUFDM0QsNkJBQXVCO0FBQUEsSUFDekI7QUFFQSxtQkFBUyxtQkFBVCxtQkFBeUIsaUJBQWlCLFNBQVMsTUFBTTtBQUN2RCxjQUFRLGVBQWUsQ0FBQyxRQUFRO0FBQ2hDLGVBQVMsZ0JBQWdCLE1BQU0sVUFBVSxRQUFRLGVBQWUsVUFBVTtBQUMxRSxlQUFTLGNBQWMsY0FBYyxRQUFRLGVBQWUsV0FBTTtBQUFBLElBQ3BFO0FBR0EsS0FBQyxjQUFjLGVBQWUsbUJBQW1CLGlCQUFpQixpQkFBaUIsbUJBQW1CLGNBQWMsWUFBWSxFQUFFLFFBQVEsZUFBYTtBQTNsQnpKLFVBQUFBO0FBNGxCSSxPQUFBQSxNQUFBLFNBQVMsU0FBUyxNQUFsQixnQkFBQUEsSUFBcUIsaUJBQWlCLFVBQVU7QUFBQSxJQUNsRCxDQUFDO0FBRUQsbUJBQVMsWUFBVCxtQkFBa0IsaUJBQWlCLFNBQVMsTUFBTTtBQUNoRCw2QkFBdUI7QUFDdkIsa0JBQVksTUFBTTtBQUNsQixnQkFBVSxhQUFNLEVBQUUsa0JBQWtCLENBQUMsSUFBSSxTQUFTO0FBQUEsSUFDcEQ7QUFFQSxtQkFBUyxZQUFULG1CQUFrQixpQkFBaUIsU0FBUyxNQUFNO0FBQ2hELFlBQU1DLFVBQVMsWUFBWSxhQUFhO0FBQ3hDLGFBQU8sT0FBTyxRQUFRQSxPQUFNO0FBQzVCLDZCQUF1QjtBQUN2QixnQkFBVSxhQUFNLEVBQUUsbUJBQW1CLENBQUMsSUFBSSxTQUFTO0FBQUEsSUFDckQ7QUFFQSxtQkFBUyxhQUFULG1CQUFtQixpQkFBaUIsU0FBUyxNQUFNO0FBQ2pELG1CQUFhO0FBQ2IsYUFBTyxPQUFPLFFBQVEsYUFBYTtBQUNuQyw2QkFBdUI7QUFDdkIsZ0JBQVUsYUFBTSxFQUFFLGtCQUFrQixDQUFDLElBQUksU0FBUztBQUFBLElBQ3BEO0FBRUEsbUJBQVMsZUFBVCxtQkFBcUIsaUJBQWlCLFNBQVMsTUFBTTtBQUVuRCxnQkFBVSxhQUFNLEVBQUUsMEJBQTBCLENBQUMsSUFBSSxRQUFRO0FBQUEsSUFFM0Q7QUFHQSxhQUFTLG1CQUFtQixTQUFTO0FBQ25DLFVBQUksU0FBUyxVQUFVO0FBSXJCLGNBQU0saUJBQWlCLENBQUMsT0FBTyxxQkFBcUIsT0FBTyxXQUFXLFFBQVEsT0FBTyxXQUFXO0FBQ2hHLGlCQUFTLFNBQVMsV0FBVyxXQUFXO0FBR3hDLFlBQUksZ0JBQWdCO0FBQ2xCLG1CQUFTLFNBQVMsY0FBYyxhQUFNLEVBQUUscUJBQXFCLENBQUM7QUFDOUQsbUJBQVMsU0FBUyxRQUFRLEVBQUUsc0JBQXNCO0FBQUEsUUFDcEQsT0FBTztBQUNMLG1CQUFTLFNBQVMsY0FBYyxnQkFBTSxFQUFFLFlBQVksQ0FBQztBQUNyRCxtQkFBUyxTQUFTLFFBQVE7QUFBQSxRQUM1QjtBQUFBLE1BQ0Y7QUFDQSxVQUFJLFNBQVMsUUFBUyxVQUFTLFFBQVEsV0FBVyxDQUFDO0FBQUEsSUFDckQ7QUFHQSxhQUFTLFVBQVUsU0FBUyxPQUFPLFVBQVU7QUFDM0MsVUFBSSxTQUFTLFFBQVE7QUFDbkIsaUJBQVMsT0FBTyxjQUFjO0FBQzlCLGlCQUFTLE9BQU8sWUFBWSxpQkFBaUIsSUFBSTtBQUNqRCxZQUFJLFdBQVcsT0FBTyxFQUFFO0FBQUEsTUFDMUI7QUFBQSxJQUNGO0FBR0EsYUFBUyxZQUFZLFNBQVMsU0FBUyxVQUFVLEdBQUcsU0FBUyxNQUFNO0FBQ2pFLFVBQUksU0FBUyxjQUFjO0FBQ3pCLGlCQUFTLGFBQWEsY0FBYyxXQUFXO0FBQUEsTUFDakQ7QUFDQSxVQUFJLFNBQVMsY0FBYztBQUN6QixpQkFBUyxhQUFhLGNBQWMsT0FBTyxZQUFZLFdBQVcsUUFBUSxRQUFRLENBQUMsSUFBSTtBQUFBLE1BQ3pGO0FBQ0EsVUFBSSxTQUFTLFlBQVk7QUFDdkIsaUJBQVMsV0FBVyxjQUFjLFdBQVc7QUFBQSxNQUMvQztBQUNBLFVBQUksU0FBUyxnQkFBZ0IsUUFBUTtBQUNuQyxpQkFBUyxhQUFhLGNBQWMsT0FBTyxLQUFLLGFBQU0sRUFBRSxvQkFBb0IsQ0FBQyxLQUFLLGFBQU0sRUFBRSxxQkFBcUIsQ0FBQztBQUNoSCxpQkFBUyxhQUFhLFlBQVksaUJBQWlCLE9BQU8sS0FBSyxXQUFXLFNBQVM7QUFBQSxNQUNyRjtBQUFBLElBQ0Y7QUFHQSxhQUFTLGNBQWM7QUFDckIsZ0JBQVUsTUFBTSxZQUFZO0FBQzVCLGlCQUFXLE1BQU07QUFDZixrQkFBVSxNQUFNLFlBQVk7QUFBQSxNQUM5QixHQUFHLEdBQUc7QUFBQSxJQUNSO0FBR0EsMkJBQXVCO0FBR3ZCLGFBQVMsY0FBYztBQXByQnpCLFVBQUFEO0FBc3JCSSxZQUFNLFFBQVEsT0FBTyxjQUFjLGVBQWU7QUFDbEQsVUFBSSxPQUFPO0FBQ1QsY0FBTSxZQUFZLGFBQU0sRUFBRSxZQUFZLENBQUM7QUFBQSxNQUN6QztBQUdBLFVBQUksU0FBUyxTQUFVLFVBQVMsU0FBUyxZQUFZLGdCQUFNLEVBQUUsWUFBWSxDQUFDO0FBQzFFLFVBQUksU0FBUyxRQUFTLFVBQVMsUUFBUSxZQUFZLGdCQUFNLEVBQUUsV0FBVyxDQUFDO0FBQ3ZFLFVBQUksU0FBUyxrQkFBbUIsVUFBUyxrQkFBa0IsWUFBWSxhQUFNLEVBQUUscUJBQXFCLENBQUM7QUFDckcsVUFBSSxTQUFTLFFBQVMsVUFBUyxRQUFRLFlBQVksYUFBTSxFQUFFLGdCQUFnQixDQUFDO0FBRzVFLFlBQU0sZUFBZSxPQUFPLGNBQWMsZ0JBQWdCLEVBQUUsY0FBYyxjQUFjLG9CQUFvQjtBQUM1RyxZQUFNLGVBQWUsT0FBTyxjQUFjLGdCQUFnQixFQUFFLGNBQWMsY0FBYyxvQkFBb0I7QUFDNUcsWUFBTSxhQUFhLE9BQU8sY0FBYyxjQUFjLEVBQUUsY0FBYyxjQUFjLG9CQUFvQjtBQUN4RyxZQUFNLFlBQVksT0FBTyxjQUFjLFdBQVcsRUFBRSxjQUFjLGNBQWMsb0JBQW9CO0FBRXBHLFVBQUksYUFBYyxjQUFhLGNBQWMsRUFBRSxjQUFjO0FBQzdELFVBQUksYUFBYyxjQUFhLGNBQWMsRUFBRSxjQUFjO0FBQzdELFVBQUksV0FBWSxZQUFXLGNBQWMsRUFBRSxjQUFjO0FBQ3pELFVBQUksVUFBVyxXQUFVLGNBQWMsRUFBRSxXQUFXO0FBR3BELFlBQU0sY0FBYyxPQUFPLGNBQWMsdUJBQXVCO0FBQ2hFLFVBQUksWUFBYSxhQUFZLFlBQVksZ0JBQU0sRUFBRSxvQkFBb0IsQ0FBQztBQUV0RSxZQUFNLGdCQUFnQixPQUFPLGVBQWUsaUJBQWlCO0FBQzdELFVBQUksZUFBZTtBQUNqQixjQUFNLFFBQVEsY0FBYyxjQUFjLGlCQUFpQjtBQUMzRCxjQUFNLFlBQVksUUFBUSxNQUFNLGNBQWM7QUFDOUMsc0JBQWMsWUFBWSxhQUFNLEVBQUUsZUFBZSxDQUFDLDhCQUE4QixTQUFTO0FBQUEsTUFDM0Y7QUFNQSxZQUFNLGtCQUFrQixTQUFTO0FBQ2pDLFVBQUksaUJBQWlCO0FBQ25CLGNBQU0sZUFBZSxnQkFBZ0IsY0FBYyx3QkFBd0I7QUFDM0UsY0FBTSxjQUFjLGdCQUFnQixjQUFjLHVCQUF1QjtBQUN6RSxZQUFJLGFBQWMsY0FBYSxjQUFjLEVBQUUsYUFBYTtBQUM1RCxZQUFJLFlBQWEsYUFBWSxjQUFjLEVBQUUsWUFBWTtBQUFBLE1BQzNEO0FBR0EsVUFBSSxTQUFTLG9CQUFvQjtBQUMvQixpQkFBUyxtQkFBbUIsY0FBYyxFQUFFLHFCQUFxQjtBQUFBLE1BQ25FO0FBR0EsVUFBSSxTQUFTLFFBQVMsVUFBUyxRQUFRLFlBQVksYUFBTSxFQUFFLGFBQWEsQ0FBQztBQUN6RSxVQUFJLFNBQVMsUUFBUyxVQUFTLFFBQVEsWUFBWSxhQUFNLEVBQUUsYUFBYSxDQUFDO0FBQ3pFLFVBQUksU0FBUyxTQUFVLFVBQVMsU0FBUyxZQUFZLGFBQU0sRUFBRSxjQUFjLENBQUM7QUFDNUUsVUFBSSxTQUFTLFdBQVksVUFBUyxXQUFXLFlBQVksYUFBTSxFQUFFLGNBQWMsQ0FBQztBQUdoRix3QkFBa0I7QUFHbEIsMkJBQW1CQSxNQUFBLDhCQUFBQSxJQUFXLFlBQVcsS0FBSztBQUc5QyxZQUFNLGVBQWUsU0FBUztBQUM5QixVQUFJLGdCQUFnQixhQUFhLFlBQVksU0FBUyxXQUFJLEdBQUc7QUFDM0QscUJBQWEsY0FBYyxhQUFNLEVBQUUscUJBQXFCLENBQUM7QUFBQSxNQUMzRDtBQUdBLFlBQU0sU0FBUyxTQUFTO0FBQ3hCLFVBQUksVUFBVSxPQUFPLFlBQVksU0FBUyxXQUFJLEdBQUc7QUFDL0MsZUFBTyxjQUFjLGFBQU0sRUFBRSxjQUFjLENBQUM7QUFBQSxNQUM5QztBQUFBLElBQ0Y7QUFHQSxtQkFBZSxtQkFBbUJFLFNBQVFDLFlBQVdDLG9CQUFtQjtBQUN0RSxhQUFPLElBQUksUUFBUSxDQUFDLFlBQVk7QUFDOUIsUUFBQUQsV0FBVSxFQUFFLDBCQUEwQixHQUFHLE1BQU07QUFHL0MsUUFBQUQsUUFBTyxvQkFBb0I7QUFHM0IsY0FBTSxnQkFBZ0IsT0FBTztBQUM3QixlQUFPLFFBQVEsT0FBTyxLQUFLLFlBQVk7QUFDckMsY0FBSUEsUUFBTyxxQkFBcUIsSUFBSSxTQUFTLFlBQVksR0FBRztBQUMxRCxnQkFBSTtBQUNGLG9CQUFNLFdBQVcsTUFBTSxjQUFjLEtBQUssT0FBTztBQUVqRCxrQkFBSSxTQUFTLE1BQU0sV0FBVyxRQUFRLE1BQU07QUFDMUMsc0JBQU0sV0FBVyxLQUFLLE1BQU0sUUFBUSxJQUFJO0FBQ3hDLG9CQUFJLFNBQVMsVUFBVSxTQUFTLE9BQU8sVUFBVSxHQUFHO0FBQ2xELHdCQUFNLFNBQVMsU0FBUyxPQUFPLENBQUM7QUFDaEMsd0JBQU0sU0FBUyxTQUFTLE9BQU8sQ0FBQztBQUdoQyx3QkFBTSxZQUFZLElBQUksTUFBTSwrQkFBK0I7QUFDM0Qsc0JBQUksV0FBVztBQUNiLG9CQUFBQSxRQUFPLFNBQVMsU0FBUyxVQUFVLENBQUMsQ0FBQztBQUNyQyxvQkFBQUEsUUFBTyxTQUFTLFNBQVMsVUFBVSxDQUFDLENBQUM7QUFBQSxrQkFDdkM7QUFHQSxrQkFBQUEsUUFBTyxTQUFTO0FBQ2hCLGtCQUFBQSxRQUFPLFNBQVM7QUFDaEIsa0JBQUFBLFFBQU8sb0JBQW9CO0FBRTNCLGtCQUFBQSxRQUFPLG9CQUFvQjtBQUMzQix5QkFBTyxRQUFRO0FBR2Ysa0JBQUFFLG1CQUFrQjtBQUNsQixvQ0FBa0I7QUFHbEIseUNBQXVCO0FBRXZCLGtCQUFBRCxXQUFVLEVBQUUsa0JBQWtCLEdBQUcsU0FBUztBQUMxQyxzQkFBSSw0Q0FBdUNELFFBQU8sTUFBTSxJQUFJQSxRQUFPLE1BQU0sVUFBVSxNQUFNLElBQUksTUFBTSxXQUFXQSxRQUFPLFdBQVcsS0FBSztBQUdySSw4QkFBWUEsT0FBTTtBQUVsQiwwQkFBUSxJQUFJO0FBQUEsZ0JBQ2Q7QUFBQSxjQUNGO0FBRUEscUJBQU87QUFBQSxZQUNULFNBQVMsT0FBTztBQUNkLGtCQUFJLDhCQUE4QixLQUFLO0FBQ3ZDLHFCQUFPLGNBQWMsS0FBSyxPQUFPO0FBQUEsWUFDbkM7QUFBQSxVQUNGO0FBQ0EsaUJBQU8sY0FBYyxLQUFLLE9BQU87QUFBQSxRQUNuQztBQUdBLG1CQUFXLE1BQU07QUFDZixjQUFJQSxRQUFPLG1CQUFtQjtBQUM1QixtQkFBTyxRQUFRO0FBQ2YsWUFBQUEsUUFBTyxvQkFBb0I7QUFDM0IsWUFBQUMsV0FBVSxFQUFFLHNCQUFzQixHQUFHLE9BQU87QUFDNUMsb0JBQVEsS0FBSztBQUFBLFVBQ2Y7QUFBQSxRQUNGLEdBQUcsSUFBTTtBQUFBLE1BQ1gsQ0FBQztBQUFBLElBQ0g7QUFHQSxXQUFPLGlCQUFpQixtQkFBbUIsV0FBVztBQUd0RCxXQUFPO0FBQUEsTUFDTDtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBLFNBQVMsTUFBTTtBQUNiLGVBQU8sb0JBQW9CLG1CQUFtQixXQUFXO0FBQ3pELGlCQUFTLEtBQUssWUFBWSxVQUFVO0FBQUEsTUFDdEM7QUFBQSxNQUNBLGNBQWM7QUFBQSxNQUNkLFlBQVksTUFBTTtBQUFBLElBQ3BCO0FBQUEsRUFDRjtBQUdBLGlCQUFzQixrQkFBa0IsUUFBUTtBQUM5QyxRQUFJO0FBQ0YsVUFBSSxxREFBMkM7QUFFL0MsVUFBSSxPQUFPLHFCQUFxQixPQUFPLFVBQVUsUUFBUSxPQUFPLFVBQVUsUUFBUSxPQUFPLFNBQVMsT0FBTyxNQUFNLEtBQUssT0FBTyxTQUFTLE9BQU8sTUFBTSxHQUFHO0FBQ2xKLFlBQUksdUVBQTZELE9BQU8sTUFBTSxLQUFLLE9BQU8sTUFBTSxHQUFHO0FBQ25HLG9CQUFZLE1BQU07QUFDbEIsZUFBTyxFQUFFLE9BQU8sT0FBTyxRQUFRLE9BQU8sT0FBTyxRQUFRLFNBQVMsS0FBSztBQUFBLE1BQ3JFO0FBR0EsWUFBTSxZQUFZLElBQUksT0FBTyxnQkFBZ0IsT0FBTyxTQUFTLE1BQU07QUFDbkUsWUFBTSxhQUFhLE9BQU8sU0FBUztBQUduQyxVQUFJLE9BQU87QUFHWCxVQUFJLFVBQVUsSUFBSSxHQUFHLEtBQUssVUFBVSxJQUFJLEdBQUcsR0FBRztBQUM1QyxnQkFBUSxTQUFTLFVBQVUsSUFBSSxHQUFHLENBQUM7QUFDbkMsZ0JBQVEsU0FBUyxVQUFVLElBQUksR0FBRyxDQUFDO0FBQUEsTUFDckM7QUFHQSxVQUFJLENBQUMsU0FBUyxDQUFDLFNBQVMsWUFBWTtBQUNsQyxjQUFNLFlBQVksV0FBVyxNQUFNLGtCQUFrQjtBQUNyRCxZQUFJLFdBQVc7QUFDYixrQkFBUSxTQUFTLFVBQVUsQ0FBQyxDQUFDO0FBQzdCLGtCQUFRLFNBQVMsVUFBVSxDQUFDLENBQUM7QUFBQSxRQUMvQjtBQUFBLE1BQ0Y7QUFHQSxVQUFJLENBQUMsU0FBUyxDQUFDLE9BQU87QUFDcEIsY0FBTSxtQkFBbUIsU0FBUyxpQkFBaUIsNkNBQTZDO0FBQ2hHLG1CQUFXLE1BQU0sa0JBQWtCO0FBQ2pDLGdCQUFNLElBQUksR0FBRyxhQUFhLFFBQVEsS0FBSyxHQUFHLGFBQWEsR0FBRztBQUMxRCxnQkFBTSxJQUFJLEdBQUcsYUFBYSxRQUFRLEtBQUssR0FBRyxhQUFhLEdBQUc7QUFDMUQsY0FBSSxLQUFLLEdBQUc7QUFDVixvQkFBUSxTQUFTLENBQUM7QUFDbEIsb0JBQVEsU0FBUyxDQUFDO0FBQ2xCO0FBQUEsVUFDRjtBQUFBLFFBQ0Y7QUFBQSxNQUNGO0FBR0EsVUFBSSxDQUFDLFNBQVMsQ0FBQyxPQUFPO0FBQ3BCLGNBQU0sY0FBYyxTQUFTLEtBQUssZUFBZTtBQUNqRCxjQUFNLGFBQWEsWUFBWSxNQUFNLHFFQUFxRTtBQUMxRyxZQUFJLFlBQVk7QUFDZCxrQkFBUSxTQUFTLFdBQVcsQ0FBQyxDQUFDO0FBQzlCLGtCQUFRLFNBQVMsV0FBVyxDQUFDLENBQUM7QUFBQSxRQUNoQztBQUFBLE1BQ0Y7QUFHQSxVQUFJLENBQUMsT0FBTyxTQUFTLEtBQUssS0FBSyxDQUFDLE9BQU8sU0FBUyxLQUFLLEdBQUc7QUFDdEQsZ0JBQVE7QUFDUixnQkFBUTtBQUNSLFlBQUksbUZBQXNFO0FBQUEsTUFDNUU7QUFHQSxVQUFJLEtBQUssSUFBSSxLQUFLLElBQUksT0FBVyxLQUFLLElBQUksS0FBSyxJQUFJLEtBQVM7QUFDMUQsWUFBSSxzRkFBeUU7QUFDN0UsZ0JBQVEsS0FBSyxJQUFJLE1BQVUsS0FBSyxJQUFJLEtBQVMsS0FBSyxDQUFDO0FBQ25ELGdCQUFRLEtBQUssSUFBSSxNQUFVLEtBQUssSUFBSSxLQUFTLEtBQUssQ0FBQztBQUFBLE1BQ3JEO0FBR0EsYUFBTyxTQUFTO0FBQ2hCLGFBQU8sU0FBUztBQUVoQixVQUFJLDhDQUFzQyxLQUFLLEtBQUssS0FBSyxHQUFHO0FBRzVELGtCQUFZLE1BQU07QUFFbEIsYUFBTyxFQUFFLE9BQU8sT0FBTyxTQUFTLEtBQUs7QUFBQSxJQUV2QyxTQUFTLE9BQU87QUFDZCxVQUFJLHdDQUFnQyxLQUFLO0FBQ3pDLGFBQU8sRUFBRSxPQUFPLEdBQUcsT0FBTyxHQUFHLFNBQVMsT0FBTyxPQUFPLE1BQU0sUUFBUTtBQUFBLElBQ3BFO0FBQUEsRUFDRjs7O0FDcDdCQSxNQUFJLFNBQVM7QUFFYixpQkFBc0IsZ0JBQWdCO0FBQ3BDLFFBQUksVUFBVSxPQUFPLFVBQVc7QUFFaEMsV0FBTyxJQUFJLFFBQVEsQ0FBQyxTQUFTLFdBQVc7QUFDdEMsWUFBTSxJQUFJLFNBQVMsY0FBYyxRQUFRO0FBQ3pDLFFBQUUsTUFBTTtBQUNSLFFBQUUsUUFBUTtBQUNWLFFBQUUsUUFBUTtBQUNWLFFBQUUsU0FBUyxNQUFNO0FBQ2YsaUJBQVM7QUFDVCxnQkFBUTtBQUFBLE1BQ1Y7QUFDQSxRQUFFLFVBQVUsTUFBTSxPQUFPLElBQUksTUFBTSw2QkFBNkIsQ0FBQztBQUNqRSxlQUFTLEtBQUssWUFBWSxDQUFDO0FBQUEsSUFDN0IsQ0FBQztBQUFBLEVBQ0g7QUFFQSxpQkFBc0IsaUJBQWlCLFNBQVMsU0FBUyxTQUFTO0FBbkJsRTtBQW9CRSxVQUFNLGNBQWM7QUFFcEIsUUFBSSxTQUFPLFlBQU8sY0FBUCxtQkFBa0IsYUFBWSxZQUFZO0FBQ25ELFVBQUk7QUFDRixjQUFNLFFBQVEsTUFBTSxPQUFPLFVBQVUsUUFBUSxTQUFTLEVBQUUsT0FBTyxDQUFDO0FBQ2hFLFlBQUksU0FBUyxNQUFNLFNBQVMsR0FBSSxRQUFPO0FBQUEsTUFDekMsUUFBUTtBQUFBLE1BRVI7QUFBQSxJQUNGO0FBR0EsV0FBTyxNQUFNLElBQUksUUFBUSxDQUFDLFlBQVk7QUFDcEMsWUFBTSxPQUFPLFNBQVMsY0FBYyxLQUFLO0FBQ3pDLFdBQUssTUFBTSxXQUFXO0FBQ3RCLFdBQUssTUFBTSxPQUFPO0FBQ2xCLGVBQVMsS0FBSyxZQUFZLElBQUk7QUFDOUIsYUFBTyxVQUFVLE9BQU8sTUFBTTtBQUFBLFFBQzVCLFNBQVM7QUFBQSxRQUNULFVBQVUsQ0FBQ0UsT0FBTTtBQUNmLG1CQUFTLEtBQUssWUFBWSxJQUFJO0FBQzlCLGtCQUFRQSxFQUFDO0FBQUEsUUFDWDtBQUFBLE1BQ0YsQ0FBQztBQUFBLElBQ0gsQ0FBQztBQUFBLEVBQ0g7QUFHQSxpQkFBc0Isa0JBQWtCLFNBQVM7QUFDL0MsV0FBTyxpQkFBaUIsU0FBUyxPQUFPO0FBQUEsRUFDMUM7OztBQ2hEQSxNQUFNLFVBQVUsQ0FBQyxNQUFNLEtBQUssTUFBTSxLQUFLLE9BQU8sSUFBSSxDQUFDO0FBMEY1QyxXQUFTLHVCQUF1QixPQUFPLEtBQUs7QUFFakQsUUFBSSxDQUFDLElBQUkscUJBQXFCLElBQUksV0FBVyxRQUFRLElBQUksV0FBVyxNQUFNO0FBQ3hFLFVBQUksa0dBQXFGO0FBQ3pGLFlBQU1DLFVBQVMsQ0FBQztBQUNoQixZQUFNLFNBQVMsS0FBSyxNQUFNLElBQUksWUFBWSxJQUFJO0FBQzlDLFlBQU0sV0FBVyxJQUFJLFlBQWEsU0FBUztBQUUzQyxlQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sS0FBSztBQUM5QixjQUFNLFNBQVMsU0FBUyxLQUFLLE1BQU0sS0FBSyxPQUFPLElBQUksUUFBUTtBQUMzRCxjQUFNLFNBQVMsU0FBUyxLQUFLLE1BQU0sS0FBSyxPQUFPLElBQUksUUFBUTtBQUMzRCxRQUFBQSxRQUFPLEtBQUssUUFBUSxNQUFNO0FBQUEsTUFDNUI7QUFDQSxhQUFPQTtBQUFBLElBQ1Q7QUFHQSxVQUFNLFNBQVMsQ0FBQztBQUNoQixVQUFNLFVBQVUsSUFBSSxZQUFZO0FBR2hDLFFBQUksV0FBVyxLQUFLLElBQUksR0FBRyxLQUFLLElBQUksU0FBUyxJQUFJLE1BQU0sQ0FBQztBQUN4RCxRQUFJLFdBQVcsS0FBSyxJQUFJLEdBQUcsS0FBSyxJQUFJLFNBQVMsSUFBSSxNQUFNLENBQUM7QUFHeEQsYUFBUyxJQUFJLEdBQUcsSUFBSSxPQUFPLEtBQUs7QUFFOUIsaUJBQVcsS0FBSyxJQUFJLEdBQUcsS0FBSyxJQUFJLFNBQVMsUUFBUSxDQUFDO0FBQ2xELGlCQUFXLEtBQUssSUFBSSxHQUFHLEtBQUssSUFBSSxTQUFTLFFBQVEsQ0FBQztBQUVsRCxhQUFPLEtBQUssVUFBVSxRQUFRO0FBRzlCO0FBR0EsVUFBSSxXQUFXLFNBQVM7QUFDdEIsbUJBQVcsS0FBSyxJQUFJLEdBQUcsS0FBSyxJQUFJLFNBQVMsSUFBSSxNQUFNLENBQUM7QUFDcEQ7QUFHQSxZQUFJLFdBQVcsU0FBUztBQUN0QixxQkFBVyxLQUFLLElBQUksR0FBRyxLQUFLLElBQUksU0FBUyxJQUFJLE1BQU0sQ0FBQztBQUFBLFFBQ3REO0FBQUEsTUFDRjtBQUFBLElBQ0Y7QUFHQSxRQUFJLE9BQU8sVUFBVSxHQUFHO0FBQ3RCLFVBQUksdUNBQTZCLE9BQU8sTUFBTSxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsQ0FBQyxlQUFlLE9BQU8sU0FBTyxDQUFDLGFBQVU7QUFBQSxJQUN2RztBQUVBLFdBQU87QUFBQSxFQUNUO0FBRU8sV0FBUyx1QkFBdUIsT0FBTyxLQUFLO0FBQ2pELFVBQU0sU0FBUyxDQUFDO0FBQ2hCLGFBQVMsSUFBSSxHQUFHLElBQUksT0FBTyxLQUFLO0FBQzlCLGFBQU8sS0FBSyxVQUFVLEdBQUcsQ0FBQztBQUFBLElBQzVCO0FBQ0EsV0FBTztBQUFBLEVBQ1Q7QUFFTyxXQUFTLFVBQVUsS0FBSztBQUM3QixRQUFJLElBQUksZUFBZSxTQUFTO0FBQzlCLGFBQU8sSUFBSTtBQUFBLElBQ2IsT0FBTztBQUVMLFlBQU0sT0FBTyxJQUFJLFlBQVksSUFBSSxZQUFZO0FBQzdDLGFBQU8sSUFBSSxZQUFZLFFBQVEsSUFBSTtBQUFBLElBQ3JDO0FBQUEsRUFDRjs7O0FDbktPLE1BQU0sUUFBUSxDQUFDLE9BQU8sSUFBSSxRQUFRLE9BQUssV0FBVyxHQUFHLEVBQUUsQ0FBQztBQWMvRCxpQkFBc0IsbUJBQW1CLElBQUksVUFBVSxPQUFPO0FBQzVELFVBQU0sWUFBWSxLQUFLLElBQUk7QUFDM0IsVUFBTSxVQUFVLFlBQVk7QUFFNUIsV0FBTyxLQUFLLElBQUksSUFBSSxZQUFZLENBQUMsU0FBUyxNQUFNLFVBQVU7QUFDeEQsWUFBTSxZQUFZLFVBQVUsS0FBSyxJQUFJO0FBRXJDLFVBQUksVUFBVTtBQUNaLGlCQUFTLFNBQVM7QUFBQSxNQUNwQjtBQUVBLFlBQU0sTUFBTSxLQUFLLElBQUksS0FBTSxTQUFTLENBQUM7QUFBQSxJQUN2QztBQUFBLEVBQ0Y7OztBQ3BCQSxpQkFBc0Isa0JBQWtCLFFBQVEsUUFBUSxPQUFPO0FBQzdELFFBQUk7QUFFRixZQUFNLFdBQVcsU0FBUyxpQkFBaUIsUUFBUTtBQUNuRCxpQkFBVyxVQUFVLFVBQVU7QUFDN0IsY0FBTSxNQUFNLE9BQU8sV0FBVyxJQUFJO0FBQ2xDLFlBQUksS0FBSztBQUVQLGdCQUFNLFdBQVcsT0FBTyxVQUFVLFdBQVcsSUFBSSxNQUFNLFNBQVMsRUFBRSxFQUFFLFNBQVMsR0FBRyxHQUFHLENBQUMsS0FBSztBQUV6RixjQUFJLFlBQVk7QUFDaEIsY0FBSSxTQUFTLFFBQVEsUUFBUSxHQUFHLENBQUM7QUFHakMsY0FBSSxPQUFPLFdBQVcsZUFBZSxPQUFPLE9BQU87QUFDakQsbUJBQU8sY0FBYyxJQUFJLE9BQU8sTUFBTSxlQUFlLENBQUM7QUFBQSxVQUN4RDtBQUFBLFFBQ0Y7QUFBQSxNQUNGO0FBQUEsSUFDRixTQUFTLE9BQU87QUFDZCxVQUFJLDhCQUE4QixLQUFLO0FBQUEsSUFDekM7QUFBQSxFQUNGO0FBR0EsaUJBQXNCLFlBQVksT0FBTyxPQUFPO0FBQzlDLFFBQUk7QUFHRixZQUFNLGVBQWUsZUFBZSxLQUFLLElBQUksS0FBSyxhQUFhLEtBQUssSUFBSSxLQUFLLG1CQUFtQixLQUFLLG1CQUFtQixLQUFLO0FBQzdILFlBQU0sY0FBYyxTQUFTLGNBQWMsWUFBWTtBQUV2RCxVQUFJLGFBQWE7QUFFZixvQkFBWSxVQUFVLElBQUksZUFBZTtBQUN6QyxtQkFBVyxNQUFNO0FBQ2Ysc0JBQVksVUFBVSxPQUFPLGVBQWU7QUFDNUMsc0JBQVksVUFBVSxJQUFJLGNBQWM7QUFDeEMscUJBQVcsTUFBTSxZQUFZLFVBQVUsT0FBTyxjQUFjLEdBQUcsR0FBSTtBQUFBLFFBQ3JFLEdBQUcsR0FBRztBQUNOLFlBQUksU0FBUyxLQUFLLElBQUksS0FBSywyQkFBMkI7QUFBQSxNQUN4RCxPQUFPO0FBRUwsY0FBTSxpQkFBaUIsU0FBUyxpQkFBaUIsUUFBUTtBQUN6RCx1QkFBZSxRQUFRLFlBQVU7QUFDL0IsZ0JBQU0sTUFBTSxPQUFPLFdBQVcsSUFBSTtBQUNsQyxjQUFJLEtBQUs7QUFFUCxrQkFBTSxZQUFZLElBQUksYUFBYSxHQUFHLEdBQUcsR0FBRyxDQUFDO0FBQzdDLGdCQUFJLGFBQWEsV0FBVyxHQUFHLENBQUM7QUFBQSxVQUNsQztBQUFBLFFBQ0YsQ0FBQztBQUNELFlBQUksNERBQXNELEtBQUssSUFBSSxLQUFLLEdBQUc7QUFBQSxNQUM3RTtBQUFBLElBQ0YsU0FBUyxPQUFPO0FBQ2QsVUFBSSw4Q0FBMkMsS0FBSztBQUFBLElBQ3REO0FBQUEsRUFDRjtBQUVBLGlCQUFzQixVQUFVLEtBQUssT0FBTyxXQUFXLGFBQWFDLGFBQVksb0JBQW9CO0FBbEVwRztBQW9FRSxRQUFJLENBQUMsSUFBSSxxQkFBcUIsSUFBSSxXQUFXLFFBQVEsSUFBSSxXQUFXLE1BQU07QUFDeEUsZ0JBQVUsbUVBQTRELE9BQU87QUFDN0UsVUFBSSwrREFBNEQ7QUFDaEUsYUFBTztBQUFBLElBQ1Q7QUFHQSxRQUFJLENBQUMsT0FBTyxTQUFTLElBQUksTUFBTSxLQUFLLENBQUMsT0FBTyxTQUFTLElBQUksTUFBTSxHQUFHO0FBQ2hFLGdCQUFVLGdEQUFzQyxJQUFJLE1BQU0sSUFBSSxJQUFJLE1BQU0sc0JBQXNCLE9BQU87QUFDckcsVUFBSSxzREFBbUQ7QUFDdkQsYUFBTztBQUFBLElBQ1Q7QUFHQSxVQUFNLG1CQUFtQixLQUFLLE1BQU0sTUFBTSxRQUFRLEtBQUs7QUFHdkQsUUFBSSxtQkFBbUIsR0FBRztBQUN4QixnQkFBVSxrREFBMkMsT0FBTztBQUM1RCxhQUFPO0FBQUEsSUFDVDtBQUlBLFVBQU0sb0JBQW9CLEtBQUssSUFBSSxrQkFBa0IsSUFBSSxrQkFBa0IsRUFBRTtBQUM3RSxVQUFNLGFBQWEsS0FBSyxJQUFJLEdBQUcsaUJBQWlCO0FBR2hELFFBQUksYUFBYSxJQUFJLGtCQUFrQjtBQUNyQyxVQUFJLDBEQUF1RCxVQUFVLElBQUksSUFBSSxnQkFBZ0IsS0FBSyxnQkFBZ0Isd0JBQXdCLE1BQU0sUUFBUSxNQUFNLFFBQVEsQ0FBQyxDQUFDLFdBQVc7QUFBQSxJQUNyTDtBQUVBLFVBQU0sU0FBUyx1QkFBdUIsWUFBWSxHQUFHO0FBQ3JELFVBQU0sU0FBUyx1QkFBdUIsWUFBWSxHQUFHO0FBR3JELFVBQU0sY0FBYyxPQUFPLENBQUM7QUFDNUIsVUFBTSxjQUFjLE9BQU8sQ0FBQztBQUU1QixjQUFVLHVCQUFnQixVQUFVLHdCQUFxQixJQUFJLFdBQVcsYUFBYSxJQUFJLE1BQU0sSUFBSSxJQUFJLE1BQU0sVUFBVSxJQUFJLE1BQU0sSUFBSSxJQUFJLE1BQU0sUUFBUSxRQUFRO0FBRS9KLFVBQU1DLEtBQUksTUFBTSxrQkFBa0IsSUFBSSxPQUFPO0FBRTdDLFVBQU0sSUFBSSxNQUFNLG9CQUFvQixJQUFJLFFBQVEsSUFBSSxRQUFRLFFBQVEsUUFBUUEsRUFBQztBQUU3RSxVQUFNLE9BQU87QUFBQSxNQUNYLEdBQUc7QUFBQSxNQUNILEdBQUc7QUFBQSxNQUNILE9BQU8sT0FBTyxDQUFDO0FBQUEsTUFDZjtBQUFBLE1BQ0E7QUFBQSxNQUNBLFFBQVEsRUFBRTtBQUFBLE1BQ1YsTUFBTSxFQUFFO0FBQUEsSUFDVjtBQUVBLFFBQUksRUFBRSxXQUFXLE9BQU8sRUFBRSxTQUFTLEVBQUUsS0FBSyxVQUFVLEtBQUssRUFBRSxLQUFLLFlBQVksY0FBYyxFQUFFLEtBQUssS0FBSztBQUNwRyxZQUFNLGdCQUFnQixFQUFFLEtBQUssV0FBVztBQUN4QyxZQUFNLFdBQVc7QUFDakIsWUFBTSxhQUFhO0FBR25CLGVBQVMsSUFBSSxHQUFHLElBQUksT0FBTyxRQUFRLEtBQUssR0FBRztBQUN6QyxjQUFNLFNBQVMsT0FBTyxDQUFDO0FBQ3ZCLGNBQU0sU0FBUyxPQUFPLElBQUksQ0FBQztBQUMzQixjQUFNLFFBQVEsT0FBTyxLQUFLLE1BQU0sSUFBSSxDQUFDLENBQUM7QUFFdEMsY0FBTSxrQkFBa0IsUUFBUSxRQUFRLEtBQUs7QUFBQSxNQUMvQztBQUdBLFlBQU0sWUFBWSxJQUFJLFFBQVEsSUFBSSxNQUFNO0FBR3hDLFlBQU1ELFlBQVc7QUFFakIsZ0JBQVUsd0JBQW1CLGFBQWEsSUFBSSxVQUFVLHdCQUFxQixJQUFJLE1BQU0sSUFBSSxJQUFJLE1BQU0sV0FBVyxJQUFJLFdBQVcsTUFBTSxTQUFTO0FBQzlJLGtCQUFZO0FBR1osVUFBSSxPQUFPLFdBQVcsZUFBZSxPQUFPLGFBQWE7QUFDdkQsY0FBTSxRQUFRLElBQUksT0FBTyxZQUFZLHdCQUF3QjtBQUFBLFVBQzNELFFBQVE7QUFBQSxZQUNOLFFBQVE7QUFBQSxZQUNSLFFBQVE7QUFBQSxZQUNSLFlBQVk7QUFBQSxZQUNaLGFBQWE7QUFBQSxZQUNiO0FBQUEsWUFDQTtBQUFBLFlBQ0EsT0FBTyxJQUFJO0FBQUEsWUFDWCxPQUFPLElBQUk7QUFBQSxZQUNYLE9BQU8sSUFBSTtBQUFBLFlBQ1gsT0FBTyxJQUFJO0FBQUEsWUFDWCxRQUFRLElBQUk7QUFBQSxZQUNaLFdBQVcsS0FBSyxJQUFJO0FBQUEsVUFDdEI7QUFBQSxRQUNGLENBQUM7QUFDRCxlQUFPLGNBQWMsS0FBSztBQUFBLE1BQzVCO0FBRUEsYUFBTztBQUFBLElBQ1Q7QUFHQSxRQUFJLEVBQUUsV0FBVyxLQUFLO0FBQ3BCLGdCQUFVLHFFQUF3RCxPQUFPO0FBQUEsSUFDM0UsV0FBVyxFQUFFLFdBQVcsS0FBSztBQUMzQixnQkFBVSx5REFBK0MsT0FBTztBQUFBLElBQ2xFLFdBQVcsRUFBRSxXQUFXLEtBQUs7QUFDM0IsZ0JBQVUsZ0RBQXdDLE9BQU87QUFBQSxJQUMzRCxXQUFXLEVBQUUsV0FBVyxLQUFLO0FBQzNCLGdCQUFVLHFGQUE2RSxPQUFPO0FBQUEsSUFDaEcsV0FBVyxFQUFFLFdBQVcsR0FBRztBQUN6QixnQkFBVSx1REFBZ0QsT0FBTztBQUFBLElBQ25FLFdBQVcsRUFBRSxXQUFXLEtBQUs7QUFDM0IsZ0JBQVUsaUVBQXVELE9BQU87QUFBQSxJQUMxRSxXQUFXLEVBQUUsV0FBVyxPQUFPLEVBQUUsV0FBVyxPQUFPLEVBQUUsV0FBVyxLQUFLO0FBQ25FLGdCQUFVLGFBQU0sRUFBRSxNQUFNLGdEQUE2QyxPQUFPO0FBQUEsSUFDOUUsV0FBVyxFQUFFLFdBQVcsS0FBSztBQUMzQixnQkFBVSwwRUFBOEQsSUFBSSxNQUFNLElBQUksSUFBSSxNQUFNLEtBQUssT0FBTztBQUFBLElBQzlHLE9BQU87QUFFTCxVQUFJO0FBQ0YsY0FBTSxTQUFTLE1BQU0sbUJBQW1CO0FBQ3hDLGNBQU0sZ0JBQWUsaUNBQVEsTUFBSyxxQkFBYztBQUNoRCxrQkFBVSxnQkFBVyxFQUFFLE1BQU0sT0FBSyxPQUFFLFNBQUYsbUJBQVEsY0FBVyxPQUFFLFNBQUYsbUJBQVEsVUFBUyxpQkFBaUIsY0FBYyxZQUFZLEtBQUssT0FBTztBQUFBLE1BQy9ILFFBQVE7QUFDTixrQkFBVSxnQkFBVyxFQUFFLE1BQU0sT0FBSyxPQUFFLFNBQUYsbUJBQVEsY0FBVyxPQUFFLFNBQUYsbUJBQVEsVUFBUyxpQkFBaUIsNEJBQXlCLE9BQU87QUFBQSxNQUN6SDtBQUFBLElBQ0Y7QUFHQSxRQUFJLDRCQUE0QixFQUFFLE1BQU0sV0FBVyxFQUFFLE1BQU0sV0FBVyxRQUFRLFdBQVcsTUFBTTtBQUUvRixXQUFPO0FBQUEsRUFDVDtBQUVBLGlCQUFzQixlQUFlLEtBQUssT0FBTyxXQUFXLGFBQWFBLGFBQVksb0JBQW9CO0FBQ3ZHLFVBQU0sY0FBYztBQUNwQixVQUFNLFlBQVk7QUFFbEIsYUFBUyxVQUFVLEdBQUcsV0FBVyxhQUFhLFdBQVc7QUFDdkQsVUFBSTtBQUNGLGNBQU0sVUFBVSxNQUFNLFVBQVUsS0FBSyxPQUFPLFdBQVcsYUFBYUEsYUFBWSxrQkFBa0I7QUFDbEcsWUFBSSxTQUFTO0FBQ1gsZ0JBQU0sYUFBYTtBQUNuQixpQkFBTztBQUFBLFFBQ1Q7QUFFQSxjQUFNLGFBQWE7QUFFbkIsWUFBSSxVQUFVLGFBQWE7QUFDekIsZ0JBQU0sUUFBUSxZQUFZLEtBQUssSUFBSSxHQUFHLFVBQVUsQ0FBQztBQUNqRCxvQkFBVSx1QkFBZ0IsT0FBTyxJQUFJLFdBQVcsT0FBTyxRQUFNLEdBQUksUUFBUSxPQUFPO0FBQ2hGLGdCQUFNLE1BQU0sS0FBSztBQUFBLFFBQ25CO0FBQUEsTUFFRixTQUFTLE9BQU87QUFDZCxZQUFJLG9CQUFvQixPQUFPLEtBQUssS0FBSztBQUN6QyxjQUFNLGFBQWE7QUFFbkIsWUFBSSxVQUFVLGFBQWE7QUFDekIsZ0JBQU0sUUFBUSxZQUFZLEtBQUssSUFBSSxHQUFHLFVBQVUsQ0FBQztBQUNqRCxvQkFBVSw4QkFBdUIsT0FBTyxJQUFJLFdBQVcscUJBQXFCLFFBQU0sR0FBSSxRQUFRLE9BQU87QUFDckcsZ0JBQU0sTUFBTSxLQUFLO0FBQUEsUUFDbkI7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUVBLFVBQU0sYUFBYTtBQUNuQixjQUFVLGlDQUFzQixXQUFXLGtEQUErQyxPQUFPO0FBQ2pHLFdBQU87QUFBQSxFQUNUO0FBRUEsaUJBQXNCLEtBQUssS0FBSyxPQUFPLFdBQVcsYUFBYUEsYUFBWSxvQkFBb0IsYUFBYTtBQUMxRyxRQUFJLHlCQUFrQjtBQUN0QixVQUFNLFVBQVU7QUFFaEIsV0FBTyxNQUFNLFNBQVM7QUFDcEIsVUFBSTtBQUVGLGNBQU0sWUFBWTtBQUdsQixZQUFJLE1BQU0sUUFBUSxRQUFRLElBQUksYUFBYTtBQUN6QyxnQkFBTSxXQUFXLEtBQUssSUFBSSxJQUFJLElBQUksY0FBYyxNQUFNLFFBQVEsU0FBUyxJQUFJLGVBQWU7QUFDMUYsb0JBQVUsNEJBQXVCLE1BQU0sUUFBUSxNQUFNLFFBQVEsQ0FBQyxDQUFDLElBQUksSUFBSSxXQUFXLEtBQUssS0FBSyxNQUFNLFdBQVMsR0FBSSxDQUFDLE1BQU0sUUFBUTtBQUU5SCxnQkFBTSxtQkFBbUIsS0FBSyxJQUFJLFVBQVUsSUFBSSxRQUFRLEdBQUcsQ0FBQyxjQUFjO0FBQ3hFLHNCQUFVLDRCQUF1QixNQUFNLFFBQVEsTUFBTSxRQUFRLENBQUMsQ0FBQyxJQUFJLElBQUksV0FBVyxNQUFNLEtBQUssTUFBTSxZQUFVLEdBQUksQ0FBQyxNQUFNLFFBQVE7QUFBQSxVQUNsSSxHQUFHLEtBQUs7QUFFUjtBQUFBLFFBQ0Y7QUFHQSxjQUFNLFVBQVUsTUFBTSxlQUFlLEtBQUssT0FBTyxXQUFXLGFBQWFBLGFBQVksa0JBQWtCO0FBRXZHLFlBQUksQ0FBQyxTQUFTO0FBRVosb0JBQVUsc0RBQStDLE9BQU87QUFDaEUsZ0JBQU0sbUJBQW1CLElBQUksV0FBVyxHQUFHLENBQUMsY0FBYztBQUN4RCxzQkFBVSxpQ0FBMEIsS0FBSyxNQUFNLFlBQVUsR0FBSSxDQUFDLEtBQUssT0FBTztBQUFBLFVBQzVFLENBQUM7QUFDRDtBQUFBLFFBQ0Y7QUFHQSxZQUFJLE1BQU0sU0FBUztBQUNqQixnQkFBTSxtQkFBbUIsSUFBSSxVQUFVLENBQUMsY0FBYztBQUNwRCxzQkFBVSx1QkFBZ0IsS0FBSyxNQUFNLFlBQVUsR0FBSSxDQUFDLGdDQUFnQyxRQUFRO0FBQUEsVUFDOUYsQ0FBQztBQUFBLFFBQ0g7QUFBQSxNQUVGLFNBQVMsT0FBTztBQUNkLFlBQUksNkJBQTBCLEtBQUs7QUFDbkMsa0JBQVUsK0JBQXFCLE1BQU0sT0FBTyxJQUFJLE9BQU87QUFHdkQsWUFBSSxNQUFNLFNBQVM7QUFDakIsZ0JBQU0sbUJBQW1CLElBQUksV0FBVyxHQUFHLENBQUMsY0FBYztBQUN4RCxzQkFBVSxtREFBc0MsS0FBSyxNQUFNLFlBQVUsR0FBSSxDQUFDLEtBQUssT0FBTztBQUFBLFVBQ3hGLENBQUM7QUFBQSxRQUNIO0FBQUEsTUFDRjtBQUFBLElBQ0Y7QUFFQSxRQUFJLDRCQUFrQjtBQUN0QixjQUFVLDZCQUFtQixRQUFRO0FBQUEsRUFDdkM7OztBQ3JTTyxNQUFNLG9CQUFOLE1BQXdCO0FBQUEsSUFDN0IsY0FBYztBQUNaLFdBQUssU0FBUztBQUNkLFdBQUssZ0JBQWdCLE9BQU87QUFDNUIsV0FBSyxXQUFXO0FBQUEsSUFDbEI7QUFBQTtBQUFBLElBR0EsT0FBTyxVQUFVO0FBQ2YsVUFBSSxLQUFLLFFBQVE7QUFDZixZQUFJLHdDQUEyQjtBQUMvQjtBQUFBLE1BQ0Y7QUFFQSxXQUFLLFNBQVM7QUFDZCxXQUFLLFdBQVc7QUFFaEIsVUFBSSxtRkFBb0U7QUFHeEUsYUFBTyxRQUFRLFVBQVUsU0FBUztBQUNoQyxjQUFNLFNBQVMsTUFBTSxLQUFLLGNBQWMsTUFBTSxRQUFRLElBQUk7QUFFMUQsWUFBSSxLQUFLLFVBQVUsS0FBSyxjQUFjLEtBQUssQ0FBQyxHQUFHLEtBQUssQ0FBQyxDQUFDLEdBQUc7QUFDdkQsZ0JBQU0sS0FBSyxjQUFjLEtBQUssQ0FBQyxHQUFHLEtBQUssQ0FBQyxHQUFHLE9BQU8sTUFBTSxDQUFDO0FBQUEsUUFDM0Q7QUFFQSxlQUFPO0FBQUEsTUFDVDtBQUdBLGlCQUFXLE1BQU07QUFDZixZQUFJLEtBQUssUUFBUTtBQUNmLGVBQUssUUFBUTtBQUNiLGNBQUksd0NBQW1DO0FBQUEsUUFDekM7QUFBQSxNQUNGLEdBQUcsR0FBSztBQUFBLElBQ1Y7QUFBQTtBQUFBLElBR0EsY0FBYyxLQUFLLFNBQVM7QUFDMUIsVUFBSSxDQUFDLE9BQU8sQ0FBQyxRQUFTLFFBQU87QUFHN0IsWUFBTSxTQUFTLElBQUksU0FBUztBQUM1QixVQUFJLENBQUMsT0FBTyxTQUFTLE9BQU8sS0FBSyxDQUFDLE9BQU8sU0FBUyxPQUFPLEtBQUssQ0FBQyxPQUFPLFNBQVMsT0FBTyxHQUFHO0FBQ3ZGLGVBQU87QUFBQSxNQUNUO0FBR0EsVUFBSSxDQUFDLFFBQVEsVUFBVSxRQUFRLE9BQU8sWUFBWSxNQUFNLFFBQVE7QUFDOUQsZUFBTztBQUFBLE1BQ1Q7QUFFQSxhQUFPO0FBQUEsSUFDVDtBQUFBO0FBQUEsSUFHQSxNQUFNLGNBQWMsS0FBSyxTQUFTLFVBQVU7QUFDMUMsVUFBSTtBQUNGLFlBQUksU0FBUztBQUNiLFlBQUksUUFBUSxNQUFNLFFBQVE7QUFHMUIsWUFBSSxRQUFRLE1BQU07QUFDaEIsY0FBSTtBQUVKLGNBQUksT0FBTyxRQUFRLFNBQVMsVUFBVTtBQUNwQyxnQkFBSTtBQUNGLHFCQUFPLEtBQUssTUFBTSxRQUFRLElBQUk7QUFBQSxZQUNoQyxRQUFRO0FBQ04scUJBQU8sUUFBUTtBQUFBLFlBQ2pCO0FBQUEsVUFDRixPQUFPO0FBQ0wsbUJBQU8sUUFBUTtBQUFBLFVBQ2pCO0FBR0EsY0FBSSxLQUFLLFVBQVUsTUFBTSxRQUFRLEtBQUssTUFBTSxHQUFHO0FBQzdDLHFCQUFTLEtBQUs7QUFBQSxVQUNoQixXQUFXLEtBQUssTUFBTSxVQUFhLEtBQUssTUFBTSxRQUFXO0FBQ3ZELHFCQUFTLENBQUMsS0FBSyxHQUFHLEtBQUssQ0FBQztBQUFBLFVBQzFCLFdBQVcsS0FBSyxhQUFhO0FBQzNCLHFCQUFTLEtBQUs7QUFBQSxVQUNoQjtBQUFBLFFBQ0Y7QUFHQSxjQUFNLFNBQVMsSUFBSSxTQUFTO0FBQzVCLGNBQU0sWUFBWSxPQUFPLE1BQU0sK0JBQStCO0FBQzlELFlBQUksV0FBVztBQUNiLGtCQUFRLFNBQVMsVUFBVSxDQUFDLENBQUM7QUFDN0Isa0JBQVEsU0FBUyxVQUFVLENBQUMsQ0FBQztBQUFBLFFBQy9CO0FBR0EsWUFBSSxDQUFDLFFBQVE7QUFDWCxnQkFBTSxnQkFBZ0IsT0FBTyxNQUFNLDJCQUEyQjtBQUM5RCxjQUFJLGVBQWU7QUFDakIsa0JBQU0sV0FBVyxtQkFBbUIsY0FBYyxDQUFDLENBQUM7QUFDcEQsZ0JBQUk7QUFDRix1QkFBUyxLQUFLLE1BQU0sUUFBUTtBQUFBLFlBQzlCLFFBQVE7QUFDTixvQkFBTSxRQUFRLFNBQVMsTUFBTSxHQUFHO0FBQ2hDLGtCQUFJLE1BQU0sVUFBVSxHQUFHO0FBQ3JCLHlCQUFTLENBQUMsU0FBUyxNQUFNLENBQUMsQ0FBQyxHQUFHLFNBQVMsTUFBTSxDQUFDLENBQUMsQ0FBQztBQUFBLGNBQ2xEO0FBQUEsWUFDRjtBQUFBLFVBQ0Y7QUFBQSxRQUNGO0FBR0EsWUFBSSxVQUFVLE9BQU8sVUFBVSxHQUFHO0FBQ2hDLGNBQUksU0FBUyxTQUFTLFFBQVE7QUFFOUIsY0FBSSxPQUFPLFVBQVUsS0FBSyxLQUFLLE9BQU8sVUFBVSxLQUFLLEdBQUc7QUFFdEQscUJBQVMsT0FBTyxDQUFDO0FBQ2pCLHFCQUFTLE9BQU8sQ0FBQztBQUNqQixzQkFBVSxRQUFRLE1BQU87QUFDekIsc0JBQVUsUUFBUSxNQUFPO0FBQ3pCLGdCQUFJLG9EQUE2QyxLQUFLLElBQUksS0FBSyxXQUFXLE1BQU0sSUFBSSxNQUFNLGVBQWUsT0FBTyxJQUFJLE9BQU8sR0FBRztBQUFBLFVBQ2hJLE9BQU87QUFFTCxzQkFBVSxPQUFPLENBQUM7QUFDbEIsc0JBQVUsT0FBTyxDQUFDO0FBQ2xCLG9CQUFRLEtBQUssTUFBTSxVQUFVLEdBQUk7QUFDakMsb0JBQVEsS0FBSyxNQUFNLFVBQVUsR0FBSTtBQUNqQyxxQkFBUyxVQUFVO0FBQ25CLHFCQUFTLFVBQVU7QUFDbkIsZ0JBQUksdURBQWdELE9BQU8sSUFBSSxPQUFPLGFBQWEsS0FBSyxJQUFJLEtBQUssV0FBVyxNQUFNLElBQUksTUFBTSxHQUFHO0FBQUEsVUFDakk7QUFHQSxjQUFJLFNBQVMsSUFBSTtBQUNmLGlCQUFLLFFBQVE7QUFFYixnQkFBSSxLQUFLLFVBQVU7QUFDakIsbUJBQUssU0FBUztBQUFBLGdCQUNaLFNBQVM7QUFBQSxnQkFDVDtBQUFBLGdCQUNBO0FBQUEsZ0JBQ0E7QUFBQSxnQkFDQTtBQUFBLGdCQUNBO0FBQUEsZ0JBQ0E7QUFBQSxjQUNGLENBQUM7QUFBQSxZQUNIO0FBQUEsVUFDRixPQUFPO0FBQ0wsZ0JBQUksaUVBQXVEO0FBQUEsVUFDN0Q7QUFBQSxRQUNGO0FBQUEsTUFFRixTQUFTLE9BQU87QUFDZCxZQUFJLDZCQUE2QixLQUFLO0FBQUEsTUFDeEM7QUFBQSxJQUNGO0FBQUE7QUFBQSxJQUdBLFVBQVU7QUFDUixVQUFJLENBQUMsS0FBSyxPQUFRO0FBRWxCLFdBQUssU0FBUztBQUNkLGFBQU8sUUFBUSxLQUFLO0FBQ3BCLFdBQUssV0FBVztBQUVoQixVQUFJLDhDQUF1QztBQUFBLElBQzdDO0FBQUEsRUFDRjtBQUdPLE1BQU0sb0JBQW9CLElBQUksa0JBQWtCOzs7QUM5SmhELFdBQVMsY0FBYyxRQUFRLE9BQU87QUFFM0MsVUFBTSxtQkFBbUI7QUFBQSxNQUN2QjtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxJQUNGO0FBRUEsZUFBVyxZQUFZLGtCQUFrQjtBQUN2QyxZQUFNLFVBQVUsU0FBUyxjQUFjLFFBQVE7QUFDL0MsVUFBSSxXQUFXLFFBQVEsaUJBQWlCLE1BQU07QUFDNUMsWUFBSSxNQUFPLFNBQVEsSUFBSSxxREFBOEMsUUFBUSxFQUFFO0FBQy9FLGVBQU87QUFBQSxNQUNUO0FBQUEsSUFDRjtBQUdBLFVBQU0sZ0JBQWdCLFNBQVMsaUJBQWlCLCtFQUErRTtBQUMvSCxRQUFJLGdCQUFnQjtBQUNwQixlQUFXLE1BQU0sZUFBZTtBQUM5QixVQUFJLEdBQUcsaUJBQWlCLFFBQVEsR0FBRyxjQUFjLE1BQU0sR0FBRyxlQUFlLElBQUk7QUFDM0U7QUFDQSxZQUFJLGlCQUFpQixHQUFHO0FBQ3RCLGNBQUksTUFBTyxTQUFRLElBQUksNkRBQXNELGFBQWEsRUFBRTtBQUM1RixpQkFBTztBQUFBLFFBQ1Q7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUVBLFFBQUksTUFBTyxTQUFRLElBQUksNkRBQXNELGFBQWEsRUFBRTtBQUM1RixXQUFPO0FBQUEsRUFDVDtBQUdPLFdBQVMsd0JBQXdCLFFBQVEsT0FBTyxjQUFjLE9BQU87QUFFMUUsVUFBTSxpQkFBaUIsU0FBUyxjQUFjLG1FQUFtRTtBQUVqSCxRQUFJLGdCQUFnQjtBQUNsQixZQUFNLGFBQWEsZUFBZSxZQUFZLFlBQVk7QUFDMUQsWUFBTSxlQUFlLFdBQVcsU0FBUyxPQUFPLEtBQUssV0FBVyxTQUFTLFFBQVE7QUFDakYsWUFBTSxlQUFlLGVBQWUsY0FBYyx3QkFBd0IsS0FDdEQsZUFBZSxjQUFjLG9CQUFvQjtBQUVyRSxVQUFJLGdCQUFnQixjQUFjO0FBQ2hDLFlBQUksTUFBTyxTQUFRLElBQUksNkVBQWdFLFVBQVUsR0FBRztBQUNwRyx1QkFBZSxNQUFNO0FBR3JCLFlBQUksYUFBYTtBQUNmLHFCQUFXLE1BQU07QUFDZixnQkFBSSxNQUFPLFNBQVEsSUFBSSxtREFBeUM7QUFDaEUsMkJBQWUsTUFBTTtBQUFBLFVBQ3ZCLEdBQUcsR0FBRztBQUFBLFFBQ1I7QUFDQSxlQUFPO0FBQUEsTUFDVDtBQUFBLElBQ0Y7QUFHQSxVQUFNLFVBQVUsU0FBUyxpQkFBaUIsUUFBUTtBQUNsRCxlQUFXLFVBQVUsU0FBUztBQUM1QixZQUFNLGFBQWEsT0FBTyxZQUFZLFlBQVk7QUFDbEQsV0FBSyxXQUFXLFNBQVMsT0FBTyxLQUFLLFdBQVcsU0FBUyxRQUFRLE1BQzdELE9BQU8saUJBQWlCLFFBQ3hCLENBQUMsT0FBTyxVQUFVO0FBQ3BCLFlBQUksTUFBTyxTQUFRLElBQUksNERBQWtELE9BQU8sWUFBWSxLQUFLLENBQUMsR0FBRztBQUNyRyxlQUFPLE1BQU07QUFHYixZQUFJLGFBQWE7QUFDZixxQkFBVyxNQUFNO0FBQ2YsZ0JBQUksTUFBTyxTQUFRLElBQUksbURBQXlDO0FBQ2hFLG1CQUFPLE1BQU07QUFBQSxVQUNmLEdBQUcsR0FBRztBQUFBLFFBQ1I7QUFDQSxlQUFPO0FBQUEsTUFDVDtBQUFBLElBQ0Y7QUFFQSxRQUFJLE1BQU8sU0FBUSxJQUFJLDhDQUFzQztBQUM3RCxXQUFPO0FBQUEsRUFDVDtBQUdBLGlCQUFzQixxQkFBcUIsY0FBYyxHQUFHLFFBQVEsTUFBTTtBQUN4RSxRQUFJLE1BQU8sU0FBUSxJQUFJLHlFQUE0RCxXQUFXLFlBQVk7QUFFMUcsYUFBUyxVQUFVLEdBQUcsV0FBVyxhQUFhLFdBQVc7QUFDdkQsVUFBSSxNQUFPLFNBQVEsSUFBSSw4QkFBdUIsT0FBTyxJQUFJLFdBQVcsK0JBQTRCO0FBR2hHLFVBQUksY0FBYyxHQUFHO0FBQ25CLFlBQUksTUFBTyxTQUFRLElBQUksa0VBQTBEO0FBQ2pGLGVBQU87QUFBQSxNQUNUO0FBR0EsVUFBSSx3QkFBd0IsT0FBTyxLQUFLLEdBQUc7QUFDekMsWUFBSSxNQUFPLFNBQVEsSUFBSSx3RUFBOEQ7QUFHckYsY0FBTSxJQUFJLFFBQVEsYUFBVyxXQUFXLFNBQVMsSUFBSSxDQUFDO0FBR3RELFlBQUksY0FBYyxHQUFHO0FBQ25CLGNBQUksTUFBTyxTQUFRLElBQUksc0VBQThELE9BQU8sRUFBRTtBQUM5RixpQkFBTztBQUFBLFFBQ1QsT0FBTztBQUNMLGNBQUksTUFBTyxTQUFRLElBQUkscUVBQTJELE9BQU8sbUJBQWdCO0FBQUEsUUFDM0c7QUFBQSxNQUNGLE9BQU87QUFDTCxZQUFJLE1BQU8sU0FBUSxJQUFJLHFFQUE2RCxPQUFPLEVBQUU7QUFBQSxNQUMvRjtBQUdBLFVBQUksVUFBVSxhQUFhO0FBQ3pCLGNBQU0sSUFBSSxRQUFRLGFBQVcsV0FBVyxTQUFTLEdBQUksQ0FBQztBQUFBLE1BQ3hEO0FBQUEsSUFDRjtBQUVBLFFBQUksTUFBTyxTQUFRLElBQUkscURBQTBDLFdBQVcsV0FBVztBQUN2RixXQUFPO0FBQUEsRUFDVDs7O0FDbElBLEdBQUMsaUJBQWlCO0FBQ2hCO0FBWkY7QUFlRSxVQUFNLG1CQUFtQjtBQUd6QixRQUFJO0FBQ0YsVUFBSSw2REFBbUQ7QUFDdkQsWUFBTSxxQkFBcUIsR0FBRyxJQUFJO0FBQUEsSUFDcEMsU0FBUyxPQUFPO0FBQ2QsVUFBSSwrREFBa0QsS0FBSztBQUFBLElBQzdEO0FBR0EsU0FBSSxZQUFPLGdCQUFQLG1CQUFvQixhQUFhO0FBQ25DLFlBQU0sRUFBRSx1QkFBdUIsaUNBQThCLENBQUM7QUFDOUQ7QUFBQSxJQUNGO0FBR0EsU0FBSSxZQUFPLGdCQUFQLG1CQUFvQixjQUFjO0FBQ3BDLFlBQU0sRUFBRSw0QkFBNEIsNkVBQW9FLENBQUM7QUFDekc7QUFBQSxJQUNGO0FBR0EsUUFBSSxDQUFDLE9BQU8sYUFBYTtBQUN2QixhQUFPLGNBQWMsQ0FBQztBQUFBLElBQ3hCO0FBR0EsV0FBTyxZQUFZLGNBQWM7QUFHakMsV0FBTyxpQkFBaUIsbUJBQW1CLE1BQU07QUE5Q25ELFVBQUFFLEtBQUFDO0FBK0NJLFdBQUlBLE9BQUFELE1BQUEsT0FBTyxnQkFBUCxnQkFBQUEsSUFBb0IsT0FBcEIsZ0JBQUFDLElBQXdCLGFBQWE7QUFDdkMsZUFBTyxZQUFZLEdBQUcsWUFBWTtBQUFBLE1BQ3BDO0FBQUEsSUFDRixDQUFDO0FBRUQsUUFBSSwwREFBZ0Q7QUFHcEQsYUFBUyxzQkFBc0JDLE1BQUs7QUFFcEMsWUFBTSxrQkFBa0IsQ0FBQyxDQUFDQSxLQUFJLHFCQUFxQkEsS0FBSSxVQUFVLFFBQVFBLEtBQUksVUFBVTtBQUV2RixZQUFNLG1CQUFtQkEsS0FBSSxXQUFXLGNBQWMsVUFBVUEsS0FBSSxXQUFXLGNBQWM7QUFFN0YsWUFBTSxtQkFBbUIsQ0FBQyxPQUFPLFNBQVNBLEtBQUksTUFBTSxLQUFLLENBQUMsT0FBTyxTQUFTQSxLQUFJLE1BQU07QUFHcEYsWUFBTSxhQUFhLENBQUMsb0JBQW9CLG9CQUFvQjtBQUM1RCxVQUFJLDRDQUFzQyxnQkFBZ0IsY0FBYyxlQUFlLGFBQWEsZ0JBQWdCLGFBQWFBLEtBQUksTUFBTSxJQUFJQSxLQUFJLE1BQU0sR0FBRztBQUU1SixhQUFPO0FBQUEsSUFDUDtBQUdBLGFBQVMsb0JBQW9CO0FBQzNCLFVBQUkscURBQXlDO0FBRTdDLHdCQUFrQixPQUFPLENBQUMsV0FBVztBQUNuQyxZQUFJLE9BQU8sU0FBUztBQUNsQixjQUFJLFNBQVMsT0FBTztBQUNwQixjQUFJLFNBQVMsT0FBTztBQUNwQixzQkFBWSxHQUFHO0FBQ2YsYUFBRyxhQUFhO0FBQ2hCLGFBQUcsVUFBVSwwQ0FBbUMsT0FBTyxLQUFLLElBQUksT0FBTyxLQUFLLEtBQUssU0FBUztBQUMxRixjQUFJLDBEQUFrRCxPQUFPLEtBQUssSUFBSSxPQUFPLEtBQUssR0FBRztBQUFBLFFBQ3ZGLE9BQU87QUFDTCxhQUFHLFVBQVUsVUFBSyxFQUFFLGdCQUFnQixxQ0FBcUMsQ0FBQyxJQUFJLE9BQU87QUFBQSxRQUN2RjtBQUFBLE1BQ0YsQ0FBQztBQUVELFNBQUcsVUFBVSxhQUFNLEVBQUUsMEJBQTBCLENBQUMsSUFBSSxRQUFRO0FBQUEsSUFDOUQ7QUFHQSxRQUFJLE1BQU0sRUFBRSxHQUFHLGVBQWUsR0FBRyxZQUFZLGFBQWEsRUFBRTtBQUc1RCxRQUFJLENBQUMsSUFBSSxTQUFTO0FBQ2hCLFlBQU0saUJBQWlCLFNBQVMsY0FBYyxpQkFBaUI7QUFDL0QsVUFBSSxnQkFBZ0I7QUFDbEIsWUFBSSxVQUFVLGVBQWUsYUFBYSxjQUFjO0FBQ3hELFlBQUksb0RBQTBDLElBQUksUUFBUSxVQUFVLEdBQUcsRUFBRSxDQUFDLEtBQUs7QUFDL0Usb0JBQVksR0FBRztBQUFBLE1BQ2pCLE9BQU87QUFDTCxZQUFJLGlFQUFvRDtBQUFBLE1BQzFEO0FBQUEsSUFDRjtBQUdBLG1CQUFlLGNBQWM7QUFDM0IsVUFBSTtBQUNGLGNBQU0sVUFBVSxNQUFNLFdBQVc7QUFDakMsWUFBSSxRQUFRLFdBQVcsUUFBUSxNQUFNO0FBQ25DLG9CQUFVLFFBQVEsUUFBUSxRQUFRLEtBQUssV0FBVztBQUNsRCxvQkFBVSxRQUFRLE1BQU0sUUFBUSxLQUFLLGNBQWM7QUFDbkQsb0JBQVUsUUFBUSxRQUFRLFFBQVEsS0FBSyxlQUFlO0FBQ3RELG9CQUFVLE9BQU8sUUFBUSxLQUFLO0FBRzlCLGNBQUksa0JBQWtCLFVBQVUsUUFBUTtBQUd4QyxnQkFBTSxTQUFTLE1BQU0sbUJBQW1CO0FBQ3hDLG9CQUFVLFNBQVM7QUFFbkIsYUFBRyxZQUFZLFVBQVUsU0FBUyxVQUFVLFFBQVEsT0FBTyxVQUFVLFlBQVksTUFBTTtBQUN2RixpQkFBTyxRQUFRO0FBQUEsUUFDakI7QUFDQSxlQUFPO0FBQUEsTUFDVCxTQUFTLE9BQU87QUFDZCxZQUFJLHVDQUFvQyxLQUFLO0FBQzdDLGVBQU87QUFBQSxNQUNUO0FBQUEsSUFDRjtBQUdBLG1CQUFlLHFCQUFxQjtBQUNsQyxVQUFJO0FBQ0YsZUFBTyxNQUFNLFlBQVk7QUFBQSxNQUMzQixTQUFTLE9BQU87QUFDZCxZQUFJLDZCQUE2QixLQUFLO0FBQ3RDLGVBQU8sRUFBRSxJQUFJLE9BQU8sT0FBTyxNQUFNLFFBQVE7QUFBQSxNQUMzQztBQUFBLElBQ0Y7QUFHQSxtQkFBZSxtQkFBbUI7QUFDaEMsYUFBTyxNQUFNLGVBQWUsS0FBSyxXQUFXLEdBQUcsV0FBVyxHQUFHLGFBQWEsTUFBTSxXQUFXLEdBQUcsa0JBQWtCO0FBQUEsSUFDbEg7QUFHQSxVQUFNLEtBQUs7QUFBQSxNQUNUO0FBQUE7QUFBQSxNQUVBLFlBQVk7QUFDVixZQUFJLFVBQVUsU0FBUztBQUNyQixhQUFHLFVBQVUsa0RBQWtDLE9BQU87QUFDdEQ7QUFBQSxRQUNGO0FBR0EsWUFBSSxDQUFDLElBQUkscUJBQXFCLElBQUksV0FBVyxRQUFRLElBQUksV0FBVyxNQUFNO0FBQ3hFLGFBQUcsVUFBVSxFQUFFLHlCQUF5QixHQUFHLE1BQU07QUFHakQsZ0JBQU0sZUFBZSxHQUFHLFdBQVcsRUFBRSxXQUFXLGVBQWUscUJBQXFCO0FBQ3BGLGNBQUksY0FBYztBQUNoQix5QkFBYSxNQUFNO0FBQUEsVUFDckI7QUFHQTtBQUFBLFFBQ0Y7QUFHQSxZQUFJLHNCQUFzQixHQUFHLEdBQUc7QUFDOUIsYUFBRyxVQUFVLDhDQUFvQyxRQUFRO0FBQ3pELGdCQUFNLGNBQWMsTUFBTSxrQkFBa0IsR0FBRztBQUMvQyxjQUFJLFlBQVksU0FBUztBQUN2QixlQUFHLFVBQVUsMEJBQXFCLFlBQVksS0FBSyxJQUFJLFlBQVksS0FBSyxLQUFLLFNBQVM7QUFDdEYsZUFBRyxhQUFhO0FBQUEsVUFDbEIsT0FBTztBQUNMLGVBQUcsVUFBVSwwREFBa0QsT0FBTztBQUN0RTtBQUFBLFVBQ0Y7QUFBQSxRQUNGO0FBR0EsV0FBRyxVQUFVLHlDQUFrQyxRQUFRO0FBQ3ZELGNBQU0sU0FBUyxNQUFNLG1CQUFtQjtBQUN4QyxZQUFJLENBQUMsT0FBTyxJQUFJO0FBQ2QsYUFBRyxVQUFVLDZEQUFtRCxPQUFPO0FBQ3ZFO0FBQUEsUUFDRjtBQUdBLFdBQUcsVUFBVSx1REFBMEMsUUFBUTtBQUMvRCxjQUFNLGNBQWMsTUFBTSxZQUFZO0FBQ3RDLFlBQUksQ0FBQyxhQUFhO0FBQ2hCLGFBQUcsVUFBVSx5REFBaUQsT0FBTztBQUNyRTtBQUFBLFFBQ0Y7QUFFQSxXQUFHLFVBQVUsOEJBQXVCLFFBQVE7QUFDNUMsV0FBRyxtQkFBbUIsSUFBSTtBQUcxQixhQUFLLEtBQUssV0FBVyxHQUFHLFdBQVcsR0FBRyxhQUFhLGFBQWEsb0JBQW9CLFdBQVc7QUFBQSxNQUNqRztBQUFBO0FBQUEsTUFHQSxNQUFNO0FBQ0osa0JBQVUsVUFBVTtBQUNwQixZQUFJLE9BQU8sYUFBYTtBQUN0QixpQkFBTyxZQUFZLGNBQWM7QUFBQSxRQUNuQztBQUNBLFdBQUcsVUFBVSxrQ0FBd0IsUUFBUTtBQUM3QyxXQUFHLG1CQUFtQixLQUFLO0FBQUEsTUFDN0I7QUFBQTtBQUFBLE1BR0EsWUFBWTtBQUNWLFdBQUcsVUFBVSx1Q0FBNkIsUUFBUTtBQUNsRCxjQUFNLGNBQWMsTUFBTSxrQkFBa0IsR0FBRztBQUMvQyxZQUFJLFlBQVksU0FBUztBQUN2QixhQUFHLFVBQVUsMEJBQXFCLFlBQVksS0FBSyxJQUFJLFlBQVksS0FBSyxLQUFLLFNBQVM7QUFDdEYsYUFBRyxhQUFhO0FBQUEsUUFDbEIsT0FBTztBQUNMLGFBQUcsVUFBVSxtQ0FBMkIsWUFBWSxTQUFTLGFBQWEsSUFBSSxPQUFPO0FBQUEsUUFDdkY7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUdBLFVBQU0sYUFBYSxHQUFHLFdBQVcsRUFBRSxXQUFXLGVBQWUsYUFBYTtBQUMxRSxRQUFJLFlBQVk7QUFDZCxpQkFBVyxpQkFBaUIsU0FBUyxpQkFBaUI7QUFBQSxJQUN4RDtBQUdBLFVBQU0sVUFBVSxHQUFHLFdBQVcsRUFBRSxXQUFXLGVBQWUsVUFBVTtBQUNwRSxRQUFJLFNBQVM7QUFDWCxjQUFRLGlCQUFpQixTQUFTLFlBQVk7QUFDNUMsWUFBSSxVQUFVLFNBQVM7QUFDckIsYUFBRyxVQUFVLHdDQUEyQixPQUFPO0FBQy9DO0FBQUEsUUFDRjtBQUVBLGNBQU0sWUFBWTtBQUNsQixXQUFHLFVBQVUsaUNBQTBCLFFBQVE7QUFDL0MsY0FBTSxVQUFVLE1BQU0saUJBQWlCO0FBQ3ZDLFlBQUksU0FBUztBQUNYLGFBQUcsVUFBVSx3Q0FBZ0MsU0FBUztBQUFBLFFBQ3hELE9BQU87QUFDTCxhQUFHLFVBQVUsbUNBQTJCLE9BQU87QUFBQSxRQUNqRDtBQUFBLE1BQ0YsQ0FBQztBQUFBLElBQ0g7QUFHQSxVQUFNLFlBQVk7QUFHbEIsV0FBTyxpQkFBaUIsd0JBQXdCLENBQUMsVUFBVTtBQUN6RCxVQUFJLDJCQUFvQixNQUFNLE9BQU8sVUFBVSx1QkFBb0IsTUFBTSxPQUFPLEtBQUssSUFBSSxNQUFNLE9BQU8sS0FBSyxHQUFHO0FBQUEsSUFDaEgsQ0FBQztBQUdELFdBQU8sUUFBUTtBQUFBLE1BQ2IsTUFBTTtBQUFBLE1BQ04sS0FBSyxPQUFPLEVBQUUsR0FBRyxJQUFJO0FBQUEsTUFDckIsU0FBUztBQUFBLE1BQ1QsZUFBZSxNQUFNO0FBRW5CLFlBQUksVUFBVSxNQUFNO0FBRWxCLGNBQUksc0NBQW1DLFVBQVUsS0FBSyxDQUFDLElBQUksVUFBVSxLQUFLLENBQUMsR0FBRztBQUFBLFFBQ2hGO0FBQUEsTUFDRjtBQUFBLE1BQ0EsYUFBYSxPQUFPLEdBQUcsTUFBTTtBQUMzQixZQUFJLDRCQUF5QixDQUFDLElBQUksQ0FBQyxNQUFNO0FBRXpDLGVBQU8sRUFBRSxVQUFVLE1BQU0sR0FBRyxFQUFFO0FBQUEsTUFDaEM7QUFBQSxNQUVBLFVBQVUsT0FBTztBQUFBLFFBQ2YsU0FBUyxVQUFVO0FBQUEsUUFDbkIsTUFBTSxVQUFVO0FBQUEsUUFDaEIsU0FBUyxVQUFVO0FBQUEsUUFDbkIsTUFBTSxVQUFVO0FBQUEsUUFDaEIsU0FBUyxVQUFVO0FBQUEsUUFDbkIsWUFBWSxJQUFJO0FBQUEsUUFDaEIsT0FBTyxJQUFJO0FBQUEsUUFDWCxVQUFVO0FBQUEsVUFDUixPQUFPLElBQUk7QUFBQSxVQUNYLE9BQU8sSUFBSTtBQUFBLFVBQ1gsVUFBVSxJQUFJO0FBQUEsVUFDZCxZQUFZLEtBQUssTUFBTSxJQUFJLFlBQVksSUFBSTtBQUFBLFVBQzNDLFVBQVU7QUFBQSxZQUNSLE1BQU0sS0FBSyxNQUFNLElBQUksWUFBWSxJQUFJO0FBQUEsWUFDckMsTUFBTSxJQUFJLFlBQVksS0FBSyxNQUFNLElBQUksWUFBWSxJQUFJLElBQUk7QUFBQSxZQUN6RCxNQUFNLEtBQUssTUFBTSxJQUFJLFlBQVksSUFBSTtBQUFBLFlBQ3JDLE1BQU0sSUFBSSxZQUFZLEtBQUssTUFBTSxJQUFJLFlBQVksSUFBSSxJQUFJO0FBQUEsVUFDM0Q7QUFBQSxRQUNGO0FBQUEsTUFDRjtBQUFBLE1BRUEsbUJBQW1CLENBQUMsVUFBVTtBQUM1QixZQUFJLG1CQUFtQixNQUFNLE9BQU8sR0FBRyxFQUFFO0FBQ3pDLG9CQUFZLEdBQUc7QUFDZixXQUFHLGFBQWE7QUFDaEIsWUFBSSxzQ0FBbUMsSUFBSSxnQkFBZ0IsRUFBRTtBQUFBLE1BQy9EO0FBQUEsTUFFQSxlQUFlLENBQUMsUUFBUTtBQUN0QixZQUFJLGNBQWMsS0FBSyxJQUFJLEdBQUcsR0FBRztBQUNqQyxvQkFBWSxHQUFHO0FBQ2YsV0FBRyxhQUFhO0FBQ2hCLFlBQUkscUNBQWtDLElBQUksV0FBVyxFQUFFO0FBQUEsTUFDekQ7QUFBQSxNQUVBLFVBQVUsQ0FBQyxZQUFZO0FBQ3JCLFlBQUksV0FBVyxLQUFLLElBQUksS0FBTSxVQUFVLEdBQUk7QUFDNUMsb0JBQVksR0FBRztBQUNmLFdBQUcsYUFBYTtBQUNoQixZQUFJLHdCQUF3QixJQUFJLFFBQVEsSUFBSTtBQUFBLE1BQzlDO0FBQUEsTUFFQSxVQUFVLE1BQU07QUFyVXBCLFlBQUFGO0FBc1VNLGNBQU0sUUFBUSxPQUFPLE1BQU0sU0FBUztBQUNwQyxjQUFNLFlBQVk7QUFBQSxVQUNoQixhQUFhLE9BQU8sU0FBUyxJQUFJLE1BQU0sS0FBSyxPQUFPLFNBQVMsSUFBSSxNQUFNO0FBQUEsVUFDdEUsWUFBWSxVQUFVLFFBQVEsUUFBUTtBQUFBLFVBQ3RDLGtCQUFnQkEsTUFBQSxVQUFVLFdBQVYsZ0JBQUFBLElBQWtCLE9BQU07QUFBQSxVQUN4QyxjQUFjLENBQUMsQ0FBQyxVQUFVO0FBQUEsVUFDMUIsYUFBYSxJQUFJLElBQUksTUFBTSxJQUFJLElBQUksTUFBTTtBQUFBLFVBQ3pDLFVBQVUsTUFBTSxTQUFTO0FBQUEsVUFDekIsaUJBQWlCLENBQUM7QUFBQSxRQUNwQjtBQUVBLFlBQUksQ0FBQyxVQUFVLGFBQWE7QUFDMUIsb0JBQVUsZ0JBQWdCLEtBQUssK0JBQStCO0FBQUEsUUFDaEU7QUFDQSxZQUFJLENBQUMsVUFBVSxZQUFZO0FBQ3pCLG9CQUFVLGdCQUFnQixLQUFLLHVDQUF1QztBQUFBLFFBQ3hFO0FBQ0EsWUFBSSxDQUFDLFVBQVUsZ0JBQWdCO0FBQzdCLG9CQUFVLGdCQUFnQixLQUFLLGtDQUErQjtBQUFBLFFBQ2hFO0FBQ0EsWUFBSSxDQUFDLFVBQVUsY0FBYztBQUMzQixvQkFBVSxnQkFBZ0IsS0FBSyxvQ0FBaUM7QUFBQSxRQUNsRTtBQUVBLGdCQUFRLE1BQU0sU0FBUztBQUN2QixlQUFPO0FBQUEsTUFDVDtBQUFBLE1BRUEsYUFBYTtBQUFBLE1BRWIsYUFBYSxNQUFNO0FBQ2pCLDRCQUFvQjtBQUNwQixjQUFNLEVBQUUsR0FBRyxjQUFjO0FBQ3pCLFdBQUcsYUFBYTtBQUNoQixZQUFJLGtEQUErQztBQUFBLE1BQ3JEO0FBQUEsTUFFQSxjQUFjLE1BQU07QUFDbEIsZUFBTztBQUFBLFVBQ0wsZ0JBQWdCLFVBQVU7QUFBQSxVQUMxQixZQUFZLFVBQVU7QUFBQSxVQUN0QixlQUFlLFVBQVU7QUFBQSxVQUN6QixpQkFBaUIsVUFBVTtBQUFBLFFBQzdCO0FBQUEsTUFDRjtBQUFBLE1BRUEsb0JBQW9CLE1BQU07QUFDeEIsa0JBQVUsYUFBYTtBQUN2QixrQkFBVSxnQkFBZ0I7QUFDMUIsa0JBQVUsa0JBQWtCO0FBQzVCLGtCQUFVLGFBQWE7QUFDdkIsWUFBSSw0QkFBNEI7QUFBQSxNQUNsQztBQUFBLE1BRUEsZUFBZSxDQUFDLGFBQWEsUUFBUTtBQUNuQyxZQUFJLG1CQUFtQixVQUFVLGtCQUFrQjtBQUNuRCxXQUFHLFVBQVUsNkJBQXNCLFVBQVUsSUFBSSxPQUFPO0FBQUEsTUFDMUQ7QUFBQSxJQUNGO0FBR0EsV0FBTyxpQkFBaUIsZ0JBQWdCLE1BQU07QUFDNUMsZ0JBQVUsVUFBVTtBQUNwQixVQUFJLE9BQU8sYUFBYTtBQUN0QixlQUFPLFlBQVksY0FBYztBQUFBLE1BQ25DO0FBQ0Esd0JBQWtCLFFBQVE7QUFDMUIsU0FBRyxRQUFRO0FBQUEsSUFDYixDQUFDO0FBRUQsUUFBSSw0Q0FBdUM7QUFDM0MsUUFBSSxvRUFBNkQ7QUFBQSxFQUVuRSxHQUFHLEVBQUUsTUFBTSxDQUFDLE1BQU07QUFDaEIsWUFBUSxNQUFNLDZCQUE2QixDQUFDO0FBQzVDLFFBQUksT0FBTyxhQUFhO0FBQ3RCLGFBQU8sWUFBWSxjQUFjO0FBQUEsSUFDbkM7QUFDQSxVQUFNLDhDQUE4QztBQUFBLEVBQ3RELENBQUM7IiwKICAibmFtZXMiOiBbIl9hIiwgImxvYWRlZCIsICJjb25maWciLCAic2V0U3RhdHVzIiwgInVwZGF0ZVpvbmVEaXNwbGF5IiwgInQiLCAiY29vcmRzIiwgImdldFNlc3Npb24iLCAidCIsICJfYSIsICJfYiIsICJjZmciXQp9Cg==

--- a/Auto-Guard.js
+++ b/Auto-Guard.js
@@ -1,5 +1,489 @@
-/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-20T07:35:17.871Z */
-(()=>{var s=(...r)=>console.log("[WPA-UI]",...r);var X="https://backend.wplace.live";async function Z(){var r,e,a;try{let o=await fetch(`${X}/me`,{credentials:"include"}).then(c=>c.json()),n=o||null,i=(o==null?void 0:o.charges)||{},l={count:(r=i.count)!=null?r:0,max:(e=i.max)!=null?e:0,cooldownMs:(a=i.cooldownMs)!=null?a:3e4};return{success:!0,data:{user:n,charges:l.count,maxCharges:l.max,chargeRegen:l.cooldownMs}}}catch(o){return{success:!1,error:o.message,data:{user:null,charges:0,maxCharges:0,chargeRegen:3e4}}}}async function j(r,e,a,o,n){try{let i=JSON.stringify({colors:o,coords:a,t:n}),l=await fetch(`${X}/s0/pixel/${r}/${e}`,{method:"POST",credentials:"include",headers:{"Content-Type":"text/plain;charset=UTF-8"},body:i}),c=null;try{c=await l.json()}catch{c={}}return{status:l.status,json:c,success:l.ok,painted:(c==null?void 0:c.painted)||0}}catch(i){return{status:0,json:{error:i.message},success:!1,painted:0}}}var P={SITEKEY:"0x4AAAAAABpqJe8FO0N84q0F",COOLDOWN_DEFAULT:31e3,TILE_SIZE:3e3,CHECK_INTERVAL:1e4,MAX_PROTECTION_SIZE:1/0,PIXELS_PER_BATCH:10,MIN_CHARGES_TO_WAIT:20,BACKEND_URL:"https://backend.wplace.live"},t={running:!1,initialized:!1,protectionArea:null,originalPixels:new Map,changes:new Map,currentCharges:0,maxCharges:50,lastCheck:0,checkInterval:null,availableColors:[],colorsChecked:!1,ui:null,totalRepaired:0,pixelsPerBatch:P.PIXELS_PER_BATCH,minChargesToWait:P.MIN_CHARGES_TO_WAIT};var H=!1;async function Pe(){if(!(H||window.turnstile))return new Promise((r,e)=>{let a=document.createElement("script");a.src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit",a.async=!0,a.defer=!0,a.onload=()=>{H=!0,r()},a.onerror=()=>e(new Error("No se pudo cargar Turnstile")),document.head.appendChild(a)})}async function be(r,e="paint"){var a;if(await Pe(),typeof((a=window.turnstile)==null?void 0:a.execute)=="function")try{let o=await window.turnstile.execute(r,{action:e});if(o&&o.length>20)return o}catch{}return await new Promise(o=>{let n=document.createElement("div");n.style.position="fixed",n.style.left="-9999px",document.body.appendChild(n),window.turnstile.render(n,{sitekey:r,callback:i=>{document.body.removeChild(n),o(i)}})})}async function V(r){return be(r,"paint")}var B=r=>new Promise(e=>setTimeout(e,r));var{Image:Ce,URL:K}=window;async function we(r,e){try{let a=`${P.BACKEND_URL}/files/s0/tiles/${r}/${e}.png`,o=await fetch(a);if(!o.ok)throw new Error(`HTTP ${o.status}`);return await o.blob()}catch(a){return s(`Error obteniendo tile ${r},${e}:`,a),null}}function T(){s("\u{1F3A8} Detectando colores disponibles...");let r=document.querySelectorAll('[id^="color-"]'),e=[];for(let a of r){if(a.querySelector("svg"))continue;let o=parseInt(a.id.replace("color-",""));if(o===0||o===5)continue;let n=a.style.backgroundColor;if(n){let i=n.match(/\d+/g);i&&i.length>=3&&e.push({id:o,r:parseInt(i[0]),g:parseInt(i[1]),b:parseInt(i[2]),element:a})}}return s(`\u2705 ${e.length} colores detectados`),e}function Ie(r,e,a,o){let n=1/0,i=null;for(let l of o){let c=Math.sqrt(Math.pow(r-l.r,2)+Math.pow(e-l.g,2)+Math.pow(a-l.b,2));c<n&&(n=c,i=l)}return i}async function q(r){let{x1:e,y1:a,x2:o,y2:n}=r,i=o-e,l=n-a;s(`\u{1F50D} Analizando \xE1rea ${i}x${l} desde (${e},${a}) hasta (${o},${n})`);let c=new Map,p=Math.floor(e/P.TILE_SIZE),h=Math.floor(a/P.TILE_SIZE),g=Math.floor(o/P.TILE_SIZE),m=Math.floor(n/P.TILE_SIZE);for(let d=h;d<=m;d++)for(let u=p;u<=g;u++)try{let b=await we(u,d);if(!b){s(`\u26A0\uFE0F No se pudo obtener tile ${u},${d}, continuando...`);continue}let y=new Ce,f=document.createElement("canvas"),C=f.getContext("2d");await new Promise((w,I)=>{y.onload=w,y.onerror=I,y.src=K.createObjectURL(b)}),f.width=y.width,f.height=y.height,C.drawImage(y,0,0);let v=C.getImageData(0,0,f.width,f.height).data,O=u*P.TILE_SIZE,D=d*P.TILE_SIZE,ge=O+P.TILE_SIZE,me=D+P.TILE_SIZE,fe=Math.max(e,O),he=Math.max(a,D),xe=Math.min(o,ge),ye=Math.min(n,me);for(let w=he;w<ye;w++)for(let I=fe;I<xe;I++){let E=I-O,A=w-D;if(E>=0&&E<P.TILE_SIZE&&A>=0&&A<P.TILE_SIZE&&E<f.width&&A<f.height){let L=(A*f.width+E)*4,W=v[L],_=v[L+1],G=v[L+2];if(v[L+3]>0){let Y=Ie(W,_,G,t.availableColors);Y&&c.set(`${I},${w}`,{r:W,g:_,b:G,colorId:Y.id,globalX:I,globalY:w,localX:E,localY:A,tileX:u,tileY:d})}}}K.revokeObjectURL(y.src)}catch(b){s(`\u274C Error analizando tile ${u},${d}:`,b)}if(s(`\u2705 An\xE1lisis completado: ${c.size} p\xEDxeles protegidos`),c.size===0){s("\u26A0\uFE0F No se encontraron p\xEDxeles existentes, creando \xE1rea virtual para protecci\xF3n");for(let d=a;d<n;d++)for(let u=e;u<o;u++){let b=Math.floor(u/P.TILE_SIZE),y=Math.floor(d/P.TILE_SIZE),f=u-b*P.TILE_SIZE,C=d-y*P.TILE_SIZE;c.set(`${u},${d}`,{r:255,g:255,b:255,colorId:1,globalX:u,globalY:d,localX:f,localY:C,tileX:b,tileY:y})}s(`\u2705 \xC1rea virtual creada: ${c.size} p\xEDxeles para proteger`)}return c}async function U(){if(!(!t.protectionArea||!t.originalPixels.size))try{let r=await q(t.protectionArea),e=new Map,a=0;for(let[o,n]of t.originalPixels){let i=r.get(o);i?i.colorId!==n.colorId&&(e.set(o,{timestamp:Date.now(),type:"changed",original:n,current:i}),a++):(e.set(o,{timestamp:Date.now(),type:"deleted",original:n,current:null}),a++)}a>0?(s(`\u{1F6A8} Detectados ${a} cambios en el \xE1rea protegida`),t.changes=e,t.ui&&(t.ui.updateStatus(`\u{1F6A8} ${a} cambios detectados`,"warning"),t.ui.updateProgress(e.size,t.originalPixels.size)),t.running&&await ve(e)):(t.lastCheck=Date.now(),t.ui&&t.ui.updateStatus("\u2705 \xC1rea protegida - sin cambios","success"))}catch(r){s("\u274C Error verificando cambios:",r),t.ui&&t.ui.updateStatus(`\u274C Error verificando: ${r.message}`,"error")}}async function ve(r){if(r.size===0)return;let e=Array.from(r.values()),a=Math.floor(t.currentCharges);if(a===0){s("\u26A0\uFE0F Sin cargas disponibles, esperando recarga..."),t.ui&&t.ui.updateStatus("\u26A1 Esperando cargas para reparar...","warning");return}let o=a<t.minChargesToWait,n=o?a:Math.min(e.length,t.pixelsPerBatch);if(s(`\u{1F6E0}\uFE0F Cargas: ${a}, M\xEDnimo: ${t.minChargesToWait}, Reparando: ${n} p\xEDxeles`),t.ui){let g=o?" (gastando todas las cargas)":"";t.ui.updateStatus(`\u{1F6E0}\uFE0F Reparando ${n} p\xEDxeles${g}...`,"info")}let i=e.slice(0,n),l=new Map;for(let g of i){let m=g.original,d=`${m.tileX},${m.tileY}`;l.has(d)||l.set(d,[]),l.get(d).push({localX:m.localX,localY:m.localY,colorId:m.colorId,globalX:m.globalX,globalY:m.globalY})}let c=0;for(let[g,m]of l){let[d,u]=g.split(",").map(Number);try{let b=[],y=[];for(let C of m)b.push(C.localX,C.localY),y.push(C.colorId);let f=await Se(d,u,b,y);if(f.success&&f.painted>0){c+=f.painted,t.currentCharges=Math.max(0,t.currentCharges-f.painted),t.totalRepaired+=f.painted;for(let C=0;C<f.painted&&C<m.length;C++){let $=m[C],v=`${$.globalX},${$.globalY}`;t.changes.delete(v)}s(`\u2705 Reparados ${f.painted} p\xEDxeles en tile (${d},${u})`)}else s(`\u274C Error reparando tile (${d},${u}):`,f.error)}catch(b){s(`\u274C Error reparando tile (${d},${u}):`,b)}l.size>1&&await B(500)}let p=Math.floor(t.currentCharges),h=t.changes.size;s(`\u{1F6E0}\uFE0F Reparaci\xF3n completada: ${c} p\xEDxeles reparados, ${p} cargas restantes`),t.ui&&(h>0&&p<t.minChargesToWait?t.ui.updateStatus(`\u23F3 Esperando ${t.minChargesToWait} cargas para continuar (${p} actuales)`,"warning"):t.ui.updateStatus(`\u2705 Reparados ${c} p\xEDxeles correctamente`,"success"),t.ui.updateStats({charges:p,repaired:t.totalRepaired,pending:h}))}async function Se(r,e,a,o){var n;try{let i=await V(P.SITEKEY),l=await j(r,e,a,o,i);return{success:l.success,painted:l.painted,status:l.status,error:l.success?null:((n=l.json)==null?void 0:n.message)||"Error desconocido"}}catch(i){return{success:!1,painted:0,error:i.message}}}function J(r){let e=document.createElement("div");e.style.cssText=`
+/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-21T06:28:30.591Z */
+(() => {
+  // src/core/logger.js
+  var log = (...a) => console.log("[WPA-UI]", ...a);
+
+  // src/core/wplace-api.js
+  var BASE = "https://backend.wplace.live";
+  async function getSession() {
+    var _a, _b, _c;
+    try {
+      const me = await fetch(`${BASE}/me`, { credentials: "include" }).then((r) => r.json());
+      const user = me || null;
+      const c = (me == null ? void 0 : me.charges) || {};
+      const charges = {
+        count: (_a = c.count) != null ? _a : 0,
+        // Mantener valor decimal original
+        max: (_b = c.max) != null ? _b : 0,
+        // Mantener valor original (puede variar por usuario)
+        cooldownMs: (_c = c.cooldownMs) != null ? _c : 3e4
+      };
+      return {
+        success: true,
+        data: {
+          user,
+          charges: charges.count,
+          maxCharges: charges.max,
+          chargeRegen: charges.cooldownMs
+        }
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message,
+        data: {
+          user: null,
+          charges: 0,
+          maxCharges: 0,
+          chargeRegen: 3e4
+        }
+      };
+    }
+  }
+  async function postPixelBatchImage(tileX, tileY, coords, colors, turnstileToken) {
+    try {
+      const body = JSON.stringify({
+        colors,
+        coords,
+        t: turnstileToken
+      });
+      const response = await fetch(`${BASE}/s0/pixel/${tileX}/${tileY}`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        body
+      });
+      let responseData = null;
+      try {
+        responseData = await response.json();
+      } catch {
+        responseData = {};
+      }
+      return {
+        status: response.status,
+        json: responseData,
+        success: response.ok,
+        painted: (responseData == null ? void 0 : responseData.painted) || 0
+      };
+    } catch (error) {
+      return {
+        status: 0,
+        json: { error: error.message },
+        success: false,
+        painted: 0
+      };
+    }
+  }
+
+  // src/guard/config.js
+  var GUARD_DEFAULTS = {
+    SITEKEY: "0x4AAAAAABpqJe8FO0N84q0F",
+    COOLDOWN_DEFAULT: 31e3,
+    TILE_SIZE: 3e3,
+    CHECK_INTERVAL: 1e4,
+    // Revisar cada 10 segundos
+    MAX_PROTECTION_SIZE: Infinity,
+    // Sin límite de píxeles protegidos
+    PIXELS_PER_BATCH: 10,
+    // Menos que Image para ser más sutil
+    MIN_CHARGES_TO_WAIT: 20,
+    // Cargas mínimas a esperar antes de continuar
+    BACKEND_URL: "https://backend.wplace.live"
+  };
+  var guardState = {
+    running: false,
+    initialized: false,
+    protectionArea: null,
+    // { x1, y1, x2, y2, tileX, tileY }
+    originalPixels: /* @__PURE__ */ new Map(),
+    // Map de "x,y" -> {r, g, b, colorId}
+    changes: /* @__PURE__ */ new Map(),
+    // Map de "x,y" -> {timestamp, originalColor, currentColor}
+    currentCharges: 0,
+    maxCharges: 50,
+    lastCheck: 0,
+    checkInterval: null,
+    availableColors: [],
+    colorsChecked: false,
+    ui: null,
+    totalRepaired: 0,
+    // Configuración editable
+    pixelsPerBatch: GUARD_DEFAULTS.PIXELS_PER_BATCH,
+    minChargesToWait: GUARD_DEFAULTS.MIN_CHARGES_TO_WAIT
+  };
+
+  // src/core/turnstile.js
+  var loaded = false;
+  async function loadTurnstile() {
+    if (loaded || window.turnstile) return;
+    return new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+      s.async = true;
+      s.defer = true;
+      s.onload = () => {
+        loaded = true;
+        resolve();
+      };
+      s.onerror = () => reject(new Error("No se pudo cargar Turnstile"));
+      document.head.appendChild(s);
+    });
+  }
+  async function executeTurnstile(siteKey, action = "paint") {
+    var _a;
+    await loadTurnstile();
+    if (typeof ((_a = window.turnstile) == null ? void 0 : _a.execute) === "function") {
+      try {
+        const token = await window.turnstile.execute(siteKey, { action });
+        if (token && token.length > 20) return token;
+      } catch {
+      }
+    }
+    return await new Promise((resolve) => {
+      const host = document.createElement("div");
+      host.style.position = "fixed";
+      host.style.left = "-9999px";
+      document.body.appendChild(host);
+      window.turnstile.render(host, {
+        sitekey: siteKey,
+        callback: (t2) => {
+          document.body.removeChild(host);
+          resolve(t2);
+        }
+      });
+    });
+  }
+  async function getTurnstileToken(siteKey) {
+    return executeTurnstile(siteKey, "paint");
+  }
+
+  // src/core/timing.js
+  var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  // src/guard/processor.js
+  var { Image, URL } = window;
+  async function getTileImage(tileX, tileY) {
+    try {
+      const url = `${GUARD_DEFAULTS.BACKEND_URL}/files/s0/tiles/${tileX}/${tileY}.png`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return await response.blob();
+    } catch (error) {
+      log(`Error obteniendo tile ${tileX},${tileY}:`, error);
+      return null;
+    }
+  }
+  function detectAvailableColors() {
+    log("\u{1F3A8} Detectando colores disponibles...");
+    const colorElements = document.querySelectorAll('[id^="color-"]');
+    const colors = [];
+    for (const element of colorElements) {
+      if (element.querySelector("svg")) continue;
+      const colorId = parseInt(element.id.replace("color-", ""));
+      if (colorId === 0 || colorId === 5) continue;
+      const bgColor = element.style.backgroundColor;
+      if (bgColor) {
+        const rgbMatch = bgColor.match(/\d+/g);
+        if (rgbMatch && rgbMatch.length >= 3) {
+          colors.push({
+            id: colorId,
+            r: parseInt(rgbMatch[0]),
+            g: parseInt(rgbMatch[1]),
+            b: parseInt(rgbMatch[2]),
+            element
+          });
+        }
+      }
+    }
+    log(`\u2705 ${colors.length} colores detectados`);
+    return colors;
+  }
+  function findClosestColor(r, g, b, availableColors) {
+    let minDistance = Infinity;
+    let closestColor = null;
+    for (const color of availableColors) {
+      const distance = Math.sqrt(
+        Math.pow(r - color.r, 2) + Math.pow(g - color.g, 2) + Math.pow(b - color.b, 2)
+      );
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestColor = color;
+      }
+    }
+    return closestColor;
+  }
+  async function analyzeAreaPixels(area) {
+    const { x1, y1, x2, y2 } = area;
+    const width = x2 - x1;
+    const height = y2 - y1;
+    log(`\u{1F50D} Analizando \xE1rea ${width}x${height} desde (${x1},${y1}) hasta (${x2},${y2})`);
+    const pixelMap = /* @__PURE__ */ new Map();
+    const startTileX = Math.floor(x1 / GUARD_DEFAULTS.TILE_SIZE);
+    const startTileY = Math.floor(y1 / GUARD_DEFAULTS.TILE_SIZE);
+    const endTileX = Math.floor(x2 / GUARD_DEFAULTS.TILE_SIZE);
+    const endTileY = Math.floor(y2 / GUARD_DEFAULTS.TILE_SIZE);
+    for (let tileY = startTileY; tileY <= endTileY; tileY++) {
+      for (let tileX = startTileX; tileX <= endTileX; tileX++) {
+        try {
+          const tileBlob = await getTileImage(tileX, tileY);
+          if (!tileBlob) {
+            log(`\u26A0\uFE0F No se pudo obtener tile ${tileX},${tileY}, continuando...`);
+            continue;
+          }
+          const img = new Image();
+          const canvas = document.createElement("canvas");
+          const ctx = canvas.getContext("2d");
+          await new Promise((resolve, reject) => {
+            img.onload = resolve;
+            img.onerror = reject;
+            img.src = URL.createObjectURL(tileBlob);
+          });
+          canvas.width = img.width;
+          canvas.height = img.height;
+          ctx.drawImage(img, 0, 0);
+          const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+          const data = imageData.data;
+          const tileStartX = tileX * GUARD_DEFAULTS.TILE_SIZE;
+          const tileStartY = tileY * GUARD_DEFAULTS.TILE_SIZE;
+          const tileEndX = tileStartX + GUARD_DEFAULTS.TILE_SIZE;
+          const tileEndY = tileStartY + GUARD_DEFAULTS.TILE_SIZE;
+          const analyzeStartX = Math.max(x1, tileStartX);
+          const analyzeStartY = Math.max(y1, tileStartY);
+          const analyzeEndX = Math.min(x2, tileEndX);
+          const analyzeEndY = Math.min(y2, tileEndY);
+          for (let globalY = analyzeStartY; globalY < analyzeEndY; globalY++) {
+            for (let globalX = analyzeStartX; globalX < analyzeEndX; globalX++) {
+              const localX = globalX - tileStartX;
+              const localY = globalY - tileStartY;
+              if (localX >= 0 && localX < GUARD_DEFAULTS.TILE_SIZE && localY >= 0 && localY < GUARD_DEFAULTS.TILE_SIZE) {
+                if (localX < canvas.width && localY < canvas.height) {
+                  const pixelIndex = (localY * canvas.width + localX) * 4;
+                  const r = data[pixelIndex];
+                  const g = data[pixelIndex + 1];
+                  const b = data[pixelIndex + 2];
+                  const a = data[pixelIndex + 3];
+                  if (a > 0) {
+                    const closestColor = findClosestColor(r, g, b, guardState.availableColors);
+                    if (closestColor) {
+                      pixelMap.set(`${globalX},${globalY}`, {
+                        r,
+                        g,
+                        b,
+                        colorId: closestColor.id,
+                        globalX,
+                        globalY,
+                        localX,
+                        localY,
+                        tileX,
+                        tileY
+                      });
+                    }
+                  }
+                }
+              }
+            }
+          }
+          URL.revokeObjectURL(img.src);
+        } catch (error) {
+          log(`\u274C Error analizando tile ${tileX},${tileY}:`, error);
+        }
+      }
+    }
+    log(`\u2705 An\xE1lisis completado: ${pixelMap.size} p\xEDxeles protegidos`);
+    if (pixelMap.size === 0) {
+      log(`\u26A0\uFE0F No se encontraron p\xEDxeles existentes, creando \xE1rea virtual para protecci\xF3n`);
+      for (let globalY = y1; globalY < y2; globalY++) {
+        for (let globalX = x1; globalX < x2; globalX++) {
+          const tileX = Math.floor(globalX / GUARD_DEFAULTS.TILE_SIZE);
+          const tileY = Math.floor(globalY / GUARD_DEFAULTS.TILE_SIZE);
+          const localX = globalX - tileX * GUARD_DEFAULTS.TILE_SIZE;
+          const localY = globalY - tileY * GUARD_DEFAULTS.TILE_SIZE;
+          pixelMap.set(`${globalX},${globalY}`, {
+            r: 255,
+            g: 255,
+            b: 255,
+            // Blanco por defecto
+            colorId: 1,
+            // ID del color blanco
+            globalX,
+            globalY,
+            localX,
+            localY,
+            tileX,
+            tileY
+          });
+        }
+      }
+      log(`\u2705 \xC1rea virtual creada: ${pixelMap.size} p\xEDxeles para proteger`);
+    }
+    return pixelMap;
+  }
+  async function checkForChanges() {
+    if (!guardState.protectionArea || !guardState.originalPixels.size) {
+      return;
+    }
+    try {
+      const currentPixels = await analyzeAreaPixels(guardState.protectionArea);
+      const changes = /* @__PURE__ */ new Map();
+      let changedCount = 0;
+      for (const [key, originalPixel] of guardState.originalPixels) {
+        const currentPixel = currentPixels.get(key);
+        if (!currentPixel) {
+          changes.set(key, {
+            timestamp: Date.now(),
+            type: "deleted",
+            original: originalPixel,
+            current: null
+          });
+          changedCount++;
+        } else if (currentPixel.colorId !== originalPixel.colorId) {
+          changes.set(key, {
+            timestamp: Date.now(),
+            type: "changed",
+            original: originalPixel,
+            current: currentPixel
+          });
+          changedCount++;
+        }
+      }
+      if (changedCount > 0) {
+        log(`\u{1F6A8} Detectados ${changedCount} cambios en el \xE1rea protegida`);
+        guardState.changes = changes;
+        if (guardState.ui) {
+          guardState.ui.updateStatus(`\u{1F6A8} ${changedCount} cambios detectados`, "warning");
+          guardState.ui.updateProgress(changes.size, guardState.originalPixels.size);
+        }
+        if (guardState.running) {
+          await repairChanges(changes);
+        }
+      } else {
+        guardState.lastCheck = Date.now();
+        if (guardState.ui) {
+          guardState.ui.updateStatus("\u2705 \xC1rea protegida - sin cambios", "success");
+        }
+      }
+    } catch (error) {
+      log(`\u274C Error verificando cambios:`, error);
+      if (guardState.ui) {
+        guardState.ui.updateStatus(`\u274C Error verificando: ${error.message}`, "error");
+      }
+    }
+  }
+  async function repairChanges(changes) {
+    if (changes.size === 0) {
+      return;
+    }
+    const changesArray = Array.from(changes.values());
+    const availableCharges = Math.floor(guardState.currentCharges);
+    if (availableCharges === 0) {
+      log(`\u26A0\uFE0F Sin cargas disponibles, esperando recarga...`);
+      if (guardState.ui) {
+        guardState.ui.updateStatus("\u26A1 Esperando cargas para reparar...", "warning");
+      }
+      return;
+    }
+    const shouldRepairAll = availableCharges < guardState.minChargesToWait;
+    const maxRepairs = shouldRepairAll ? availableCharges : Math.min(changesArray.length, guardState.pixelsPerBatch);
+    log(`\u{1F6E0}\uFE0F Cargas: ${availableCharges}, M\xEDnimo: ${guardState.minChargesToWait}, Reparando: ${maxRepairs} p\xEDxeles`);
+    if (guardState.ui) {
+      const repairMode = shouldRepairAll ? " (gastando todas las cargas)" : "";
+      guardState.ui.updateStatus(`\u{1F6E0}\uFE0F Reparando ${maxRepairs} p\xEDxeles${repairMode}...`, "info");
+    }
+    const pixelsToRepair = changesArray.slice(0, maxRepairs);
+    const changesByTile = /* @__PURE__ */ new Map();
+    for (const change of pixelsToRepair) {
+      const original = change.original;
+      const tileKey = `${original.tileX},${original.tileY}`;
+      if (!changesByTile.has(tileKey)) {
+        changesByTile.set(tileKey, []);
+      }
+      changesByTile.get(tileKey).push({
+        localX: original.localX,
+        localY: original.localY,
+        colorId: original.colorId,
+        globalX: original.globalX,
+        globalY: original.globalY
+      });
+    }
+    let totalRepaired = 0;
+    for (const [tileKey, tileChanges] of changesByTile) {
+      const [tileX, tileY] = tileKey.split(",").map(Number);
+      try {
+        const coords = [];
+        const colors = [];
+        for (const change of tileChanges) {
+          coords.push(change.localX, change.localY);
+          colors.push(change.colorId);
+        }
+        const result = await paintPixelBatch(tileX, tileY, coords, colors);
+        if (result.success && result.painted > 0) {
+          totalRepaired += result.painted;
+          guardState.currentCharges = Math.max(0, guardState.currentCharges - result.painted);
+          guardState.totalRepaired += result.painted;
+          for (let i = 0; i < result.painted && i < tileChanges.length; i++) {
+            const change = tileChanges[i];
+            const key = `${change.globalX},${change.globalY}`;
+            guardState.changes.delete(key);
+          }
+          log(`\u2705 Reparados ${result.painted} p\xEDxeles en tile (${tileX},${tileY})`);
+        } else {
+          log(`\u274C Error reparando tile (${tileX},${tileY}):`, result.error);
+        }
+      } catch (error) {
+        log(`\u274C Error reparando tile (${tileX},${tileY}):`, error);
+      }
+      if (changesByTile.size > 1) {
+        await sleep(500);
+      }
+    }
+    const remainingCharges = Math.floor(guardState.currentCharges);
+    const remainingChanges = guardState.changes.size;
+    log(`\u{1F6E0}\uFE0F Reparaci\xF3n completada: ${totalRepaired} p\xEDxeles reparados, ${remainingCharges} cargas restantes`);
+    if (guardState.ui) {
+      if (remainingChanges > 0 && remainingCharges < guardState.minChargesToWait) {
+        guardState.ui.updateStatus(`\u23F3 Esperando ${guardState.minChargesToWait} cargas para continuar (${remainingCharges} actuales)`, "warning");
+      } else {
+        guardState.ui.updateStatus(`\u2705 Reparados ${totalRepaired} p\xEDxeles correctamente`, "success");
+      }
+      guardState.ui.updateStats({
+        charges: remainingCharges,
+        repaired: guardState.totalRepaired,
+        pending: remainingChanges
+      });
+    }
+  }
+  async function paintPixelBatch(tileX, tileY, coords, colors) {
+    var _a;
+    try {
+      const token = await getTurnstileToken(GUARD_DEFAULTS.SITEKEY);
+      const response = await postPixelBatchImage(
+        tileX,
+        tileY,
+        coords,
+        colors,
+        token
+      );
+      return {
+        success: response.success,
+        painted: response.painted,
+        status: response.status,
+        error: response.success ? null : ((_a = response.json) == null ? void 0 : _a.message) || "Error desconocido"
+      };
+    } catch (error) {
+      return {
+        success: false,
+        painted: 0,
+        error: error.message
+      };
+    }
+  }
+
+  // src/guard/ui.js
+  function createGuardUI(texts) {
+    const container = document.createElement("div");
+    container.style.cssText = `
     position: fixed;
     top: 20px;
     right: 20px;
@@ -11,10 +495,11 @@
     font-family: 'Segoe UI', Roboto, sans-serif;
     z-index: 9999;
     box-shadow: 0 5px 15px rgba(0,0,0,0.5);
-  `,e.innerHTML=`
+  `;
+    container.innerHTML = `
     <div style="padding: 12px 15px; background: #2d3748; color: #60a5fa; font-size: 16px; font-weight: 600; display: flex; justify-content: space-between; align-items: center; cursor: move;" class="guard-header">
       <div style="display: flex; align-items: center; gap: 8px;">
-        \u{1F6E1}\uFE0F <span>${r.title}</span>
+        \u{1F6E1}\uFE0F <span>${texts.title}</span>
       </div>
       <button id="closeBtn" style="background: none; border: none; color: #eee; cursor: pointer; opacity: 0.7; padding: 5px;">\u274C</button>
     </div>
@@ -23,7 +508,7 @@
       <!-- Estado de inicializaci\xF3n -->
       <div id="initSection">
         <button id="initBtn" style="width: 100%; padding: 10px; background: #60a5fa; color: white; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; margin-bottom: 10px;">
-          \u{1F916} ${r.initBot}
+          \u{1F916} ${texts.initBot}
         </button>
       </div>
       
@@ -32,7 +517,7 @@
         <!-- Botones de \xE1rea - en dos columnas -->
         <div style="display: flex; gap: 10px; margin-bottom: 15px;">
           <button id="selectAreaBtn" style="flex: 1; padding: 10px; background: #8b5cf6; color: white; border: none; border-radius: 6px; font-weight: 600; cursor: pointer;">
-            \u{1F3AF} ${r.selectArea}
+            \u{1F3AF} ${texts.selectArea}
           </button>
           <button id="loadAreaBtn" style="flex: 1; padding: 10px; background: #f59e0b; color: white; border: none; border-radius: 6px; font-weight: 600; cursor: pointer;">
             \u{1F4C1} Cargar Archivo
@@ -43,7 +528,7 @@
         <div style="margin-bottom: 15px;">
           <div style="display: flex; gap: 10px; margin-bottom: 8px;">
             <div style="flex: 1;">
-              <label style="display: block; margin-bottom: 5px; font-size: 12px; color: #cbd5e0;">${r.upperLeft}:</label>
+              <label style="display: block; margin-bottom: 5px; font-size: 12px; color: #cbd5e0;">${texts.upperLeft}:</label>
               <div style="display: flex; gap: 5px;">
                 <input id="x1Input" type="number" placeholder="X1" readonly style="flex: 1; padding: 5px; background: #374151; border: 1px solid #4b5563; border-radius: 4px; color: #d1d5db; font-size: 13px;">
                 <input id="y1Input" type="number" placeholder="Y1" readonly style="flex: 1; padding: 5px; background: #374151; border: 1px solid #4b5563; border-radius: 4px; color: #d1d5db; font-size: 13px;">
@@ -53,7 +538,7 @@
           
           <div style="display: flex; gap: 10px; margin-bottom: 15px;">
             <div style="flex: 1;">
-              <label style="display: block; margin-bottom: 5px; font-size: 12px; color: #cbd5e0;">${r.lowerRight}:</label>
+              <label style="display: block; margin-bottom: 5px; font-size: 12px; color: #cbd5e0;">${texts.lowerRight}:</label>
               <div style="display: flex; gap: 5px;">
                 <input id="x2Input" type="number" placeholder="X2" readonly style="flex: 1; padding: 5px; background: #374151; border: 1px solid #4b5563; border-radius: 4px; color: #d1d5db; font-size: 13px;">
                 <input id="y2Input" type="number" placeholder="Y2" readonly style="flex: 1; padding: 5px; background: #374151; border: 1px solid #4b5563; border-radius: 4px; color: #d1d5db; font-size: 13px;">
@@ -63,27 +548,27 @@
         </div>
         
         <button id="startBtn" style="width: 100%; padding: 10px; background: #10b981; color: white; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; margin-bottom: 10px;" disabled>
-          \u25B6\uFE0F ${r.startProtection}
+          \u25B6\uFE0F ${texts.startProtection}
         </button>
         
         <button id="stopBtn" style="width: 100%; padding: 10px; background: #ef4444; color: white; border: none; border-radius: 6px; font-weight: 600; cursor: pointer;" disabled>
-          \u23F9\uFE0F ${r.stopProtection}
+          \u23F9\uFE0F ${texts.stopProtection}
         </button>
       </div>
       
       <!-- Estad\xEDsticas -->
       <div id="statsSection" style="background: #2d3748; padding: 10px; border-radius: 6px; margin-top: 10px;">
         <div style="font-size: 13px; margin-bottom: 5px;">
-          <span>\u{1F4CA} ${r.protectedPixels}: </span><span id="protectedCount">0</span>
+          <span>\u{1F4CA} ${texts.protectedPixels}: </span><span id="protectedCount">0</span>
         </div>
         <div style="font-size: 13px; margin-bottom: 5px;">
-          <span>\u{1F6A8} ${r.detectedChanges}: </span><span id="changesCount">0</span>
+          <span>\u{1F6A8} ${texts.detectedChanges}: </span><span id="changesCount">0</span>
         </div>
         <div style="font-size: 13px; margin-bottom: 5px;">
-          <span>\u26A1 ${r.charges}: </span><span id="chargesCount">0</span>
+          <span>\u26A1 ${texts.charges}: </span><span id="chargesCount">0</span>
         </div>
         <div style="font-size: 13px;">
-          <span>\u{1F6E0}\uFE0F ${r.repairedPixels}: </span><span id="repairedCount">0</span>
+          <span>\u{1F6E0}\uFE0F ${texts.repairedPixels}: </span><span id="repairedCount">0</span>
         </div>
       </div>
       
@@ -112,15 +597,2426 @@
       
       <!-- Estado -->
       <div id="statusBar" style="background: #2d3748; padding: 8px; border-radius: 4px; text-align: center; font-size: 13px; margin-top: 10px;">
-        \u23F3 ${r.waitingInit}
+        \u23F3 ${texts.waitingInit}
       </div>
     </div>
-  `,document.body.appendChild(e);let a=document.createElement("input");a.type="file",a.accept=".json",a.style.display="none",document.body.appendChild(a),Ee(e);let o={initBtn:e.querySelector("#initBtn"),selectAreaBtn:e.querySelector("#selectAreaBtn"),loadAreaBtn:e.querySelector("#loadAreaBtn"),x1Input:e.querySelector("#x1Input"),y1Input:e.querySelector("#y1Input"),x2Input:e.querySelector("#x2Input"),y2Input:e.querySelector("#y2Input"),startBtn:e.querySelector("#startBtn"),stopBtn:e.querySelector("#stopBtn"),closeBtn:e.querySelector("#closeBtn"),initSection:e.querySelector("#initSection"),areaSection:e.querySelector("#areaSection"),protectedCount:e.querySelector("#protectedCount"),changesCount:e.querySelector("#changesCount"),chargesCount:e.querySelector("#chargesCount"),repairedCount:e.querySelector("#repairedCount"),statusBar:e.querySelector("#statusBar"),areaFileInput:a,pixelsPerBatchInput:e.querySelector("#pixelsPerBatchInput"),minChargesInput:e.querySelector("#minChargesInput"),saveBtn:e.querySelector("#saveBtn")};return{elements:o,updateStatus:(i,l="info")=>{o.statusBar.textContent=i;let c={info:"#60a5fa",success:"#10b981",warning:"#f59e0b",error:"#ef4444"};o.statusBar.style.color=c[l]||c.info},updateProgress:(i,l)=>{o.changesCount.textContent=i,o.protectedCount.textContent=l},updateStats:i=>{i.charges!==void 0&&(o.chargesCount.textContent=i.charges),i.repaired!==void 0&&(o.repairedCount.textContent=i.repaired),i.pending!==void 0&&(o.changesCount.textContent=i.pending)},showAreaSection:()=>{o.initSection.style.display="none",o.areaSection.style.display="block"},setInitButtonVisible:i=>{o.initSection.style.display=i?"block":"none"},setInitialized:i=>{o.initBtn.disabled=i,i&&(o.initBtn.style.opacity="0.5",o.initBtn.style.cursor="not-allowed")},enableStartBtn:()=>{o.startBtn.disabled=!1},setRunningState:i=>{o.startBtn.disabled=i,o.stopBtn.disabled=!i,o.selectAreaBtn.disabled=i},updateCoordinates:i=>{i.x1!==void 0&&(o.x1Input.value=i.x1),i.y1!==void 0&&(o.y1Input.value=i.y1),i.x2!==void 0&&(o.x2Input.value=i.x2),i.y2!==void 0&&(o.y2Input.value=i.y2)},destroy:()=>{e.remove(),a.remove()}}}function Q(r,e,a={}){return new Promise(o=>{let n=document.createElement("div");n.className="modal-overlay",n.style.position="fixed",n.style.top="0",n.style.left="0",n.style.width="100%",n.style.height="100%",n.style.background="rgba(0,0,0,0.7)",n.style.zIndex="10001",n.style.display="flex",n.style.alignItems="center",n.style.justifyContent="center";let i=document.createElement("div");i.style.background="#1a1a1a",i.style.border="2px solid #333",i.style.borderRadius="15px",i.style.padding="25px",i.style.color="#eee",i.style.minWidth="350px",i.style.maxWidth="400px",i.style.boxShadow="0 10px 30px rgba(0,0,0,0.5)",i.style.fontFamily="'Segoe UI', Roboto, sans-serif",i.innerHTML=`
-      <h3 style="margin: 0 0 15px 0; text-align: center; font-size: 18px;">${e}</h3>
-      <p style="margin: 0 0 20px 0; text-align: center; line-height: 1.4;">${r}</p>
+  `;
+    document.body.appendChild(container);
+    const areaFileInput = document.createElement("input");
+    areaFileInput.type = "file";
+    areaFileInput.accept = ".json";
+    areaFileInput.style.display = "none";
+    document.body.appendChild(areaFileInput);
+    makeDraggable(container);
+    const elements = {
+      initBtn: container.querySelector("#initBtn"),
+      selectAreaBtn: container.querySelector("#selectAreaBtn"),
+      loadAreaBtn: container.querySelector("#loadAreaBtn"),
+      x1Input: container.querySelector("#x1Input"),
+      y1Input: container.querySelector("#y1Input"),
+      x2Input: container.querySelector("#x2Input"),
+      y2Input: container.querySelector("#y2Input"),
+      startBtn: container.querySelector("#startBtn"),
+      stopBtn: container.querySelector("#stopBtn"),
+      closeBtn: container.querySelector("#closeBtn"),
+      initSection: container.querySelector("#initSection"),
+      areaSection: container.querySelector("#areaSection"),
+      protectedCount: container.querySelector("#protectedCount"),
+      changesCount: container.querySelector("#changesCount"),
+      chargesCount: container.querySelector("#chargesCount"),
+      repairedCount: container.querySelector("#repairedCount"),
+      statusBar: container.querySelector("#statusBar"),
+      areaFileInput,
+      pixelsPerBatchInput: container.querySelector("#pixelsPerBatchInput"),
+      minChargesInput: container.querySelector("#minChargesInput"),
+      saveBtn: container.querySelector("#saveBtn")
+    };
+    const ui = {
+      elements,
+      updateStatus: (message, type = "info") => {
+        elements.statusBar.textContent = message;
+        const colors = {
+          info: "#60a5fa",
+          success: "#10b981",
+          warning: "#f59e0b",
+          error: "#ef4444"
+        };
+        elements.statusBar.style.color = colors[type] || colors.info;
+      },
+      updateProgress: (current, total) => {
+        elements.changesCount.textContent = current;
+        elements.protectedCount.textContent = total;
+      },
+      updateStats: (stats) => {
+        if (stats.charges !== void 0) elements.chargesCount.textContent = stats.charges;
+        if (stats.repaired !== void 0) elements.repairedCount.textContent = stats.repaired;
+        if (stats.pending !== void 0) elements.changesCount.textContent = stats.pending;
+      },
+      showAreaSection: () => {
+        elements.initSection.style.display = "none";
+        elements.areaSection.style.display = "block";
+      },
+      setInitButtonVisible: (visible) => {
+        elements.initSection.style.display = visible ? "block" : "none";
+      },
+      setInitialized: (initialized) => {
+        elements.initBtn.disabled = initialized;
+        if (initialized) {
+          elements.initBtn.style.opacity = "0.5";
+          elements.initBtn.style.cursor = "not-allowed";
+        }
+      },
+      enableStartBtn: () => {
+        elements.startBtn.disabled = false;
+      },
+      setRunningState: (running) => {
+        elements.startBtn.disabled = running;
+        elements.stopBtn.disabled = !running;
+        elements.selectAreaBtn.disabled = running;
+      },
+      updateCoordinates: (coords) => {
+        if (coords.x1 !== void 0) elements.x1Input.value = coords.x1;
+        if (coords.y1 !== void 0) elements.y1Input.value = coords.y1;
+        if (coords.x2 !== void 0) elements.x2Input.value = coords.x2;
+        if (coords.y2 !== void 0) elements.y2Input.value = coords.y2;
+      },
+      destroy: () => {
+        container.remove();
+        areaFileInput.remove();
+      }
+    };
+    return ui;
+  }
+  function showConfirmDialog(message, title, buttons = {}) {
+    return new Promise((resolve) => {
+      const overlay = document.createElement("div");
+      overlay.className = "modal-overlay";
+      overlay.style.position = "fixed";
+      overlay.style.top = "0";
+      overlay.style.left = "0";
+      overlay.style.width = "100%";
+      overlay.style.height = "100%";
+      overlay.style.background = "rgba(0,0,0,0.7)";
+      overlay.style.zIndex = "10001";
+      overlay.style.display = "flex";
+      overlay.style.alignItems = "center";
+      overlay.style.justifyContent = "center";
+      const modal = document.createElement("div");
+      modal.style.background = "#1a1a1a";
+      modal.style.border = "2px solid #333";
+      modal.style.borderRadius = "15px";
+      modal.style.padding = "25px";
+      modal.style.color = "#eee";
+      modal.style.minWidth = "350px";
+      modal.style.maxWidth = "400px";
+      modal.style.boxShadow = "0 10px 30px rgba(0,0,0,0.5)";
+      modal.style.fontFamily = "'Segoe UI', Roboto, sans-serif";
+      modal.innerHTML = `
+      <h3 style="margin: 0 0 15px 0; text-align: center; font-size: 18px;">${title}</h3>
+      <p style="margin: 0 0 20px 0; text-align: center; line-height: 1.4;">${message}</p>
       <div style="display: flex; gap: 10px; justify-content: center;">
-        ${a.save?`<button class="save-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #10b981; color: white;">${a.save}</button>`:""}
-        ${a.discard?`<button class="discard-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #ef4444; color: white;">${a.discard}</button>`:""}
-        ${a.cancel?`<button class="cancel-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #2d3748; color: white;">${a.cancel}</button>`:""}
+        ${buttons.save ? `<button class="save-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #10b981; color: white;">${buttons.save}</button>` : ""}
+        ${buttons.discard ? `<button class="discard-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #ef4444; color: white;">${buttons.discard}</button>` : ""}
+        ${buttons.cancel ? `<button class="cancel-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #2d3748; color: white;">${buttons.cancel}</button>` : ""}
       </div>
-    `,n.appendChild(i),document.body.appendChild(n);let l=i.querySelector(".save-btn"),c=i.querySelector(".discard-btn"),p=i.querySelector(".cancel-btn"),h=()=>{document.body.removeChild(n)};l&&l.addEventListener("click",()=>{h(),o("save")}),c&&c.addEventListener("click",()=>{h(),o("discard")}),p&&p.addEventListener("click",()=>{h(),o("cancel")}),n.addEventListener("click",g=>{g.target===n&&(h(),o("cancel"))})})}function Ee(r){let e=!1,a,o,n,i;r.querySelector(".guard-header").addEventListener("mousedown",c=>{c.target.id!=="closeBtn"&&(e=!0,a=c.clientX,o=c.clientY,n=parseInt(window.getComputedStyle(r).left,10),i=parseInt(window.getComputedStyle(r).top,10),r.style.cursor="grabbing")}),document.addEventListener("mousemove",c=>{if(!e)return;let p=c.clientX-a,h=c.clientY-o;r.style.left=`${n+p}px`,r.style.top=`${i+h}px`,r.style.right="auto"}),document.addEventListener("mouseup",()=>{e&&(e=!1,r.style.cursor="default")})}function Ae(r,e){let{x1:a,y1:o,x2:n,y2:i}=r,l=n-a,c=i-o,p=[];if(e<=1)return[r];if(l>=c){let g=Math.floor(l/e);for(let m=0;m<e;m++){let d=a+m*g,u=m===e-1?n:d+g;p.push({x1:d,y1:o,x2:u,y2:i})}}else{let g=Math.floor(c/e);for(let m=0;m<e;m++){let d=o+m*g,u=m===e-1?i:d+g;p.push({x1:a,y1:d,x2:n,y2:u})}}return p}function Be(r,e){let a=[],{x1:o,y1:n,x2:i,y2:l}=r;for(let[c,p]of e.entries()){let[h,g]=c.split(",").map(Number);h>=o&&h<=i&&g>=n&&g<=l&&a.push({key:c,...p})}return a}function ee(r=null,e=null){try{if(!t.protectionArea||!t.originalPixels.size)throw new Error("No hay progreso para guardar");let a=e&&e>1?Ae(t.protectionArea,e):[t.protectionArea],o=[];for(let n=0;n<a.length;n++){let i=a[n],l=Be(i,t.originalPixels),c={version:"1.0",timestamp:Date.now(),protectionData:{area:{...i},protectedPixels:l.length,splitInfo:e>1?{total:e,current:n+1,originalArea:{...t.protectionArea}}:null},progress:{totalRepaired:t.totalRepaired,lastCheck:t.lastCheck},config:{maxProtectionSize:1e5,pixelsPerBatch:10,checkInterval:1e4},colors:t.availableColors.map(b=>({id:b.id,r:b.r,g:b.g,b:b.b})),originalPixels:l},p=JSON.stringify(c,null,2),h=new window.Blob([p],{type:"application/json"}),g=e>1?`_parte${n+1}de${e}`:"",m=r||`wplace_GUARD_${new Date().toISOString().slice(0,19).replace(/:/g,"-")}${g}.json`,d=window.URL.createObjectURL(h),u=document.createElement("a");u.href=d,u.download=m,document.body.appendChild(u),u.click(),document.body.removeChild(u),window.URL.revokeObjectURL(d),o.push({success:!0,filename:m}),s(`\u2705 Progreso guardado: ${m}`)}return{success:!0,filename:o.length===1?o[0].filename:`${o.length} archivos`,files:o}}catch(a){return s("\u274C Error guardando progreso:",a),{success:!1,error:a.message}}}async function te(r){return new Promise(e=>{try{let a=new window.FileReader;a.onload=async o=>{try{let n=JSON.parse(o.target.result),l=["protectionData","originalPixels","colors"].filter(c=>!(c in n));if(l.length>0)throw new Error(`Campos requeridos faltantes: ${l.join(", ")}`);if(t.availableColors.length>0){let c=n.colors.map(g=>g.id),p=t.availableColors.map(g=>g.id);c.filter(g=>p.includes(g)).length<c.length*.8&&s("\u26A0\uFE0F Los colores guardados no coinciden completamente con los actuales")}n.protectionData?t.protectionArea=n.protectionData.area:n.protectionArea&&(t.protectionArea=n.protectionArea),t.originalPixels=new Map;for(let c of n.originalPixels){let{key:p,...h}=c;t.originalPixels.set(p,h)}n.progress?(t.totalRepaired=n.progress.totalRepaired||0,t.lastCheck=n.progress.lastCheck||0):n.statistics&&(t.totalRepaired=n.statistics.totalRepaired||0,t.lastCheck=n.statistics.lastCheck||0),t.changes.clear(),t.ui&&(t.ui.updateCoordinates({x1:t.protectionArea.x1,y1:t.protectionArea.y1,x2:t.protectionArea.x2,y2:t.protectionArea.y2}),t.ui.updateProgress(0,t.originalPixels.size),t.ui.updateStats({repaired:t.totalRepaired}),t.ui.enableStartBtn()),s(`\u2705 Progreso cargado: ${t.originalPixels.size} p\xEDxeles protegidos`),e({success:!0,data:n,protectedPixels:t.originalPixels.size,area:t.protectionArea})}catch(n){s("\u274C Error parseando archivo de progreso:",n),e({success:!1,error:n.message})}},a.onerror=()=>{let o="Error leyendo archivo";s("\u274C",o),e({success:!1,error:o})},a.readAsText(r)}catch(a){s("\u274C Error cargando progreso:",a),e({success:!1,error:a.message})}})}function re(){return t.protectionArea&&t.originalPixels.size>0}var ae={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selecci\xF3n",user:"Usuario",charges:"Cargas",backend:"Backend",database:"Database",uptime:"Uptime",close:"Cerrar",launch:"Lanzar",loading:"Cargando\u2026",executing:"Ejecutando\u2026",downloading:"Descargando script\u2026",chooseBot:"Elige un bot y presiona Lanzar",readyToLaunch:"Listo para lanzar",loadError:"Error al cargar",loadErrorMsg:"No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",checking:"\u{1F504} Verificando...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Iniciar Auto-BOT",uploadImage:"Subir Imagen",resizeImage:"Redimensionar Imagen",selectPosition:"Seleccionar Posici\xF3n",startPainting:"Iniciar Pintura",stopPainting:"Detener Pintura",saveProgress:"Guardar Progreso",loadProgress:"Cargar Progreso",checkingColors:"\u{1F50D} Verificando colores disponibles...",noColorsFound:"\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",colorsFound:"\u2705 {count} colores disponibles encontrados",loadingImage:"\u{1F5BC}\uFE0F Cargando imagen...",imageLoaded:"\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",imageError:"\u274C Error al cargar la imagen",selectPositionAlert:"\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Posici\xF3n establecida con \xE9xito!",positionTimeout:"\u274C Tiempo agotado para seleccionar posici\xF3n",positionDetected:"\u{1F3AF} Posici\xF3n detectada, procesando...",positionError:"\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",startPaintingMsg:"\u{1F3A8} Iniciando pintura...",paintingProgress:"\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",noCharges:"\u231B Sin cargas. Esperando {time}...",paintingStopped:"\u23F9\uFE0F Pintura detenida por el usuario",paintingComplete:"\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",paintingError:"\u274C Error durante la pintura",missingRequirements:"\u274C Carga una imagen y selecciona una posici\xF3n primero",progress:"Progreso",userName:"Usuario",pixels:"P\xEDxeles",charges:"Cargas",estimatedTime:"Tiempo estimado",initMessage:"Haz clic en 'Iniciar Auto-BOT' para comenzar",waitingInit:"Esperando inicializaci\xF3n...",resizeSuccess:"\u2705 Imagen redimensionada a {width}x{height}",paintingPaused:"\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",pixelsPerBatch:"P\xEDxeles por lote",batchSize:"Tama\xF1o del lote",nextBatchTime:"Siguiente lote en",useAllCharges:"Usar todas las cargas disponibles",showOverlay:"Mostrar overlay",maxCharges:"Cargas m\xE1ximas por lote",waitingForCharges:"\u23F3 Esperando cargas: {current}/{needed}",timeRemaining:"Tiempo restante",cooldownWaiting:"\u23F3 Esperando {time} para continuar...",progressSaved:"\u2705 Progreso guardado como {filename}",progressLoaded:"\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",progressLoadError:"\u274C Error al cargar progreso: {error}",progressSaveError:"\u274C Error al guardar progreso: {error}",confirmSaveProgress:"\xBFDeseas guardar el progreso actual antes de detener?",saveProgressTitle:"Guardar Progreso",discardProgress:"Descartar",cancel:"Cancelar",minimize:"Minimizar",width:"Ancho",height:"Alto",keepAspect:"Mantener proporci\xF3n",apply:"Aplicar",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",waitingChargesCountdown:"\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Bot iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",manualInitRequired:"\u{1F527} Inicio manual requerido",retryAttempt:"\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",retryError:"\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",retryFailed:"\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",networkError:"\u{1F310} Error de red. Reintentando...",serverError:"\u{1F525} Error del servidor. Reintentando...",timeoutError:"\u23F0 Timeout del servidor. Reintentando..."},farm:{title:"WPlace Farm Bot",start:"Iniciar",stop:"Detener",stopped:"Bot detenido",calibrate:"Calibrar",paintOnce:"Una vez",checkingStatus:"Verificando estado...",configuration:"Configuraci\xF3n",delay:"Delay (ms)",pixelsPerBatch:"P\xEDxeles/lote",minCharges:"Cargas m\xEDn",colorMode:"Modo color",random:"Aleatorio",fixed:"Fijo",range:"Rango",fixedColor:"Color fijo",advanced:"Avanzado",tileX:"Tile X",tileY:"Tile Y",customPalette:"Paleta personalizada",paletteExample:"ej: #FF0000,#00FF00,#0000FF",capture:"Capturar",painted:"Pintados",charges:"Cargas",retries:"Fallos",tile:"Tile",configSaved:"Configuraci\xF3n guardada",configLoaded:"Configuraci\xF3n cargada",configReset:"Configuraci\xF3n reiniciada",captureInstructions:"Pinta un p\xEDxel manualmente para capturar coordenadas...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Iniciando bot...",stoppingBot:"Deteniendo bot...",calibrating:"Calibrando...",alreadyRunning:"Auto-Farm ya est\xE1 corriendo.",imageRunningWarning:"Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",selectPosition:"Seleccionar Zona",selectPositionAlert:"\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Zona establecida! Radio: 500px",positionTimeout:"\u274C Tiempo agotado para seleccionar zona",missingPosition:"\u274C Selecciona una zona primero usando 'Seleccionar Zona'",farmRadius:"Radio farm",positionInfo:"Zona actual",farmingInRadius:"\u{1F33E} Farming en radio {radius}px desde ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",noPosition:"Sin zona",currentZone:"Zona: ({x},{y})",autoSelectPosition:"\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"},common:{yes:"S\xED",no:"No",ok:"Aceptar",cancel:"Cancelar",close:"Cerrar",save:"Guardar",load:"Cargar",delete:"Eliminar",edit:"Editar",start:"Iniciar",stop:"Detener",pause:"Pausar",resume:"Reanudar",reset:"Reiniciar",settings:"Configuraci\xF3n",help:"Ayuda",about:"Acerca de",language:"Idioma",loading:"Cargando...",error:"Error",success:"\xC9xito",warning:"Advertencia",info:"Informaci\xF3n",languageChanged:"Idioma cambiado a {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Inicializar Guard-BOT",selectArea:"Seleccionar \xC1rea",captureArea:"Capturar \xC1rea",startProtection:"Iniciar Protecci\xF3n",stopProtection:"Detener Protecci\xF3n",upperLeft:"Esquina Superior Izquierda",lowerRight:"Esquina Inferior Derecha",protectedPixels:"P\xEDxeles Protegidos",detectedChanges:"Cambios Detectados",repairedPixels:"P\xEDxeles Reparados",charges:"Cargas",waitingInit:"Esperando inicializaci\xF3n...",checkingColors:"\u{1F3A8} Verificando colores disponibles...",noColorsFound:"\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",colorsFound:"\u2705 {count} colores disponibles encontrados",initSuccess:"\u2705 Guard-BOT inicializado correctamente",initError:"\u274C Error inicializando Guard-BOT",invalidCoords:"\u274C Coordenadas inv\xE1lidas",invalidArea:"\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",areaTooLarge:"\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",capturingArea:"\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",areaCaptured:"\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",captureError:"\u274C Error capturando \xE1rea: {error}",captureFirst:"\u274C Primero captura un \xE1rea de protecci\xF3n",protectionStarted:"\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",protectionStopped:"\u23F9\uFE0F Protecci\xF3n detenida",noChanges:"\u2705 \xC1rea protegida - sin cambios detectados",changesDetected:"\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",repairing:"\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",repairedSuccess:"\u2705 Reparados {count} p\xEDxeles correctamente",repairError:"\u274C Error reparando p\xEDxeles: {error}",noCharges:"\u26A0\uFE0F Sin cargas suficientes para reparar cambios",checkingChanges:"\u{1F50D} Verificando cambios en \xE1rea protegida...",errorChecking:"\u274C Error verificando cambios: {error}",guardActive:"\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",lastCheck:"\xDAltima verificaci\xF3n: {time}",nextCheck:"Pr\xF3xima verificaci\xF3n en: {time}s",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Guard-BOT iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",manualInitRequired:"\u{1F527} Inicio manual requerido",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",selectUpperLeft:"\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",selectLowerRight:"\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",waitingUpperLeft:"\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",waitingLowerRight:"\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",upperLeftCaptured:"\u2705 Esquina superior izquierda capturada: ({x}, {y})",lowerRightCaptured:"\u2705 Esquina inferior derecha capturada: ({x}, {y})",selectionTimeout:"\u274C Tiempo agotado para selecci\xF3n",selectionError:"\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"}};var oe={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selection",user:"User",charges:"Charges",backend:"Backend",database:"Database",uptime:"Uptime",close:"Close",launch:"Launch",loading:"Loading\u2026",executing:"Executing\u2026",downloading:"Downloading script\u2026",chooseBot:"Choose a bot and press Launch",readyToLaunch:"Ready to launch",loadError:"Load error",loadErrorMsg:"Could not load the selected bot. Check your connection or try again.",checking:"\u{1F504} Checking...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialize Auto-BOT",uploadImage:"Upload Image",resizeImage:"Resize Image",selectPosition:"Select Position",startPainting:"Start Painting",stopPainting:"Stop Painting",saveProgress:"Save Progress",loadProgress:"Load Progress",checkingColors:"\u{1F50D} Checking available colors...",noColorsFound:"\u274C Open the color palette on the site and try again!",colorsFound:"\u2705 Found {count} available colors",loadingImage:"\u{1F5BC}\uFE0F Loading image...",imageLoaded:"\u2705 Image loaded with {count} valid pixels",imageError:"\u274C Error loading image",selectPositionAlert:"Paint the first pixel at the location where you want the art to start!",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Position set successfully!",positionTimeout:"\u274C Timeout for position selection",positionDetected:"\u{1F3AF} Position detected, processing...",positionError:"\u274C Error detecting position, please try again",startPaintingMsg:"\u{1F3A8} Starting painting...",paintingProgress:"\u{1F9F1} Progress: {painted}/{total} pixels...",noCharges:"\u231B No charges. Waiting {time}...",paintingStopped:"\u23F9\uFE0F Painting stopped by user",paintingComplete:"\u2705 Painting completed! {count} pixels painted.",paintingError:"\u274C Error during painting",missingRequirements:"\u274C Load an image and select a position first",progress:"Progress",userName:"User",pixels:"Pixels",charges:"Charges",estimatedTime:"Estimated time",initMessage:"Click 'Initialize Auto-BOT' to begin",waitingInit:"Waiting for initialization...",resizeSuccess:"\u2705 Image resized to {width}x{height}",paintingPaused:"\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",pixelsPerBatch:"Pixels per batch",batchSize:"Batch size",nextBatchTime:"Next batch in",useAllCharges:"Use all available charges",showOverlay:"Show overlay",maxCharges:"Max charges per batch",waitingForCharges:"\u23F3 Waiting for charges: {current}/{needed}",timeRemaining:"Time remaining",cooldownWaiting:"\u23F3 Waiting {time} to continue...",progressSaved:"\u2705 Progress saved as {filename}",progressLoaded:"\u2705 Progress loaded: {painted}/{total} pixels painted",progressLoadError:"\u274C Error loading progress: {error}",progressSaveError:"\u274C Error saving progress: {error}",confirmSaveProgress:"Do you want to save the current progress before stopping?",saveProgressTitle:"Save Progress",discardProgress:"Discard",cancel:"Cancel",minimize:"Minimize",width:"Width",height:"Height",keepAspect:"Keep aspect ratio",apply:"Apply",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",waitingChargesCountdown:"\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Bot auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",manualInitRequired:"\u{1F527} Manual initialization required",retryAttempt:"\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",retryError:"\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",retryFailed:"\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",networkError:"\u{1F310} Network error. Retrying...",serverError:"\u{1F525} Server error. Retrying...",timeoutError:"\u23F0 Server timeout. Retrying..."},farm:{title:"WPlace Farm Bot",start:"Start",stop:"Stop",stopped:"Bot stopped",calibrate:"Calibrate",paintOnce:"Once",checkingStatus:"Checking status...",configuration:"Configuration",delay:"Delay (ms)",pixelsPerBatch:"Pixels/batch",minCharges:"Min charges",colorMode:"Color mode",random:"Random",fixed:"Fixed",range:"Range",fixedColor:"Fixed color",advanced:"Advanced",tileX:"Tile X",tileY:"Tile Y",customPalette:"Custom palette",paletteExample:"e.g: #FF0000,#00FF00,#0000FF",capture:"Capture",painted:"Painted",charges:"Charges",retries:"Retries",tile:"Tile",configSaved:"Configuration saved",configLoaded:"Configuration loaded",configReset:"Configuration reset",captureInstructions:"Paint a pixel manually to capture coordinates...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Starting bot...",stoppingBot:"Stopping bot...",calibrating:"Calibrating...",alreadyRunning:"Auto-Farm is already running.",imageRunningWarning:"Auto-Image is running. Close it before starting Auto-Farm.",selectPosition:"Select Area",selectPositionAlert:"\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Area set! Radius: 500px",positionTimeout:"\u274C Timeout for area selection",missingPosition:"\u274C Select an area first using 'Select Area'",farmRadius:"Farm radius",positionInfo:"Current area",farmingInRadius:"\u{1F33E} Farming in {radius}px radius from ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",noPosition:"No area",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"},common:{yes:"Yes",no:"No",ok:"OK",cancel:"Cancel",close:"Close",save:"Save",load:"Load",delete:"Delete",edit:"Edit",start:"Start",stop:"Stop",pause:"Pause",resume:"Resume",reset:"Reset",settings:"Settings",help:"Help",about:"About",language:"Language",loading:"Loading...",error:"Error",success:"Success",warning:"Warning",info:"Information",languageChanged:"Language changed to {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialize Guard-BOT",selectArea:"Select Area",captureArea:"Capture Area",startProtection:"Start Protection",stopProtection:"Stop Protection",upperLeft:"Upper Left Corner",lowerRight:"Lower Right Corner",protectedPixels:"Protected Pixels",detectedChanges:"Detected Changes",repairedPixels:"Repaired Pixels",charges:"Charges",waitingInit:"Waiting for initialization...",checkingColors:"\u{1F3A8} Checking available colors...",noColorsFound:"\u274C No colors found. Open the color palette on the site.",colorsFound:"\u2705 Found {count} available colors",initSuccess:"\u2705 Guard-BOT initialized successfully",initError:"\u274C Error initializing Guard-BOT",invalidCoords:"\u274C Invalid coordinates",invalidArea:"\u274C Area must have upper left corner less than lower right corner",areaTooLarge:"\u274C Area too large: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capturing protection area...",areaCaptured:"\u2705 Area captured: {count} pixels under protection",captureError:"\u274C Error capturing area: {error}",captureFirst:"\u274C First capture a protection area",protectionStarted:"\u{1F6E1}\uFE0F Protection started - monitoring area",protectionStopped:"\u23F9\uFE0F Protection stopped",noChanges:"\u2705 Protected area - no changes detected",changesDetected:"\u{1F6A8} {count} changes detected in protected area",repairing:"\u{1F6E0}\uFE0F Repairing {count} altered pixels...",repairedSuccess:"\u2705 Successfully repaired {count} pixels",repairError:"\u274C Error repairing pixels: {error}",noCharges:"\u26A0\uFE0F Insufficient charges to repair changes",checkingChanges:"\u{1F50D} Checking changes in protected area...",errorChecking:"\u274C Error checking changes: {error}",guardActive:"\u{1F6E1}\uFE0F Guardian active - area under protection",lastCheck:"Last check: {time}",nextCheck:"Next check in: {time}s",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Guard-BOT auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",manualInitRequired:"\u{1F527} Manual initialization required",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",selectUpperLeft:"\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",selectLowerRight:"\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",waitingUpperLeft:"\u{1F446} Waiting for upper left corner selection...",waitingLowerRight:"\u{1F446} Waiting for lower right corner selection...",upperLeftCaptured:"\u2705 Upper left corner captured: ({x}, {y})",lowerRightCaptured:"\u2705 Lower right corner captured: ({x}, {y})",selectionTimeout:"\u274C Selection timeout",selectionError:"\u274C Selection error, please try again"}};var ne={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"S\xE9lection",user:"Utilisateur",charges:"Charges",backend:"Backend",database:"Base de donn\xE9es",uptime:"Temps actif",close:"Fermer",launch:"Lancer",loading:"Chargement\u2026",executing:"Ex\xE9cution\u2026",downloading:"T\xE9l\xE9chargement du script\u2026",chooseBot:"Choisissez un bot et appuyez sur Lancer",readyToLaunch:"Pr\xEAt \xE0 lancer",loadError:"Erreur de chargement",loadErrorMsg:"Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",checking:"\u{1F504} V\xE9rification...",online:"\u{1F7E2} En ligne",offline:"\u{1F534} Hors ligne",ok:"\u{1F7E2} OK",error:"\u{1F534} Erreur",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialiser Auto-BOT",uploadImage:"T\xE9l\xE9charger Image",resizeImage:"Redimensionner Image",selectPosition:"S\xE9lectionner Position",startPainting:"Commencer Peinture",stopPainting:"Arr\xEAter Peinture",saveProgress:"Sauvegarder Progr\xE8s",loadProgress:"Charger Progr\xE8s",checkingColors:"\u{1F50D} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",loadingImage:"\u{1F5BC}\uFE0F Chargement de l'image...",imageLoaded:"\u2705 Image charg\xE9e avec {count} pixels valides",imageError:"\u274C Erreur lors du chargement de l'image",selectPositionAlert:"Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Position d\xE9finie avec succ\xE8s!",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",positionDetected:"\u{1F3AF} Position d\xE9tect\xE9e, traitement...",positionError:"\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",startPaintingMsg:"\u{1F3A8} D\xE9but de la peinture...",paintingProgress:"\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",noCharges:"\u231B Aucune charge. Attendre {time}...",paintingStopped:"\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",paintingComplete:"\u2705 Peinture termin\xE9e! {count} pixels peints.",paintingError:"\u274C Erreur pendant la peinture",missingRequirements:"\u274C Chargez une image et s\xE9lectionnez une position d'abord",progress:"Progr\xE8s",userName:"Usager",pixels:"Pixels",charges:"Charges",estimatedTime:"Temps estim\xE9",initMessage:"Cliquez sur 'Initialiser Auto-BOT' pour commencer",waitingInit:"En attente d'initialisation...",resizeSuccess:"\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",paintingPaused:"\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",pixelsPerBatch:"Pixels par lot",batchSize:"Taille du lot",nextBatchTime:"Prochain lot dans",useAllCharges:"Utiliser toutes les charges disponibles",showOverlay:"Afficher l'overlay",maxCharges:"Charges max par lot",waitingForCharges:"\u23F3 En attente de charges: {current}/{needed}",timeRemaining:"Temps restant",cooldownWaiting:"\u23F3 Attendre {time} pour continuer...",progressSaved:"\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",progressLoaded:"\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",progressLoadError:"\u274C Erreur lors du chargement du progr\xE8s: {error}",progressSaveError:"\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",confirmSaveProgress:"Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",saveProgressTitle:"Sauvegarder Progr\xE8s",discardProgress:"Abandonner",cancel:"Annuler",minimize:"Minimiser",width:"Largeur",height:"Hauteur",keepAspect:"Garder les proportions",apply:"Appliquer",overlayOn:"Overlay : ON",overlayOff:"Overlay : OFF",passCompleted:"\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",waitingChargesCountdown:"\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Bot d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",manualInitRequired:"\u{1F527} Initialisation manuelle requise",retryAttempt:"\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",retryError:"\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",retryFailed:"\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",networkError:"\u{1F310} Erreur r\xE9seau. Nouvel essai...",serverError:"\u{1F525} Erreur serveur. Nouvel essai...",timeoutError:"\u23F0 Timeout serveur. Nouvel essai..."},farm:{title:"WPlace Farm Bot",start:"D\xE9marrer",stop:"Arr\xEAter",stopped:"Bot arr\xEAt\xE9",calibrate:"Calibrer",paintOnce:"Une fois",checkingStatus:"V\xE9rification du statut...",configuration:"Configuration",delay:"D\xE9lai (ms)",pixelsPerBatch:"Pixels/lot",minCharges:"Charges min",colorMode:"Mode couleur",random:"Al\xE9atoire",fixed:"Fixe",range:"Plage",fixedColor:"Couleur fixe",advanced:"Avanc\xE9",tileX:"Tuile X",tileY:"Tuile Y",customPalette:"Palette personnalis\xE9e",paletteExample:"ex: #FF0000,#00FF00,#0000FF",capture:"Capturer",painted:"Peints",charges:"Charges",retries:"\xC9checs",tile:"Tuile",configSaved:"Configuration sauvegard\xE9e",configLoaded:"Configuration charg\xE9e",configReset:"Configuration r\xE9initialis\xE9e",captureInstructions:"Peindre un pixel manuellement pour capturer les coordonn\xE9es...",backendOnline:"Backend En ligne",backendOffline:"Backend Hors ligne",startingBot:"D\xE9marrage du bot...",stoppingBot:"Arr\xEAt du bot...",calibrating:"Calibrage...",alreadyRunning:"Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",imageRunningWarning:"Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",selectPosition:"S\xE9lectionner Zone",selectPositionAlert:"\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Zone d\xE9finie! Rayon: 500px",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",missingPosition:"\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",farmRadius:"Rayon farm",positionInfo:"Zone actuelle",farmingInRadius:"\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",noPosition:"Aucune zone",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"},common:{yes:"Oui",no:"Non",ok:"OK",cancel:"Annuler",close:"Fermer",save:"Sauvegarder",load:"Charger",delete:"Supprimer",edit:"Modifier",start:"D\xE9marrer",stop:"Arr\xEAter",pause:"Pause",resume:"Reprendre",reset:"R\xE9initialiser",settings:"Param\xE8tres",help:"Aide",about:"\xC0 propos",language:"Langue",loading:"Chargement...",error:"Erreur",success:"Succ\xE8s",warning:"Avertissement",info:"Information",languageChanged:"Langue chang\xE9e en {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialiser Guard-BOT",selectArea:"S\xE9lectionner Zone",captureArea:"Capturer Zone",startProtection:"D\xE9marrer Protection",stopProtection:"Arr\xEAter Protection",upperLeft:"Coin Sup\xE9rieur Gauche",lowerRight:"Coin Inf\xE9rieur Droit",protectedPixels:"Pixels Prot\xE9g\xE9s",detectedChanges:"Changements D\xE9tect\xE9s",repairedPixels:"Pixels R\xE9par\xE9s",charges:"Charges",waitingInit:"En attente d'initialisation...",checkingColors:"\u{1F3A8} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",initSuccess:"\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",initError:"\u274C Erreur lors de l'initialisation de Guard-BOT",invalidCoords:"\u274C Coordonn\xE9es invalides",invalidArea:"\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",areaTooLarge:"\u274C Zone trop grande: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capture de la zone de protection...",areaCaptured:"\u2705 Zone captur\xE9e: {count} pixels sous protection",captureError:"\u274C Erreur lors de la capture de zone: {error}",captureFirst:"\u274C Capturez d'abord une zone de protection",protectionStarted:"\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",protectionStopped:"\u23F9\uFE0F Protection arr\xEAt\xE9e",noChanges:"\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",changesDetected:"\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",repairing:"\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",repairedSuccess:"\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",repairError:"\u274C Erreur lors de la r\xE9paration des pixels: {error}",noCharges:"\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",checkingChanges:"\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",errorChecking:"\u274C Erreur lors de la v\xE9rification des changements: {error}",guardActive:"\u{1F6E1}\uFE0F Gardien actif - zone sous protection",lastCheck:"Derni\xE8re v\xE9rification: {time}",nextCheck:"Prochaine v\xE9rification dans: {time}s",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",manualInitRequired:"\u{1F527} Initialisation manuelle requise",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",selectUpperLeft:"\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",selectLowerRight:"\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",waitingUpperLeft:"\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",waitingLowerRight:"\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",upperLeftCaptured:"\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",lowerRightCaptured:"\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",selectionTimeout:"\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",selectionError:"\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"}};var ie={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",autoImage:"\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",autoGuard:"\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",selection:"\u0412\u044B\u0431\u0440\u0430\u043D\u043E",user:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",charges:"\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",backend:"\u0411\u044D\u043A\u0435\u043D\u0434",database:"\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",uptime:"\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",launch:"\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",executing:"\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",downloading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",chooseBot:"\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",readyToLaunch:"\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",loadError:"\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",loadErrorMsg:"\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",checking:"\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",online:"\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",offline:"\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",ok:"\u{1F7E2} \u041E\u041A",error:"\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",unknown:"-"},image:{title:"WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",uploadImage:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",resizeImage:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",startPainting:"\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",stopPainting:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",saveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",loadProgress:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",checkingColors:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",loadingImage:"\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",imageLoaded:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",imageError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPositionAlert:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",positionDetected:"\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",positionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",startPaintingMsg:"\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",paintingProgress:"\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",noCharges:"\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",paintingStopped:"\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",paintingComplete:"\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",paintingError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",missingRequirements:"\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",progress:"\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",userName:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",pixels:"\u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",estimatedTime:"\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",initMessage:"\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",resizeSuccess:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",paintingPaused:"\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",batchSize:"\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",nextBatchTime:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",useAllCharges:"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",showOverlay:"\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",maxCharges:"\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",waitingForCharges:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",timeRemaining:"\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",cooldownWaiting:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",progressSaved:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",progressLoaded:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",progressLoadError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",progressSaveError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",confirmSaveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",saveProgressTitle:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",discardProgress:"\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",minimize:"\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",width:"\u0428\u0438\u0440\u0438\u043D\u0430",height:"\u0412\u044B\u0441\u043E\u0442\u0430",keepAspect:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",apply:"\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",passCompleted:"\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",waitingChargesRegen:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",waitingChargesCountdown:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",retryAttempt:"\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryError:"\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryFailed:"\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",networkError:"\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",serverError:"\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",timeoutError:"\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."},farm:{title:"WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",stopped:"\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",calibrate:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",paintOnce:"\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",checkingStatus:"\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",configuration:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",delay:"\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",minCharges:"\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",colorMode:"\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",random:"\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",fixed:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",range:"\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",fixedColor:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",advanced:"\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",tileX:"\u041F\u043B\u0438\u0442\u043A\u0430 X",tileY:"\u041F\u043B\u0438\u0442\u043A\u0430 Y",customPalette:"\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",paletteExample:"\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",capture:"\u0417\u0430\u0445\u0432\u0430\u0442",painted:"\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",retries:"\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",tile:"\u041F\u043B\u0438\u0442\u043A\u0430",configSaved:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",configLoaded:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",configReset:"\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",captureInstructions:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",backendOnline:"\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",backendOffline:"\u0411\u044D\u043A\u044D\u043D\u0434",startingBot:"\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",stoppingBot:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",calibrating:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",alreadyRunning:"\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",imageRunningWarning:"\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C",selectPositionAlert:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",missingPosition:"\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",farmRadius:"\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",positionInfo:"\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",farmingInRadius:"\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",selectEmptyArea:"\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",noPosition:"\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",currentZone:"\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",autoSelectPosition:"\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."},common:{yes:"\u0414\u0430",no:"\u041D\u0435\u0442",ok:"\u041E\u041A",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",save:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",load:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",delete:"\u0423\u0434\u0430\u043B\u0438\u0442\u044C",edit:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",pause:"\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",resume:"\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",reset:"\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",settings:"\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",help:"\u041F\u043E\u043C\u043E\u0449\u044C",about:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",language:"\u042F\u0437\u044B\u043A",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",error:"\u041E\u0448\u0438\u0431\u043A\u0430",success:"\u0423\u0441\u043F\u0435\u0445",warning:"\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",info:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",languageChanged:"\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"},guard:{title:"WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",selectArea:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",captureArea:"\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",startProtection:"\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",stopProtection:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",upperLeft:"\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",lowerRight:"\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",protectedPixels:"\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",detectedChanges:"\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",repairedPixels:"\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",checkingColors:"\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",initSuccess:"\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",initError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",invalidCoords:"\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",invalidArea:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",areaTooLarge:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",capturingArea:"\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",areaCaptured:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",captureError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",captureFirst:"\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",protectionStarted:"\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",protectionStopped:"\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",noChanges:"\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",changesDetected:"\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",repairing:"\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",repairedSuccess:"\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",repairError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",noCharges:"\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",checkingChanges:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",errorChecking:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",guardActive:"\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",lastCheck:"\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",nextCheck:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",selectUpperLeft:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",selectLowerRight:"\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",waitingUpperLeft:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",waitingLowerRight:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",upperLeftCaptured:"\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",lowerRightCaptured:"\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",selectionTimeout:"\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",selectionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"}};var S={es:ae,en:oe,fr:ne,ru:ie},M="es",k=S[M];function Te(){let e=(window.navigator.language||window.navigator.userLanguage||"es").split("-")[0].toLowerCase();return S[e]?e:"es"}function ke(){return null}function N(){let r=ke(),e=Te(),a="es";return r&&S[r]?a=r:e&&S[e]&&(a=e),Re(a),a}function Re(r){if(!S[r]){console.warn(`Idioma '${r}' no disponible. Usando '${M}'`);return}M=r,k=S[r],typeof window!="undefined"&&window.CustomEvent&&window.dispatchEvent(new window.CustomEvent("languageChanged",{detail:{language:r,translations:k}}))}function x(r,e={}){let a=r.split("."),o=k;for(let n of a)if(o&&typeof o=="object"&&n in o)o=o[n];else return console.warn(`Clave de traducci\xF3n no encontrada: '${r}'`),r;return typeof o!="string"?(console.warn(`Clave de traducci\xF3n no es string: '${r}'`),r):ze(o,e)}function ze(r,e){return!e||Object.keys(e).length===0?r:r.replace(/\{(\w+)\}/g,(a,o)=>e[o]!==void 0?e[o]:a)}function se(r){return k[r]?k[r]:(console.warn(`Secci\xF3n de traducci\xF3n no encontrada: '${r}'`),{})}N();function R(r=!1){let e=['[data-testid="color-picker"]',".color-picker",".palette",'[class*="color"][class*="picker"]','[class*="palette"]'];for(let n of e){let i=document.querySelector(n);if(i&&i.offsetParent!==null)return r&&console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por selector: ${n}`),!0}let a=document.querySelectorAll('[style*="background-color"], [style*="background:"], .color, [class*="color"]'),o=0;for(let n of a)if(n.offsetParent!==null&&n.offsetWidth>10&&n.offsetHeight>10&&(o++,o>=5))return r&&console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por colores visibles: ${o}`),!0;return r&&console.log(`[WPA-UI] \u{1F50D} Paleta no detectada. Colores visibles: ${o}`),!1}function F(r=!1,e=!1){let a=document.querySelector("button.btn.btn-primary.btn-lg, button.btn.btn-primary.sm\\:btn-xl");if(a){let n=a.textContent.toLowerCase(),i=n.includes("paint")||n.includes("pintar"),l=a.querySelector('svg path[d*="240-120"]')||a.querySelector('svg path[d*="M15"]');if(i||l)return r&&console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por selector espec\xEDfico: "${n}"`),a.click(),e&&setTimeout(()=>{r&&console.log("[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint"),a.click()},500),!0}let o=document.querySelectorAll("button");for(let n of o){let i=n.textContent.toLowerCase();if((i.includes("paint")||i.includes("pintar"))&&n.offsetParent!==null&&!n.disabled)return r&&console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por texto: "${n.textContent.trim()}"`),n.click(),e&&setTimeout(()=>{r&&console.log("[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint"),n.click()},500),!0}return r&&console.log("[WPA-UI] \u274C Bot\xF3n Paint no encontrado"),!1}async function ce(r=3,e=!0){e&&console.log(`[WPA-UI] \u{1F916} Iniciando auto-click del bot\xF3n Paint (m\xE1ximo ${r} intentos)`);for(let a=1;a<=r;a++){if(e&&console.log(`[WPA-UI] \u{1F3AF} Intento ${a}/${r} - Buscando bot\xF3n Paint...`),R())return e&&console.log("[WPA-UI] \u2705 Paleta ya est\xE1 abierta, auto-click completado"),!0;if(F(e,!1)){if(e&&console.log("[WPA-UI] \u{1F446} Clic en bot\xF3n Paint realizado (sin segundo clic)"),await new Promise(o=>setTimeout(o,1500)),R())return e&&console.log(`[WPA-UI] \u2705 Paleta abierta exitosamente despu\xE9s del intento ${a}`),!0;e&&console.log(`[WPA-UI] \u26A0\uFE0F Paleta no detectada tras el clic en intento ${a}. Reintentar\xE1.`)}else e&&console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado para clic en intento ${a}`);a<r&&await new Promise(o=>setTimeout(o,1e3))}return e&&console.log(`[WPA-UI] \u274C Auto-click fall\xF3 despu\xE9s de ${r} intentos`),!1}var{setInterval:Le,clearInterval:le}=window;async function de(){if(s("\u{1F6E1}\uFE0F Iniciando WPlace Auto-Guard"),N(),!!Fe()){window.__wplaceBot={...window.__wplaceBot,guardRunning:!0};try{let r=se("guard");t.ui=J(r),$e();async function e(){if(s("\u{1F916} Intentando auto-inicio del Guard..."),t.ui.updateStatus(x("guard.paletteNotFound"),"info"),R()){if(s("\u{1F3A8} Paleta parece abierta. Validando colores..."),T().length>0)return t.ui.updateStatus(x("guard.paletteDetected"),"success"),!0;s('\u26A0\uFE0F Paleta "abierta" pero sin colores detectados. Intentando presionar Paint...')}if(s("\u{1F50D} Buscando bot\xF3n Paint..."),t.ui.updateStatus(x("guard.clickingPaintButton"),"info"),F()){if(s("\u{1F446} Bot\xF3n Paint encontrado y presionado"),await B(3e3),T().length>0)return s("\u2705 Colores detectados tras presionar Paint"),t.ui.updateStatus(x("guard.paletteDetected"),"success"),!0;R()?s("\u2705 Paleta abierta, pero sin colores accesibles a\xFAn"):s("\u274C La paleta no se abri\xF3 despu\xE9s de hacer clic")}else s("\u274C Bot\xF3n Paint no encontrado");return t.ui.updateStatus(x("guard.autoInitFailed"),"warning"),!1}setTimeout(async()=>{try{t.ui.updateStatus(x("guard.autoInitializing"),"info"),s("\u{1F916} Intentando auto-inicio..."),await e()?(t.ui.updateStatus(x("guard.autoInitSuccess"),"success"),s("\u2705 Auto-inicio exitoso"),t.ui.setInitButtonVisible(!1),await ue(!0)&&s("\u{1F680} Guard-BOT auto-iniciado completamente")):(t.ui.updateStatus(x("guard.autoInitFailed"),"warning"),s("\u26A0\uFE0F Auto-inicio fall\xF3, se requiere inicio manual"),t.ui.setInitButtonVisible(!0))}catch(a){s("\u274C Error en auto-inicio:",a),t.ui.updateStatus(x("guard.manualInitRequired"),"warning")}},1e3),window.addEventListener("beforeunload",()=>{pe(),window.__wplaceBot&&(window.__wplaceBot.guardRunning=!1)}),s("\u2705 Auto-Guard cargado correctamente")}catch(r){throw s("\u274C Error inicializando Auto-Guard:",r),window.__wplaceBot&&(window.__wplaceBot.guardRunning=!1),r}}}function Fe(){var r,e;return(r=window.__wplaceBot)!=null&&r.imageRunning?(alert("Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Guard."),!1):(e=window.__wplaceBot)!=null&&e.farmRunning?(alert("Auto-Farm est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Guard."),!1):!0}function $e(){let{elements:r}=t.ui;r.closeBtn.addEventListener("click",()=>{pe(),t.ui.destroy(),window.__wplaceBot&&(window.__wplaceBot.guardRunning=!1)}),r.initBtn.addEventListener("click",()=>ue()),r.selectAreaBtn.addEventListener("click",Oe),r.loadAreaBtn.addEventListener("click",()=>{r.areaFileInput.click()}),r.areaFileInput.addEventListener("change",async()=>{if(r.areaFileInput.files.length>0){let e=await te(r.areaFileInput.files[0]);e.success?(t.ui.updateStatus(`\u2705 Protecci\xF3n cargada: ${e.protectedPixels} p\xEDxeles protegidos`,"success"),s("\u2705 \xC1rea de protecci\xF3n cargada desde archivo")):(t.ui.updateStatus(`\u274C Error al cargar protecci\xF3n: ${e.error}`,"error"),s(`\u274C Error cargando archivo: ${e.error}`))}}),r.startBtn.addEventListener("click",qe),r.stopBtn.addEventListener("click",async()=>{t.running=!1,t.loopId=null,t.ui.setRunningState(!1),t.ui.updateStatus("\u23F9\uFE0F Protecci\xF3n detenida","warning"),t.checkInterval&&(le(t.checkInterval),t.checkInterval=null)}),r.saveBtn.addEventListener("click",async()=>{if(!re()){t.ui.updateStatus("\u274C No hay \xE1rea protegida para guardar","error");return}if(await Q('\xBFDeseas dividir el \xE1rea protegida en partes para m\xFAltiples usuarios?<br><br><label for="splitCountInput">N\xFAmero de partes (1 = sin dividir):</label><br><input type="number" id="splitCountInput" min="1" max="20" value="1" style="margin: 5px 0; padding: 5px; width: 100px; background: #374151; border: 1px solid #4b5563; border-radius: 4px; color: #d1d5db;">',"Opciones de Guardado",{save:"Guardar",cancel:"Cancelar"})==="save"){let a=document.querySelector("#splitCountInput"),o=parseInt(a==null?void 0:a.value)||1,n=await ee(null,o);n.success?t.ui.updateStatus(`\u2705 Protecci\xF3n guardada${o>1?` (dividida en ${o} partes)`:""}`,"success"):t.ui.updateStatus(`\u274C Error al guardar: ${n.error}`,"error")}}),r.pixelsPerBatchInput.addEventListener("change",e=>{t.pixelsPerBatch=Math.max(1,Math.min(50,parseInt(e.target.value)||10)),e.target.value=t.pixelsPerBatch}),r.minChargesInput.addEventListener("change",e=>{t.minChargesToWait=Math.max(1,Math.min(100,parseInt(e.target.value)||20)),e.target.value=t.minChargesToWait}),r.pixelsPerBatchInput.value=t.pixelsPerBatch,r.minChargesInput.value=t.minChargesToWait}async function ue(r=!1){var e;try{t.ui.updateStatus(x("guard.checkingColors"),"info");let a=T();if(a.length===0&&(s("\u26A0\uFE0F 0 colores detectados. Intentando abrir paleta (fallback)..."),t.ui.updateStatus(x("guard.clickingPaintButton"),"info"),F()&&(await B(2500),a=T())),a.length===0)return t.ui.updateStatus(x("guard.noColorsFound"),"error"),!1;t.availableColors=a,t.colorsChecked=!0;let o=await Z();return o.success&&(t.currentCharges=o.data.charges,t.maxCharges=o.data.maxCharges,t.ui.updateStats({charges:Math.floor(t.currentCharges)}),s(`\u{1F464} Usuario: ${((e=o.data.user)==null?void 0:e.name)||"An\xF3nimo"} - Cargas: ${t.currentCharges}`)),t.initialized=!0,t.ui.updateStatus(x("guard.colorsFound",{count:a.length}),"success"),t.ui.showAreaSection(),r||s(`\u2705 ${a.length} colores disponibles detectados`),t.ui.setInitialized(!0),!0}catch(a){return s("\u274C Error inicializando:",a),t.ui.updateStatus(x("guard.initError"),"error"),!1}}var z=window.fetch;async function Oe(){s("\u{1F3AF} Iniciando selecci\xF3n paso a paso del \xE1rea");let r=null,e=null,a="upperLeft",o=!1,n=()=>{window.fetch!==z&&(window.fetch=z,s("\u{1F504} Fetch original restaurado"))};(()=>{window.fetch=async(l,c)=>{if(!o&&typeof l=="string"&&l.includes("/s0/pixel/")&&c&&c.method==="POST")try{s(`\u{1F3AF} Interceptando request de pintado: ${l}`);let p=await z(l,c);if(p.ok&&c.body){let h;try{h=JSON.parse(c.body)}catch(g){return s("Error parseando body del request:",g),p}if(h.coords&&Array.isArray(h.coords)&&h.coords.length>=2){let g=h.coords[0],m=h.coords[1],d=l.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);if(d){let u=parseInt(d[1]),b=parseInt(d[2]),y=u*3e3+g,f=b*3e3+m;if(a==="upperLeft")r={x:y,y:f},t.ui.updateCoordinates({x1:y,y1:f}),t.ui.updateStatus(x("guard.upperLeftCaptured",{x:y,y:f}),"success"),s(`\u2705 Esquina superior izquierda capturada: (${y}, ${f})`),a="lowerRight",setTimeout(()=>{a==="lowerRight"&&t.ui.updateStatus(x("guard.selectLowerRight"),"info")},1500);else if(a==="lowerRight"){if(e={x:y,y:f},t.ui.updateCoordinates({x2:y,y2:f}),t.ui.updateStatus(x("guard.lowerRightCaptured",{x:y,y:f}),"success"),s(`\u2705 Esquina inferior derecha capturada: (${y}, ${f})`),o=!0,n(),r.x>=e.x||r.y>=e.y)return t.ui.updateStatus(x("guard.invalidArea"),"error"),p;setTimeout(async()=>{await De(r,e)},1e3)}}}}return p}catch(p){return s("\u274C Error interceptando pixel:",p),n(),z(l,c)}return z(l,c)}})(),t.ui.updateStatus(x("guard.selectUpperLeft"),"info"),setTimeout(()=>{o||(n(),t.ui.updateStatus(x("guard.selectionTimeout"),"error"),s("\u23F0 Timeout en selecci\xF3n de \xE1rea"))},12e4)}async function De(r,e){try{let a={x1:r.x,y1:r.y,x2:e.x,y2:e.y};t.ui.updateStatus(x("guard.capturingArea"),"info");let o=await q(a);t.protectionArea=a,t.originalPixels=o,t.changes.clear(),t.ui.updateProgress(0,o.size),t.ui.updateStatus(x("guard.areaCaptured",{count:o.size}),"success"),t.ui.enableStartBtn(),s(`\u2705 \xC1rea capturada: ${o.size} p\xEDxeles protegidos`)}catch(a){s("\u274C Error capturando \xE1rea:",a),t.ui.updateStatus(x("guard.captureError",{error:a.message}),"error")}}async function qe(){if(!t.protectionArea||!t.originalPixels.size){t.ui.updateStatus(x("guard.captureFirst"),"error");return}t.running=!0,t.ui.setRunningState(!0),t.ui.updateStatus(x("guard.protectionStarted"),"success"),s("\u{1F6E1}\uFE0F Iniciando protecci\xF3n del \xE1rea"),t.checkInterval=Le(U,P.CHECK_INTERVAL),await U()}function pe(){t.running=!1,t.checkInterval&&(le(t.checkInterval),t.checkInterval=null),t.ui&&(t.ui.setRunningState(!1),t.ui.updateStatus(x("guard.protectionStopped"),"warning")),s("\u23F9\uFE0F Protecci\xF3n detenida")}(async function(){var r;try{console.log("[WPA-Guard] \u{1F916} Iniciando auto-click del bot\xF3n Paint..."),await ce(3,!0)}catch(e){console.log("[WPA-Guard] \u26A0\uFE0F Error en auto-click del bot\xF3n Paint:",e)}(r=window.__wplaceBot)!=null&&r.guardRunning?alert("Auto-Guard ya est\xE1 corriendo."):de().catch(e=>{console.error("[WPA-GUARD] Error en Auto-Guard:",e),window.__wplaceBot&&(window.__wplaceBot.guardRunning=!1),alert("Auto-Guard: error inesperado. Revisa consola.")})})();})();
+    `;
+      overlay.appendChild(modal);
+      document.body.appendChild(overlay);
+      const saveBtn = modal.querySelector(".save-btn");
+      const discardBtn = modal.querySelector(".discard-btn");
+      const cancelBtn = modal.querySelector(".cancel-btn");
+      const cleanup = () => {
+        document.body.removeChild(overlay);
+      };
+      if (saveBtn) {
+        saveBtn.addEventListener("click", () => {
+          cleanup();
+          resolve("save");
+        });
+      }
+      if (discardBtn) {
+        discardBtn.addEventListener("click", () => {
+          cleanup();
+          resolve("discard");
+        });
+      }
+      if (cancelBtn) {
+        cancelBtn.addEventListener("click", () => {
+          cleanup();
+          resolve("cancel");
+        });
+      }
+      overlay.addEventListener("click", (e) => {
+        if (e.target === overlay) {
+          cleanup();
+          resolve("cancel");
+        }
+      });
+    });
+  }
+  function makeDraggable(element) {
+    let isDragging = false;
+    let startX, startY, startLeft, startTop;
+    const header = element.querySelector(".guard-header");
+    header.addEventListener("mousedown", (e) => {
+      if (e.target.id === "closeBtn") return;
+      isDragging = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      startLeft = parseInt(window.getComputedStyle(element).left, 10);
+      startTop = parseInt(window.getComputedStyle(element).top, 10);
+      element.style.cursor = "grabbing";
+    });
+    document.addEventListener("mousemove", (e) => {
+      if (!isDragging) return;
+      const deltaX = e.clientX - startX;
+      const deltaY = e.clientY - startY;
+      element.style.left = `${startLeft + deltaX}px`;
+      element.style.top = `${startTop + deltaY}px`;
+      element.style.right = "auto";
+    });
+    document.addEventListener("mouseup", () => {
+      if (isDragging) {
+        isDragging = false;
+        element.style.cursor = "default";
+      }
+    });
+  }
+
+  // src/guard/save-load.js
+  function splitProtectionArea(area, splitCount) {
+    const { x1, y1, x2, y2 } = area;
+    const width = x2 - x1;
+    const height = y2 - y1;
+    const areas = [];
+    if (splitCount <= 1) {
+      return [area];
+    }
+    const divideHorizontally = width >= height;
+    if (divideHorizontally) {
+      const segmentWidth = Math.floor(width / splitCount);
+      for (let i = 0; i < splitCount; i++) {
+        const startX = x1 + i * segmentWidth;
+        const endX = i === splitCount - 1 ? x2 : startX + segmentWidth;
+        areas.push({
+          x1: startX,
+          y1,
+          x2: endX,
+          y2
+        });
+      }
+    } else {
+      const segmentHeight = Math.floor(height / splitCount);
+      for (let i = 0; i < splitCount; i++) {
+        const startY = y1 + i * segmentHeight;
+        const endY = i === splitCount - 1 ? y2 : startY + segmentHeight;
+        areas.push({
+          x1,
+          y1: startY,
+          x2,
+          y2: endY
+        });
+      }
+    }
+    return areas;
+  }
+  function getPixelsInArea(area, pixelsMap) {
+    const pixels = [];
+    const { x1, y1, x2, y2 } = area;
+    for (const [key, value] of pixelsMap.entries()) {
+      const [x, y] = key.split(",").map(Number);
+      if (x >= x1 && x <= x2 && y >= y1 && y <= y2) {
+        pixels.push({ key, ...value });
+      }
+    }
+    return pixels;
+  }
+  function saveProgress(filename = null, splitCount = null) {
+    try {
+      if (!guardState.protectionArea || !guardState.originalPixels.size) {
+        throw new Error("No hay progreso para guardar");
+      }
+      const areas = splitCount && splitCount > 1 ? splitProtectionArea(guardState.protectionArea, splitCount) : [guardState.protectionArea];
+      const results = [];
+      for (let i = 0; i < areas.length; i++) {
+        const area = areas[i];
+        const areaPixels = getPixelsInArea(area, guardState.originalPixels);
+        const progressData = {
+          version: "1.0",
+          timestamp: Date.now(),
+          protectionData: {
+            area: { ...area },
+            protectedPixels: areaPixels.length,
+            splitInfo: splitCount > 1 ? {
+              total: splitCount,
+              current: i + 1,
+              originalArea: { ...guardState.protectionArea }
+            } : null
+          },
+          progress: {
+            totalRepaired: guardState.totalRepaired,
+            lastCheck: guardState.lastCheck
+          },
+          config: {
+            maxProtectionSize: 1e5,
+            pixelsPerBatch: 10,
+            checkInterval: 1e4
+          },
+          // Filtrar solo los datos serializables de los colores (sin elementos DOM)
+          colors: guardState.availableColors.map((color) => ({
+            id: color.id,
+            r: color.r,
+            g: color.g,
+            b: color.b
+          })),
+          // Convertir Map a array para serialización - solo píxeles del área
+          originalPixels: areaPixels
+        };
+        const dataStr = JSON.stringify(progressData, null, 2);
+        const blob = new window.Blob([dataStr], { type: "application/json" });
+        const suffix = splitCount > 1 ? `_parte${i + 1}de${splitCount}` : "";
+        const finalFilename = filename || `wplace_GUARD_${(/* @__PURE__ */ new Date()).toISOString().slice(0, 19).replace(/:/g, "-")}${suffix}.json`;
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = finalFilename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        window.URL.revokeObjectURL(url);
+        results.push({ success: true, filename: finalFilename });
+        log(`\u2705 Progreso guardado: ${finalFilename}`);
+      }
+      return {
+        success: true,
+        filename: results.length === 1 ? results[0].filename : `${results.length} archivos`,
+        files: results
+      };
+    } catch (error) {
+      log("\u274C Error guardando progreso:", error);
+      return { success: false, error: error.message };
+    }
+  }
+  async function loadProgress(file) {
+    return new Promise((resolve) => {
+      try {
+        const reader = new window.FileReader();
+        reader.onload = async (e) => {
+          try {
+            const progressData = JSON.parse(e.target.result);
+            const requiredFields = ["protectionData", "originalPixels", "colors"];
+            const missingFields = requiredFields.filter((field) => !(field in progressData));
+            if (missingFields.length > 0) {
+              throw new Error(`Campos requeridos faltantes: ${missingFields.join(", ")}`);
+            }
+            if (guardState.availableColors.length > 0) {
+              const savedColorIds = progressData.colors.map((c) => c.id);
+              const currentColorIds = guardState.availableColors.map((c) => c.id);
+              const commonColors = savedColorIds.filter((id) => currentColorIds.includes(id));
+              if (commonColors.length < savedColorIds.length * 0.8) {
+                log("\u26A0\uFE0F Los colores guardados no coinciden completamente con los actuales");
+              }
+            }
+            if (progressData.protectionData) {
+              guardState.protectionArea = progressData.protectionData.area;
+            } else if (progressData.protectionArea) {
+              guardState.protectionArea = progressData.protectionArea;
+            }
+            guardState.originalPixels = /* @__PURE__ */ new Map();
+            for (const pixelData of progressData.originalPixels) {
+              const { key, ...pixelInfo } = pixelData;
+              guardState.originalPixels.set(key, pixelInfo);
+            }
+            if (progressData.progress) {
+              guardState.totalRepaired = progressData.progress.totalRepaired || 0;
+              guardState.lastCheck = progressData.progress.lastCheck || 0;
+            } else if (progressData.statistics) {
+              guardState.totalRepaired = progressData.statistics.totalRepaired || 0;
+              guardState.lastCheck = progressData.statistics.lastCheck || 0;
+            }
+            guardState.changes.clear();
+            if (guardState.ui) {
+              guardState.ui.updateCoordinates({
+                x1: guardState.protectionArea.x1,
+                y1: guardState.protectionArea.y1,
+                x2: guardState.protectionArea.x2,
+                y2: guardState.protectionArea.y2
+              });
+              guardState.ui.updateProgress(0, guardState.originalPixels.size);
+              guardState.ui.updateStats({
+                repaired: guardState.totalRepaired
+              });
+              guardState.ui.enableStartBtn();
+            }
+            log(`\u2705 Progreso cargado: ${guardState.originalPixels.size} p\xEDxeles protegidos`);
+            resolve({
+              success: true,
+              data: progressData,
+              protectedPixels: guardState.originalPixels.size,
+              area: guardState.protectionArea
+            });
+          } catch (parseError) {
+            log("\u274C Error parseando archivo de progreso:", parseError);
+            resolve({ success: false, error: parseError.message });
+          }
+        };
+        reader.onerror = () => {
+          const error = "Error leyendo archivo";
+          log("\u274C", error);
+          resolve({ success: false, error });
+        };
+        reader.readAsText(file);
+      } catch (error) {
+        log("\u274C Error cargando progreso:", error);
+        resolve({ success: false, error: error.message });
+      }
+    });
+  }
+  function hasProgress() {
+    return guardState.protectionArea && guardState.originalPixels.size > 0;
+  }
+
+  // src/locales/es.js
+  var es = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selecci\xF3n",
+      user: "Usuario",
+      charges: "Cargas",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Cerrar",
+      launch: "Lanzar",
+      loading: "Cargando\u2026",
+      executing: "Ejecutando\u2026",
+      downloading: "Descargando script\u2026",
+      chooseBot: "Elige un bot y presiona Lanzar",
+      readyToLaunch: "Listo para lanzar",
+      loadError: "Error al cargar",
+      loadErrorMsg: "No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",
+      checking: "\u{1F504} Verificando...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Iniciar Auto-BOT",
+      uploadImage: "Subir Imagen",
+      resizeImage: "Redimensionar Imagen",
+      selectPosition: "Seleccionar Posici\xF3n",
+      startPainting: "Iniciar Pintura",
+      stopPainting: "Detener Pintura",
+      saveProgress: "Guardar Progreso",
+      loadProgress: "Cargar Progreso",
+      checkingColors: "\u{1F50D} Verificando colores disponibles...",
+      noColorsFound: "\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      loadingImage: "\u{1F5BC}\uFE0F Cargando imagen...",
+      imageLoaded: "\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",
+      imageError: "\u274C Error al cargar la imagen",
+      selectPositionAlert: "\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Posici\xF3n establecida con \xE9xito!",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar posici\xF3n",
+      positionDetected: "\u{1F3AF} Posici\xF3n detectada, procesando...",
+      positionError: "\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",
+      startPaintingMsg: "\u{1F3A8} Iniciando pintura...",
+      paintingProgress: "\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",
+      noCharges: "\u231B Sin cargas. Esperando {time}...",
+      paintingStopped: "\u23F9\uFE0F Pintura detenida por el usuario",
+      paintingComplete: "\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",
+      paintingError: "\u274C Error durante la pintura",
+      missingRequirements: "\u274C Carga una imagen y selecciona una posici\xF3n primero",
+      progress: "Progreso",
+      userName: "Usuario",
+      pixels: "P\xEDxeles",
+      charges: "Cargas",
+      estimatedTime: "Tiempo estimado",
+      initMessage: "Haz clic en 'Iniciar Auto-BOT' para comenzar",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      resizeSuccess: "\u2705 Imagen redimensionada a {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",
+      pixelsPerBatch: "P\xEDxeles por lote",
+      batchSize: "Tama\xF1o del lote",
+      nextBatchTime: "Siguiente lote en",
+      useAllCharges: "Usar todas las cargas disponibles",
+      showOverlay: "Mostrar overlay",
+      maxCharges: "Cargas m\xE1ximas por lote",
+      waitingForCharges: "\u23F3 Esperando cargas: {current}/{needed}",
+      timeRemaining: "Tiempo restante",
+      cooldownWaiting: "\u23F3 Esperando {time} para continuar...",
+      progressSaved: "\u2705 Progreso guardado como {filename}",
+      progressLoaded: "\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",
+      progressLoadError: "\u274C Error al cargar progreso: {error}",
+      progressSaveError: "\u274C Error al guardar progreso: {error}",
+      confirmSaveProgress: "\xBFDeseas guardar el progreso actual antes de detener?",
+      saveProgressTitle: "Guardar Progreso",
+      discardProgress: "Descartar",
+      cancel: "Cancelar",
+      minimize: "Minimizar",
+      width: "Ancho",
+      height: "Alto",
+      keepAspect: "Mantener proporci\xF3n",
+      apply: "Aplicar",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",
+      waitingChargesCountdown: "\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Bot iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      retryAttempt: "\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",
+      retryError: "\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",
+      retryFailed: "\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",
+      networkError: "\u{1F310} Error de red. Reintentando...",
+      serverError: "\u{1F525} Error del servidor. Reintentando...",
+      timeoutError: "\u23F0 Timeout del servidor. Reintentando..."
+    },
+    // Farm Module (por implementar)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Iniciar",
+      stop: "Detener",
+      stopped: "Bot detenido",
+      calibrate: "Calibrar",
+      paintOnce: "Una vez",
+      checkingStatus: "Verificando estado...",
+      configuration: "Configuraci\xF3n",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "P\xEDxeles/lote",
+      minCharges: "Cargas m\xEDn",
+      colorMode: "Modo color",
+      random: "Aleatorio",
+      fixed: "Fijo",
+      range: "Rango",
+      fixedColor: "Color fijo",
+      advanced: "Avanzado",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Paleta personalizada",
+      paletteExample: "ej: #FF0000,#00FF00,#0000FF",
+      capture: "Capturar",
+      painted: "Pintados",
+      charges: "Cargas",
+      retries: "Fallos",
+      tile: "Tile",
+      configSaved: "Configuraci\xF3n guardada",
+      configLoaded: "Configuraci\xF3n cargada",
+      configReset: "Configuraci\xF3n reiniciada",
+      captureInstructions: "Pinta un p\xEDxel manualmente para capturar coordenadas...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Iniciando bot...",
+      stoppingBot: "Deteniendo bot...",
+      calibrating: "Calibrando...",
+      alreadyRunning: "Auto-Farm ya est\xE1 corriendo.",
+      imageRunningWarning: "Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",
+      selectPosition: "Seleccionar Zona",
+      selectPositionAlert: "\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Zona establecida! Radio: 500px",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar zona",
+      missingPosition: "\u274C Selecciona una zona primero usando 'Seleccionar Zona'",
+      farmRadius: "Radio farm",
+      positionInfo: "Zona actual",
+      farmingInRadius: "\u{1F33E} Farming en radio {radius}px desde ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",
+      noPosition: "Sin zona",
+      currentZone: "Zona: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "S\xED",
+      no: "No",
+      ok: "Aceptar",
+      cancel: "Cancelar",
+      close: "Cerrar",
+      save: "Guardar",
+      load: "Cargar",
+      delete: "Eliminar",
+      edit: "Editar",
+      start: "Iniciar",
+      stop: "Detener",
+      pause: "Pausar",
+      resume: "Reanudar",
+      reset: "Reiniciar",
+      settings: "Configuraci\xF3n",
+      help: "Ayuda",
+      about: "Acerca de",
+      language: "Idioma",
+      loading: "Cargando...",
+      error: "Error",
+      success: "\xC9xito",
+      warning: "Advertencia",
+      info: "Informaci\xF3n",
+      languageChanged: "Idioma cambiado a {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Inicializar Guard-BOT",
+      selectArea: "Seleccionar \xC1rea",
+      captureArea: "Capturar \xC1rea",
+      startProtection: "Iniciar Protecci\xF3n",
+      stopProtection: "Detener Protecci\xF3n",
+      upperLeft: "Esquina Superior Izquierda",
+      lowerRight: "Esquina Inferior Derecha",
+      protectedPixels: "P\xEDxeles Protegidos",
+      detectedChanges: "Cambios Detectados",
+      repairedPixels: "P\xEDxeles Reparados",
+      charges: "Cargas",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      checkingColors: "\u{1F3A8} Verificando colores disponibles...",
+      noColorsFound: "\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      initSuccess: "\u2705 Guard-BOT inicializado correctamente",
+      initError: "\u274C Error inicializando Guard-BOT",
+      invalidCoords: "\u274C Coordenadas inv\xE1lidas",
+      invalidArea: "\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",
+      areaTooLarge: "\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",
+      capturingArea: "\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",
+      areaCaptured: "\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",
+      captureError: "\u274C Error capturando \xE1rea: {error}",
+      captureFirst: "\u274C Primero captura un \xE1rea de protecci\xF3n",
+      protectionStarted: "\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",
+      protectionStopped: "\u23F9\uFE0F Protecci\xF3n detenida",
+      noChanges: "\u2705 \xC1rea protegida - sin cambios detectados",
+      changesDetected: "\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",
+      repairing: "\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",
+      repairedSuccess: "\u2705 Reparados {count} p\xEDxeles correctamente",
+      repairError: "\u274C Error reparando p\xEDxeles: {error}",
+      noCharges: "\u26A0\uFE0F Sin cargas suficientes para reparar cambios",
+      checkingChanges: "\u{1F50D} Verificando cambios en \xE1rea protegida...",
+      errorChecking: "\u274C Error verificando cambios: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",
+      lastCheck: "\xDAltima verificaci\xF3n: {time}",
+      nextCheck: "Pr\xF3xima verificaci\xF3n en: {time}s",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Guard-BOT iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      selectUpperLeft: "\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",
+      selectLowerRight: "\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",
+      waitingUpperLeft: "\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",
+      waitingLowerRight: "\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",
+      upperLeftCaptured: "\u2705 Esquina superior izquierda capturada: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Esquina inferior derecha capturada: ({x}, {y})",
+      selectionTimeout: "\u274C Tiempo agotado para selecci\xF3n",
+      selectionError: "\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"
+    }
+  };
+
+  // src/locales/en.js
+  var en = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selection",
+      user: "User",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Close",
+      launch: "Launch",
+      loading: "Loading\u2026",
+      executing: "Executing\u2026",
+      downloading: "Downloading script\u2026",
+      chooseBot: "Choose a bot and press Launch",
+      readyToLaunch: "Ready to launch",
+      loadError: "Load error",
+      loadErrorMsg: "Could not load the selected bot. Check your connection or try again.",
+      checking: "\u{1F504} Checking...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialize Auto-BOT",
+      uploadImage: "Upload Image",
+      resizeImage: "Resize Image",
+      selectPosition: "Select Position",
+      startPainting: "Start Painting",
+      stopPainting: "Stop Painting",
+      saveProgress: "Save Progress",
+      loadProgress: "Load Progress",
+      checkingColors: "\u{1F50D} Checking available colors...",
+      noColorsFound: "\u274C Open the color palette on the site and try again!",
+      colorsFound: "\u2705 Found {count} available colors",
+      loadingImage: "\u{1F5BC}\uFE0F Loading image...",
+      imageLoaded: "\u2705 Image loaded with {count} valid pixels",
+      imageError: "\u274C Error loading image",
+      selectPositionAlert: "Paint the first pixel at the location where you want the art to start!",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Position set successfully!",
+      positionTimeout: "\u274C Timeout for position selection",
+      positionDetected: "\u{1F3AF} Position detected, processing...",
+      positionError: "\u274C Error detecting position, please try again",
+      startPaintingMsg: "\u{1F3A8} Starting painting...",
+      paintingProgress: "\u{1F9F1} Progress: {painted}/{total} pixels...",
+      noCharges: "\u231B No charges. Waiting {time}...",
+      paintingStopped: "\u23F9\uFE0F Painting stopped by user",
+      paintingComplete: "\u2705 Painting completed! {count} pixels painted.",
+      paintingError: "\u274C Error during painting",
+      missingRequirements: "\u274C Load an image and select a position first",
+      progress: "Progress",
+      userName: "User",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Estimated time",
+      initMessage: "Click 'Initialize Auto-BOT' to begin",
+      waitingInit: "Waiting for initialization...",
+      resizeSuccess: "\u2705 Image resized to {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels per batch",
+      batchSize: "Batch size",
+      nextBatchTime: "Next batch in",
+      useAllCharges: "Use all available charges",
+      showOverlay: "Show overlay",
+      maxCharges: "Max charges per batch",
+      waitingForCharges: "\u23F3 Waiting for charges: {current}/{needed}",
+      timeRemaining: "Time remaining",
+      cooldownWaiting: "\u23F3 Waiting {time} to continue...",
+      progressSaved: "\u2705 Progress saved as {filename}",
+      progressLoaded: "\u2705 Progress loaded: {painted}/{total} pixels painted",
+      progressLoadError: "\u274C Error loading progress: {error}",
+      progressSaveError: "\u274C Error saving progress: {error}",
+      confirmSaveProgress: "Do you want to save the current progress before stopping?",
+      saveProgressTitle: "Save Progress",
+      discardProgress: "Discard",
+      cancel: "Cancel",
+      minimize: "Minimize",
+      width: "Width",
+      height: "Height",
+      keepAspect: "Keep aspect ratio",
+      apply: "Apply",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",
+      waitingChargesCountdown: "\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Bot auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      retryAttempt: "\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",
+      retryError: "\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",
+      retryFailed: "\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",
+      networkError: "\u{1F310} Network error. Retrying...",
+      serverError: "\u{1F525} Server error. Retrying...",
+      timeoutError: "\u23F0 Server timeout. Retrying..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Start",
+      stop: "Stop",
+      stopped: "Bot stopped",
+      calibrate: "Calibrate",
+      paintOnce: "Once",
+      checkingStatus: "Checking status...",
+      configuration: "Configuration",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "Pixels/batch",
+      minCharges: "Min charges",
+      colorMode: "Color mode",
+      random: "Random",
+      fixed: "Fixed",
+      range: "Range",
+      fixedColor: "Fixed color",
+      advanced: "Advanced",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Custom palette",
+      paletteExample: "e.g: #FF0000,#00FF00,#0000FF",
+      capture: "Capture",
+      painted: "Painted",
+      charges: "Charges",
+      retries: "Retries",
+      tile: "Tile",
+      configSaved: "Configuration saved",
+      configLoaded: "Configuration loaded",
+      configReset: "Configuration reset",
+      captureInstructions: "Paint a pixel manually to capture coordinates...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Starting bot...",
+      stoppingBot: "Stopping bot...",
+      calibrating: "Calibrating...",
+      alreadyRunning: "Auto-Farm is already running.",
+      imageRunningWarning: "Auto-Image is running. Close it before starting Auto-Farm.",
+      selectPosition: "Select Area",
+      selectPositionAlert: "\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Area set! Radius: 500px",
+      positionTimeout: "\u274C Timeout for area selection",
+      missingPosition: "\u274C Select an area first using 'Select Area'",
+      farmRadius: "Farm radius",
+      positionInfo: "Current area",
+      farmingInRadius: "\u{1F33E} Farming in {radius}px radius from ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",
+      noPosition: "No area",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"
+    },
+    // Common/Shared
+    common: {
+      yes: "Yes",
+      no: "No",
+      ok: "OK",
+      cancel: "Cancel",
+      close: "Close",
+      save: "Save",
+      load: "Load",
+      delete: "Delete",
+      edit: "Edit",
+      start: "Start",
+      stop: "Stop",
+      pause: "Pause",
+      resume: "Resume",
+      reset: "Reset",
+      settings: "Settings",
+      help: "Help",
+      about: "About",
+      language: "Language",
+      loading: "Loading...",
+      error: "Error",
+      success: "Success",
+      warning: "Warning",
+      info: "Information",
+      languageChanged: "Language changed to {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialize Guard-BOT",
+      selectArea: "Select Area",
+      captureArea: "Capture Area",
+      startProtection: "Start Protection",
+      stopProtection: "Stop Protection",
+      upperLeft: "Upper Left Corner",
+      lowerRight: "Lower Right Corner",
+      protectedPixels: "Protected Pixels",
+      detectedChanges: "Detected Changes",
+      repairedPixels: "Repaired Pixels",
+      charges: "Charges",
+      waitingInit: "Waiting for initialization...",
+      checkingColors: "\u{1F3A8} Checking available colors...",
+      noColorsFound: "\u274C No colors found. Open the color palette on the site.",
+      colorsFound: "\u2705 Found {count} available colors",
+      initSuccess: "\u2705 Guard-BOT initialized successfully",
+      initError: "\u274C Error initializing Guard-BOT",
+      invalidCoords: "\u274C Invalid coordinates",
+      invalidArea: "\u274C Area must have upper left corner less than lower right corner",
+      areaTooLarge: "\u274C Area too large: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capturing protection area...",
+      areaCaptured: "\u2705 Area captured: {count} pixels under protection",
+      captureError: "\u274C Error capturing area: {error}",
+      captureFirst: "\u274C First capture a protection area",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection started - monitoring area",
+      protectionStopped: "\u23F9\uFE0F Protection stopped",
+      noChanges: "\u2705 Protected area - no changes detected",
+      changesDetected: "\u{1F6A8} {count} changes detected in protected area",
+      repairing: "\u{1F6E0}\uFE0F Repairing {count} altered pixels...",
+      repairedSuccess: "\u2705 Successfully repaired {count} pixels",
+      repairError: "\u274C Error repairing pixels: {error}",
+      noCharges: "\u26A0\uFE0F Insufficient charges to repair changes",
+      checkingChanges: "\u{1F50D} Checking changes in protected area...",
+      errorChecking: "\u274C Error checking changes: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardian active - area under protection",
+      lastCheck: "Last check: {time}",
+      nextCheck: "Next check in: {time}s",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Guard-BOT auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      selectUpperLeft: "\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",
+      selectLowerRight: "\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",
+      waitingUpperLeft: "\u{1F446} Waiting for upper left corner selection...",
+      waitingLowerRight: "\u{1F446} Waiting for lower right corner selection...",
+      upperLeftCaptured: "\u2705 Upper left corner captured: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Lower right corner captured: ({x}, {y})",
+      selectionTimeout: "\u274C Selection timeout",
+      selectionError: "\u274C Selection error, please try again"
+    }
+  };
+
+  // src/locales/fr.js
+  var fr = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "S\xE9lection",
+      user: "Utilisateur",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Base de donn\xE9es",
+      uptime: "Temps actif",
+      close: "Fermer",
+      launch: "Lancer",
+      loading: "Chargement\u2026",
+      executing: "Ex\xE9cution\u2026",
+      downloading: "T\xE9l\xE9chargement du script\u2026",
+      chooseBot: "Choisissez un bot et appuyez sur Lancer",
+      readyToLaunch: "Pr\xEAt \xE0 lancer",
+      loadError: "Erreur de chargement",
+      loadErrorMsg: "Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",
+      checking: "\u{1F504} V\xE9rification...",
+      online: "\u{1F7E2} En ligne",
+      offline: "\u{1F534} Hors ligne",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Erreur",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialiser Auto-BOT",
+      uploadImage: "T\xE9l\xE9charger Image",
+      resizeImage: "Redimensionner Image",
+      selectPosition: "S\xE9lectionner Position",
+      startPainting: "Commencer Peinture",
+      stopPainting: "Arr\xEAter Peinture",
+      saveProgress: "Sauvegarder Progr\xE8s",
+      loadProgress: "Charger Progr\xE8s",
+      checkingColors: "\u{1F50D} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      loadingImage: "\u{1F5BC}\uFE0F Chargement de l'image...",
+      imageLoaded: "\u2705 Image charg\xE9e avec {count} pixels valides",
+      imageError: "\u274C Erreur lors du chargement de l'image",
+      selectPositionAlert: "Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Position d\xE9finie avec succ\xE8s!",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",
+      positionDetected: "\u{1F3AF} Position d\xE9tect\xE9e, traitement...",
+      positionError: "\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",
+      startPaintingMsg: "\u{1F3A8} D\xE9but de la peinture...",
+      paintingProgress: "\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",
+      noCharges: "\u231B Aucune charge. Attendre {time}...",
+      paintingStopped: "\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",
+      paintingComplete: "\u2705 Peinture termin\xE9e! {count} pixels peints.",
+      paintingError: "\u274C Erreur pendant la peinture",
+      missingRequirements: "\u274C Chargez une image et s\xE9lectionnez une position d'abord",
+      progress: "Progr\xE8s",
+      userName: "Usager",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Temps estim\xE9",
+      initMessage: "Cliquez sur 'Initialiser Auto-BOT' pour commencer",
+      waitingInit: "En attente d'initialisation...",
+      resizeSuccess: "\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels par lot",
+      batchSize: "Taille du lot",
+      nextBatchTime: "Prochain lot dans",
+      useAllCharges: "Utiliser toutes les charges disponibles",
+      showOverlay: "Afficher l'overlay",
+      maxCharges: "Charges max par lot",
+      waitingForCharges: "\u23F3 En attente de charges: {current}/{needed}",
+      timeRemaining: "Temps restant",
+      cooldownWaiting: "\u23F3 Attendre {time} pour continuer...",
+      progressSaved: "\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",
+      progressLoaded: "\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",
+      progressLoadError: "\u274C Erreur lors du chargement du progr\xE8s: {error}",
+      progressSaveError: "\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",
+      confirmSaveProgress: "Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",
+      saveProgressTitle: "Sauvegarder Progr\xE8s",
+      discardProgress: "Abandonner",
+      cancel: "Annuler",
+      minimize: "Minimiser",
+      width: "Largeur",
+      height: "Hauteur",
+      keepAspect: "Garder les proportions",
+      apply: "Appliquer",
+      overlayOn: "Overlay : ON",
+      overlayOff: "Overlay : OFF",
+      passCompleted: "\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",
+      waitingChargesCountdown: "\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Bot d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      retryAttempt: "\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",
+      retryError: "\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",
+      retryFailed: "\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",
+      networkError: "\u{1F310} Erreur r\xE9seau. Nouvel essai...",
+      serverError: "\u{1F525} Erreur serveur. Nouvel essai...",
+      timeoutError: "\u23F0 Timeout serveur. Nouvel essai..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      stopped: "Bot arr\xEAt\xE9",
+      calibrate: "Calibrer",
+      paintOnce: "Une fois",
+      checkingStatus: "V\xE9rification du statut...",
+      configuration: "Configuration",
+      delay: "D\xE9lai (ms)",
+      pixelsPerBatch: "Pixels/lot",
+      minCharges: "Charges min",
+      colorMode: "Mode couleur",
+      random: "Al\xE9atoire",
+      fixed: "Fixe",
+      range: "Plage",
+      fixedColor: "Couleur fixe",
+      advanced: "Avanc\xE9",
+      tileX: "Tuile X",
+      tileY: "Tuile Y",
+      customPalette: "Palette personnalis\xE9e",
+      paletteExample: "ex: #FF0000,#00FF00,#0000FF",
+      capture: "Capturer",
+      painted: "Peints",
+      charges: "Charges",
+      retries: "\xC9checs",
+      tile: "Tuile",
+      configSaved: "Configuration sauvegard\xE9e",
+      configLoaded: "Configuration charg\xE9e",
+      configReset: "Configuration r\xE9initialis\xE9e",
+      captureInstructions: "Peindre un pixel manuellement pour capturer les coordonn\xE9es...",
+      backendOnline: "Backend En ligne",
+      backendOffline: "Backend Hors ligne",
+      startingBot: "D\xE9marrage du bot...",
+      stoppingBot: "Arr\xEAt du bot...",
+      calibrating: "Calibrage...",
+      alreadyRunning: "Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",
+      imageRunningWarning: "Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",
+      selectPosition: "S\xE9lectionner Zone",
+      selectPositionAlert: "\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Zone d\xE9finie! Rayon: 500px",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",
+      missingPosition: "\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",
+      farmRadius: "Rayon farm",
+      positionInfo: "Zone actuelle",
+      farmingInRadius: "\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",
+      noPosition: "Aucune zone",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "Oui",
+      no: "Non",
+      ok: "OK",
+      cancel: "Annuler",
+      close: "Fermer",
+      save: "Sauvegarder",
+      load: "Charger",
+      delete: "Supprimer",
+      edit: "Modifier",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      pause: "Pause",
+      resume: "Reprendre",
+      reset: "R\xE9initialiser",
+      settings: "Param\xE8tres",
+      help: "Aide",
+      about: "\xC0 propos",
+      language: "Langue",
+      loading: "Chargement...",
+      error: "Erreur",
+      success: "Succ\xE8s",
+      warning: "Avertissement",
+      info: "Information",
+      languageChanged: "Langue chang\xE9e en {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialiser Guard-BOT",
+      selectArea: "S\xE9lectionner Zone",
+      captureArea: "Capturer Zone",
+      startProtection: "D\xE9marrer Protection",
+      stopProtection: "Arr\xEAter Protection",
+      upperLeft: "Coin Sup\xE9rieur Gauche",
+      lowerRight: "Coin Inf\xE9rieur Droit",
+      protectedPixels: "Pixels Prot\xE9g\xE9s",
+      detectedChanges: "Changements D\xE9tect\xE9s",
+      repairedPixels: "Pixels R\xE9par\xE9s",
+      charges: "Charges",
+      waitingInit: "En attente d'initialisation...",
+      checkingColors: "\u{1F3A8} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      initSuccess: "\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",
+      initError: "\u274C Erreur lors de l'initialisation de Guard-BOT",
+      invalidCoords: "\u274C Coordonn\xE9es invalides",
+      invalidArea: "\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",
+      areaTooLarge: "\u274C Zone trop grande: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capture de la zone de protection...",
+      areaCaptured: "\u2705 Zone captur\xE9e: {count} pixels sous protection",
+      captureError: "\u274C Erreur lors de la capture de zone: {error}",
+      captureFirst: "\u274C Capturez d'abord une zone de protection",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",
+      protectionStopped: "\u23F9\uFE0F Protection arr\xEAt\xE9e",
+      noChanges: "\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",
+      changesDetected: "\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",
+      repairing: "\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",
+      repairedSuccess: "\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",
+      repairError: "\u274C Erreur lors de la r\xE9paration des pixels: {error}",
+      noCharges: "\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",
+      checkingChanges: "\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",
+      errorChecking: "\u274C Erreur lors de la v\xE9rification des changements: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Gardien actif - zone sous protection",
+      lastCheck: "Derni\xE8re v\xE9rification: {time}",
+      nextCheck: "Prochaine v\xE9rification dans: {time}s",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      selectUpperLeft: "\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",
+      selectLowerRight: "\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",
+      waitingUpperLeft: "\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",
+      waitingLowerRight: "\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",
+      upperLeftCaptured: "\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",
+      selectionTimeout: "\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",
+      selectionError: "\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"
+    }
+  };
+
+  // src/locales/ru.js
+  var ru = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      autoImage: "\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      autoGuard: "\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      selection: "\u0412\u044B\u0431\u0440\u0430\u043D\u043E",
+      user: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      charges: "\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      backend: "\u0411\u044D\u043A\u0435\u043D\u0434",
+      database: "\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",
+      uptime: "\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      launch: "\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",
+      executing: "\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",
+      downloading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",
+      chooseBot: "\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      readyToLaunch: "\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",
+      loadError: "\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",
+      loadErrorMsg: "\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",
+      checking: "\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",
+      online: "\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",
+      offline: "\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",
+      ok: "\u{1F7E2} \u041E\u041A",
+      error: "\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",
+      uploadImage: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      resizeImage: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      startPainting: "\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",
+      stopPainting: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",
+      saveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      loadProgress: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      checkingColors: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      loadingImage: "\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",
+      imageLoaded: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",
+      imageError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPositionAlert: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",
+      positionDetected: "\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",
+      positionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",
+      startPaintingMsg: "\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",
+      paintingProgress: "\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      noCharges: "\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",
+      paintingComplete: "\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",
+      paintingError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",
+      missingRequirements: "\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      progress: "\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      userName: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      pixels: "\u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      estimatedTime: "\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",
+      initMessage: "\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      resizeSuccess: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",
+      batchSize: "\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",
+      nextBatchTime: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",
+      useAllCharges: "\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",
+      showOverlay: "\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",
+      maxCharges: "\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      waitingForCharges: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",
+      timeRemaining: "\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",
+      cooldownWaiting: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",
+      progressSaved: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",
+      progressLoaded: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",
+      progressLoadError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      progressSaveError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      confirmSaveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",
+      saveProgressTitle: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      discardProgress: "\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      minimize: "\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",
+      width: "\u0428\u0438\u0440\u0438\u043D\u0430",
+      height: "\u0412\u044B\u0441\u043E\u0442\u0430",
+      keepAspect: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",
+      apply: "\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",
+      passCompleted: "\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",
+      waitingChargesRegen: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",
+      waitingChargesCountdown: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      retryAttempt: "\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryError: "\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryFailed: "\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",
+      networkError: "\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      serverError: "\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      timeoutError: "\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      stopped: "\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",
+      calibrate: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",
+      paintOnce: "\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",
+      checkingStatus: "\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",
+      configuration: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",
+      delay: "\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      minCharges: "\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",
+      colorMode: "\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",
+      random: "\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",
+      fixed: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",
+      range: "\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",
+      fixedColor: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",
+      advanced: "\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",
+      tileX: "\u041F\u043B\u0438\u0442\u043A\u0430 X",
+      tileY: "\u041F\u043B\u0438\u0442\u043A\u0430 Y",
+      customPalette: "\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",
+      paletteExample: "\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",
+      capture: "\u0417\u0430\u0445\u0432\u0430\u0442",
+      painted: "\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      retries: "\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",
+      tile: "\u041F\u043B\u0438\u0442\u043A\u0430",
+      configSaved: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",
+      configLoaded: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",
+      configReset: "\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",
+      captureInstructions: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",
+      backendOnline: "\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",
+      backendOffline: "\u0411\u044D\u043A\u044D\u043D\u0434",
+      startingBot: "\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",
+      stoppingBot: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",
+      calibrating: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",
+      alreadyRunning: "\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",
+      imageRunningWarning: "\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C",
+      selectPositionAlert: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      missingPosition: "\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",
+      farmRadius: "\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",
+      positionInfo: "\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",
+      farmingInRadius: "\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",
+      noPosition: "\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      currentZone: "\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."
+    },
+    // Common/Shared
+    common: {
+      yes: "\u0414\u0430",
+      no: "\u041D\u0435\u0442",
+      ok: "\u041E\u041A",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      save: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",
+      load: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",
+      delete: "\u0423\u0434\u0430\u043B\u0438\u0442\u044C",
+      edit: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",
+      pause: "\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      resume: "\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",
+      reset: "\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",
+      settings: "\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",
+      help: "\u041F\u043E\u043C\u043E\u0449\u044C",
+      about: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      language: "\u042F\u0437\u044B\u043A",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",
+      error: "\u041E\u0448\u0438\u0431\u043A\u0430",
+      success: "\u0423\u0441\u043F\u0435\u0445",
+      warning: "\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",
+      info: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      languageChanged: "\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",
+      selectArea: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      captureArea: "\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      startProtection: "\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      stopProtection: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      upperLeft: "\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      lowerRight: "\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      protectedPixels: "\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      detectedChanges: "\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      repairedPixels: "\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      checkingColors: "\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      initSuccess: "\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",
+      initError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",
+      invalidCoords: "\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",
+      invalidArea: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",
+      areaTooLarge: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",
+      capturingArea: "\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",
+      areaCaptured: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      captureError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",
+      captureFirst: "\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",
+      protectionStarted: "\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      protectionStopped: "\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",
+      noChanges: "\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",
+      changesDetected: "\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      repairing: "\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      repairedSuccess: "\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",
+      repairError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",
+      noCharges: "\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",
+      checkingChanges: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",
+      errorChecking: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      lastCheck: "\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",
+      nextCheck: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      selectUpperLeft: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",
+      selectLowerRight: "\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      waitingUpperLeft: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      waitingLowerRight: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      upperLeftCaptured: "\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      selectionTimeout: "\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",
+      selectionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"
+    }
+  };
+
+  // src/locales/zh-Hans.js
+  var zhHans = {
+    // 启动器
+    launcher: {
+      title: "WPlace \u81EA\u52A8\u673A\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52A8\u519C\u573A",
+      autoImage: "\u{1F3A8} \u81EA\u52A8\u7ED8\u56FE",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52A8\u5B88\u62A4",
+      selection: "\u9009\u62E9",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6570",
+      backend: "\u540E\u7AEF",
+      database: "\u6570\u636E\u5E93",
+      uptime: "\u8FD0\u884C\u65F6\u95F4",
+      close: "\u5173\u95ED",
+      launch: "\u542F\u52A8",
+      loading: "\u52A0\u8F7D\u4E2D\u2026",
+      executing: "\u6267\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F7D\u811A\u672C\u2026",
+      chooseBot: "\u9009\u62E9\u4E00\u4E2A\u673A\u5668\u4EBA\u5E76\u70B9\u51FB\u542F\u52A8",
+      readyToLaunch: "\u51C6\u5907\u542F\u52A8",
+      loadError: "\u52A0\u8F7D\u9519\u8BEF",
+      loadErrorMsg: "\u65E0\u6CD5\u52A0\u8F7D\u6240\u9009\u673A\u5668\u4EBA\u3002\u8BF7\u68C0\u67E5\u7F51\u7EDC\u8FDE\u63A5\u6216\u91CD\u8BD5\u3002",
+      checking: "\u{1F504} \u68C0\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7EBF",
+      offline: "\u{1F534} \u79BB\u7EBF",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u9519\u8BEF",
+      unknown: "-"
+    },
+    // 绘图模块
+    image: {
+      title: "WPlace \u81EA\u52A8\u7ED8\u56FE",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA",
+      uploadImage: "\u4E0A\u4F20\u56FE\u7247",
+      resizeImage: "\u8C03\u6574\u56FE\u7247\u5927\u5C0F",
+      selectPosition: "\u9009\u62E9\u4F4D\u7F6E",
+      startPainting: "\u5F00\u59CB\u7ED8\u5236",
+      stopPainting: "\u505C\u6B62\u7ED8\u5236",
+      saveProgress: "\u4FDD\u5B58\u8FDB\u5EA6",
+      loadProgress: "\u52A0\u8F7D\u8FDB\u5EA6",
+      checkingColors: "\u{1F50D} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u540E\u91CD\u8BD5\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F7D\u56FE\u7247...",
+      imageLoaded: "\u2705 \u56FE\u7247\u5DF2\u52A0\u8F7D\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u4E2A",
+      imageError: "\u274C \u56FE\u7247\u52A0\u8F7D\u5931\u8D25",
+      selectPositionAlert: "\u8BF7\u5728\u4F60\u60F3\u5F00\u59CB\u7ED8\u5236\u7684\u5730\u65B9\u6D82\u7B2C\u4E00\u4E2A\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8BBE\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9009\u62E9\u8D85\u65F6",
+      positionDetected: "\u{1F3AF} \u5DF2\u68C0\u6D4B\u5230\u4F4D\u7F6E\uFF0C\u5904\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u68C0\u6D4B\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5",
+      startPaintingMsg: "\u{1F3A8} \u5F00\u59CB\u7ED8\u5236...",
+      paintingProgress: "\u{1F9F1} \u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6CA1\u6709\u6B21\u6570\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7ED8\u5236",
+      paintingComplete: "\u2705 \u7ED8\u5236\u5B8C\u6210\uFF01\u5171\u7ED8\u5236 {count} \u4E2A\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7ED8\u5236\u8FC7\u7A0B\u4E2D\u51FA\u9519",
+      missingRequirements: "\u274C \u8BF7\u5148\u52A0\u8F7D\u56FE\u7247\u5E76\u9009\u62E9\u4F4D\u7F6E",
+      progress: "\u8FDB\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      estimatedTime: "\u9884\u8BA1\u65F6\u95F4",
+      initMessage: "\u70B9\u51FB\u201C\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA\u201D\u5F00\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u56FE\u7247\u5DF2\u8C03\u6574\u4E3A {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7ED8\u5236\u6682\u505C\u4E8E\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6570",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u65F6\u95F4",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6570",
+      showOverlay: "\u663E\u793A\u8986\u76D6\u5C42",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6570",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed}",
+      timeRemaining: "\u5269\u4F59\u65F6\u95F4",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u540E\u7EE7\u7EED...",
+      progressSaved: "\u2705 \u8FDB\u5EA6\u5DF2\u4FDD\u5B58\u4E3A {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F7D\u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7ED8\u5236",
+      progressLoadError: "\u274C \u52A0\u8F7D\u8FDB\u5EA6\u5931\u8D25: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u8FDB\u5EA6\u5931\u8D25: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u5F53\u524D\u8FDB\u5EA6\u5417\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u8FDB\u5EA6",
+      discardProgress: "\u653E\u5F03",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BBD\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7EB5\u6A2A\u6BD4",
+      apply: "\u5E94\u7528",
+      overlayOn: "\u8986\u76D6\u5C42: \u5F00\u542F",
+      overlayOff: "\u8986\u76D6\u5C42: \u5173\u95ED",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7ED8\u5236 {painted} \u50CF\u7D20 | \u8FDB\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6570\u6062\u590D: {current}/{needed} - \u65F6\u95F4: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed} - \u5269\u4F59: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8BD5 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5C1D\u8BD5\u51FA\u9519\uFF0C\u5C06\u5728 {delay} \u79D2\u540E\u91CD\u8BD5...",
+      retryFailed: "\u274C \u8D85\u8FC7 {maxAttempts} \u6B21\u5C1D\u8BD5\u5931\u8D25\u3002\u7EE7\u7EED\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7F51\u7EDC\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      serverError: "\u{1F525} \u670D\u52A1\u5668\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      timeoutError: "\u23F0 \u670D\u52A1\u5668\u8D85\u65F6\uFF0C\u6B63\u5728\u91CD\u8BD5..."
+    },
+    // 农场模块（待实现）
+    farm: {
+      title: "WPlace \u519C\u573A\u673A\u5668\u4EBA",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u673A\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u51C6",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u68C0\u67E5\u72B6\u6001\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u8FDF (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6570",
+      colorMode: "\u989C\u8272\u6A21\u5F0F",
+      random: "\u968F\u673A",
+      fixed: "\u56FA\u5B9A",
+      range: "\u8303\u56F4",
+      fixedColor: "\u56FA\u5B9A\u989C\u8272",
+      advanced: "\u9AD8\u7EA7",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u4E49\u8C03\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u83B7",
+      painted: "\u5DF2\u7ED8\u5236",
+      charges: "\u6B21\u6570",
+      retries: "\u91CD\u8BD5",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F7D",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8BF7\u624B\u52A8\u7ED8\u5236\u4E00\u4E2A\u50CF\u7D20\u4EE5\u6355\u83B7\u5750\u6807...",
+      backendOnline: "\u540E\u7AEF\u5728\u7EBF",
+      backendOffline: "\u540E\u7AEF\u79BB\u7EBF",
+      startingBot: "\u6B63\u5728\u542F\u52A8\u673A\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u673A\u5668\u4EBA...",
+      calibrating: "\u6821\u51C6\u4E2D...",
+      alreadyRunning: "\u81EA\u52A8\u519C\u573A\u5DF2\u5728\u8FD0\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52A8\u7ED8\u56FE\u6B63\u5728\u8FD0\u884C\uFF0C\u8BF7\u5148\u5173\u95ED\u518D\u542F\u52A8\u81EA\u52A8\u519C\u573A\u3002",
+      selectPosition: "\u9009\u62E9\u533A\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u56FE\u7684\u7A7A\u767D\u533A\u57DF\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u533A\u57DF\u8BBE\u7F6E\u6210\u529F\uFF01\u534A\u5F84: 500px",
+      positionTimeout: "\u274C \u533A\u57DF\u9009\u62E9\u8D85\u65F6",
+      missingPosition: "\u274C \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF08\u4F7F\u7528\u201C\u9009\u62E9\u533A\u57DF\u201D\u6309\u94AE\uFF09",
+      farmRadius: "\u519C\u573A\u534A\u5F84",
+      positionInfo: "\u5F53\u524D\u533A\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F84 {radius}px \u5728 ({x},{y}) \u519C\u573A",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8BF7\u9009\u62E9\u7A7A\u767D\u533A\u57DF\u4EE5\u907F\u514D\u51B2\u7A81",
+      noPosition: "\u672A\u9009\u62E9\u533A\u57DF",
+      currentZone: "\u533A\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF0C\u5728\u5730\u56FE\u4E0A\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u786E\u8BA4",
+      cancel: "\u53D6\u6D88",
+      close: "\u5173\u95ED",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F7D",
+      delete: "\u5220\u9664",
+      edit: "\u7F16\u8F91",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u6682\u505C",
+      resume: "\u7EE7\u7EED",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8BBE\u7F6E",
+      help: "\u5E2E\u52A9",
+      about: "\u5173\u4E8E",
+      language: "\u8BED\u8A00",
+      loading: "\u52A0\u8F7D\u4E2D...",
+      error: "\u9519\u8BEF",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8BED\u8A00\u5DF2\u5207\u6362\u4E3A {language}"
+    },
+    // 守护模块
+    guard: {
+      title: "WPlace \u81EA\u52A8\u5B88\u62A4",
+      initBot: "\u521D\u59CB\u5316\u5B88\u62A4\u673A\u5668\u4EBA",
+      selectArea: "\u9009\u62E9\u533A\u57DF",
+      captureArea: "\u6355\u83B7\u533A\u57DF",
+      startProtection: "\u5F00\u59CB\u5B88\u62A4",
+      stopProtection: "\u505C\u6B62\u5B88\u62A4",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u62A4\u50CF\u7D20",
+      detectedChanges: "\u68C0\u6D4B\u5230\u7684\u53D8\u5316",
+      repairedPixels: "\u4FEE\u590D\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u989C\u8272\uFF0C\u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      initSuccess: "\u2705 \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u5931\u8D25",
+      invalidCoords: "\u274C \u5750\u6807\u65E0\u6548",
+      invalidArea: "\u274C \u533A\u57DF\u65E0\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u987B\u5C0F\u4E8E\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u533A\u57DF\u8FC7\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u83B7\u5B88\u62A4\u533A\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u533A\u57DF\u6355\u83B7\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u62A4",
+      captureError: "\u274C \u6355\u83B7\u533A\u57DF\u51FA\u9519: {error}",
+      captureFirst: "\u274C \u8BF7\u5148\u6355\u83B7\u4E00\u4E2A\u5B88\u62A4\u533A\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u62A4\u5DF2\u542F\u52A8 - \u533A\u57DF\u76D1\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u62A4\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u533A\u57DF\u5B89\u5168 - \u672A\u68C0\u6D4B\u5230\u53D8\u5316",
+      changesDetected: "\u{1F6A8} \u68C0\u6D4B\u5230 {count} \u4E2A\u53D8\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u590D {count} \u4E2A\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u590D {count} \u4E2A\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u590D\u51FA\u9519: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6570\u4E0D\u8DB3\uFF0C\u65E0\u6CD5\u4FEE\u590D",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u68C0\u67E5\u533A\u57DF\u53D8\u5316...",
+      errorChecking: "\u274C \u68C0\u67E5\u51FA\u9519: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u62A4\u4E2D - \u533A\u57DF\u53D7\u4FDD\u62A4",
+      lastCheck: "\u4E0A\u6B21\u68C0\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u68C0\u67E5: {time} \u79D2\u540E",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u62A4\u533A\u57DF\u7684\u5DE6\u4E0A\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73B0\u5728\u5728\u53F3\u4E0B\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u83B7\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u83B7\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9009\u62E9\u8D85\u65F6",
+      selectionError: "\u274C \u9009\u62E9\u51FA\u9519\uFF0C\u8BF7\u91CD\u8BD5"
+    }
+  };
+
+  // src/locales/zh-Hant.js
+  var zhHant = {
+    // 啓動器
+    launcher: {
+      title: "WPlace \u81EA\u52D5\u6A5F\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52D5\u8FB2\u5834",
+      autoImage: "\u{1F3A8} \u81EA\u52D5\u7E6A\u5716",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52D5\u5B88\u8B77",
+      selection: "\u9078\u64C7",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6578",
+      backend: "\u5F8C\u7AEF",
+      database: "\u6578\u64DA\u5EAB",
+      uptime: "\u904B\u884C\u6642\u9593",
+      close: "\u95DC\u9589",
+      launch: "\u5553\u52D5",
+      loading: "\u52A0\u8F09\u4E2D\u2026",
+      executing: "\u57F7\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F09\u8173\u672C\u2026",
+      chooseBot: "\u9078\u64C7\u4E00\u500B\u6A5F\u5668\u4EBA\u4E26\u9EDE\u64CA\u5553\u52D5",
+      readyToLaunch: "\u6E96\u5099\u5553\u52D5",
+      loadError: "\u52A0\u8F09\u932F\u8AA4",
+      loadErrorMsg: "\u7121\u6CD5\u52A0\u8F09\u6240\u9078\u6A5F\u5668\u4EBA\u3002\u8ACB\u6AA2\u67E5\u7DB2\u7D61\u9023\u63A5\u6216\u91CD\u8A66\u3002",
+      checking: "\u{1F504} \u6AA2\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7DDA",
+      offline: "\u{1F534} \u96E2\u7DDA",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u932F\u8AA4",
+      unknown: "-"
+    },
+    // 繪圖模塊
+    image: {
+      title: "WPlace \u81EA\u52D5\u7E6A\u5716",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA",
+      uploadImage: "\u4E0A\u50B3\u5716\u7247",
+      resizeImage: "\u8ABF\u6574\u5716\u7247\u5927\u5C0F",
+      selectPosition: "\u9078\u64C7\u4F4D\u7F6E",
+      startPainting: "\u958B\u59CB\u7E6A\u88FD",
+      stopPainting: "\u505C\u6B62\u7E6A\u88FD",
+      saveProgress: "\u4FDD\u5B58\u9032\u5EA6",
+      loadProgress: "\u52A0\u8F09\u9032\u5EA6",
+      checkingColors: "\u{1F50D} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u5F8C\u91CD\u8A66\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F09\u5716\u7247...",
+      imageLoaded: "\u2705 \u5716\u7247\u5DF2\u52A0\u8F09\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u500B",
+      imageError: "\u274C \u5716\u7247\u52A0\u8F09\u5931\u6557",
+      selectPositionAlert: "\u8ACB\u5728\u4F60\u60F3\u958B\u59CB\u7E6A\u88FD\u7684\u5730\u65B9\u5857\u7B2C\u4E00\u500B\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8A2D\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9078\u64C7\u8D85\u6642",
+      positionDetected: "\u{1F3AF} \u5DF2\u6AA2\u6E2C\u5230\u4F4D\u7F6E\uFF0C\u8655\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u6AA2\u6E2C\u5931\u6557\uFF0C\u8ACB\u91CD\u8A66",
+      startPaintingMsg: "\u{1F3A8} \u958B\u59CB\u7E6A\u88FD...",
+      paintingProgress: "\u{1F9F1} \u9032\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6C92\u6709\u6B21\u6578\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7E6A\u88FD",
+      paintingComplete: "\u2705 \u7E6A\u88FD\u5B8C\u6210\uFF01\u5171\u7E6A\u88FD {count} \u500B\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7E6A\u88FD\u904E\u7A0B\u4E2D\u51FA\u932F",
+      missingRequirements: "\u274C \u8ACB\u5148\u52A0\u8F09\u5716\u7247\u4E26\u9078\u64C7\u4F4D\u7F6E",
+      progress: "\u9032\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      estimatedTime: "\u9810\u8A08\u6642\u9593",
+      initMessage: "\u9EDE\u64CA\u201C\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA\u201D\u958B\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u5716\u7247\u5DF2\u8ABF\u6574\u70BA {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7E6A\u88FD\u66AB\u505C\u65BC\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6578",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u6642\u9593",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6578",
+      showOverlay: "\u986F\u793A\u8986\u84CB\u5C64",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6578",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed}",
+      timeRemaining: "\u5269\u9918\u6642\u9593",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u5F8C\u7E7C\u7E8C...",
+      progressSaved: "\u2705 \u9032\u5EA6\u5DF2\u4FDD\u5B58\u70BA {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F09\u9032\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7E6A\u88FD",
+      progressLoadError: "\u274C \u52A0\u8F09\u9032\u5EA6\u5931\u6557: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u9032\u5EA6\u5931\u6557: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u7576\u524D\u9032\u5EA6\u55CE\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u9032\u5EA6",
+      discardProgress: "\u653E\u68C4",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BEC\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7E31\u6A6B\u6BD4",
+      apply: "\u61C9\u7528",
+      overlayOn: "\u8986\u84CB\u5C64: \u958B\u5553",
+      overlayOff: "\u8986\u84CB\u5C64: \u95DC\u9589",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7E6A\u88FD {painted} \u50CF\u7D20 | \u9032\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6578\u6062\u5FA9: {current}/{needed} - \u6642\u9593: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed} - \u5269\u9918: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8A66 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5617\u8A66\u51FA\u932F\uFF0C\u5C07\u5728 {delay} \u79D2\u5F8C\u91CD\u8A66...",
+      retryFailed: "\u274C \u8D85\u904E {maxAttempts} \u6B21\u5617\u8A66\u5931\u6557\u3002\u7E7C\u7E8C\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7DB2\u7D61\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      serverError: "\u{1F525} \u670D\u52D9\u5668\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      timeoutError: "\u23F0 \u670D\u52D9\u5668\u8D85\u6642\uFF0C\u6B63\u5728\u91CD\u8A66..."
+    },
+    // 農場模塊（待實現）
+    farm: {
+      title: "WPlace \u8FB2\u5834\u6A5F\u5668\u4EBA",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u6A5F\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u6E96",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u6AA2\u67E5\u72C0\u614B\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u9072 (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6578",
+      colorMode: "\u984F\u8272\u6A21\u5F0F",
+      random: "\u96A8\u6A5F",
+      fixed: "\u56FA\u5B9A",
+      range: "\u7BC4\u570D",
+      fixedColor: "\u56FA\u5B9A\u984F\u8272",
+      advanced: "\u9AD8\u7D1A",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u7FA9\u8ABF\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u7372",
+      painted: "\u5DF2\u7E6A\u88FD",
+      charges: "\u6B21\u6578",
+      retries: "\u91CD\u8A66",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F09",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8ACB\u624B\u52D5\u7E6A\u88FD\u4E00\u500B\u50CF\u7D20\u4EE5\u6355\u7372\u5EA7\u6A19...",
+      backendOnline: "\u5F8C\u7AEF\u5728\u7DDA",
+      backendOffline: "\u5F8C\u7AEF\u96E2\u7DDA",
+      startingBot: "\u6B63\u5728\u5553\u52D5\u6A5F\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u6A5F\u5668\u4EBA...",
+      calibrating: "\u6821\u6E96\u4E2D...",
+      alreadyRunning: "\u81EA\u52D5\u8FB2\u5834\u5DF2\u5728\u904B\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52D5\u7E6A\u5716\u6B63\u5728\u904B\u884C\uFF0C\u8ACB\u5148\u95DC\u9589\u518D\u5553\u52D5\u81EA\u52D5\u8FB2\u5834\u3002",
+      selectPosition: "\u9078\u64C7\u5340\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u5716\u7684\u7A7A\u767D\u5340\u57DF\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u5340\u57DF\u8A2D\u7F6E\u6210\u529F\uFF01\u534A\u5F91: 500px",
+      positionTimeout: "\u274C \u5340\u57DF\u9078\u64C7\u8D85\u6642",
+      missingPosition: "\u274C \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF08\u4F7F\u7528\u201C\u9078\u64C7\u5340\u57DF\u201D\u6309\u9215\uFF09",
+      farmRadius: "\u8FB2\u5834\u534A\u5F91",
+      positionInfo: "\u7576\u524D\u5340\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F91 {radius}px \u5728 ({x},{y}) \u8FB2\u5834",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8ACB\u9078\u64C7\u7A7A\u767D\u5340\u57DF\u4EE5\u907F\u514D\u885D\u7A81",
+      noPosition: "\u672A\u9078\u64C7\u5340\u57DF",
+      currentZone: "\u5340\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF0C\u5728\u5730\u5716\u4E0A\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u78BA\u8A8D",
+      cancel: "\u53D6\u6D88",
+      close: "\u95DC\u9589",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F09",
+      delete: "\u522A\u9664",
+      edit: "\u7DE8\u8F2F",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u66AB\u505C",
+      resume: "\u7E7C\u7E8C",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8A2D\u7F6E",
+      help: "\u5E6B\u52A9",
+      about: "\u95DC\u65BC",
+      language: "\u8A9E\u8A00",
+      loading: "\u52A0\u8F09\u4E2D...",
+      error: "\u932F\u8AA4",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8A9E\u8A00\u5DF2\u5207\u63DB\u70BA {language}"
+    },
+    // 守護模塊
+    guard: {
+      title: "WPlace \u81EA\u52D5\u5B88\u8B77",
+      initBot: "\u521D\u59CB\u5316\u5B88\u8B77\u6A5F\u5668\u4EBA",
+      selectArea: "\u9078\u64C7\u5340\u57DF",
+      captureArea: "\u6355\u7372\u5340\u57DF",
+      startProtection: "\u958B\u59CB\u5B88\u8B77",
+      stopProtection: "\u505C\u6B62\u5B88\u8B77",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u8B77\u50CF\u7D20",
+      detectedChanges: "\u6AA2\u6E2C\u5230\u7684\u8B8A\u5316",
+      repairedPixels: "\u4FEE\u5FA9\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u984F\u8272\uFF0C\u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      initSuccess: "\u2705 \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u5931\u6557",
+      invalidCoords: "\u274C \u5EA7\u6A19\u7121\u6548",
+      invalidArea: "\u274C \u5340\u57DF\u7121\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u9808\u5C0F\u65BC\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u5340\u57DF\u904E\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u7372\u5B88\u8B77\u5340\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u5340\u57DF\u6355\u7372\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u8B77",
+      captureError: "\u274C \u6355\u7372\u5340\u57DF\u51FA\u932F: {error}",
+      captureFirst: "\u274C \u8ACB\u5148\u6355\u7372\u4E00\u500B\u5B88\u8B77\u5340\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u8B77\u5DF2\u5553\u52D5 - \u5340\u57DF\u76E3\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u8B77\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u5340\u57DF\u5B89\u5168 - \u672A\u6AA2\u6E2C\u5230\u8B8A\u5316",
+      changesDetected: "\u{1F6A8} \u6AA2\u6E2C\u5230 {count} \u500B\u8B8A\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u5FA9\u51FA\u932F: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6578\u4E0D\u8DB3\uFF0C\u7121\u6CD5\u4FEE\u5FA9",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u6AA2\u67E5\u5340\u57DF\u8B8A\u5316...",
+      errorChecking: "\u274C \u6AA2\u67E5\u51FA\u932F: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u8B77\u4E2D - \u5340\u57DF\u53D7\u4FDD\u8B77",
+      lastCheck: "\u4E0A\u6B21\u6AA2\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u6AA2\u67E5: {time} \u79D2\u5F8C",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u8B77\u5340\u57DF\u7684\u5DE6\u4E0A\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73FE\u5728\u5728\u53F3\u4E0B\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u7372\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u7372\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9078\u64C7\u8D85\u6642",
+      selectionError: "\u274C \u9078\u64C7\u51FA\u932F\uFF0C\u8ACB\u91CD\u8A66"
+    }
+  };
+
+  // src/locales/index.js
+  var translations = {
+    es,
+    en,
+    fr,
+    ru,
+    zhHans,
+    zhHant
+  };
+  var currentLanguage = "es";
+  var currentTranslations = translations[currentLanguage];
+  function detectBrowserLanguage() {
+    const browserLang = window.navigator.language || window.navigator.userLanguage || "es";
+    const langCode = browserLang.split("-")[0].toLowerCase();
+    if (translations[langCode]) {
+      return langCode;
+    }
+    return "es";
+  }
+  function getSavedLanguage() {
+    return null;
+  }
+  function saveLanguage(langCode) {
+    return;
+  }
+  function initializeLanguage() {
+    const savedLang = getSavedLanguage();
+    const browserLang = detectBrowserLanguage();
+    let selectedLang = "es";
+    if (savedLang && translations[savedLang]) {
+      selectedLang = savedLang;
+    } else if (browserLang && translations[browserLang]) {
+      selectedLang = browserLang;
+    }
+    setLanguage(selectedLang);
+    return selectedLang;
+  }
+  function setLanguage(langCode) {
+    if (!translations[langCode]) {
+      console.warn(`Idioma '${langCode}' no disponible. Usando '${currentLanguage}'`);
+      return;
+    }
+    currentLanguage = langCode;
+    currentTranslations = translations[langCode];
+    saveLanguage(langCode);
+    if (typeof window !== "undefined" && window.CustomEvent) {
+      window.dispatchEvent(new window.CustomEvent("languageChanged", {
+        detail: { language: langCode, translations: currentTranslations }
+      }));
+    }
+  }
+  function t(key, params = {}) {
+    const keys = key.split(".");
+    let value = currentTranslations;
+    for (const k of keys) {
+      if (value && typeof value === "object" && k in value) {
+        value = value[k];
+      } else {
+        console.warn(`Clave de traducci\xF3n no encontrada: '${key}'`);
+        return key;
+      }
+    }
+    if (typeof value !== "string") {
+      console.warn(`Clave de traducci\xF3n no es string: '${key}'`);
+      return key;
+    }
+    return interpolate(value, params);
+  }
+  function interpolate(text, params) {
+    if (!params || Object.keys(params).length === 0) {
+      return text;
+    }
+    return text.replace(/\{(\w+)\}/g, (match, key) => {
+      return params[key] !== void 0 ? params[key] : match;
+    });
+  }
+  function getSection(section) {
+    if (currentTranslations[section]) {
+      return currentTranslations[section];
+    }
+    console.warn(`Secci\xF3n de traducci\xF3n no encontrada: '${section}'`);
+    return {};
+  }
+  initializeLanguage();
+
+  // src/core/dom.js
+  function isPaletteOpen(debug = false) {
+    const paletteSelectors = [
+      '[data-testid="color-picker"]',
+      ".color-picker",
+      ".palette",
+      '[class*="color"][class*="picker"]',
+      '[class*="palette"]'
+    ];
+    for (const selector of paletteSelectors) {
+      const element = document.querySelector(selector);
+      if (element && element.offsetParent !== null) {
+        if (debug) console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por selector: ${selector}`);
+        return true;
+      }
+    }
+    const colorElements = document.querySelectorAll('[style*="background-color"], [style*="background:"], .color, [class*="color"]');
+    let visibleColors = 0;
+    for (const el of colorElements) {
+      if (el.offsetParent !== null && el.offsetWidth > 10 && el.offsetHeight > 10) {
+        visibleColors++;
+        if (visibleColors >= 5) {
+          if (debug) console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por colores visibles: ${visibleColors}`);
+          return true;
+        }
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u{1F50D} Paleta no detectada. Colores visibles: ${visibleColors}`);
+    return false;
+  }
+  function findAndClickPaintButton(debug = false, doubleClick = false) {
+    const specificButton = document.querySelector("button.btn.btn-primary.btn-lg, button.btn.btn-primary.sm\\:btn-xl");
+    if (specificButton) {
+      const buttonText = specificButton.textContent.toLowerCase();
+      const hasPaintText = buttonText.includes("paint") || buttonText.includes("pintar");
+      const hasPaintIcon = specificButton.querySelector('svg path[d*="240-120"]') || specificButton.querySelector('svg path[d*="M15"]');
+      if (hasPaintText || hasPaintIcon) {
+        if (debug) console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por selector espec\xEDfico: "${buttonText}"`);
+        specificButton.click();
+        if (doubleClick) {
+          setTimeout(() => {
+            if (debug) console.log(`[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint`);
+            specificButton.click();
+          }, 500);
+        }
+        return true;
+      }
+    }
+    const buttons = document.querySelectorAll("button");
+    for (const button of buttons) {
+      const buttonText = button.textContent.toLowerCase();
+      if ((buttonText.includes("paint") || buttonText.includes("pintar")) && button.offsetParent !== null && !button.disabled) {
+        if (debug) console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por texto: "${button.textContent.trim()}"`);
+        button.click();
+        if (doubleClick) {
+          setTimeout(() => {
+            if (debug) console.log(`[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint`);
+            button.click();
+          }, 500);
+        }
+        return true;
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado`);
+    return false;
+  }
+  async function autoClickPaintButton(maxAttempts = 3, debug = true) {
+    if (debug) console.log(`[WPA-UI] \u{1F916} Iniciando auto-click del bot\xF3n Paint (m\xE1ximo ${maxAttempts} intentos)`);
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (debug) console.log(`[WPA-UI] \u{1F3AF} Intento ${attempt}/${maxAttempts} - Buscando bot\xF3n Paint...`);
+      if (isPaletteOpen()) {
+        if (debug) console.log(`[WPA-UI] \u2705 Paleta ya est\xE1 abierta, auto-click completado`);
+        return true;
+      }
+      if (findAndClickPaintButton(debug, false)) {
+        if (debug) console.log(`[WPA-UI] \u{1F446} Clic en bot\xF3n Paint realizado (sin segundo clic)`);
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        if (isPaletteOpen()) {
+          if (debug) console.log(`[WPA-UI] \u2705 Paleta abierta exitosamente despu\xE9s del intento ${attempt}`);
+          return true;
+        } else {
+          if (debug) console.log(`[WPA-UI] \u26A0\uFE0F Paleta no detectada tras el clic en intento ${attempt}. Reintentar\xE1.`);
+        }
+      } else {
+        if (debug) console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado para clic en intento ${attempt}`);
+      }
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 1e3));
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u274C Auto-click fall\xF3 despu\xE9s de ${maxAttempts} intentos`);
+    return false;
+  }
+
+  // src/guard/index.js
+  var { setInterval, clearInterval } = window;
+  async function runGuard() {
+    log("\u{1F6E1}\uFE0F Iniciando WPlace Auto-Guard");
+    initializeLanguage();
+    if (!checkExistingBots()) {
+      return;
+    }
+    window.__wplaceBot = {
+      ...window.__wplaceBot,
+      guardRunning: true
+    };
+    try {
+      const texts = getSection("guard");
+      guardState.ui = createGuardUI(texts);
+      setupEventListeners();
+      async function tryAutoInit() {
+        log("\u{1F916} Intentando auto-inicio del Guard...");
+        guardState.ui.updateStatus(t("guard.paletteNotFound"), "info");
+        if (isPaletteOpen()) {
+          log("\u{1F3A8} Paleta parece abierta. Validando colores...");
+          const colorsNow = detectAvailableColors();
+          if (colorsNow.length > 0) {
+            guardState.ui.updateStatus(t("guard.paletteDetected"), "success");
+            return true;
+          }
+          log('\u26A0\uFE0F Paleta "abierta" pero sin colores detectados. Intentando presionar Paint...');
+        }
+        log("\u{1F50D} Buscando bot\xF3n Paint...");
+        guardState.ui.updateStatus(t("guard.clickingPaintButton"), "info");
+        if (findAndClickPaintButton()) {
+          log("\u{1F446} Bot\xF3n Paint encontrado y presionado");
+          await sleep(3e3);
+          const colorsAfter = detectAvailableColors();
+          if (colorsAfter.length > 0) {
+            log("\u2705 Colores detectados tras presionar Paint");
+            guardState.ui.updateStatus(t("guard.paletteDetected"), "success");
+            return true;
+          }
+          if (isPaletteOpen()) {
+            log("\u2705 Paleta abierta, pero sin colores accesibles a\xFAn");
+          } else {
+            log("\u274C La paleta no se abri\xF3 despu\xE9s de hacer clic");
+          }
+        } else {
+          log("\u274C Bot\xF3n Paint no encontrado");
+        }
+        guardState.ui.updateStatus(t("guard.autoInitFailed"), "warning");
+        return false;
+      }
+      setTimeout(async () => {
+        try {
+          guardState.ui.updateStatus(t("guard.autoInitializing"), "info");
+          log("\u{1F916} Intentando auto-inicio...");
+          const autoInitSuccess = await tryAutoInit();
+          if (autoInitSuccess) {
+            guardState.ui.updateStatus(t("guard.autoInitSuccess"), "success");
+            log("\u2705 Auto-inicio exitoso");
+            guardState.ui.setInitButtonVisible(false);
+            const initResult = await initializeGuard(true);
+            if (initResult) {
+              log("\u{1F680} Guard-BOT auto-iniciado completamente");
+            }
+          } else {
+            guardState.ui.updateStatus(t("guard.autoInitFailed"), "warning");
+            log("\u26A0\uFE0F Auto-inicio fall\xF3, se requiere inicio manual");
+            guardState.ui.setInitButtonVisible(true);
+          }
+        } catch (error) {
+          log("\u274C Error en auto-inicio:", error);
+          guardState.ui.updateStatus(t("guard.manualInitRequired"), "warning");
+        }
+      }, 1e3);
+      window.addEventListener("beforeunload", () => {
+        stopGuard();
+        if (window.__wplaceBot) {
+          window.__wplaceBot.guardRunning = false;
+        }
+      });
+      log("\u2705 Auto-Guard cargado correctamente");
+    } catch (error) {
+      log("\u274C Error inicializando Auto-Guard:", error);
+      if (window.__wplaceBot) {
+        window.__wplaceBot.guardRunning = false;
+      }
+      throw error;
+    }
+  }
+  function checkExistingBots() {
+    var _a, _b;
+    if ((_a = window.__wplaceBot) == null ? void 0 : _a.imageRunning) {
+      alert("Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Guard.");
+      return false;
+    }
+    if ((_b = window.__wplaceBot) == null ? void 0 : _b.farmRunning) {
+      alert("Auto-Farm est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Guard.");
+      return false;
+    }
+    return true;
+  }
+  function setupEventListeners() {
+    const { elements } = guardState.ui;
+    elements.closeBtn.addEventListener("click", () => {
+      stopGuard();
+      guardState.ui.destroy();
+      if (window.__wplaceBot) {
+        window.__wplaceBot.guardRunning = false;
+      }
+    });
+    elements.initBtn.addEventListener("click", () => initializeGuard());
+    elements.selectAreaBtn.addEventListener("click", selectAreaStepByStep);
+    elements.loadAreaBtn.addEventListener("click", () => {
+      elements.areaFileInput.click();
+    });
+    elements.areaFileInput.addEventListener("change", async () => {
+      if (elements.areaFileInput.files.length > 0) {
+        const result = await loadProgress(elements.areaFileInput.files[0]);
+        if (result.success) {
+          guardState.ui.updateStatus(`\u2705 Protecci\xF3n cargada: ${result.protectedPixels} p\xEDxeles protegidos`, "success");
+          log(`\u2705 \xC1rea de protecci\xF3n cargada desde archivo`);
+        } else {
+          guardState.ui.updateStatus(`\u274C Error al cargar protecci\xF3n: ${result.error}`, "error");
+          log(`\u274C Error cargando archivo: ${result.error}`);
+        }
+      }
+    });
+    elements.startBtn.addEventListener("click", startGuard);
+    elements.stopBtn.addEventListener("click", async () => {
+      guardState.running = false;
+      guardState.loopId = null;
+      guardState.ui.setRunningState(false);
+      guardState.ui.updateStatus("\u23F9\uFE0F Protecci\xF3n detenida", "warning");
+      if (guardState.checkInterval) {
+        clearInterval(guardState.checkInterval);
+        guardState.checkInterval = null;
+      }
+    });
+    elements.saveBtn.addEventListener("click", async () => {
+      if (!hasProgress()) {
+        guardState.ui.updateStatus("\u274C No hay \xE1rea protegida para guardar", "error");
+        return;
+      }
+      const splitConfirm = await showConfirmDialog(
+        '\xBFDeseas dividir el \xE1rea protegida en partes para m\xFAltiples usuarios?<br><br><label for="splitCountInput">N\xFAmero de partes (1 = sin dividir):</label><br><input type="number" id="splitCountInput" min="1" max="20" value="1" style="margin: 5px 0; padding: 5px; width: 100px; background: #374151; border: 1px solid #4b5563; border-radius: 4px; color: #d1d5db;">',
+        "Opciones de Guardado",
+        {
+          save: "Guardar",
+          cancel: "Cancelar"
+        }
+      );
+      if (splitConfirm === "save") {
+        const splitInput = document.querySelector("#splitCountInput");
+        const splitCount = parseInt(splitInput == null ? void 0 : splitInput.value) || 1;
+        const result = await saveProgress(null, splitCount);
+        if (result.success) {
+          guardState.ui.updateStatus(`\u2705 Protecci\xF3n guardada${splitCount > 1 ? ` (dividida en ${splitCount} partes)` : ""}`, "success");
+        } else {
+          guardState.ui.updateStatus(`\u274C Error al guardar: ${result.error}`, "error");
+        }
+      }
+    });
+    elements.pixelsPerBatchInput.addEventListener("change", (e) => {
+      guardState.pixelsPerBatch = Math.max(1, Math.min(50, parseInt(e.target.value) || 10));
+      e.target.value = guardState.pixelsPerBatch;
+    });
+    elements.minChargesInput.addEventListener("change", (e) => {
+      guardState.minChargesToWait = Math.max(1, Math.min(100, parseInt(e.target.value) || 20));
+      e.target.value = guardState.minChargesToWait;
+    });
+    elements.pixelsPerBatchInput.value = guardState.pixelsPerBatch;
+    elements.minChargesInput.value = guardState.minChargesToWait;
+  }
+  async function initializeGuard(isAutoInit = false) {
+    var _a;
+    try {
+      guardState.ui.updateStatus(t("guard.checkingColors"), "info");
+      let colors = detectAvailableColors();
+      if (colors.length === 0) {
+        log("\u26A0\uFE0F 0 colores detectados. Intentando abrir paleta (fallback)...");
+        guardState.ui.updateStatus(t("guard.clickingPaintButton"), "info");
+        if (findAndClickPaintButton()) {
+          await sleep(2500);
+          colors = detectAvailableColors();
+        }
+      }
+      if (colors.length === 0) {
+        guardState.ui.updateStatus(t("guard.noColorsFound"), "error");
+        return false;
+      }
+      guardState.availableColors = colors;
+      guardState.colorsChecked = true;
+      const session = await getSession();
+      if (session.success) {
+        guardState.currentCharges = session.data.charges;
+        guardState.maxCharges = session.data.maxCharges;
+        guardState.ui.updateStats({ charges: Math.floor(guardState.currentCharges) });
+        log(`\u{1F464} Usuario: ${((_a = session.data.user) == null ? void 0 : _a.name) || "An\xF3nimo"} - Cargas: ${guardState.currentCharges}`);
+      }
+      guardState.initialized = true;
+      guardState.ui.updateStatus(t("guard.colorsFound", { count: colors.length }), "success");
+      guardState.ui.showAreaSection();
+      if (!isAutoInit) {
+        log(`\u2705 ${colors.length} colores disponibles detectados`);
+      }
+      guardState.ui.setInitialized(true);
+      return true;
+    } catch (error) {
+      log("\u274C Error inicializando:", error);
+      guardState.ui.updateStatus(t("guard.initError"), "error");
+      return false;
+    }
+  }
+  var originalFetch = window.fetch;
+  async function selectAreaStepByStep() {
+    log("\u{1F3AF} Iniciando selecci\xF3n paso a paso del \xE1rea");
+    let upperLeftCorner = null;
+    let lowerRightCorner = null;
+    let selectionPhase = "upperLeft";
+    let positionCaptured = false;
+    const restoreFetch = () => {
+      if (window.fetch !== originalFetch) {
+        window.fetch = originalFetch;
+        log("\u{1F504} Fetch original restaurado");
+      }
+    };
+    const setupFetchInterception = () => {
+      window.fetch = async (url, options) => {
+        if (!positionCaptured && typeof url === "string" && url.includes("/s0/pixel/") && options && options.method === "POST") {
+          try {
+            log(`\u{1F3AF} Interceptando request de pintado: ${url}`);
+            const response = await originalFetch(url, options);
+            if (response.ok && options.body) {
+              let bodyData;
+              try {
+                bodyData = JSON.parse(options.body);
+              } catch (parseError) {
+                log("Error parseando body del request:", parseError);
+                return response;
+              }
+              if (bodyData.coords && Array.isArray(bodyData.coords) && bodyData.coords.length >= 2) {
+                const localX = bodyData.coords[0];
+                const localY = bodyData.coords[1];
+                const tileMatch = url.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);
+                if (tileMatch) {
+                  const tileX = parseInt(tileMatch[1]);
+                  const tileY = parseInt(tileMatch[2]);
+                  const globalX = tileX * 3e3 + localX;
+                  const globalY = tileY * 3e3 + localY;
+                  if (selectionPhase === "upperLeft") {
+                    upperLeftCorner = { x: globalX, y: globalY };
+                    guardState.ui.updateCoordinates({ x1: globalX, y1: globalY });
+                    guardState.ui.updateStatus(t("guard.upperLeftCaptured", { x: globalX, y: globalY }), "success");
+                    log(`\u2705 Esquina superior izquierda capturada: (${globalX}, ${globalY})`);
+                    selectionPhase = "lowerRight";
+                    setTimeout(() => {
+                      if (selectionPhase === "lowerRight") {
+                        guardState.ui.updateStatus(t("guard.selectLowerRight"), "info");
+                      }
+                    }, 1500);
+                  } else if (selectionPhase === "lowerRight") {
+                    lowerRightCorner = { x: globalX, y: globalY };
+                    guardState.ui.updateCoordinates({ x2: globalX, y2: globalY });
+                    guardState.ui.updateStatus(t("guard.lowerRightCaptured", { x: globalX, y: globalY }), "success");
+                    log(`\u2705 Esquina inferior derecha capturada: (${globalX}, ${globalY})`);
+                    positionCaptured = true;
+                    restoreFetch();
+                    if (upperLeftCorner.x >= lowerRightCorner.x || upperLeftCorner.y >= lowerRightCorner.y) {
+                      guardState.ui.updateStatus(t("guard.invalidArea"), "error");
+                      return response;
+                    }
+                    setTimeout(async () => {
+                      await captureAreaFromCoordinates(upperLeftCorner, lowerRightCorner);
+                    }, 1e3);
+                  }
+                }
+              }
+            }
+            return response;
+          } catch (error) {
+            log("\u274C Error interceptando pixel:", error);
+            restoreFetch();
+            return originalFetch(url, options);
+          }
+        }
+        return originalFetch(url, options);
+      };
+    };
+    setupFetchInterception();
+    guardState.ui.updateStatus(t("guard.selectUpperLeft"), "info");
+    setTimeout(() => {
+      if (!positionCaptured) {
+        restoreFetch();
+        guardState.ui.updateStatus(t("guard.selectionTimeout"), "error");
+        log("\u23F0 Timeout en selecci\xF3n de \xE1rea");
+      }
+    }, 12e4);
+  }
+  async function captureAreaFromCoordinates(upperLeft, lowerRight) {
+    try {
+      const area = {
+        x1: upperLeft.x,
+        y1: upperLeft.y,
+        x2: lowerRight.x,
+        y2: lowerRight.y
+      };
+      guardState.ui.updateStatus(t("guard.capturingArea"), "info");
+      const pixelMap = await analyzeAreaPixels(area);
+      guardState.protectionArea = area;
+      guardState.originalPixels = pixelMap;
+      guardState.changes.clear();
+      guardState.ui.updateProgress(0, pixelMap.size);
+      guardState.ui.updateStatus(t("guard.areaCaptured", { count: pixelMap.size }), "success");
+      guardState.ui.enableStartBtn();
+      log(`\u2705 \xC1rea capturada: ${pixelMap.size} p\xEDxeles protegidos`);
+    } catch (error) {
+      log("\u274C Error capturando \xE1rea:", error);
+      guardState.ui.updateStatus(t("guard.captureError", { error: error.message }), "error");
+    }
+  }
+  async function startGuard() {
+    if (!guardState.protectionArea || !guardState.originalPixels.size) {
+      guardState.ui.updateStatus(t("guard.captureFirst"), "error");
+      return;
+    }
+    guardState.running = true;
+    guardState.ui.setRunningState(true);
+    guardState.ui.updateStatus(t("guard.protectionStarted"), "success");
+    log("\u{1F6E1}\uFE0F Iniciando protecci\xF3n del \xE1rea");
+    guardState.checkInterval = setInterval(checkForChanges, GUARD_DEFAULTS.CHECK_INTERVAL);
+    await checkForChanges();
+  }
+  function stopGuard() {
+    guardState.running = false;
+    if (guardState.checkInterval) {
+      clearInterval(guardState.checkInterval);
+      guardState.checkInterval = null;
+    }
+    if (guardState.ui) {
+      guardState.ui.setRunningState(false);
+      guardState.ui.updateStatus(t("guard.protectionStopped"), "warning");
+    }
+    log("\u23F9\uFE0F Protecci\xF3n detenida");
+  }
+
+  // src/entries/guard.js
+  (async function() {
+    var _a;
+    try {
+      console.log("[WPA-Guard] \u{1F916} Iniciando auto-click del bot\xF3n Paint...");
+      await autoClickPaintButton(3, true);
+    } catch (error) {
+      console.log("[WPA-Guard] \u26A0\uFE0F Error en auto-click del bot\xF3n Paint:", error);
+    }
+    if ((_a = window.__wplaceBot) == null ? void 0 : _a.guardRunning) {
+      alert("Auto-Guard ya est\xE1 corriendo.");
+    } else {
+      runGuard().catch((error) => {
+        console.error("[WPA-GUARD] Error en Auto-Guard:", error);
+        if (window.__wplaceBot) {
+          window.__wplaceBot.guardRunning = false;
+        }
+        alert("Auto-Guard: error inesperado. Revisa consola.");
+      });
+    }
+  })();
+})();
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsic3JjL2NvcmUvbG9nZ2VyLmpzIiwgInNyYy9jb3JlL3dwbGFjZS1hcGkuanMiLCAic3JjL2d1YXJkL2NvbmZpZy5qcyIsICJzcmMvY29yZS90dXJuc3RpbGUuanMiLCAic3JjL2NvcmUvdGltaW5nLmpzIiwgInNyYy9ndWFyZC9wcm9jZXNzb3IuanMiLCAic3JjL2d1YXJkL3VpLmpzIiwgInNyYy9ndWFyZC9zYXZlLWxvYWQuanMiLCAic3JjL2xvY2FsZXMvZXMuanMiLCAic3JjL2xvY2FsZXMvZW4uanMiLCAic3JjL2xvY2FsZXMvZnIuanMiLCAic3JjL2xvY2FsZXMvcnUuanMiLCAic3JjL2xvY2FsZXMvemgtSGFucy5qcyIsICJzcmMvbG9jYWxlcy96aC1IYW50LmpzIiwgInNyYy9sb2NhbGVzL2luZGV4LmpzIiwgInNyYy9jb3JlL2RvbS5qcyIsICJzcmMvZ3VhcmQvaW5kZXguanMiLCAic3JjL2VudHJpZXMvZ3VhcmQuanMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImV4cG9ydCBjb25zdCBsb2dnZXIgPSB7XG4gIGRlYnVnRW5hYmxlZDogZmFsc2UsXG4gIHNldERlYnVnKHYpIHsgdGhpcy5kZWJ1Z0VuYWJsZWQgPSAhIXY7IH0sXG4gIGRlYnVnKC4uLmEpIHsgaWYgKHRoaXMuZGVidWdFbmFibGVkKSBjb25zb2xlLmRlYnVnKFwiW0JPVF1cIiwgLi4uYSk7IH0sXG4gIGluZm8oLi4uYSkgIHsgY29uc29sZS5pbmZvKFwiW0JPVF1cIiwgLi4uYSk7IH0sXG4gIHdhcm4oLi4uYSkgIHsgY29uc29sZS53YXJuKFwiW0JPVF1cIiwgLi4uYSk7IH0sXG4gIGVycm9yKC4uLmEpIHsgY29uc29sZS5lcnJvcihcIltCT1RdXCIsIC4uLmEpOyB9XG59O1xuXG4vLyBGYXJtLXNwZWNpZmljIGxvZ2dlclxuZXhwb3J0IGNvbnN0IGxvZyA9ICguLi5hKSA9PiBjb25zb2xlLmxvZygnW1dQQS1VSV0nLCAuLi5hKTtcblxuLy8gVXRpbGl0eSBmdW5jdGlvbnNcbmV4cG9ydCBjb25zdCBub29wID0gKCkgPT4ge307XG5leHBvcnQgY29uc3QgY2xhbXAgPSAobiwgYSwgYikgPT4gTWF0aC5tYXgoYSwgTWF0aC5taW4oYiwgbikpO1xuIiwgImltcG9ydCB7IGZldGNoV2l0aFRpbWVvdXQgfSBmcm9tIFwiLi9odHRwLmpzXCI7XG5cbmNvbnN0IEJBU0UgPSBcImh0dHBzOi8vYmFja2VuZC53cGxhY2UubGl2ZVwiO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gZ2V0U2Vzc2lvbigpIHtcbiAgdHJ5IHtcbiAgICBjb25zdCBtZSA9IGF3YWl0IGZldGNoKGAke0JBU0V9L21lYCwgeyBjcmVkZW50aWFsczogJ2luY2x1ZGUnIH0pLnRoZW4ociA9PiByLmpzb24oKSk7XG4gICAgY29uc3QgdXNlciA9IG1lIHx8IG51bGw7XG4gICAgY29uc3QgYyA9IG1lPy5jaGFyZ2VzIHx8IHt9O1xuICAgIGNvbnN0IGNoYXJnZXMgPSB7XG4gICAgICBjb3VudDogYy5jb3VudCA/PyAwLCAgICAgICAgLy8gTWFudGVuZXIgdmFsb3IgZGVjaW1hbCBvcmlnaW5hbFxuICAgICAgbWF4OiBjLm1heCA/PyAwLCAgICAgICAgICAgIC8vIE1hbnRlbmVyIHZhbG9yIG9yaWdpbmFsIChwdWVkZSB2YXJpYXIgcG9yIHVzdWFyaW8pXG4gICAgICBjb29sZG93bk1zOiBjLmNvb2xkb3duTXMgPz8gMzAwMDBcbiAgICB9O1xuICAgIFxuICAgIHJldHVybiB7IFxuICAgICAgc3VjY2VzczogdHJ1ZSxcbiAgICAgIGRhdGE6IHtcbiAgICAgICAgdXNlciwgXG4gICAgICAgIGNoYXJnZXM6IGNoYXJnZXMuY291bnQsXG4gICAgICAgIG1heENoYXJnZXM6IGNoYXJnZXMubWF4LFxuICAgICAgICBjaGFyZ2VSZWdlbjogY2hhcmdlcy5jb29sZG93bk1zXG4gICAgICB9XG4gICAgfTtcbiAgfSBjYXRjaCAoZXJyb3IpIHsgXG4gICAgcmV0dXJuIHsgXG4gICAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICAgIGVycm9yOiBlcnJvci5tZXNzYWdlLFxuICAgICAgZGF0YToge1xuICAgICAgICB1c2VyOiBudWxsLCBcbiAgICAgICAgY2hhcmdlczogMCxcbiAgICAgICAgbWF4Q2hhcmdlczogMCxcbiAgICAgICAgY2hhcmdlUmVnZW46IDMwMDAwXG4gICAgICB9XG4gICAgfTsgXG4gIH1cbn1cblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGNoZWNrSGVhbHRoKCkge1xuICB0cnkge1xuICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgZmV0Y2goYCR7QkFTRX0vaGVhbHRoYCwge1xuICAgICAgbWV0aG9kOiAnR0VUJyxcbiAgICAgIGNyZWRlbnRpYWxzOiAnaW5jbHVkZSdcbiAgICB9KTtcbiAgICBcbiAgICBpZiAocmVzcG9uc2Uub2spIHtcbiAgICAgIGNvbnN0IGhlYWx0aCA9IGF3YWl0IHJlc3BvbnNlLmpzb24oKTtcbiAgICAgIHJldHVybiB7XG4gICAgICAgIC4uLmhlYWx0aCxcbiAgICAgICAgbGFzdENoZWNrOiBEYXRlLm5vdygpLFxuICAgICAgICBzdGF0dXM6ICdvbmxpbmUnXG4gICAgICB9O1xuICAgIH0gZWxzZSB7XG4gICAgICByZXR1cm4ge1xuICAgICAgICBkYXRhYmFzZTogZmFsc2UsXG4gICAgICAgIHVwOiBmYWxzZSxcbiAgICAgICAgdXB0aW1lOiAnTi9BJyxcbiAgICAgICAgbGFzdENoZWNrOiBEYXRlLm5vdygpLFxuICAgICAgICBzdGF0dXM6ICdlcnJvcicsXG4gICAgICAgIHN0YXR1c0NvZGU6IHJlc3BvbnNlLnN0YXR1c1xuICAgICAgfTtcbiAgICB9XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIGRhdGFiYXNlOiBmYWxzZSxcbiAgICAgIHVwOiBmYWxzZSxcbiAgICAgIHVwdGltZTogJ04vQScsXG4gICAgICBsYXN0Q2hlY2s6IERhdGUubm93KCksXG4gICAgICBzdGF0dXM6ICdvZmZsaW5lJyxcbiAgICAgIGVycm9yOiBlcnJvci5tZXNzYWdlXG4gICAgfTtcbiAgfVxufVxuXG4vLyBVbmlmaWNhIHBvc3QgZGUgcFx1MDBFRHhlbCBwb3IgbG90ZXMgKGJhdGNoIHBvciB0aWxlKS5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwb3N0UGl4ZWxCYXRjaCh7IHRpbGVYLCB0aWxlWSwgcGl4ZWxzLCB0dXJuc3RpbGVUb2tlbiB9KSB7XG4gIC8vIHBpeGVsczogW3t4LHksY29sb3J9LCBcdTIwMjZdIHJlbGF0aXZvcyBhbCB0aWxlXG4gIGNvbnN0IGJvZHkgPSBKU09OLnN0cmluZ2lmeSh7IHBpeGVscywgdG9rZW46IHR1cm5zdGlsZVRva2VuIH0pO1xuICBjb25zdCByID0gYXdhaXQgZmV0Y2hXaXRoVGltZW91dChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICBtZXRob2Q6IFwiUE9TVFwiLFxuICAgIGhlYWRlcnM6IHsgXCJDb250ZW50LVR5cGVcIjogXCJ0ZXh0L3BsYWluO2NoYXJzZXQ9VVRGLThcIiB9LFxuICAgIGJvZHksXG4gICAgY3JlZGVudGlhbHM6IFwiaW5jbHVkZVwiXG4gIH0pO1xuICBcbiAgLy8gQWxndW5hcyByZXNwdWVzdGFzIHB1ZWRlbiBubyB0cmFlciBKU09OIGF1bnF1ZSBzZWFuIDIwMC5cbiAgaWYgKHIuc3RhdHVzID09PSAyMDApIHtcbiAgICB0cnkgeyByZXR1cm4gYXdhaXQgci5qc29uKCk7IH0gY2F0Y2ggeyByZXR1cm4geyBvazogdHJ1ZSB9OyB9XG4gIH1cbiAgXG4gIGxldCBtc2cgPSBgSFRUUCAke3Iuc3RhdHVzfWA7XG4gIHRyeSB7IFxuICAgIGNvbnN0IGogPSBhd2FpdCByLmpzb24oKTsgXG4gICAgbXNnID0gaj8ubWVzc2FnZSB8fCBtc2c7IFxuICB9IGNhdGNoIHtcbiAgICAvLyBSZXNwb25zZSBub3QgSlNPTlxuICB9XG4gIHRocm93IG5ldyBFcnJvcihgcGFpbnQgZmFpbGVkOiAke21zZ31gKTtcbn1cblxuLy8gVmVyc2lcdTAwRjNuICdzYWZlJyBxdWUgbm8gYXJyb2phIGV4Y2VwY2lvbmVzIHkgcmV0b3JuYSBzdGF0dXMvanNvblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHBvc3RQaXhlbEJhdGNoU2FmZSh0aWxlWCwgdGlsZVksIHBpeGVscywgdHVybnN0aWxlVG9rZW4pIHtcbiAgdHJ5IHtcbiAgICBjb25zdCBib2R5ID0gSlNPTi5zdHJpbmdpZnkoeyBwaXhlbHMsIHRva2VuOiB0dXJuc3RpbGVUb2tlbiB9KTtcbiAgICBjb25zdCByID0gYXdhaXQgZmV0Y2hXaXRoVGltZW91dChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICAgIG1ldGhvZDogXCJQT1NUXCIsXG4gICAgICBoZWFkZXJzOiB7IFwiQ29udGVudC1UeXBlXCI6IFwidGV4dC9wbGFpbjtjaGFyc2V0PVVURi04XCIgfSxcbiAgICAgIGJvZHksXG4gICAgICBjcmVkZW50aWFsczogXCJpbmNsdWRlXCJcbiAgICB9KTtcbiAgbGV0IGpzb24gPSB7fTtcbiAgLy8gSWYgcmVzcG9uc2UgaXMgbm90IEpTT04sIGlnbm9yZSBwYXJzZSBlcnJvclxuICB0cnkgeyBqc29uID0gYXdhaXQgci5qc29uKCk7IH0gY2F0Y2ggeyAvKiBpZ25vcmUgKi8gfVxuICAgIHJldHVybiB7IHN0YXR1czogci5zdGF0dXMsIGpzb24sIHN1Y2Nlc3M6IHIub2sgfTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICByZXR1cm4geyBzdGF0dXM6IDAsIGpzb246IHsgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfSwgc3VjY2VzczogZmFsc2UgfTtcbiAgfVxufVxuXG4vLyBQb3N0IHBcdTAwRUR4ZWwgcGFyYSBmYXJtICh2ZXJzaVx1MDBGM24gY29ycmVnaWRhIGNvbiBmb3JtYXRvIG9yaWdpbmFsKVxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHBvc3RQaXhlbChjb29yZHMsIGNvbG9ycywgdHVybnN0aWxlVG9rZW4sIHRpbGVYLCB0aWxlWSkge1xuICB0cnkge1xuICAgIGNvbnN0IGJvZHkgPSBKU09OLnN0cmluZ2lmeSh7IFxuICAgICAgY29sb3JzOiBjb2xvcnMsIFxuICAgICAgY29vcmRzOiBjb29yZHMsIFxuICAgICAgdDogdHVybnN0aWxlVG9rZW4gXG4gICAgfSk7XG4gICAgXG4gICAgY29uc3QgY29udHJvbGxlciA9IG5ldyBBYm9ydENvbnRyb2xsZXIoKTtcbiAgICBjb25zdCB0aW1lb3V0SWQgPSBzZXRUaW1lb3V0KCgpID0+IGNvbnRyb2xsZXIuYWJvcnQoKSwgMTUwMDApOyAvLyBUaW1lb3V0IGRlIDE1IHNlZ3VuZG9zXG5cbiAgICBjb25zdCByZXNwb25zZSA9IGF3YWl0IGZldGNoKGAke0JBU0V9L3MwL3BpeGVsLyR7dGlsZVh9LyR7dGlsZVl9YCwge1xuICAgICAgbWV0aG9kOiAnUE9TVCcsXG4gICAgICBjcmVkZW50aWFsczogJ2luY2x1ZGUnLFxuICAgICAgaGVhZGVyczogeyAnQ29udGVudC1UeXBlJzogJ3RleHQvcGxhaW47Y2hhcnNldD1VVEYtOCcgfSxcbiAgICAgIGJvZHk6IGJvZHksXG4gICAgICBzaWduYWw6IGNvbnRyb2xsZXIuc2lnbmFsXG4gICAgfSk7XG5cbiAgICBjbGVhclRpbWVvdXQodGltZW91dElkKTtcblxuICAgIGxldCByZXNwb25zZURhdGEgPSBudWxsO1xuICAgIHRyeSB7XG4gICAgICBjb25zdCB0ZXh0ID0gYXdhaXQgcmVzcG9uc2UudGV4dCgpO1xuICAgICAgaWYgKHRleHQpIHtcbiAgICAgICAgcmVzcG9uc2VEYXRhID0gSlNPTi5wYXJzZSh0ZXh0KTtcbiAgICAgIH1cbiAgICB9IGNhdGNoIHtcbiAgICAgIHJlc3BvbnNlRGF0YSA9IHt9OyAvLyBJZ25vcmFyIGVycm9yZXMgZGUgSlNPTiBwYXJzZVxuICAgIH1cblxuICAgIHJldHVybiB7XG4gICAgICBzdGF0dXM6IHJlc3BvbnNlLnN0YXR1cyxcbiAgICAgIGpzb246IHJlc3BvbnNlRGF0YSxcbiAgICAgIHN1Y2Nlc3M6IHJlc3BvbnNlLm9rXG4gICAgfTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICByZXR1cm4ge1xuICAgICAgc3RhdHVzOiAwLFxuICAgICAganNvbjogeyBlcnJvcjogZXJyb3IubWVzc2FnZSB9LFxuICAgICAgc3VjY2VzczogZmFsc2VcbiAgICB9O1xuICB9XG59XG5cbi8vIFBvc3QgcFx1MDBFRHhlbCBwYXJhIEF1dG8tSW1hZ2UgKGZvcm1hdG8gb3JpZ2luYWwgY29ycmVjdG8pXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcG9zdFBpeGVsQmF0Y2hJbWFnZSh0aWxlWCwgdGlsZVksIGNvb3JkcywgY29sb3JzLCB0dXJuc3RpbGVUb2tlbikge1xuICB0cnkge1xuICAgIGNvbnN0IGJvZHkgPSBKU09OLnN0cmluZ2lmeSh7IFxuICAgICAgY29sb3JzOiBjb2xvcnMsIFxuICAgICAgY29vcmRzOiBjb29yZHMsIFxuICAgICAgdDogdHVybnN0aWxlVG9rZW4gXG4gICAgfSk7XG4gICAgXG4gICAgY29uc3QgcmVzcG9uc2UgPSBhd2FpdCBmZXRjaChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICAgIG1ldGhvZDogJ1BPU1QnLFxuICAgICAgY3JlZGVudGlhbHM6ICdpbmNsdWRlJyxcbiAgICAgIGhlYWRlcnM6IHsgJ0NvbnRlbnQtVHlwZSc6ICd0ZXh0L3BsYWluO2NoYXJzZXQ9VVRGLTgnIH0sXG4gICAgICBib2R5OiBib2R5XG4gICAgfSk7XG5cbiAgICBsZXQgcmVzcG9uc2VEYXRhID0gbnVsbDtcbiAgICB0cnkge1xuICAgICAgcmVzcG9uc2VEYXRhID0gYXdhaXQgcmVzcG9uc2UuanNvbigpO1xuICAgIH0gY2F0Y2gge1xuICAgICAgcmVzcG9uc2VEYXRhID0ge307IC8vIElnbm9yYXIgZXJyb3JlcyBkZSBKU09OIHBhcnNlXG4gICAgfVxuXG4gICAgcmV0dXJuIHtcbiAgICAgIHN0YXR1czogcmVzcG9uc2Uuc3RhdHVzLFxuICAgICAganNvbjogcmVzcG9uc2VEYXRhLFxuICAgICAgc3VjY2VzczogcmVzcG9uc2Uub2ssXG4gICAgICBwYWludGVkOiByZXNwb25zZURhdGE/LnBhaW50ZWQgfHwgMFxuICAgIH07XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIHN0YXR1czogMCxcbiAgICAgIGpzb246IHsgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfSxcbiAgICAgIHN1Y2Nlc3M6IGZhbHNlLFxuICAgICAgcGFpbnRlZDogMFxuICAgIH07XG4gIH1cbn1cbiIsICIvLyBDb25maWd1cmFjaVx1MDBGM24gcGFyYSBBdXRvLUd1YXJkXG5leHBvcnQgY29uc3QgR1VBUkRfREVGQVVMVFMgPSB7XG4gIFNJVEVLRVk6IFwiMHg0QUFBQUFBQnBxSmU4Rk8wTjg0cTBGXCIsXG4gIENPT0xET1dOX0RFRkFVTFQ6IDMxMDAwLFxuICBUSUxFX1NJWkU6IDMwMDAsXG4gIENIRUNLX0lOVEVSVkFMOiAxMDAwMCwgLy8gUmV2aXNhciBjYWRhIDEwIHNlZ3VuZG9zXG4gIE1BWF9QUk9URUNUSU9OX1NJWkU6IEluZmluaXR5LCAvLyBTaW4gbFx1MDBFRG1pdGUgZGUgcFx1MDBFRHhlbGVzIHByb3RlZ2lkb3NcbiAgUElYRUxTX1BFUl9CQVRDSDogMTAsIC8vIE1lbm9zIHF1ZSBJbWFnZSBwYXJhIHNlciBtXHUwMEUxcyBzdXRpbFxuICBNSU5fQ0hBUkdFU19UT19XQUlUOiAyMCwgLy8gQ2FyZ2FzIG1cdTAwRURuaW1hcyBhIGVzcGVyYXIgYW50ZXMgZGUgY29udGludWFyXG4gIEJBQ0tFTkRfVVJMOiBcImh0dHBzOi8vYmFja2VuZC53cGxhY2UubGl2ZVwiXG59O1xuXG4vLyBFc3RhZG8gZ2xvYmFsIGRlbCBHdWFyZFxuZXhwb3J0IGNvbnN0IGd1YXJkU3RhdGUgPSB7XG4gIHJ1bm5pbmc6IGZhbHNlLFxuICBpbml0aWFsaXplZDogZmFsc2UsXG4gIHByb3RlY3Rpb25BcmVhOiBudWxsLCAvLyB7IHgxLCB5MSwgeDIsIHkyLCB0aWxlWCwgdGlsZVkgfVxuICBvcmlnaW5hbFBpeGVsczogbmV3IE1hcCgpLCAvLyBNYXAgZGUgXCJ4LHlcIiAtPiB7ciwgZywgYiwgY29sb3JJZH1cbiAgY2hhbmdlczogbmV3IE1hcCgpLCAvLyBNYXAgZGUgXCJ4LHlcIiAtPiB7dGltZXN0YW1wLCBvcmlnaW5hbENvbG9yLCBjdXJyZW50Q29sb3J9XG4gIGN1cnJlbnRDaGFyZ2VzOiAwLFxuICBtYXhDaGFyZ2VzOiA1MCxcbiAgbGFzdENoZWNrOiAwLFxuICBjaGVja0ludGVydmFsOiBudWxsLFxuICBhdmFpbGFibGVDb2xvcnM6IFtdLFxuICBjb2xvcnNDaGVja2VkOiBmYWxzZSxcbiAgdWk6IG51bGwsXG4gIHRvdGFsUmVwYWlyZWQ6IDAsXG4gIC8vIENvbmZpZ3VyYWNpXHUwMEYzbiBlZGl0YWJsZVxuICBwaXhlbHNQZXJCYXRjaDogR1VBUkRfREVGQVVMVFMuUElYRUxTX1BFUl9CQVRDSCxcbiAgbWluQ2hhcmdlc1RvV2FpdDogR1VBUkRfREVGQVVMVFMuTUlOX0NIQVJHRVNfVE9fV0FJVFxufTtcbiIsICJsZXQgbG9hZGVkID0gZmFsc2U7XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBsb2FkVHVybnN0aWxlKCkge1xuICBpZiAobG9hZGVkIHx8IHdpbmRvdy50dXJuc3RpbGUpIHJldHVybjtcbiAgXG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgY29uc3QgcyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ3NjcmlwdCcpO1xuICAgIHMuc3JjID0gJ2h0dHBzOi8vY2hhbGxlbmdlcy5jbG91ZGZsYXJlLmNvbS90dXJuc3RpbGUvdjAvYXBpLmpzP3JlbmRlcj1leHBsaWNpdCc7XG4gICAgcy5hc3luYyA9IHRydWU7IFxuICAgIHMuZGVmZXIgPSB0cnVlO1xuICAgIHMub25sb2FkID0gKCkgPT4ge1xuICAgICAgbG9hZGVkID0gdHJ1ZTtcbiAgICAgIHJlc29sdmUoKTtcbiAgICB9O1xuICAgIHMub25lcnJvciA9ICgpID0+IHJlamVjdChuZXcgRXJyb3IoJ05vIHNlIHB1ZG8gY2FyZ2FyIFR1cm5zdGlsZScpKTtcbiAgICBkb2N1bWVudC5oZWFkLmFwcGVuZENoaWxkKHMpO1xuICB9KTtcbn1cblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGV4ZWN1dGVUdXJuc3RpbGUoc2l0ZUtleSwgYWN0aW9uID0gXCJwYWludFwiKSB7XG4gIGF3YWl0IGxvYWRUdXJuc3RpbGUoKTtcbiAgXG4gIGlmICh0eXBlb2Ygd2luZG93LnR1cm5zdGlsZT8uZXhlY3V0ZSA9PT0gJ2Z1bmN0aW9uJykge1xuICAgIHRyeSB7XG4gICAgICBjb25zdCB0b2tlbiA9IGF3YWl0IHdpbmRvdy50dXJuc3RpbGUuZXhlY3V0ZShzaXRlS2V5LCB7IGFjdGlvbiB9KTtcbiAgICAgIGlmICh0b2tlbiAmJiB0b2tlbi5sZW5ndGggPiAyMCkgcmV0dXJuIHRva2VuO1xuICAgIH0gY2F0Y2ggeyBcbiAgICAgIC8qIGZhbGxiYWNrIGFiYWpvICovIFxuICAgIH1cbiAgfVxuICBcbiAgLy8gRmFsbGJhY2s6IHJlbmRlciBvY3VsdG9cbiAgcmV0dXJuIGF3YWl0IG5ldyBQcm9taXNlKChyZXNvbHZlKSA9PiB7XG4gICAgY29uc3QgaG9zdCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICAgIGhvc3Quc3R5bGUucG9zaXRpb24gPSAnZml4ZWQnOyBcbiAgICBob3N0LnN0eWxlLmxlZnQgPSAnLTk5OTlweCc7XG4gICAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChob3N0KTtcbiAgICB3aW5kb3cudHVybnN0aWxlLnJlbmRlcihob3N0LCB7IFxuICAgICAgc2l0ZWtleTogc2l0ZUtleSwgXG4gICAgICBjYWxsYmFjazogKHQpID0+IHtcbiAgICAgICAgZG9jdW1lbnQuYm9keS5yZW1vdmVDaGlsZChob3N0KTtcbiAgICAgICAgcmVzb2x2ZSh0KTtcbiAgICAgIH0gXG4gICAgfSk7XG4gIH0pO1xufVxuXG4vLyBWZXJzaVx1MDBGM24gb3JpZ2luYWwgcGFyYSBjb21wYXRpYmlsaWRhZFxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGdldFR1cm5zdGlsZVRva2VuKHNpdGVLZXkpIHtcbiAgcmV0dXJuIGV4ZWN1dGVUdXJuc3RpbGUoc2l0ZUtleSwgJ3BhaW50Jyk7XG59XG5cbi8vIERldGVjdGEgZGluXHUwMEUxbWljYW1lbnRlIGxhIHNpdGVrZXkgZGUgVHVybnN0aWxlIGRlbCBET00gbyBkZWwgY29udGV4dG8gZ2xvYmFsLlxuLy8gUHJpb3JpZGFkOiBbZGF0YS1zaXRla2V5XSA+IC5jZi10dXJuc3RpbGVbZGF0YS1zaXRla2V5XSA+IHdpbmRvdy5fX1RVUk5TVElMRV9TSVRFS0VZID4gZmFsbGJhY2tcbmV4cG9ydCBmdW5jdGlvbiBkZXRlY3RTaXRlS2V5KGZhbGxiYWNrID0gJycpIHtcbiAgdHJ5IHtcbiAgICAvLyAxKSBFbGVtZW50byBjb24gYXRyaWJ1dG8gZGF0YS1zaXRla2V5IChjb21cdTAwRkFuIGVuIGludGVncmFjaW9uZXMgZXhwbFx1MDBFRGNpdGFzKVxuICAgIGNvbnN0IGVsID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvcignW2RhdGEtc2l0ZWtleV0nKTtcbiAgICBpZiAoZWwpIHtcbiAgICAgIGNvbnN0IGtleSA9IGVsLmdldEF0dHJpYnV0ZSgnZGF0YS1zaXRla2V5Jyk7XG4gICAgICBpZiAoa2V5ICYmIGtleS5sZW5ndGggPiAxMCkgcmV0dXJuIGtleTtcbiAgICB9XG4gICAgLy8gMikgV2lkZ2V0IFR1cm5zdGlsZSBpbnNlcnRhZG8gKC5jZi10dXJuc3RpbGUpXG4gICAgY29uc3QgY2YgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKCcuY2YtdHVybnN0aWxlJyk7XG4gICAgaWYgKGNmICYmIGNmLmRhdGFzZXQ/LnNpdGVrZXkgJiYgY2YuZGF0YXNldC5zaXRla2V5Lmxlbmd0aCA+IDEwKSB7XG4gICAgICByZXR1cm4gY2YuZGF0YXNldC5zaXRla2V5O1xuICAgIH1cbiAgICAvLyAzKSBWYXJpYWJsZSBnbG9iYWwgb3BjaW9uYWxcbiAgICBpZiAodHlwZW9mIHdpbmRvdyAhPT0gJ3VuZGVmaW5lZCcgJiYgd2luZG93Ll9fVFVSTlNUSUxFX1NJVEVLRVkgJiYgd2luZG93Ll9fVFVSTlNUSUxFX1NJVEVLRVkubGVuZ3RoID4gMTApIHtcbiAgICAgIHJldHVybiB3aW5kb3cuX19UVVJOU1RJTEVfU0lURUtFWTtcbiAgICB9XG4gIH0gY2F0Y2gge1xuICAgIC8vIGlnbm9yZVxuICB9XG4gIHJldHVybiBmYWxsYmFjaztcbn1cbiIsICJleHBvcnQgY29uc3Qgc2xlZXAgPSAobXMpID0+IG5ldyBQcm9taXNlKHIgPT4gc2V0VGltZW91dChyLCBtcykpO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcmV0cnkoZm4sIHsgdHJpZXMgPSAzLCBiYXNlID0gNTAwIH0gPSB7fSkge1xuICBsZXQgbGFzdDtcbiAgZm9yIChsZXQgaSA9IDA7IGkgPCB0cmllczsgaSsrKSB7XG4gICAgdHJ5IHsgcmV0dXJuIGF3YWl0IGZuKCk7IH1cbiAgICBjYXRjaCAoZSkgeyBsYXN0ID0gZTsgYXdhaXQgc2xlZXAoYmFzZSAqIDIgKiogaSk7IH1cbiAgfVxuICB0aHJvdyBsYXN0O1xufVxuXG5leHBvcnQgY29uc3QgcmFuZEludCA9IChuKSA9PiBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiBuKTtcblxuLy8gU2xlZXAgd2l0aCBjb3VudGRvd24gKGZyb20gZmFybSlcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBzbGVlcFdpdGhDb3VudGRvd24obXMsIG9uVXBkYXRlLCBzdGF0ZSkge1xuICBjb25zdCBzdGFydFRpbWUgPSBEYXRlLm5vdygpO1xuICBjb25zdCBlbmRUaW1lID0gc3RhcnRUaW1lICsgbXM7XG4gIFxuICB3aGlsZSAoRGF0ZS5ub3coKSA8IGVuZFRpbWUgJiYgKCFzdGF0ZSB8fCBzdGF0ZS5ydW5uaW5nKSkge1xuICAgIGNvbnN0IHJlbWFpbmluZyA9IGVuZFRpbWUgLSBEYXRlLm5vdygpO1xuICAgIFxuICAgIGlmIChvblVwZGF0ZSkge1xuICAgICAgb25VcGRhdGUocmVtYWluaW5nKTtcbiAgICB9XG4gICAgXG4gICAgYXdhaXQgc2xlZXAoTWF0aC5taW4oMTAwMCwgcmVtYWluaW5nKSk7XG4gIH1cbn1cbiIsICJpbXBvcnQgeyBsb2cgfSBmcm9tIFwiLi4vY29yZS9sb2dnZXIuanNcIjtcbmltcG9ydCB7IHBvc3RQaXhlbEJhdGNoSW1hZ2UgfSBmcm9tIFwiLi4vY29yZS93cGxhY2UtYXBpLmpzXCI7XG5pbXBvcnQgeyBnZXRUdXJuc3RpbGVUb2tlbiB9IGZyb20gXCIuLi9jb3JlL3R1cm5zdGlsZS5qc1wiO1xuaW1wb3J0IHsgZ3VhcmRTdGF0ZSwgR1VBUkRfREVGQVVMVFMgfSBmcm9tIFwiLi9jb25maWcuanNcIjtcbmltcG9ydCB7IHNsZWVwIH0gZnJvbSBcIi4uL2NvcmUvdGltaW5nLmpzXCI7XG5cbi8vIEdsb2JhbHMgZGVsIG5hdmVnYWRvclxuY29uc3QgeyBJbWFnZSwgVVJMIH0gPSB3aW5kb3c7XG5cbi8vIE9idGVuZXIgaW1hZ2VuIGRlIHRpbGUgZGVzZGUgbGEgQVBJXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gZ2V0VGlsZUltYWdlKHRpbGVYLCB0aWxlWSkge1xuICB0cnkge1xuICAgIGNvbnN0IHVybCA9IGAke0dVQVJEX0RFRkFVTFRTLkJBQ0tFTkRfVVJMfS9maWxlcy9zMC90aWxlcy8ke3RpbGVYfS8ke3RpbGVZfS5wbmdgO1xuICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgZmV0Y2godXJsKTtcbiAgICBcbiAgICBpZiAoIXJlc3BvbnNlLm9rKSB7XG4gICAgICB0aHJvdyBuZXcgRXJyb3IoYEhUVFAgJHtyZXNwb25zZS5zdGF0dXN9YCk7XG4gICAgfVxuICAgIFxuICAgIHJldHVybiBhd2FpdCByZXNwb25zZS5ibG9iKCk7XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgbG9nKGBFcnJvciBvYnRlbmllbmRvIHRpbGUgJHt0aWxlWH0sJHt0aWxlWX06YCwgZXJyb3IpO1xuICAgIHJldHVybiBudWxsO1xuICB9XG59XG5cbi8vIERldGVjdGFyIGNvbG9yZXMgZGlzcG9uaWJsZXMgZGVsIHNpdGlvXG5leHBvcnQgZnVuY3Rpb24gZGV0ZWN0QXZhaWxhYmxlQ29sb3JzKCkge1xuICBsb2coXCJcdUQ4M0NcdURGQTggRGV0ZWN0YW5kbyBjb2xvcmVzIGRpc3BvbmlibGVzLi4uXCIpO1xuICBjb25zdCBjb2xvckVsZW1lbnRzID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbCgnW2lkXj1cImNvbG9yLVwiXScpO1xuICBjb25zdCBjb2xvcnMgPSBbXTtcblxuICBmb3IgKGNvbnN0IGVsZW1lbnQgb2YgY29sb3JFbGVtZW50cykge1xuICAgIGlmIChlbGVtZW50LnF1ZXJ5U2VsZWN0b3IoXCJzdmdcIikpIGNvbnRpbnVlO1xuICAgIFxuICAgIGNvbnN0IGNvbG9ySWQgPSBwYXJzZUludChlbGVtZW50LmlkLnJlcGxhY2UoXCJjb2xvci1cIiwgXCJcIikpO1xuICAgIGlmIChjb2xvcklkID09PSAwIHx8IGNvbG9ySWQgPT09IDUpIGNvbnRpbnVlOyAvLyBFdml0YXIgY29sb3JlcyBlc3BlY2lhbGVzXG4gICAgXG4gICAgY29uc3QgYmdDb2xvciA9IGVsZW1lbnQuc3R5bGUuYmFja2dyb3VuZENvbG9yO1xuICAgIGlmIChiZ0NvbG9yKSB7XG4gICAgICBjb25zdCByZ2JNYXRjaCA9IGJnQ29sb3IubWF0Y2goL1xcZCsvZyk7XG4gICAgICBpZiAocmdiTWF0Y2ggJiYgcmdiTWF0Y2gubGVuZ3RoID49IDMpIHtcbiAgICAgICAgY29sb3JzLnB1c2goe1xuICAgICAgICAgIGlkOiBjb2xvcklkLFxuICAgICAgICAgIHI6IHBhcnNlSW50KHJnYk1hdGNoWzBdKSxcbiAgICAgICAgICBnOiBwYXJzZUludChyZ2JNYXRjaFsxXSksXG4gICAgICAgICAgYjogcGFyc2VJbnQocmdiTWF0Y2hbMl0pLFxuICAgICAgICAgIGVsZW1lbnQ6IGVsZW1lbnRcbiAgICAgICAgfSk7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgbG9nKGBcdTI3MDUgJHtjb2xvcnMubGVuZ3RofSBjb2xvcmVzIGRldGVjdGFkb3NgKTtcbiAgcmV0dXJuIGNvbG9ycztcbn1cblxuLy8gRW5jb250cmFyIGVsIGNvbG9yIG1cdTAwRTFzIGNlcmNhbm8gZGlzcG9uaWJsZVxuZXhwb3J0IGZ1bmN0aW9uIGZpbmRDbG9zZXN0Q29sb3IociwgZywgYiwgYXZhaWxhYmxlQ29sb3JzKSB7XG4gIGxldCBtaW5EaXN0YW5jZSA9IEluZmluaXR5O1xuICBsZXQgY2xvc2VzdENvbG9yID0gbnVsbDtcblxuICBmb3IgKGNvbnN0IGNvbG9yIG9mIGF2YWlsYWJsZUNvbG9ycykge1xuICAgIGNvbnN0IGRpc3RhbmNlID0gTWF0aC5zcXJ0KFxuICAgICAgTWF0aC5wb3cociAtIGNvbG9yLnIsIDIpICtcbiAgICAgIE1hdGgucG93KGcgLSBjb2xvci5nLCAyKSArXG4gICAgICBNYXRoLnBvdyhiIC0gY29sb3IuYiwgMilcbiAgICApO1xuXG4gICAgaWYgKGRpc3RhbmNlIDwgbWluRGlzdGFuY2UpIHtcbiAgICAgIG1pbkRpc3RhbmNlID0gZGlzdGFuY2U7XG4gICAgICBjbG9zZXN0Q29sb3IgPSBjb2xvcjtcbiAgICB9XG4gIH1cblxuICByZXR1cm4gY2xvc2VzdENvbG9yO1xufVxuXG4vLyBBbmFsaXphciBwXHUwMEVEeGVsZXMgZGUgdW4gXHUwMEUxcmVhIGVzcGVjXHUwMEVEZmljYVxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGFuYWx5emVBcmVhUGl4ZWxzKGFyZWEpIHtcbiAgY29uc3QgeyB4MSwgeTEsIHgyLCB5MiB9ID0gYXJlYTtcbiAgY29uc3Qgd2lkdGggPSB4MiAtIHgxO1xuICBjb25zdCBoZWlnaHQgPSB5MiAtIHkxO1xuXG4gIGxvZyhgXHVEODNEXHVERDBEIEFuYWxpemFuZG8gXHUwMEUxcmVhICR7d2lkdGh9eCR7aGVpZ2h0fSBkZXNkZSAoJHt4MX0sJHt5MX0pIGhhc3RhICgke3gyfSwke3kyfSlgKTtcbiAgXG4gIGNvbnN0IHBpeGVsTWFwID0gbmV3IE1hcCgpO1xuICBcbiAgLy8gT2J0ZW5lciB0aWxlcyBcdTAwRkFuaWNvcyBxdWUgY3VicmVuIGVsIFx1MDBFMXJlYVxuICBjb25zdCBzdGFydFRpbGVYID0gTWF0aC5mbG9vcih4MSAvIEdVQVJEX0RFRkFVTFRTLlRJTEVfU0laRSk7XG4gIGNvbnN0IHN0YXJ0VGlsZVkgPSBNYXRoLmZsb29yKHkxIC8gR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFKTtcbiAgY29uc3QgZW5kVGlsZVggPSBNYXRoLmZsb29yKHgyIC8gR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFKTtcbiAgY29uc3QgZW5kVGlsZVkgPSBNYXRoLmZsb29yKHkyIC8gR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFKTtcbiAgXG4gIC8vIFBhcmEgc2ltcGxpZmljYXIsIGFuYWxpemFyIHRpbGUgcG9yIHRpbGVcbiAgZm9yIChsZXQgdGlsZVkgPSBzdGFydFRpbGVZOyB0aWxlWSA8PSBlbmRUaWxlWTsgdGlsZVkrKykge1xuICAgIGZvciAobGV0IHRpbGVYID0gc3RhcnRUaWxlWDsgdGlsZVggPD0gZW5kVGlsZVg7IHRpbGVYKyspIHtcbiAgICAgIHRyeSB7XG4gICAgICAgIGNvbnN0IHRpbGVCbG9iID0gYXdhaXQgZ2V0VGlsZUltYWdlKHRpbGVYLCB0aWxlWSk7XG4gICAgICAgIGlmICghdGlsZUJsb2IpIHtcbiAgICAgICAgICBsb2coYFx1MjZBMFx1RkUwRiBObyBzZSBwdWRvIG9idGVuZXIgdGlsZSAke3RpbGVYfSwke3RpbGVZfSwgY29udGludWFuZG8uLi5gKTtcbiAgICAgICAgICBjb250aW51ZTtcbiAgICAgICAgfVxuXG4gICAgICAgIC8vIENyZWFyIGNhbnZhcyBwYXJhIGFuYWxpemFyIGxhIGltYWdlblxuICAgICAgICBjb25zdCBpbWcgPSBuZXcgSW1hZ2UoKTtcbiAgICAgICAgY29uc3QgY2FudmFzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnY2FudmFzJyk7XG4gICAgICAgIGNvbnN0IGN0eCA9IGNhbnZhcy5nZXRDb250ZXh0KCcyZCcpO1xuICAgICAgICBcbiAgICAgICAgYXdhaXQgbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgICAgIGltZy5vbmxvYWQgPSByZXNvbHZlO1xuICAgICAgICAgIGltZy5vbmVycm9yID0gcmVqZWN0O1xuICAgICAgICAgIGltZy5zcmMgPSBVUkwuY3JlYXRlT2JqZWN0VVJMKHRpbGVCbG9iKTtcbiAgICAgICAgfSk7XG5cbiAgICAgICAgY2FudmFzLndpZHRoID0gaW1nLndpZHRoO1xuICAgICAgICBjYW52YXMuaGVpZ2h0ID0gaW1nLmhlaWdodDtcbiAgICAgICAgY3R4LmRyYXdJbWFnZShpbWcsIDAsIDApO1xuICAgICAgICBcbiAgICAgICAgY29uc3QgaW1hZ2VEYXRhID0gY3R4LmdldEltYWdlRGF0YSgwLCAwLCBjYW52YXMud2lkdGgsIGNhbnZhcy5oZWlnaHQpO1xuICAgICAgICBjb25zdCBkYXRhID0gaW1hZ2VEYXRhLmRhdGE7XG5cbiAgICAgICAgLy8gQW5hbGl6YXIgcFx1MDBFRHhlbGVzIGVuIGVsIFx1MDBFMXJlYSBlc3BlY2lmaWNhZGEgZGUgZXN0ZSB0aWxlXG4gICAgICAgIGNvbnN0IHRpbGVTdGFydFggPSB0aWxlWCAqIEdVQVJEX0RFRkFVTFRTLlRJTEVfU0laRTtcbiAgICAgICAgY29uc3QgdGlsZVN0YXJ0WSA9IHRpbGVZICogR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFO1xuICAgICAgICBjb25zdCB0aWxlRW5kWCA9IHRpbGVTdGFydFggKyBHVUFSRF9ERUZBVUxUUy5USUxFX1NJWkU7XG4gICAgICAgIGNvbnN0IHRpbGVFbmRZID0gdGlsZVN0YXJ0WSArIEdVQVJEX0RFRkFVTFRTLlRJTEVfU0laRTtcbiAgICAgICAgXG4gICAgICAgIC8vIENhbGN1bGFyIGludGVyc2VjY2lcdTAwRjNuIGRlbCBcdTAwRTFyZWEgY29uIGVzdGUgdGlsZVxuICAgICAgICBjb25zdCBhbmFseXplU3RhcnRYID0gTWF0aC5tYXgoeDEsIHRpbGVTdGFydFgpO1xuICAgICAgICBjb25zdCBhbmFseXplU3RhcnRZID0gTWF0aC5tYXgoeTEsIHRpbGVTdGFydFkpO1xuICAgICAgICBjb25zdCBhbmFseXplRW5kWCA9IE1hdGgubWluKHgyLCB0aWxlRW5kWCk7XG4gICAgICAgIGNvbnN0IGFuYWx5emVFbmRZID0gTWF0aC5taW4oeTIsIHRpbGVFbmRZKTtcbiAgICAgICAgXG4gICAgICAgIGZvciAobGV0IGdsb2JhbFkgPSBhbmFseXplU3RhcnRZOyBnbG9iYWxZIDwgYW5hbHl6ZUVuZFk7IGdsb2JhbFkrKykge1xuICAgICAgICAgIGZvciAobGV0IGdsb2JhbFggPSBhbmFseXplU3RhcnRYOyBnbG9iYWxYIDwgYW5hbHl6ZUVuZFg7IGdsb2JhbFgrKykge1xuICAgICAgICAgICAgY29uc3QgbG9jYWxYID0gZ2xvYmFsWCAtIHRpbGVTdGFydFg7XG4gICAgICAgICAgICBjb25zdCBsb2NhbFkgPSBnbG9iYWxZIC0gdGlsZVN0YXJ0WTtcbiAgICAgICAgICAgIFxuICAgICAgICAgICAgLy8gVmVyaWZpY2FyIHF1ZSBlc3RhbW9zIGRlbnRybyBkZSBsb3MgbFx1MDBFRG1pdGVzIGRlbCB0aWxlXG4gICAgICAgICAgICBpZiAobG9jYWxYID49IDAgJiYgbG9jYWxYIDwgR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFICYmIFxuICAgICAgICAgICAgICAgIGxvY2FsWSA+PSAwICYmIGxvY2FsWSA8IEdVQVJEX0RFRkFVTFRTLlRJTEVfU0laRSkge1xuICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgLy8gTGFzIGNvb3JkZW5hZGFzIGRlIGxhIGltYWdlbiBzb24gMToxIGNvbiBsYXMgY29vcmRlbmFkYXMgZGVsIHRpbGVcbiAgICAgICAgICAgICAgaWYgKGxvY2FsWCA8IGNhbnZhcy53aWR0aCAmJiBsb2NhbFkgPCBjYW52YXMuaGVpZ2h0KSB7XG4gICAgICAgICAgICAgICAgY29uc3QgcGl4ZWxJbmRleCA9IChsb2NhbFkgKiBjYW52YXMud2lkdGggKyBsb2NhbFgpICogNDtcbiAgICAgICAgICAgICAgICBjb25zdCByID0gZGF0YVtwaXhlbEluZGV4XTtcbiAgICAgICAgICAgICAgICBjb25zdCBnID0gZGF0YVtwaXhlbEluZGV4ICsgMV07XG4gICAgICAgICAgICAgICAgY29uc3QgYiA9IGRhdGFbcGl4ZWxJbmRleCArIDJdO1xuICAgICAgICAgICAgICAgIGNvbnN0IGEgPSBkYXRhW3BpeGVsSW5kZXggKyAzXTtcbiAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICBpZiAoYSA+IDApIHsgLy8gUFx1MDBFRHhlbCB2aXNpYmxlXG4gICAgICAgICAgICAgICAgICBjb25zdCBjbG9zZXN0Q29sb3IgPSBmaW5kQ2xvc2VzdENvbG9yKHIsIGcsIGIsIGd1YXJkU3RhdGUuYXZhaWxhYmxlQ29sb3JzKTtcbiAgICAgICAgICAgICAgICAgIGlmIChjbG9zZXN0Q29sb3IpIHtcbiAgICAgICAgICAgICAgICAgICAgcGl4ZWxNYXAuc2V0KGAke2dsb2JhbFh9LCR7Z2xvYmFsWX1gLCB7XG4gICAgICAgICAgICAgICAgICAgICAgciwgZywgYixcbiAgICAgICAgICAgICAgICAgICAgICBjb2xvcklkOiBjbG9zZXN0Q29sb3IuaWQsXG4gICAgICAgICAgICAgICAgICAgICAgZ2xvYmFsWCxcbiAgICAgICAgICAgICAgICAgICAgICBnbG9iYWxZLFxuICAgICAgICAgICAgICAgICAgICAgIGxvY2FsWCxcbiAgICAgICAgICAgICAgICAgICAgICBsb2NhbFksXG4gICAgICAgICAgICAgICAgICAgICAgdGlsZVgsXG4gICAgICAgICAgICAgICAgICAgICAgdGlsZVlcbiAgICAgICAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG4gICAgICAgICAgfVxuICAgICAgICB9XG5cbiAgICAgICAgVVJMLnJldm9rZU9iamVjdFVSTChpbWcuc3JjKTtcbiAgICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICAgIGxvZyhgXHUyNzRDIEVycm9yIGFuYWxpemFuZG8gdGlsZSAke3RpbGVYfSwke3RpbGVZfTpgLCBlcnJvcik7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgbG9nKGBcdTI3MDUgQW5cdTAwRTFsaXNpcyBjb21wbGV0YWRvOiAke3BpeGVsTWFwLnNpemV9IHBcdTAwRUR4ZWxlcyBwcm90ZWdpZG9zYCk7XG4gIFxuICAvLyBTaSBubyBlbmNvbnRyYW1vcyBwXHUwMEVEeGVsZXMsIGNyZWFyIHBcdTAwRUR4ZWxlcyBcInZpcnR1YWxlc1wiIHBhcmEgZWwgXHUwMEUxcmVhIHNlbGVjY2lvbmFkYVxuICBpZiAocGl4ZWxNYXAuc2l6ZSA9PT0gMCkge1xuICAgIGxvZyhgXHUyNkEwXHVGRTBGIE5vIHNlIGVuY29udHJhcm9uIHBcdTAwRUR4ZWxlcyBleGlzdGVudGVzLCBjcmVhbmRvIFx1MDBFMXJlYSB2aXJ0dWFsIHBhcmEgcHJvdGVjY2lcdTAwRjNuYCk7XG4gICAgXG4gICAgLy8gQ3JlYXIgZW50cmFkYXMgdmlydHVhbGVzIHBhcmEgY2FkYSBwXHUwMEVEeGVsIGRlbCBcdTAwRTFyZWFcbiAgICBmb3IgKGxldCBnbG9iYWxZID0geTE7IGdsb2JhbFkgPCB5MjsgZ2xvYmFsWSsrKSB7XG4gICAgICBmb3IgKGxldCBnbG9iYWxYID0geDE7IGdsb2JhbFggPCB4MjsgZ2xvYmFsWCsrKSB7XG4gICAgICAgIGNvbnN0IHRpbGVYID0gTWF0aC5mbG9vcihnbG9iYWxYIC8gR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFKTtcbiAgICAgICAgY29uc3QgdGlsZVkgPSBNYXRoLmZsb29yKGdsb2JhbFkgLyBHVUFSRF9ERUZBVUxUUy5USUxFX1NJWkUpO1xuICAgICAgICBjb25zdCBsb2NhbFggPSBnbG9iYWxYIC0gKHRpbGVYICogR1VBUkRfREVGQVVMVFMuVElMRV9TSVpFKTtcbiAgICAgICAgY29uc3QgbG9jYWxZID0gZ2xvYmFsWSAtICh0aWxlWSAqIEdVQVJEX0RFRkFVTFRTLlRJTEVfU0laRSk7XG4gICAgICAgIFxuICAgICAgICAvLyBVc2FyIGNvbG9yIGJsYW5jbyBwb3IgZGVmZWN0byAoSUQgMSkgcGFyYSBwXHUwMEVEeGVsZXMgdmFjXHUwMEVEb3NcbiAgICAgICAgcGl4ZWxNYXAuc2V0KGAke2dsb2JhbFh9LCR7Z2xvYmFsWX1gLCB7XG4gICAgICAgICAgcjogMjU1LCBnOiAyNTUsIGI6IDI1NSwgLy8gQmxhbmNvIHBvciBkZWZlY3RvXG4gICAgICAgICAgY29sb3JJZDogMSwgLy8gSUQgZGVsIGNvbG9yIGJsYW5jb1xuICAgICAgICAgIGdsb2JhbFgsXG4gICAgICAgICAgZ2xvYmFsWSxcbiAgICAgICAgICBsb2NhbFgsXG4gICAgICAgICAgbG9jYWxZLFxuICAgICAgICAgIHRpbGVYLFxuICAgICAgICAgIHRpbGVZXG4gICAgICAgIH0pO1xuICAgICAgfVxuICAgIH1cbiAgICBcbiAgICBsb2coYFx1MjcwNSBcdTAwQzFyZWEgdmlydHVhbCBjcmVhZGE6ICR7cGl4ZWxNYXAuc2l6ZX0gcFx1MDBFRHhlbGVzIHBhcmEgcHJvdGVnZXJgKTtcbiAgfVxuICBcbiAgcmV0dXJuIHBpeGVsTWFwO1xufVxuXG4vLyBEZXRlY3RhciBjYW1iaW9zIGVuIGVsIFx1MDBFMXJlYSBwcm90ZWdpZGFcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBjaGVja0ZvckNoYW5nZXMoKSB7XG4gIGlmICghZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYSB8fCAhZ3VhcmRTdGF0ZS5vcmlnaW5hbFBpeGVscy5zaXplKSB7XG4gICAgcmV0dXJuO1xuICB9XG5cbiAgdHJ5IHtcbiAgICBjb25zdCBjdXJyZW50UGl4ZWxzID0gYXdhaXQgYW5hbHl6ZUFyZWFQaXhlbHMoZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYSk7XG4gICAgY29uc3QgY2hhbmdlcyA9IG5ldyBNYXAoKTtcbiAgICBsZXQgY2hhbmdlZENvdW50ID0gMDtcblxuICAgIC8vIENvbXBhcmFyIHBcdTAwRUR4ZWxlcyBvcmlnaW5hbGVzIHZzIGFjdHVhbGVzXG4gICAgZm9yIChjb25zdCBba2V5LCBvcmlnaW5hbFBpeGVsXSBvZiBndWFyZFN0YXRlLm9yaWdpbmFsUGl4ZWxzKSB7XG4gICAgICBjb25zdCBjdXJyZW50UGl4ZWwgPSBjdXJyZW50UGl4ZWxzLmdldChrZXkpO1xuICAgICAgXG4gICAgICBpZiAoIWN1cnJlbnRQaXhlbCkge1xuICAgICAgICAvLyBQXHUwMEVEeGVsIGZ1ZSBib3JyYWRvXG4gICAgICAgIGNoYW5nZXMuc2V0KGtleSwge1xuICAgICAgICAgIHRpbWVzdGFtcDogRGF0ZS5ub3coKSxcbiAgICAgICAgICB0eXBlOiAnZGVsZXRlZCcsXG4gICAgICAgICAgb3JpZ2luYWw6IG9yaWdpbmFsUGl4ZWwsXG4gICAgICAgICAgY3VycmVudDogbnVsbFxuICAgICAgICB9KTtcbiAgICAgICAgY2hhbmdlZENvdW50Kys7XG4gICAgICB9IGVsc2UgaWYgKGN1cnJlbnRQaXhlbC5jb2xvcklkICE9PSBvcmlnaW5hbFBpeGVsLmNvbG9ySWQpIHtcbiAgICAgICAgLy8gUFx1MDBFRHhlbCBjYW1iaVx1MDBGMyBkZSBjb2xvclxuICAgICAgICBjaGFuZ2VzLnNldChrZXksIHtcbiAgICAgICAgICB0aW1lc3RhbXA6IERhdGUubm93KCksXG4gICAgICAgICAgdHlwZTogJ2NoYW5nZWQnLFxuICAgICAgICAgIG9yaWdpbmFsOiBvcmlnaW5hbFBpeGVsLFxuICAgICAgICAgIGN1cnJlbnQ6IGN1cnJlbnRQaXhlbFxuICAgICAgICB9KTtcbiAgICAgICAgY2hhbmdlZENvdW50Kys7XG4gICAgICB9XG4gICAgfVxuXG4gICAgaWYgKGNoYW5nZWRDb3VudCA+IDApIHtcbiAgICAgIGxvZyhgXHVEODNEXHVERUE4IERldGVjdGFkb3MgJHtjaGFuZ2VkQ291bnR9IGNhbWJpb3MgZW4gZWwgXHUwMEUxcmVhIHByb3RlZ2lkYWApO1xuICAgICAgZ3VhcmRTdGF0ZS5jaGFuZ2VzID0gY2hhbmdlcztcbiAgICAgIFxuICAgICAgLy8gQWN0dWFsaXphciBVSVxuICAgICAgaWYgKGd1YXJkU3RhdGUudWkpIHtcbiAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoYFx1RDgzRFx1REVBOCAke2NoYW5nZWRDb3VudH0gY2FtYmlvcyBkZXRlY3RhZG9zYCwgJ3dhcm5pbmcnKTtcbiAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVQcm9ncmVzcyhjaGFuZ2VzLnNpemUsIGd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMuc2l6ZSk7XG4gICAgICB9XG4gICAgICBcbiAgICAgIC8vIEluaWNpYXIgcmVwYXJhY2lcdTAwRjNuIGF1dG9tXHUwMEUxdGljYSBzaSBlc3RcdTAwRTEgaGFiaWxpdGFkYVxuICAgICAgaWYgKGd1YXJkU3RhdGUucnVubmluZykge1xuICAgICAgICBhd2FpdCByZXBhaXJDaGFuZ2VzKGNoYW5nZXMpO1xuICAgICAgfVxuICAgIH0gZWxzZSB7XG4gICAgICAvLyBBY3R1YWxpemFyIHRpbWVzdGFtcCBkZSBcdTAwRkFsdGltYSB2ZXJpZmljYWNpXHUwMEYzblxuICAgICAgZ3VhcmRTdGF0ZS5sYXN0Q2hlY2sgPSBEYXRlLm5vdygpO1xuICAgICAgaWYgKGd1YXJkU3RhdGUudWkpIHtcbiAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoJ1x1MjcwNSBcdTAwQzFyZWEgcHJvdGVnaWRhIC0gc2luIGNhbWJpb3MnLCAnc3VjY2VzcycpO1xuICAgICAgfVxuICAgIH1cblxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZyhgXHUyNzRDIEVycm9yIHZlcmlmaWNhbmRvIGNhbWJpb3M6YCwgZXJyb3IpO1xuICAgIGlmIChndWFyZFN0YXRlLnVpKSB7XG4gICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyhgXHUyNzRDIEVycm9yIHZlcmlmaWNhbmRvOiAke2Vycm9yLm1lc3NhZ2V9YCwgJ2Vycm9yJyk7XG4gICAgfVxuICB9XG59XG5cbi8vIFJlcGFyYXIgbG9zIGNhbWJpb3MgZGV0ZWN0YWRvcyAtIGFob3JhIGNvbiBnZXN0aVx1MDBGM24gZGUgY2FyZ2FzIG1cdTAwRURuaW1hc1xuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHJlcGFpckNoYW5nZXMoY2hhbmdlcykge1xuICBpZiAoY2hhbmdlcy5zaXplID09PSAwKSB7XG4gICAgcmV0dXJuO1xuICB9XG5cbiAgY29uc3QgY2hhbmdlc0FycmF5ID0gQXJyYXkuZnJvbShjaGFuZ2VzLnZhbHVlcygpKTtcbiAgY29uc3QgYXZhaWxhYmxlQ2hhcmdlcyA9IE1hdGguZmxvb3IoZ3VhcmRTdGF0ZS5jdXJyZW50Q2hhcmdlcyk7XG4gIFxuICAvLyBTaSBubyBoYXkgY2FyZ2FzIHN1ZmljaWVudGVzIHBhcmEgcmVwYXJhciBuaSB1biBwXHUwMEVEeGVsLCBlc3BlcmFyXG4gIGlmIChhdmFpbGFibGVDaGFyZ2VzID09PSAwKSB7XG4gICAgbG9nKGBcdTI2QTBcdUZFMEYgU2luIGNhcmdhcyBkaXNwb25pYmxlcywgZXNwZXJhbmRvIHJlY2FyZ2EuLi5gKTtcbiAgICBpZiAoZ3VhcmRTdGF0ZS51aSkge1xuICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoJ1x1MjZBMSBFc3BlcmFuZG8gY2FyZ2FzIHBhcmEgcmVwYXJhci4uLicsICd3YXJuaW5nJyk7XG4gICAgfVxuICAgIHJldHVybjtcbiAgfVxuXG4gIC8vIFNpIGhheSBkYVx1MDBGMW9zIHBlcm8gbWVub3MgY2FyZ2FzIHF1ZSBlbCBtXHUwMEVEbmltbyBjb25maWd1cmFkbywgZ2FzdGFyIHRvZGFzIGxhcyBkaXNwb25pYmxlc1xuICBjb25zdCBzaG91bGRSZXBhaXJBbGwgPSBhdmFpbGFibGVDaGFyZ2VzIDwgZ3VhcmRTdGF0ZS5taW5DaGFyZ2VzVG9XYWl0O1xuICBjb25zdCBtYXhSZXBhaXJzID0gc2hvdWxkUmVwYWlyQWxsIFxuICAgID8gYXZhaWxhYmxlQ2hhcmdlcyAgLy8gR2FzdGFyIHRvZGFzIGxhcyBjYXJnYXMgZGlzcG9uaWJsZXNcbiAgICA6IE1hdGgubWluKGNoYW5nZXNBcnJheS5sZW5ndGgsIGd1YXJkU3RhdGUucGl4ZWxzUGVyQmF0Y2gpOyAvLyBVc2FyIGxvdGUgbm9ybWFsXG4gIFxuICBsb2coYFx1RDgzRFx1REVFMFx1RkUwRiBDYXJnYXM6ICR7YXZhaWxhYmxlQ2hhcmdlc30sIE1cdTAwRURuaW1vOiAke2d1YXJkU3RhdGUubWluQ2hhcmdlc1RvV2FpdH0sIFJlcGFyYW5kbzogJHttYXhSZXBhaXJzfSBwXHUwMEVEeGVsZXNgKTtcbiAgXG4gIGlmIChndWFyZFN0YXRlLnVpKSB7XG4gICAgY29uc3QgcmVwYWlyTW9kZSA9IHNob3VsZFJlcGFpckFsbCA/IFwiIChnYXN0YW5kbyB0b2RhcyBsYXMgY2FyZ2FzKVwiIDogXCJcIjtcbiAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyhgXHVEODNEXHVERUUwXHVGRTBGIFJlcGFyYW5kbyAke21heFJlcGFpcnN9IHBcdTAwRUR4ZWxlcyR7cmVwYWlyTW9kZX0uLi5gLCAnaW5mbycpO1xuICB9XG4gIFxuICAvLyBQcm9jZXNhciBwXHUwMEVEeGVsZXMgZW4gbG90ZXMgbVx1MDBFMXMgcGVxdWVcdTAwRjFvcyBwYXJhIG1lam9yIHJlbmRpbWllbnRvXG4gIGNvbnN0IHBpeGVsc1RvUmVwYWlyID0gY2hhbmdlc0FycmF5LnNsaWNlKDAsIG1heFJlcGFpcnMpO1xuICBcbiAgLy8gQWdydXBhciBjYW1iaW9zIHBvciB0aWxlIHBhcmEgZWZpY2llbmNpYVxuICBjb25zdCBjaGFuZ2VzQnlUaWxlID0gbmV3IE1hcCgpO1xuICBcbiAgZm9yIChjb25zdCBjaGFuZ2Ugb2YgcGl4ZWxzVG9SZXBhaXIpIHtcbiAgICBjb25zdCBvcmlnaW5hbCA9IGNoYW5nZS5vcmlnaW5hbDtcbiAgICBjb25zdCB0aWxlS2V5ID0gYCR7b3JpZ2luYWwudGlsZVh9LCR7b3JpZ2luYWwudGlsZVl9YDtcbiAgICBcbiAgICBpZiAoIWNoYW5nZXNCeVRpbGUuaGFzKHRpbGVLZXkpKSB7XG4gICAgICBjaGFuZ2VzQnlUaWxlLnNldCh0aWxlS2V5LCBbXSk7XG4gICAgfVxuICAgIFxuICAgIGNoYW5nZXNCeVRpbGUuZ2V0KHRpbGVLZXkpLnB1c2goe1xuICAgICAgbG9jYWxYOiBvcmlnaW5hbC5sb2NhbFgsXG4gICAgICBsb2NhbFk6IG9yaWdpbmFsLmxvY2FsWSxcbiAgICAgIGNvbG9ySWQ6IG9yaWdpbmFsLmNvbG9ySWQsXG4gICAgICBnbG9iYWxYOiBvcmlnaW5hbC5nbG9iYWxYLFxuICAgICAgZ2xvYmFsWTogb3JpZ2luYWwuZ2xvYmFsWVxuICAgIH0pO1xuICB9XG4gIFxuICBsZXQgdG90YWxSZXBhaXJlZCA9IDA7XG4gIFxuICAvLyBSZXBhcmFyIHBvciBsb3RlcyBkZSB0aWxlXG4gIGZvciAoY29uc3QgW3RpbGVLZXksIHRpbGVDaGFuZ2VzXSBvZiBjaGFuZ2VzQnlUaWxlKSB7XG4gICAgY29uc3QgW3RpbGVYLCB0aWxlWV0gPSB0aWxlS2V5LnNwbGl0KCcsJykubWFwKE51bWJlcik7XG4gICAgXG4gICAgdHJ5IHtcbiAgICAgIGNvbnN0IGNvb3JkcyA9IFtdO1xuICAgICAgY29uc3QgY29sb3JzID0gW107XG4gICAgICBcbiAgICAgIGZvciAoY29uc3QgY2hhbmdlIG9mIHRpbGVDaGFuZ2VzKSB7XG4gICAgICAgIGNvb3Jkcy5wdXNoKGNoYW5nZS5sb2NhbFgsIGNoYW5nZS5sb2NhbFkpO1xuICAgICAgICBjb2xvcnMucHVzaChjaGFuZ2UuY29sb3JJZCk7XG4gICAgICB9XG4gICAgICBcbiAgICAgIGNvbnN0IHJlc3VsdCA9IGF3YWl0IHBhaW50UGl4ZWxCYXRjaCh0aWxlWCwgdGlsZVksIGNvb3JkcywgY29sb3JzKTtcbiAgICAgIFxuICAgICAgaWYgKHJlc3VsdC5zdWNjZXNzICYmIHJlc3VsdC5wYWludGVkID4gMCkge1xuICAgICAgICB0b3RhbFJlcGFpcmVkICs9IHJlc3VsdC5wYWludGVkO1xuICAgICAgICBndWFyZFN0YXRlLmN1cnJlbnRDaGFyZ2VzID0gTWF0aC5tYXgoMCwgZ3VhcmRTdGF0ZS5jdXJyZW50Q2hhcmdlcyAtIHJlc3VsdC5wYWludGVkKTtcbiAgICAgICAgZ3VhcmRTdGF0ZS50b3RhbFJlcGFpcmVkICs9IHJlc3VsdC5wYWludGVkO1xuICAgICAgICBcbiAgICAgICAgLy8gUmVtb3ZlciBjYW1iaW9zIHJlcGFyYWRvcyBleGl0b3NhbWVudGVcbiAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQucGFpbnRlZCAmJiBpIDwgdGlsZUNoYW5nZXMubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICBjb25zdCBjaGFuZ2UgPSB0aWxlQ2hhbmdlc1tpXTtcbiAgICAgICAgICBjb25zdCBrZXkgPSBgJHtjaGFuZ2UuZ2xvYmFsWH0sJHtjaGFuZ2UuZ2xvYmFsWX1gO1xuICAgICAgICAgIGd1YXJkU3RhdGUuY2hhbmdlcy5kZWxldGUoa2V5KTtcbiAgICAgICAgfVxuICAgICAgICBcbiAgICAgICAgbG9nKGBcdTI3MDUgUmVwYXJhZG9zICR7cmVzdWx0LnBhaW50ZWR9IHBcdTAwRUR4ZWxlcyBlbiB0aWxlICgke3RpbGVYfSwke3RpbGVZfSlgKTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIGxvZyhgXHUyNzRDIEVycm9yIHJlcGFyYW5kbyB0aWxlICgke3RpbGVYfSwke3RpbGVZfSk6YCwgcmVzdWx0LmVycm9yKTtcbiAgICAgIH1cbiAgICAgIFxuICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICBsb2coYFx1Mjc0QyBFcnJvciByZXBhcmFuZG8gdGlsZSAoJHt0aWxlWH0sJHt0aWxlWX0pOmAsIGVycm9yKTtcbiAgICB9XG4gICAgXG4gICAgLy8gUGF1c2EgZW50cmUgdGlsZXMgcGFyYSBldml0YXIgcmF0ZSBsaW1pdGluZ1xuICAgIGlmIChjaGFuZ2VzQnlUaWxlLnNpemUgPiAxKSB7XG4gICAgICBhd2FpdCBzbGVlcCg1MDApO1xuICAgIH1cbiAgfVxuICBcbiAgY29uc3QgcmVtYWluaW5nQ2hhcmdlcyA9IE1hdGguZmxvb3IoZ3VhcmRTdGF0ZS5jdXJyZW50Q2hhcmdlcyk7XG4gIGNvbnN0IHJlbWFpbmluZ0NoYW5nZXMgPSBndWFyZFN0YXRlLmNoYW5nZXMuc2l6ZTtcbiAgXG4gIGxvZyhgXHVEODNEXHVERUUwXHVGRTBGIFJlcGFyYWNpXHUwMEYzbiBjb21wbGV0YWRhOiAke3RvdGFsUmVwYWlyZWR9IHBcdTAwRUR4ZWxlcyByZXBhcmFkb3MsICR7cmVtYWluaW5nQ2hhcmdlc30gY2FyZ2FzIHJlc3RhbnRlc2ApO1xuICBcbiAgaWYgKGd1YXJkU3RhdGUudWkpIHtcbiAgICBpZiAocmVtYWluaW5nQ2hhbmdlcyA+IDAgJiYgcmVtYWluaW5nQ2hhcmdlcyA8IGd1YXJkU3RhdGUubWluQ2hhcmdlc1RvV2FpdCkge1xuICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoYFx1MjNGMyBFc3BlcmFuZG8gJHtndWFyZFN0YXRlLm1pbkNoYXJnZXNUb1dhaXR9IGNhcmdhcyBwYXJhIGNvbnRpbnVhciAoJHtyZW1haW5pbmdDaGFyZ2VzfSBhY3R1YWxlcylgLCAnd2FybmluZycpO1xuICAgIH0gZWxzZSB7XG4gICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyhgXHUyNzA1IFJlcGFyYWRvcyAke3RvdGFsUmVwYWlyZWR9IHBcdTAwRUR4ZWxlcyBjb3JyZWN0YW1lbnRlYCwgJ3N1Y2Nlc3MnKTtcbiAgICB9XG4gICAgXG4gICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0cyh7XG4gICAgICBjaGFyZ2VzOiByZW1haW5pbmdDaGFyZ2VzLFxuICAgICAgcmVwYWlyZWQ6IGd1YXJkU3RhdGUudG90YWxSZXBhaXJlZCxcbiAgICAgIHBlbmRpbmc6IHJlbWFpbmluZ0NoYW5nZXNcbiAgICB9KTtcbiAgfVxufVxuXG4vLyBQaW50YXIgbVx1MDBGQWx0aXBsZXMgcFx1MDBFRHhlbGVzIGVuIHVuIHNvbG8gdGlsZVxuYXN5bmMgZnVuY3Rpb24gcGFpbnRQaXhlbEJhdGNoKHRpbGVYLCB0aWxlWSwgY29vcmRzLCBjb2xvcnMpIHtcbiAgdHJ5IHtcbiAgICBjb25zdCB0b2tlbiA9IGF3YWl0IGdldFR1cm5zdGlsZVRva2VuKEdVQVJEX0RFRkFVTFRTLlNJVEVLRVkpO1xuICAgIFxuICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgcG9zdFBpeGVsQmF0Y2hJbWFnZShcbiAgICAgIHRpbGVYLCBcbiAgICAgIHRpbGVZLCBcbiAgICAgIGNvb3JkcywgXG4gICAgICBjb2xvcnMsIFxuICAgICAgdG9rZW5cbiAgICApO1xuICAgIFxuICAgIHJldHVybiB7XG4gICAgICBzdWNjZXNzOiByZXNwb25zZS5zdWNjZXNzLFxuICAgICAgcGFpbnRlZDogcmVzcG9uc2UucGFpbnRlZCxcbiAgICAgIHN0YXR1czogcmVzcG9uc2Uuc3RhdHVzLFxuICAgICAgZXJyb3I6IHJlc3BvbnNlLnN1Y2Nlc3MgPyBudWxsIDogKHJlc3BvbnNlLmpzb24/Lm1lc3NhZ2UgfHwgJ0Vycm9yIGRlc2Nvbm9jaWRvJylcbiAgICB9O1xuICB9IGNhdGNoIChlcnJvcikge1xuICAgIHJldHVybiB7XG4gICAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICAgIHBhaW50ZWQ6IDAsXG4gICAgICBlcnJvcjogZXJyb3IubWVzc2FnZVxuICAgIH07XG4gIH1cbn1cblxuLy8gUGludGFyIHVuIHBcdTAwRUR4ZWwgaW5kaXZpZHVhbFxuXG4iLCAiZXhwb3J0IGZ1bmN0aW9uIGNyZWF0ZUd1YXJkVUkodGV4dHMpIHtcbiAgLy8gQ3JlYXIgY29udGVuZWRvciBwcmluY2lwYWxcbiAgY29uc3QgY29udGFpbmVyID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnZGl2Jyk7XG4gIGNvbnRhaW5lci5zdHlsZS5jc3NUZXh0ID0gYFxuICAgIHBvc2l0aW9uOiBmaXhlZDtcbiAgICB0b3A6IDIwcHg7XG4gICAgcmlnaHQ6IDIwcHg7XG4gICAgd2lkdGg6IDM1MHB4O1xuICAgIGJhY2tncm91bmQ6ICMxYTFhMWE7XG4gICAgYm9yZGVyOiAxcHggc29saWQgIzMzMztcbiAgICBib3JkZXItcmFkaXVzOiA4cHg7XG4gICAgY29sb3I6ICNlZWU7XG4gICAgZm9udC1mYW1pbHk6ICdTZWdvZSBVSScsIFJvYm90bywgc2Fucy1zZXJpZjtcbiAgICB6LWluZGV4OiA5OTk5O1xuICAgIGJveC1zaGFkb3c6IDAgNXB4IDE1cHggcmdiYSgwLDAsMCwwLjUpO1xuICBgO1xuXG4gIGNvbnRhaW5lci5pbm5lckhUTUwgPSBgXG4gICAgPGRpdiBzdHlsZT1cInBhZGRpbmc6IDEycHggMTVweDsgYmFja2dyb3VuZDogIzJkMzc0ODsgY29sb3I6ICM2MGE1ZmE7IGZvbnQtc2l6ZTogMTZweDsgZm9udC13ZWlnaHQ6IDYwMDsgZGlzcGxheTogZmxleDsganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuOyBhbGlnbi1pdGVtczogY2VudGVyOyBjdXJzb3I6IG1vdmU7XCIgY2xhc3M9XCJndWFyZC1oZWFkZXJcIj5cbiAgICAgIDxkaXYgc3R5bGU9XCJkaXNwbGF5OiBmbGV4OyBhbGlnbi1pdGVtczogY2VudGVyOyBnYXA6IDhweDtcIj5cbiAgICAgICAgXHVEODNEXHVERUUxXHVGRTBGIDxzcGFuPiR7dGV4dHMudGl0bGV9PC9zcGFuPlxuICAgICAgPC9kaXY+XG4gICAgICA8YnV0dG9uIGlkPVwiY2xvc2VCdG5cIiBzdHlsZT1cImJhY2tncm91bmQ6IG5vbmU7IGJvcmRlcjogbm9uZTsgY29sb3I6ICNlZWU7IGN1cnNvcjogcG9pbnRlcjsgb3BhY2l0eTogMC43OyBwYWRkaW5nOiA1cHg7XCI+XHUyNzRDPC9idXR0b24+XG4gICAgPC9kaXY+XG4gICAgXG4gICAgPGRpdiBzdHlsZT1cInBhZGRpbmc6IDE1cHg7XCI+XG4gICAgICA8IS0tIEVzdGFkbyBkZSBpbmljaWFsaXphY2lcdTAwRjNuIC0tPlxuICAgICAgPGRpdiBpZD1cImluaXRTZWN0aW9uXCI+XG4gICAgICAgIDxidXR0b24gaWQ9XCJpbml0QnRuXCIgc3R5bGU9XCJ3aWR0aDogMTAwJTsgcGFkZGluZzogMTBweDsgYmFja2dyb3VuZDogIzYwYTVmYTsgY29sb3I6IHdoaXRlOyBib3JkZXI6IG5vbmU7IGJvcmRlci1yYWRpdXM6IDZweDsgZm9udC13ZWlnaHQ6IDYwMDsgY3Vyc29yOiBwb2ludGVyOyBtYXJnaW4tYm90dG9tOiAxMHB4O1wiPlxuICAgICAgICAgIFx1RDgzRVx1REQxNiAke3RleHRzLmluaXRCb3R9XG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgPC9kaXY+XG4gICAgICBcbiAgICAgIDwhLS0gU2VsZWNjaVx1MDBGM24gZGUgXHUwMEUxcmVhIC0tPlxuICAgICAgPGRpdiBpZD1cImFyZWFTZWN0aW9uXCIgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPlxuICAgICAgICA8IS0tIEJvdG9uZXMgZGUgXHUwMEUxcmVhIC0gZW4gZG9zIGNvbHVtbmFzIC0tPlxuICAgICAgICA8ZGl2IHN0eWxlPVwiZGlzcGxheTogZmxleDsgZ2FwOiAxMHB4OyBtYXJnaW4tYm90dG9tOiAxNXB4O1wiPlxuICAgICAgICAgIDxidXR0b24gaWQ9XCJzZWxlY3RBcmVhQnRuXCIgc3R5bGU9XCJmbGV4OiAxOyBwYWRkaW5nOiAxMHB4OyBiYWNrZ3JvdW5kOiAjOGI1Y2Y2OyBjb2xvcjogd2hpdGU7IGJvcmRlcjogbm9uZTsgYm9yZGVyLXJhZGl1czogNnB4OyBmb250LXdlaWdodDogNjAwOyBjdXJzb3I6IHBvaW50ZXI7XCI+XG4gICAgICAgICAgICBcdUQ4M0NcdURGQUYgJHt0ZXh0cy5zZWxlY3RBcmVhfVxuICAgICAgICAgIDwvYnV0dG9uPlxuICAgICAgICAgIDxidXR0b24gaWQ9XCJsb2FkQXJlYUJ0blwiIHN0eWxlPVwiZmxleDogMTsgcGFkZGluZzogMTBweDsgYmFja2dyb3VuZDogI2Y1OWUwYjsgY29sb3I6IHdoaXRlOyBib3JkZXI6IG5vbmU7IGJvcmRlci1yYWRpdXM6IDZweDsgZm9udC13ZWlnaHQ6IDYwMDsgY3Vyc29yOiBwb2ludGVyO1wiPlxuICAgICAgICAgICAgXHVEODNEXHVEQ0MxIENhcmdhciBBcmNoaXZvXG4gICAgICAgICAgPC9idXR0b24+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICBcbiAgICAgICAgPCEtLSBDb29yZGVuYWRhcyBjYXB0dXJhZGFzIChzb2xvIGxlY3R1cmEpIC0tPlxuICAgICAgICA8ZGl2IHN0eWxlPVwibWFyZ2luLWJvdHRvbTogMTVweDtcIj5cbiAgICAgICAgICA8ZGl2IHN0eWxlPVwiZGlzcGxheTogZmxleDsgZ2FwOiAxMHB4OyBtYXJnaW4tYm90dG9tOiA4cHg7XCI+XG4gICAgICAgICAgICA8ZGl2IHN0eWxlPVwiZmxleDogMTtcIj5cbiAgICAgICAgICAgICAgPGxhYmVsIHN0eWxlPVwiZGlzcGxheTogYmxvY2s7IG1hcmdpbi1ib3R0b206IDVweDsgZm9udC1zaXplOiAxMnB4OyBjb2xvcjogI2NiZDVlMDtcIj4ke3RleHRzLnVwcGVyTGVmdH06PC9sYWJlbD5cbiAgICAgICAgICAgICAgPGRpdiBzdHlsZT1cImRpc3BsYXk6IGZsZXg7IGdhcDogNXB4O1wiPlxuICAgICAgICAgICAgICAgIDxpbnB1dCBpZD1cIngxSW5wdXRcIiB0eXBlPVwibnVtYmVyXCIgcGxhY2Vob2xkZXI9XCJYMVwiIHJlYWRvbmx5IHN0eWxlPVwiZmxleDogMTsgcGFkZGluZzogNXB4OyBiYWNrZ3JvdW5kOiAjMzc0MTUxOyBib3JkZXI6IDFweCBzb2xpZCAjNGI1NTYzOyBib3JkZXItcmFkaXVzOiA0cHg7IGNvbG9yOiAjZDFkNWRiOyBmb250LXNpemU6IDEzcHg7XCI+XG4gICAgICAgICAgICAgICAgPGlucHV0IGlkPVwieTFJbnB1dFwiIHR5cGU9XCJudW1iZXJcIiBwbGFjZWhvbGRlcj1cIlkxXCIgcmVhZG9ubHkgc3R5bGU9XCJmbGV4OiAxOyBwYWRkaW5nOiA1cHg7IGJhY2tncm91bmQ6ICMzNzQxNTE7IGJvcmRlcjogMXB4IHNvbGlkICM0YjU1NjM7IGJvcmRlci1yYWRpdXM6IDRweDsgY29sb3I6ICNkMWQ1ZGI7IGZvbnQtc2l6ZTogMTNweDtcIj5cbiAgICAgICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICBcbiAgICAgICAgICA8ZGl2IHN0eWxlPVwiZGlzcGxheTogZmxleDsgZ2FwOiAxMHB4OyBtYXJnaW4tYm90dG9tOiAxNXB4O1wiPlxuICAgICAgICAgICAgPGRpdiBzdHlsZT1cImZsZXg6IDE7XCI+XG4gICAgICAgICAgICAgIDxsYWJlbCBzdHlsZT1cImRpc3BsYXk6IGJsb2NrOyBtYXJnaW4tYm90dG9tOiA1cHg7IGZvbnQtc2l6ZTogMTJweDsgY29sb3I6ICNjYmQ1ZTA7XCI+JHt0ZXh0cy5sb3dlclJpZ2h0fTo8L2xhYmVsPlxuICAgICAgICAgICAgICA8ZGl2IHN0eWxlPVwiZGlzcGxheTogZmxleDsgZ2FwOiA1cHg7XCI+XG4gICAgICAgICAgICAgICAgPGlucHV0IGlkPVwieDJJbnB1dFwiIHR5cGU9XCJudW1iZXJcIiBwbGFjZWhvbGRlcj1cIlgyXCIgcmVhZG9ubHkgc3R5bGU9XCJmbGV4OiAxOyBwYWRkaW5nOiA1cHg7IGJhY2tncm91bmQ6ICMzNzQxNTE7IGJvcmRlcjogMXB4IHNvbGlkICM0YjU1NjM7IGJvcmRlci1yYWRpdXM6IDRweDsgY29sb3I6ICNkMWQ1ZGI7IGZvbnQtc2l6ZTogMTNweDtcIj5cbiAgICAgICAgICAgICAgICA8aW5wdXQgaWQ9XCJ5MklucHV0XCIgdHlwZT1cIm51bWJlclwiIHBsYWNlaG9sZGVyPVwiWTJcIiByZWFkb25seSBzdHlsZT1cImZsZXg6IDE7IHBhZGRpbmc6IDVweDsgYmFja2dyb3VuZDogIzM3NDE1MTsgYm9yZGVyOiAxcHggc29saWQgIzRiNTU2MzsgYm9yZGVyLXJhZGl1czogNHB4OyBjb2xvcjogI2QxZDVkYjsgZm9udC1zaXplOiAxM3B4O1wiPlxuICAgICAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICA8L2Rpdj5cbiAgICAgICAgXG4gICAgICAgIDxidXR0b24gaWQ9XCJzdGFydEJ0blwiIHN0eWxlPVwid2lkdGg6IDEwMCU7IHBhZGRpbmc6IDEwcHg7IGJhY2tncm91bmQ6ICMxMGI5ODE7IGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA2cHg7IGZvbnQtd2VpZ2h0OiA2MDA7IGN1cnNvcjogcG9pbnRlcjsgbWFyZ2luLWJvdHRvbTogMTBweDtcIiBkaXNhYmxlZD5cbiAgICAgICAgICBcdTI1QjZcdUZFMEYgJHt0ZXh0cy5zdGFydFByb3RlY3Rpb259XG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgICBcbiAgICAgICAgPGJ1dHRvbiBpZD1cInN0b3BCdG5cIiBzdHlsZT1cIndpZHRoOiAxMDAlOyBwYWRkaW5nOiAxMHB4OyBiYWNrZ3JvdW5kOiAjZWY0NDQ0OyBjb2xvcjogd2hpdGU7IGJvcmRlcjogbm9uZTsgYm9yZGVyLXJhZGl1czogNnB4OyBmb250LXdlaWdodDogNjAwOyBjdXJzb3I6IHBvaW50ZXI7XCIgZGlzYWJsZWQ+XG4gICAgICAgICAgXHUyM0Y5XHVGRTBGICR7dGV4dHMuc3RvcFByb3RlY3Rpb259XG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgPC9kaXY+XG4gICAgICBcbiAgICAgIDwhLS0gRXN0YWRcdTAwRURzdGljYXMgLS0+XG4gICAgICA8ZGl2IGlkPVwic3RhdHNTZWN0aW9uXCIgc3R5bGU9XCJiYWNrZ3JvdW5kOiAjMmQzNzQ4OyBwYWRkaW5nOiAxMHB4OyBib3JkZXItcmFkaXVzOiA2cHg7IG1hcmdpbi10b3A6IDEwcHg7XCI+XG4gICAgICAgIDxkaXYgc3R5bGU9XCJmb250LXNpemU6IDEzcHg7IG1hcmdpbi1ib3R0b206IDVweDtcIj5cbiAgICAgICAgICA8c3Bhbj5cdUQ4M0RcdURDQ0EgJHt0ZXh0cy5wcm90ZWN0ZWRQaXhlbHN9OiA8L3NwYW4+PHNwYW4gaWQ9XCJwcm90ZWN0ZWRDb3VudFwiPjA8L3NwYW4+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICA8ZGl2IHN0eWxlPVwiZm9udC1zaXplOiAxM3B4OyBtYXJnaW4tYm90dG9tOiA1cHg7XCI+XG4gICAgICAgICAgPHNwYW4+XHVEODNEXHVERUE4ICR7dGV4dHMuZGV0ZWN0ZWRDaGFuZ2VzfTogPC9zcGFuPjxzcGFuIGlkPVwiY2hhbmdlc0NvdW50XCI+MDwvc3Bhbj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIDxkaXYgc3R5bGU9XCJmb250LXNpemU6IDEzcHg7IG1hcmdpbi1ib3R0b206IDVweDtcIj5cbiAgICAgICAgICA8c3Bhbj5cdTI2QTEgJHt0ZXh0cy5jaGFyZ2VzfTogPC9zcGFuPjxzcGFuIGlkPVwiY2hhcmdlc0NvdW50XCI+MDwvc3Bhbj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIDxkaXYgc3R5bGU9XCJmb250LXNpemU6IDEzcHg7XCI+XG4gICAgICAgICAgPHNwYW4+XHVEODNEXHVERUUwXHVGRTBGICR7dGV4dHMucmVwYWlyZWRQaXhlbHN9OiA8L3NwYW4+PHNwYW4gaWQ9XCJyZXBhaXJlZENvdW50XCI+MDwvc3Bhbj5cbiAgICAgICAgPC9kaXY+XG4gICAgICA8L2Rpdj5cbiAgICAgIFxuICAgICAgPCEtLSBDb250cm9sZXMgZGUgY29uZmlndXJhY2lcdTAwRjNuIC0tPlxuICAgICAgPGRpdiBpZD1cImNvbmZpZ1NlY3Rpb25cIiBzdHlsZT1cImJhY2tncm91bmQ6ICMyZDM3NDg7IHBhZGRpbmc6IDEwcHg7IGJvcmRlci1yYWRpdXM6IDZweDsgbWFyZ2luLXRvcDogMTBweDtcIj5cbiAgICAgICAgPGg0IHN0eWxlPVwibWFyZ2luOiAwIDAgMTBweCAwOyBmb250LXNpemU6IDE0cHg7IGNvbG9yOiAjY2JkNWUwO1wiPlx1MjY5OVx1RkUwRiBDb25maWd1cmFjaVx1MDBGM248L2g0PlxuICAgICAgICBcbiAgICAgICAgPGRpdiBzdHlsZT1cImRpc3BsYXk6IGZsZXg7IGdhcDogMTBweDsgbWFyZ2luLWJvdHRvbTogMTBweDtcIj5cbiAgICAgICAgICA8ZGl2IHN0eWxlPVwiZmxleDogMTtcIj5cbiAgICAgICAgICAgIDxsYWJlbCBzdHlsZT1cImRpc3BsYXk6IGJsb2NrOyBtYXJnaW4tYm90dG9tOiA1cHg7IGZvbnQtc2l6ZTogMTJweDsgY29sb3I6ICNjYmQ1ZTA7XCI+UFx1MDBFRHhlbGVzIHBvciBsb3RlOjwvbGFiZWw+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJwaXhlbHNQZXJCYXRjaElucHV0XCIgdHlwZT1cIm51bWJlclwiIG1pbj1cIjFcIiBtYXg9XCI1MFwiIHN0eWxlPVwid2lkdGg6IDEwMCU7IHBhZGRpbmc6IDVweDsgYmFja2dyb3VuZDogIzM3NDE1MTsgYm9yZGVyOiAxcHggc29saWQgIzRiNTU2MzsgYm9yZGVyLXJhZGl1czogNHB4OyBjb2xvcjogI2QxZDVkYjsgZm9udC1zaXplOiAxM3B4O1wiPlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgc3R5bGU9XCJmbGV4OiAxO1wiPlxuICAgICAgICAgICAgPGxhYmVsIHN0eWxlPVwiZGlzcGxheTogYmxvY2s7IG1hcmdpbi1ib3R0b206IDVweDsgZm9udC1zaXplOiAxMnB4OyBjb2xvcjogI2NiZDVlMDtcIj5DYXJnYXMgbVx1MDBFRG5pbWFzOjwvbGFiZWw+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJtaW5DaGFyZ2VzSW5wdXRcIiB0eXBlPVwibnVtYmVyXCIgbWluPVwiMVwiIG1heD1cIjEwMFwiIHN0eWxlPVwid2lkdGg6IDEwMCU7IHBhZGRpbmc6IDVweDsgYmFja2dyb3VuZDogIzM3NDE1MTsgYm9yZGVyOiAxcHggc29saWQgIzRiNTU2MzsgYm9yZGVyLXJhZGl1czogNHB4OyBjb2xvcjogI2QxZDVkYjsgZm9udC1zaXplOiAxM3B4O1wiPlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICA8L2Rpdj5cbiAgICAgICAgXG4gICAgICAgIDwhLS0gQ29udHJvbGVzIGRlIHNhdmUvbG9hZCAtLT5cbiAgICAgICAgPGRpdiBzdHlsZT1cImRpc3BsYXk6IGZsZXg7IGdhcDogMTBweDtcIj5cbiAgICAgICAgICA8YnV0dG9uIGlkPVwic2F2ZUJ0blwiIHN0eWxlPVwid2lkdGg6IDEwMCU7IHBhZGRpbmc6IDhweDsgYmFja2dyb3VuZDogIzEwYjk4MTsgY29sb3I6IHdoaXRlOyBib3JkZXI6IG5vbmU7IGJvcmRlci1yYWRpdXM6IDZweDsgZm9udC13ZWlnaHQ6IDYwMDsgY3Vyc29yOiBwb2ludGVyOyBmb250LXNpemU6IDEzcHg7XCI+XG4gICAgICAgICAgICBcdUQ4M0RcdURDQkUgR3VhcmRhciBQcm90ZWNjaVx1MDBGM25cbiAgICAgICAgICA8L2J1dHRvbj5cbiAgICAgICAgPC9kaXY+XG4gICAgICA8L2Rpdj5cbiAgICAgIFxuICAgICAgPCEtLSBFc3RhZG8gLS0+XG4gICAgICA8ZGl2IGlkPVwic3RhdHVzQmFyXCIgc3R5bGU9XCJiYWNrZ3JvdW5kOiAjMmQzNzQ4OyBwYWRkaW5nOiA4cHg7IGJvcmRlci1yYWRpdXM6IDRweDsgdGV4dC1hbGlnbjogY2VudGVyOyBmb250LXNpemU6IDEzcHg7IG1hcmdpbi10b3A6IDEwcHg7XCI+XG4gICAgICAgIFx1MjNGMyAke3RleHRzLndhaXRpbmdJbml0fVxuICAgICAgPC9kaXY+XG4gICAgPC9kaXY+XG4gIGA7XG5cbiAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChjb250YWluZXIpO1xuXG4gIC8vIElucHV0IG9jdWx0byBwYXJhIGFyY2hpdm9zIGRlIFx1MDBFMXJlYVxuICBjb25zdCBhcmVhRmlsZUlucHV0ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnaW5wdXQnKTtcbiAgYXJlYUZpbGVJbnB1dC50eXBlID0gJ2ZpbGUnO1xuICBhcmVhRmlsZUlucHV0LmFjY2VwdCA9ICcuanNvbic7XG4gIGFyZWFGaWxlSW5wdXQuc3R5bGUuZGlzcGxheSA9ICdub25lJztcbiAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChhcmVhRmlsZUlucHV0KTtcblxuICAvLyBIYWNlciBhcnJhc3RyYWJsZVxuICBtYWtlRHJhZ2dhYmxlKGNvbnRhaW5lcik7XG5cbiAgLy8gRWxlbWVudG9zXG4gIGNvbnN0IGVsZW1lbnRzID0ge1xuICAgIGluaXRCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcjaW5pdEJ0bicpLFxuICAgIHNlbGVjdEFyZWFCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcjc2VsZWN0QXJlYUJ0bicpLFxuICAgIGxvYWRBcmVhQnRuOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignI2xvYWRBcmVhQnRuJyksXG4gICAgeDFJbnB1dDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyN4MUlucHV0JyksXG4gICAgeTFJbnB1dDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyN5MUlucHV0JyksXG4gICAgeDJJbnB1dDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyN4MklucHV0JyksXG4gICAgeTJJbnB1dDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyN5MklucHV0JyksXG4gICAgc3RhcnRCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcjc3RhcnRCdG4nKSxcbiAgICBzdG9wQnRuOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignI3N0b3BCdG4nKSxcbiAgICBjbG9zZUJ0bjogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyNjbG9zZUJ0bicpLFxuICAgIGluaXRTZWN0aW9uOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignI2luaXRTZWN0aW9uJyksXG4gICAgYXJlYVNlY3Rpb246IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcjYXJlYVNlY3Rpb24nKSxcbiAgICBwcm90ZWN0ZWRDb3VudDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyNwcm90ZWN0ZWRDb3VudCcpLFxuICAgIGNoYW5nZXNDb3VudDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyNjaGFuZ2VzQ291bnQnKSxcbiAgICBjaGFyZ2VzQ291bnQ6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcjY2hhcmdlc0NvdW50JyksXG4gICAgcmVwYWlyZWRDb3VudDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyNyZXBhaXJlZENvdW50JyksXG4gICAgc3RhdHVzQmFyOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignI3N0YXR1c0JhcicpLFxuICAgIGFyZWFGaWxlSW5wdXQ6IGFyZWFGaWxlSW5wdXQsXG4gICAgcGl4ZWxzUGVyQmF0Y2hJbnB1dDogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJyNwaXhlbHNQZXJCYXRjaElucHV0JyksXG4gICAgbWluQ2hhcmdlc0lucHV0OiBjb250YWluZXIucXVlcnlTZWxlY3RvcignI21pbkNoYXJnZXNJbnB1dCcpLFxuICAgIHNhdmVCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcjc2F2ZUJ0bicpXG4gIH07XG5cbiAgLy8gQVBJIGRlIGxhIFVJXG4gIGNvbnN0IHVpID0ge1xuICAgIGVsZW1lbnRzLFxuICAgIFxuICAgIHVwZGF0ZVN0YXR1czogKG1lc3NhZ2UsIHR5cGUgPSAnaW5mbycpID0+IHtcbiAgICAgIGVsZW1lbnRzLnN0YXR1c0Jhci50ZXh0Q29udGVudCA9IG1lc3NhZ2U7XG4gICAgICBjb25zdCBjb2xvcnMgPSB7XG4gICAgICAgIGluZm86ICcjNjBhNWZhJyxcbiAgICAgICAgc3VjY2VzczogJyMxMGI5ODEnLFxuICAgICAgICB3YXJuaW5nOiAnI2Y1OWUwYicsXG4gICAgICAgIGVycm9yOiAnI2VmNDQ0NCdcbiAgICAgIH07XG4gICAgICBlbGVtZW50cy5zdGF0dXNCYXIuc3R5bGUuY29sb3IgPSBjb2xvcnNbdHlwZV0gfHwgY29sb3JzLmluZm87XG4gICAgfSxcblxuICAgIHVwZGF0ZVByb2dyZXNzOiAoY3VycmVudCwgdG90YWwpID0+IHtcbiAgICAgIGVsZW1lbnRzLmNoYW5nZXNDb3VudC50ZXh0Q29udGVudCA9IGN1cnJlbnQ7XG4gICAgICBlbGVtZW50cy5wcm90ZWN0ZWRDb3VudC50ZXh0Q29udGVudCA9IHRvdGFsO1xuICAgIH0sXG5cbiAgICB1cGRhdGVTdGF0czogKHN0YXRzKSA9PiB7XG4gICAgICBpZiAoc3RhdHMuY2hhcmdlcyAhPT0gdW5kZWZpbmVkKSBlbGVtZW50cy5jaGFyZ2VzQ291bnQudGV4dENvbnRlbnQgPSBzdGF0cy5jaGFyZ2VzO1xuICAgICAgaWYgKHN0YXRzLnJlcGFpcmVkICE9PSB1bmRlZmluZWQpIGVsZW1lbnRzLnJlcGFpcmVkQ291bnQudGV4dENvbnRlbnQgPSBzdGF0cy5yZXBhaXJlZDtcbiAgICAgIGlmIChzdGF0cy5wZW5kaW5nICE9PSB1bmRlZmluZWQpIGVsZW1lbnRzLmNoYW5nZXNDb3VudC50ZXh0Q29udGVudCA9IHN0YXRzLnBlbmRpbmc7XG4gICAgfSxcblxuICAgIHNob3dBcmVhU2VjdGlvbjogKCkgPT4ge1xuICAgICAgZWxlbWVudHMuaW5pdFNlY3Rpb24uc3R5bGUuZGlzcGxheSA9ICdub25lJztcbiAgICAgIGVsZW1lbnRzLmFyZWFTZWN0aW9uLnN0eWxlLmRpc3BsYXkgPSAnYmxvY2snO1xuICAgIH0sXG5cbiAgICBzZXRJbml0QnV0dG9uVmlzaWJsZTogKHZpc2libGUpID0+IHtcbiAgICAgIGVsZW1lbnRzLmluaXRTZWN0aW9uLnN0eWxlLmRpc3BsYXkgPSB2aXNpYmxlID8gJ2Jsb2NrJyA6ICdub25lJztcbiAgICB9LFxuXG4gICAgc2V0SW5pdGlhbGl6ZWQ6IChpbml0aWFsaXplZCkgPT4ge1xuICAgICAgZWxlbWVudHMuaW5pdEJ0bi5kaXNhYmxlZCA9IGluaXRpYWxpemVkO1xuICAgICAgaWYgKGluaXRpYWxpemVkKSB7XG4gICAgICAgIGVsZW1lbnRzLmluaXRCdG4uc3R5bGUub3BhY2l0eSA9ICcwLjUnO1xuICAgICAgICBlbGVtZW50cy5pbml0QnRuLnN0eWxlLmN1cnNvciA9ICdub3QtYWxsb3dlZCc7XG4gICAgICB9XG4gICAgfSxcblxuICAgIGVuYWJsZVN0YXJ0QnRuOiAoKSA9PiB7XG4gICAgICBlbGVtZW50cy5zdGFydEJ0bi5kaXNhYmxlZCA9IGZhbHNlO1xuICAgIH0sXG5cbiAgICBzZXRSdW5uaW5nU3RhdGU6IChydW5uaW5nKSA9PiB7XG4gICAgICBlbGVtZW50cy5zdGFydEJ0bi5kaXNhYmxlZCA9IHJ1bm5pbmc7XG4gICAgICBlbGVtZW50cy5zdG9wQnRuLmRpc2FibGVkID0gIXJ1bm5pbmc7XG4gICAgICBlbGVtZW50cy5zZWxlY3RBcmVhQnRuLmRpc2FibGVkID0gcnVubmluZztcbiAgICB9LFxuXG4gICAgdXBkYXRlQ29vcmRpbmF0ZXM6IChjb29yZHMpID0+IHtcbiAgICAgIGlmIChjb29yZHMueDEgIT09IHVuZGVmaW5lZCkgZWxlbWVudHMueDFJbnB1dC52YWx1ZSA9IGNvb3Jkcy54MTtcbiAgICAgIGlmIChjb29yZHMueTEgIT09IHVuZGVmaW5lZCkgZWxlbWVudHMueTFJbnB1dC52YWx1ZSA9IGNvb3Jkcy55MTtcbiAgICAgIGlmIChjb29yZHMueDIgIT09IHVuZGVmaW5lZCkgZWxlbWVudHMueDJJbnB1dC52YWx1ZSA9IGNvb3Jkcy54MjtcbiAgICAgIGlmIChjb29yZHMueTIgIT09IHVuZGVmaW5lZCkgZWxlbWVudHMueTJJbnB1dC52YWx1ZSA9IGNvb3Jkcy55MjtcbiAgICB9LFxuXG4gICAgZGVzdHJveTogKCkgPT4ge1xuICAgICAgY29udGFpbmVyLnJlbW92ZSgpO1xuICAgICAgYXJlYUZpbGVJbnB1dC5yZW1vdmUoKTtcbiAgICB9XG4gIH07XG5cbiAgcmV0dXJuIHVpO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gc2hvd0NvbmZpcm1EaWFsb2cobWVzc2FnZSwgdGl0bGUsIGJ1dHRvbnMgPSB7fSkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUpID0+IHtcbiAgICBjb25zdCBvdmVybGF5ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnZGl2Jyk7XG4gICAgb3ZlcmxheS5jbGFzc05hbWUgPSAnbW9kYWwtb3ZlcmxheSc7XG4gICAgb3ZlcmxheS5zdHlsZS5wb3NpdGlvbiA9ICdmaXhlZCc7XG4gICAgb3ZlcmxheS5zdHlsZS50b3AgPSAnMCc7XG4gICAgb3ZlcmxheS5zdHlsZS5sZWZ0ID0gJzAnO1xuICAgIG92ZXJsYXkuc3R5bGUud2lkdGggPSAnMTAwJSc7XG4gICAgb3ZlcmxheS5zdHlsZS5oZWlnaHQgPSAnMTAwJSc7XG4gICAgb3ZlcmxheS5zdHlsZS5iYWNrZ3JvdW5kID0gJ3JnYmEoMCwwLDAsMC43KSc7XG4gICAgb3ZlcmxheS5zdHlsZS56SW5kZXggPSAnMTAwMDEnO1xuICAgIG92ZXJsYXkuc3R5bGUuZGlzcGxheSA9ICdmbGV4JztcbiAgICBvdmVybGF5LnN0eWxlLmFsaWduSXRlbXMgPSAnY2VudGVyJztcbiAgICBvdmVybGF5LnN0eWxlLmp1c3RpZnlDb250ZW50ID0gJ2NlbnRlcic7XG4gICAgXG4gICAgY29uc3QgbW9kYWwgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdkaXYnKTtcbiAgICBtb2RhbC5zdHlsZS5iYWNrZ3JvdW5kID0gJyMxYTFhMWEnO1xuICAgIG1vZGFsLnN0eWxlLmJvcmRlciA9ICcycHggc29saWQgIzMzMyc7XG4gICAgbW9kYWwuc3R5bGUuYm9yZGVyUmFkaXVzID0gJzE1cHgnO1xuICAgIG1vZGFsLnN0eWxlLnBhZGRpbmcgPSAnMjVweCc7XG4gICAgbW9kYWwuc3R5bGUuY29sb3IgPSAnI2VlZSc7XG4gICAgbW9kYWwuc3R5bGUubWluV2lkdGggPSAnMzUwcHgnO1xuICAgIG1vZGFsLnN0eWxlLm1heFdpZHRoID0gJzQwMHB4JztcbiAgICBtb2RhbC5zdHlsZS5ib3hTaGFkb3cgPSAnMCAxMHB4IDMwcHggcmdiYSgwLDAsMCwwLjUpJztcbiAgICBtb2RhbC5zdHlsZS5mb250RmFtaWx5ID0gXCInU2Vnb2UgVUknLCBSb2JvdG8sIHNhbnMtc2VyaWZcIjtcbiAgICBcbiAgICBtb2RhbC5pbm5lckhUTUwgPSBgXG4gICAgICA8aDMgc3R5bGU9XCJtYXJnaW46IDAgMCAxNXB4IDA7IHRleHQtYWxpZ246IGNlbnRlcjsgZm9udC1zaXplOiAxOHB4O1wiPiR7dGl0bGV9PC9oMz5cbiAgICAgIDxwIHN0eWxlPVwibWFyZ2luOiAwIDAgMjBweCAwOyB0ZXh0LWFsaWduOiBjZW50ZXI7IGxpbmUtaGVpZ2h0OiAxLjQ7XCI+JHttZXNzYWdlfTwvcD5cbiAgICAgIDxkaXYgc3R5bGU9XCJkaXNwbGF5OiBmbGV4OyBnYXA6IDEwcHg7IGp1c3RpZnktY29udGVudDogY2VudGVyO1wiPlxuICAgICAgICAke2J1dHRvbnMuc2F2ZSA/IGA8YnV0dG9uIGNsYXNzPVwic2F2ZS1idG5cIiBzdHlsZT1cInBhZGRpbmc6IDEwcHggMjBweDsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA4cHg7IGZvbnQtc2l6ZTogMTRweDsgZm9udC13ZWlnaHQ6IGJvbGQ7IGN1cnNvcjogcG9pbnRlcjsgbWluLXdpZHRoOiAxMDBweDsgYmFja2dyb3VuZDogIzEwYjk4MTsgY29sb3I6IHdoaXRlO1wiPiR7YnV0dG9ucy5zYXZlfTwvYnV0dG9uPmAgOiAnJ31cbiAgICAgICAgJHtidXR0b25zLmRpc2NhcmQgPyBgPGJ1dHRvbiBjbGFzcz1cImRpc2NhcmQtYnRuXCIgc3R5bGU9XCJwYWRkaW5nOiAxMHB4IDIwcHg7IGJvcmRlcjogbm9uZTsgYm9yZGVyLXJhZGl1czogOHB4OyBmb250LXNpemU6IDE0cHg7IGZvbnQtd2VpZ2h0OiBib2xkOyBjdXJzb3I6IHBvaW50ZXI7IG1pbi13aWR0aDogMTAwcHg7IGJhY2tncm91bmQ6ICNlZjQ0NDQ7IGNvbG9yOiB3aGl0ZTtcIj4ke2J1dHRvbnMuZGlzY2FyZH08L2J1dHRvbj5gIDogJyd9XG4gICAgICAgICR7YnV0dG9ucy5jYW5jZWwgPyBgPGJ1dHRvbiBjbGFzcz1cImNhbmNlbC1idG5cIiBzdHlsZT1cInBhZGRpbmc6IDEwcHggMjBweDsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA4cHg7IGZvbnQtc2l6ZTogMTRweDsgZm9udC13ZWlnaHQ6IGJvbGQ7IGN1cnNvcjogcG9pbnRlcjsgbWluLXdpZHRoOiAxMDBweDsgYmFja2dyb3VuZDogIzJkMzc0ODsgY29sb3I6IHdoaXRlO1wiPiR7YnV0dG9ucy5jYW5jZWx9PC9idXR0b24+YCA6ICcnfVxuICAgICAgPC9kaXY+XG4gICAgYDtcbiAgICBcbiAgICBvdmVybGF5LmFwcGVuZENoaWxkKG1vZGFsKTtcbiAgICBkb2N1bWVudC5ib2R5LmFwcGVuZENoaWxkKG92ZXJsYXkpO1xuICAgIFxuICAgIC8vIEV2ZW50IGxpc3RlbmVyc1xuICAgIGNvbnN0IHNhdmVCdG4gPSBtb2RhbC5xdWVyeVNlbGVjdG9yKCcuc2F2ZS1idG4nKTtcbiAgICBjb25zdCBkaXNjYXJkQnRuID0gbW9kYWwucXVlcnlTZWxlY3RvcignLmRpc2NhcmQtYnRuJyk7XG4gICAgY29uc3QgY2FuY2VsQnRuID0gbW9kYWwucXVlcnlTZWxlY3RvcignLmNhbmNlbC1idG4nKTtcbiAgICBcbiAgICBjb25zdCBjbGVhbnVwID0gKCkgPT4ge1xuICAgICAgZG9jdW1lbnQuYm9keS5yZW1vdmVDaGlsZChvdmVybGF5KTtcbiAgICB9O1xuICAgIFxuICAgIGlmIChzYXZlQnRuKSB7XG4gICAgICBzYXZlQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgICAgICBjbGVhbnVwKCk7XG4gICAgICAgIHJlc29sdmUoJ3NhdmUnKTtcbiAgICAgIH0pO1xuICAgIH1cbiAgICBcbiAgICBpZiAoZGlzY2FyZEJ0bikge1xuICAgICAgZGlzY2FyZEJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsICgpID0+IHtcbiAgICAgICAgY2xlYW51cCgpO1xuICAgICAgICByZXNvbHZlKCdkaXNjYXJkJyk7XG4gICAgICB9KTtcbiAgICB9XG4gICAgXG4gICAgaWYgKGNhbmNlbEJ0bikge1xuICAgICAgY2FuY2VsQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgICAgICBjbGVhbnVwKCk7XG4gICAgICAgIHJlc29sdmUoJ2NhbmNlbCcpO1xuICAgICAgfSk7XG4gICAgfVxuICAgIFxuICAgIC8vIENlcnJhciBjb24gb3ZlcmxheVxuICAgIG92ZXJsYXkuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoZSkgPT4ge1xuICAgICAgaWYgKGUudGFyZ2V0ID09PSBvdmVybGF5KSB7XG4gICAgICAgIGNsZWFudXAoKTtcbiAgICAgICAgcmVzb2x2ZSgnY2FuY2VsJyk7XG4gICAgICB9XG4gICAgfSk7XG4gIH0pO1xufVxuXG5mdW5jdGlvbiBtYWtlRHJhZ2dhYmxlKGVsZW1lbnQpIHtcbiAgbGV0IGlzRHJhZ2dpbmcgPSBmYWxzZTtcbiAgbGV0IHN0YXJ0WCwgc3RhcnRZLCBzdGFydExlZnQsIHN0YXJ0VG9wO1xuXG4gIGNvbnN0IGhlYWRlciA9IGVsZW1lbnQucXVlcnlTZWxlY3RvcignLmd1YXJkLWhlYWRlcicpO1xuICBoZWFkZXIuYWRkRXZlbnRMaXN0ZW5lcignbW91c2Vkb3duJywgKGUpID0+IHtcbiAgICBpZiAoZS50YXJnZXQuaWQgPT09ICdjbG9zZUJ0bicpIHJldHVybjtcbiAgICBcbiAgICBpc0RyYWdnaW5nID0gdHJ1ZTtcbiAgICBzdGFydFggPSBlLmNsaWVudFg7XG4gICAgc3RhcnRZID0gZS5jbGllbnRZO1xuICAgIHN0YXJ0TGVmdCA9IHBhcnNlSW50KHdpbmRvdy5nZXRDb21wdXRlZFN0eWxlKGVsZW1lbnQpLmxlZnQsIDEwKTtcbiAgICBzdGFydFRvcCA9IHBhcnNlSW50KHdpbmRvdy5nZXRDb21wdXRlZFN0eWxlKGVsZW1lbnQpLnRvcCwgMTApO1xuICAgIFxuICAgIGVsZW1lbnQuc3R5bGUuY3Vyc29yID0gJ2dyYWJiaW5nJztcbiAgfSk7XG5cbiAgZG9jdW1lbnQuYWRkRXZlbnRMaXN0ZW5lcignbW91c2Vtb3ZlJywgKGUpID0+IHtcbiAgICBpZiAoIWlzRHJhZ2dpbmcpIHJldHVybjtcbiAgICBcbiAgICBjb25zdCBkZWx0YVggPSBlLmNsaWVudFggLSBzdGFydFg7XG4gICAgY29uc3QgZGVsdGFZID0gZS5jbGllbnRZIC0gc3RhcnRZO1xuICAgIFxuICAgIGVsZW1lbnQuc3R5bGUubGVmdCA9IGAke3N0YXJ0TGVmdCArIGRlbHRhWH1weGA7XG4gICAgZWxlbWVudC5zdHlsZS50b3AgPSBgJHtzdGFydFRvcCArIGRlbHRhWX1weGA7XG4gICAgZWxlbWVudC5zdHlsZS5yaWdodCA9ICdhdXRvJztcbiAgfSk7XG5cbiAgZG9jdW1lbnQuYWRkRXZlbnRMaXN0ZW5lcignbW91c2V1cCcsICgpID0+IHtcbiAgICBpZiAoaXNEcmFnZ2luZykge1xuICAgICAgaXNEcmFnZ2luZyA9IGZhbHNlO1xuICAgICAgZWxlbWVudC5zdHlsZS5jdXJzb3IgPSAnZGVmYXVsdCc7XG4gICAgfVxuICB9KTtcbn1cbiIsICJpbXBvcnQgeyBndWFyZFN0YXRlIH0gZnJvbSAnLi9jb25maWcuanMnO1xuaW1wb3J0IHsgbG9nIH0gZnJvbSAnLi4vY29yZS9sb2dnZXIuanMnO1xuXG4vLyBGdW5jaVx1MDBGM24gcGFyYSBkaXZpZGlyIGVsIFx1MDBFMXJlYSBkZSBwcm90ZWNjaVx1MDBGM24gZW4gbVx1MDBGQWx0aXBsZXMgcGFydGVzXG5mdW5jdGlvbiBzcGxpdFByb3RlY3Rpb25BcmVhKGFyZWEsIHNwbGl0Q291bnQpIHtcbiAgY29uc3QgeyB4MSwgeTEsIHgyLCB5MiB9ID0gYXJlYTtcbiAgY29uc3Qgd2lkdGggPSB4MiAtIHgxO1xuICBjb25zdCBoZWlnaHQgPSB5MiAtIHkxO1xuICBjb25zdCBhcmVhcyA9IFtdO1xuICBcbiAgaWYgKHNwbGl0Q291bnQgPD0gMSkge1xuICAgIHJldHVybiBbYXJlYV07XG4gIH1cbiAgXG4gIC8vIERldGVybWluYXIgc2kgZGl2aWRpciBob3Jpem9udGFsIG8gdmVydGljYWxtZW50ZSBiYXNhZG8gZW4gbGFzIGRpbWVuc2lvbmVzXG4gIGNvbnN0IGRpdmlkZUhvcml6b250YWxseSA9IHdpZHRoID49IGhlaWdodDtcbiAgXG4gIGlmIChkaXZpZGVIb3Jpem9udGFsbHkpIHtcbiAgICBjb25zdCBzZWdtZW50V2lkdGggPSBNYXRoLmZsb29yKHdpZHRoIC8gc3BsaXRDb3VudCk7XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBzcGxpdENvdW50OyBpKyspIHtcbiAgICAgIGNvbnN0IHN0YXJ0WCA9IHgxICsgKGkgKiBzZWdtZW50V2lkdGgpO1xuICAgICAgY29uc3QgZW5kWCA9IGkgPT09IHNwbGl0Q291bnQgLSAxID8geDIgOiBzdGFydFggKyBzZWdtZW50V2lkdGg7XG4gICAgICBhcmVhcy5wdXNoKHtcbiAgICAgICAgeDE6IHN0YXJ0WCxcbiAgICAgICAgeTE6IHkxLFxuICAgICAgICB4MjogZW5kWCxcbiAgICAgICAgeTI6IHkyXG4gICAgICB9KTtcbiAgICB9XG4gIH0gZWxzZSB7XG4gICAgY29uc3Qgc2VnbWVudEhlaWdodCA9IE1hdGguZmxvb3IoaGVpZ2h0IC8gc3BsaXRDb3VudCk7XG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBzcGxpdENvdW50OyBpKyspIHtcbiAgICAgIGNvbnN0IHN0YXJ0WSA9IHkxICsgKGkgKiBzZWdtZW50SGVpZ2h0KTtcbiAgICAgIGNvbnN0IGVuZFkgPSBpID09PSBzcGxpdENvdW50IC0gMSA/IHkyIDogc3RhcnRZICsgc2VnbWVudEhlaWdodDtcbiAgICAgIGFyZWFzLnB1c2goe1xuICAgICAgICB4MTogeDEsXG4gICAgICAgIHkxOiBzdGFydFksXG4gICAgICAgIHgyOiB4MixcbiAgICAgICAgeTI6IGVuZFlcbiAgICAgIH0pO1xuICAgIH1cbiAgfVxuICBcbiAgcmV0dXJuIGFyZWFzO1xufVxuXG4vLyBGdW5jaVx1MDBGM24gcGFyYSBvYnRlbmVyIHBcdTAwRUR4ZWxlcyBkZW50cm8gZGUgdW4gXHUwMEUxcmVhIGVzcGVjXHUwMEVEZmljYVxuZnVuY3Rpb24gZ2V0UGl4ZWxzSW5BcmVhKGFyZWEsIHBpeGVsc01hcCkge1xuICBjb25zdCBwaXhlbHMgPSBbXTtcbiAgY29uc3QgeyB4MSwgeTEsIHgyLCB5MiB9ID0gYXJlYTtcbiAgXG4gIGZvciAoY29uc3QgW2tleSwgdmFsdWVdIG9mIHBpeGVsc01hcC5lbnRyaWVzKCkpIHtcbiAgICBjb25zdCBbeCwgeV0gPSBrZXkuc3BsaXQoJywnKS5tYXAoTnVtYmVyKTtcbiAgICBpZiAoeCA+PSB4MSAmJiB4IDw9IHgyICYmIHkgPj0geTEgJiYgeSA8PSB5Mikge1xuICAgICAgcGl4ZWxzLnB1c2goeyBrZXksIC4uLnZhbHVlIH0pO1xuICAgIH1cbiAgfVxuICBcbiAgcmV0dXJuIHBpeGVscztcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIHNhdmVQcm9ncmVzcyhmaWxlbmFtZSA9IG51bGwsIHNwbGl0Q291bnQgPSBudWxsKSB7XG4gIHRyeSB7XG4gICAgaWYgKCFndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhIHx8ICFndWFyZFN0YXRlLm9yaWdpbmFsUGl4ZWxzLnNpemUpIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcignTm8gaGF5IHByb2dyZXNvIHBhcmEgZ3VhcmRhcicpO1xuICAgIH1cbiAgICBcbiAgICBjb25zdCBhcmVhcyA9IHNwbGl0Q291bnQgJiYgc3BsaXRDb3VudCA+IDEgPyBcbiAgICAgIHNwbGl0UHJvdGVjdGlvbkFyZWEoZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYSwgc3BsaXRDb3VudCkgOiBcbiAgICAgIFtndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhXTtcbiAgICBcbiAgICBjb25zdCByZXN1bHRzID0gW107XG4gICAgXG4gICAgZm9yIChsZXQgaSA9IDA7IGkgPCBhcmVhcy5sZW5ndGg7IGkrKykge1xuICAgICAgY29uc3QgYXJlYSA9IGFyZWFzW2ldO1xuICAgICAgY29uc3QgYXJlYVBpeGVscyA9IGdldFBpeGVsc0luQXJlYShhcmVhLCBndWFyZFN0YXRlLm9yaWdpbmFsUGl4ZWxzKTtcbiAgICAgIFxuICAgICAgY29uc3QgcHJvZ3Jlc3NEYXRhID0ge1xuICAgICAgICB2ZXJzaW9uOiBcIjEuMFwiLFxuICAgICAgICB0aW1lc3RhbXA6IERhdGUubm93KCksXG4gICAgICAgIHByb3RlY3Rpb25EYXRhOiB7XG4gICAgICAgICAgYXJlYTogeyAuLi5hcmVhIH0sXG4gICAgICAgICAgcHJvdGVjdGVkUGl4ZWxzOiBhcmVhUGl4ZWxzLmxlbmd0aCxcbiAgICAgICAgICBzcGxpdEluZm86IHNwbGl0Q291bnQgPiAxID8geyBcbiAgICAgICAgICAgIHRvdGFsOiBzcGxpdENvdW50LCBcbiAgICAgICAgICAgIGN1cnJlbnQ6IGkgKyAxLFxuICAgICAgICAgICAgb3JpZ2luYWxBcmVhOiB7IC4uLmd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEgfVxuICAgICAgICAgIH0gOiBudWxsXG4gICAgICAgIH0sXG4gICAgICAgIHByb2dyZXNzOiB7XG4gICAgICAgICAgdG90YWxSZXBhaXJlZDogZ3VhcmRTdGF0ZS50b3RhbFJlcGFpcmVkLFxuICAgICAgICAgIGxhc3RDaGVjazogZ3VhcmRTdGF0ZS5sYXN0Q2hlY2tcbiAgICAgICAgfSxcbiAgICAgICAgY29uZmlnOiB7XG4gICAgICAgICAgbWF4UHJvdGVjdGlvblNpemU6IDEwMDAwMCxcbiAgICAgICAgICBwaXhlbHNQZXJCYXRjaDogMTAsXG4gICAgICAgICAgY2hlY2tJbnRlcnZhbDogMTAwMDBcbiAgICAgICAgfSxcbiAgICAgICAgLy8gRmlsdHJhciBzb2xvIGxvcyBkYXRvcyBzZXJpYWxpemFibGVzIGRlIGxvcyBjb2xvcmVzIChzaW4gZWxlbWVudG9zIERPTSlcbiAgICAgICAgY29sb3JzOiBndWFyZFN0YXRlLmF2YWlsYWJsZUNvbG9ycy5tYXAoY29sb3IgPT4gKHtcbiAgICAgICAgICBpZDogY29sb3IuaWQsXG4gICAgICAgICAgcjogY29sb3IucixcbiAgICAgICAgICBnOiBjb2xvci5nLFxuICAgICAgICAgIGI6IGNvbG9yLmJcbiAgICAgICAgfSkpLFxuICAgICAgICAvLyBDb252ZXJ0aXIgTWFwIGEgYXJyYXkgcGFyYSBzZXJpYWxpemFjaVx1MDBGM24gLSBzb2xvIHBcdTAwRUR4ZWxlcyBkZWwgXHUwMEUxcmVhXG4gICAgICAgIG9yaWdpbmFsUGl4ZWxzOiBhcmVhUGl4ZWxzXG4gICAgICB9O1xuICAgICAgXG4gICAgICBjb25zdCBkYXRhU3RyID0gSlNPTi5zdHJpbmdpZnkocHJvZ3Jlc3NEYXRhLCBudWxsLCAyKTtcbiAgICAgIGNvbnN0IGJsb2IgPSBuZXcgd2luZG93LkJsb2IoW2RhdGFTdHJdLCB7IHR5cGU6ICdhcHBsaWNhdGlvbi9qc29uJyB9KTtcbiAgICAgIFxuICAgICAgY29uc3Qgc3VmZml4ID0gc3BsaXRDb3VudCA+IDEgPyBgX3BhcnRlJHtpICsgMX1kZSR7c3BsaXRDb3VudH1gIDogJyc7XG4gICAgICBjb25zdCBmaW5hbEZpbGVuYW1lID0gZmlsZW5hbWUgfHwgXG4gICAgICAgIGB3cGxhY2VfR1VBUkRfJHtuZXcgRGF0ZSgpLnRvSVNPU3RyaW5nKCkuc2xpY2UoMCwgMTkpLnJlcGxhY2UoLzovZywgJy0nKX0ke3N1ZmZpeH0uanNvbmA7XG4gICAgICBcbiAgICAgIC8vIENyZWFyIHkgZGlzcGFyYXIgZGVzY2FyZ2FcbiAgICAgIGNvbnN0IHVybCA9IHdpbmRvdy5VUkwuY3JlYXRlT2JqZWN0VVJMKGJsb2IpO1xuICAgICAgY29uc3QgbGluayA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2EnKTtcbiAgICAgIGxpbmsuaHJlZiA9IHVybDtcbiAgICAgIGxpbmsuZG93bmxvYWQgPSBmaW5hbEZpbGVuYW1lO1xuICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChsaW5rKTtcbiAgICAgIGxpbmsuY2xpY2soKTtcbiAgICAgIGRvY3VtZW50LmJvZHkucmVtb3ZlQ2hpbGQobGluayk7XG4gICAgICB3aW5kb3cuVVJMLnJldm9rZU9iamVjdFVSTCh1cmwpO1xuICAgICAgXG4gICAgICByZXN1bHRzLnB1c2goeyBzdWNjZXNzOiB0cnVlLCBmaWxlbmFtZTogZmluYWxGaWxlbmFtZSB9KTtcbiAgICAgIGxvZyhgXHUyNzA1IFByb2dyZXNvIGd1YXJkYWRvOiAke2ZpbmFsRmlsZW5hbWV9YCk7XG4gICAgfVxuICAgIFxuICAgIHJldHVybiB7IFxuICAgICAgc3VjY2VzczogdHJ1ZSwgXG4gICAgICBmaWxlbmFtZTogcmVzdWx0cy5sZW5ndGggPT09IDEgPyByZXN1bHRzWzBdLmZpbGVuYW1lIDogYCR7cmVzdWx0cy5sZW5ndGh9IGFyY2hpdm9zYCxcbiAgICAgIGZpbGVzOiByZXN1bHRzXG4gICAgfTtcbiAgICBcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1Mjc0QyBFcnJvciBndWFyZGFuZG8gcHJvZ3Jlc286JywgZXJyb3IpO1xuICAgIHJldHVybiB7IHN1Y2Nlc3M6IGZhbHNlLCBlcnJvcjogZXJyb3IubWVzc2FnZSB9O1xuICB9XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBsb2FkUHJvZ3Jlc3MoZmlsZSkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUpID0+IHtcbiAgICB0cnkge1xuICAgICAgY29uc3QgcmVhZGVyID0gbmV3IHdpbmRvdy5GaWxlUmVhZGVyKCk7XG4gICAgICBcbiAgICAgIHJlYWRlci5vbmxvYWQgPSBhc3luYyAoZSkgPT4ge1xuICAgICAgICB0cnkge1xuICAgICAgICAgIGNvbnN0IHByb2dyZXNzRGF0YSA9IEpTT04ucGFyc2UoZS50YXJnZXQucmVzdWx0KTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBWYWxpZGFyIGVzdHJ1Y3R1cmEgZGVsIGFyY2hpdm9cbiAgICAgICAgICBjb25zdCByZXF1aXJlZEZpZWxkcyA9IFsncHJvdGVjdGlvbkRhdGEnLCAnb3JpZ2luYWxQaXhlbHMnLCAnY29sb3JzJ107XG4gICAgICAgICAgY29uc3QgbWlzc2luZ0ZpZWxkcyA9IHJlcXVpcmVkRmllbGRzLmZpbHRlcihmaWVsZCA9PiAhKGZpZWxkIGluIHByb2dyZXNzRGF0YSkpO1xuICAgICAgICAgIFxuICAgICAgICAgIGlmIChtaXNzaW5nRmllbGRzLmxlbmd0aCA+IDApIHtcbiAgICAgICAgICAgIHRocm93IG5ldyBFcnJvcihgQ2FtcG9zIHJlcXVlcmlkb3MgZmFsdGFudGVzOiAke21pc3NpbmdGaWVsZHMuam9pbignLCAnKX1gKTtcbiAgICAgICAgICB9XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gVmVyaWZpY2FyIGNvbXBhdGliaWxpZGFkIGRlIGNvbG9yZXNcbiAgICAgICAgICBpZiAoZ3VhcmRTdGF0ZS5hdmFpbGFibGVDb2xvcnMubGVuZ3RoID4gMCkge1xuICAgICAgICAgICAgY29uc3Qgc2F2ZWRDb2xvcklkcyA9IHByb2dyZXNzRGF0YS5jb2xvcnMubWFwKGMgPT4gYy5pZCk7XG4gICAgICAgICAgICBjb25zdCBjdXJyZW50Q29sb3JJZHMgPSBndWFyZFN0YXRlLmF2YWlsYWJsZUNvbG9ycy5tYXAoYyA9PiBjLmlkKTtcbiAgICAgICAgICAgIGNvbnN0IGNvbW1vbkNvbG9ycyA9IHNhdmVkQ29sb3JJZHMuZmlsdGVyKGlkID0+IGN1cnJlbnRDb2xvcklkcy5pbmNsdWRlcyhpZCkpO1xuICAgICAgICAgICAgXG4gICAgICAgICAgICBpZiAoY29tbW9uQ29sb3JzLmxlbmd0aCA8IHNhdmVkQ29sb3JJZHMubGVuZ3RoICogMC44KSB7XG4gICAgICAgICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIExvcyBjb2xvcmVzIGd1YXJkYWRvcyBubyBjb2luY2lkZW4gY29tcGxldGFtZW50ZSBjb24gbG9zIGFjdHVhbGVzJyk7XG4gICAgICAgICAgICB9XG4gICAgICAgICAgfVxuICAgICAgICAgIFxuICAgICAgICAgIC8vIFJlc3RhdXJhciBlc3RhZG9cbiAgICAgICAgICBpZiAocHJvZ3Jlc3NEYXRhLnByb3RlY3Rpb25EYXRhKSB7XG4gICAgICAgICAgICBndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhID0gcHJvZ3Jlc3NEYXRhLnByb3RlY3Rpb25EYXRhLmFyZWE7XG4gICAgICAgICAgfSBlbHNlIGlmIChwcm9ncmVzc0RhdGEucHJvdGVjdGlvbkFyZWEpIHtcbiAgICAgICAgICAgIC8vIENvbXBhdGliaWxpZGFkIGNvbiBmb3JtYXRvIGFudGVyaW9yXG4gICAgICAgICAgICBndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhID0gcHJvZ3Jlc3NEYXRhLnByb3RlY3Rpb25BcmVhO1xuICAgICAgICAgIH1cbiAgICAgICAgICBcbiAgICAgICAgICAvLyBDb252ZXJ0aXIgYXJyYXkgZGUgcFx1MDBFRHhlbGVzIGRlIHZ1ZWx0YSBhIE1hcFxuICAgICAgICAgIGd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMgPSBuZXcgTWFwKCk7XG4gICAgICAgICAgZm9yIChjb25zdCBwaXhlbERhdGEgb2YgcHJvZ3Jlc3NEYXRhLm9yaWdpbmFsUGl4ZWxzKSB7XG4gICAgICAgICAgICBjb25zdCB7IGtleSwgLi4ucGl4ZWxJbmZvIH0gPSBwaXhlbERhdGE7XG4gICAgICAgICAgICBndWFyZFN0YXRlLm9yaWdpbmFsUGl4ZWxzLnNldChrZXksIHBpeGVsSW5mbyk7XG4gICAgICAgICAgfVxuICAgICAgICAgIFxuICAgICAgICAgIC8vIFJlc3RhdXJhciBlc3RhZFx1MDBFRHN0aWNhcyBzaSBlc3RcdTAwRTFuIGRpc3BvbmlibGVzXG4gICAgICAgICAgaWYgKHByb2dyZXNzRGF0YS5wcm9ncmVzcykge1xuICAgICAgICAgICAgZ3VhcmRTdGF0ZS50b3RhbFJlcGFpcmVkID0gcHJvZ3Jlc3NEYXRhLnByb2dyZXNzLnRvdGFsUmVwYWlyZWQgfHwgMDtcbiAgICAgICAgICAgIGd1YXJkU3RhdGUubGFzdENoZWNrID0gcHJvZ3Jlc3NEYXRhLnByb2dyZXNzLmxhc3RDaGVjayB8fCAwO1xuICAgICAgICAgIH0gZWxzZSBpZiAocHJvZ3Jlc3NEYXRhLnN0YXRpc3RpY3MpIHtcbiAgICAgICAgICAgIC8vIENvbXBhdGliaWxpZGFkIGNvbiBmb3JtYXRvIGFudGVyaW9yXG4gICAgICAgICAgICBndWFyZFN0YXRlLnRvdGFsUmVwYWlyZWQgPSBwcm9ncmVzc0RhdGEuc3RhdGlzdGljcy50b3RhbFJlcGFpcmVkIHx8IDA7XG4gICAgICAgICAgICBndWFyZFN0YXRlLmxhc3RDaGVjayA9IHByb2dyZXNzRGF0YS5zdGF0aXN0aWNzLmxhc3RDaGVjayB8fCAwO1xuICAgICAgICAgIH1cbiAgICAgICAgICBcbiAgICAgICAgICAvLyBMaW1waWFyIGNhbWJpb3MgcHJldmlvc1xuICAgICAgICAgIGd1YXJkU3RhdGUuY2hhbmdlcy5jbGVhcigpO1xuICAgICAgICAgIFxuICAgICAgICAgIC8vIEFjdHVhbGl6YXIgVUkgY29uIGxvcyBkYXRvcyBjYXJnYWRvc1xuICAgICAgICAgIGlmIChndWFyZFN0YXRlLnVpKSB7XG4gICAgICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZUNvb3JkaW5hdGVzKHtcbiAgICAgICAgICAgICAgeDE6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEueDEsXG4gICAgICAgICAgICAgIHkxOiBndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhLnkxLFxuICAgICAgICAgICAgICB4MjogZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYS54MixcbiAgICAgICAgICAgICAgeTI6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEueTJcbiAgICAgICAgICAgIH0pO1xuICAgICAgICAgICAgXG4gICAgICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVByb2dyZXNzKDAsIGd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMuc2l6ZSk7XG4gICAgICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXRzKHtcbiAgICAgICAgICAgICAgcmVwYWlyZWQ6IGd1YXJkU3RhdGUudG90YWxSZXBhaXJlZFxuICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIGd1YXJkU3RhdGUudWkuZW5hYmxlU3RhcnRCdG4oKTtcbiAgICAgICAgICB9XG4gICAgICAgICAgXG4gICAgICAgICAgbG9nKGBcdTI3MDUgUHJvZ3Jlc28gY2FyZ2FkbzogJHtndWFyZFN0YXRlLm9yaWdpbmFsUGl4ZWxzLnNpemV9IHBcdTAwRUR4ZWxlcyBwcm90ZWdpZG9zYCk7XG4gICAgICAgICAgXG4gICAgICAgICAgcmVzb2x2ZSh7IFxuICAgICAgICAgICAgc3VjY2VzczogdHJ1ZSwgXG4gICAgICAgICAgICBkYXRhOiBwcm9ncmVzc0RhdGEsXG4gICAgICAgICAgICBwcm90ZWN0ZWRQaXhlbHM6IGd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMuc2l6ZSxcbiAgICAgICAgICAgIGFyZWE6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWFcbiAgICAgICAgICB9KTtcbiAgICAgICAgICBcbiAgICAgICAgfSBjYXRjaCAocGFyc2VFcnJvcikge1xuICAgICAgICAgIGxvZygnXHUyNzRDIEVycm9yIHBhcnNlYW5kbyBhcmNoaXZvIGRlIHByb2dyZXNvOicsIHBhcnNlRXJyb3IpO1xuICAgICAgICAgIHJlc29sdmUoeyBzdWNjZXNzOiBmYWxzZSwgZXJyb3I6IHBhcnNlRXJyb3IubWVzc2FnZSB9KTtcbiAgICAgICAgfVxuICAgICAgfTtcbiAgICAgIFxuICAgICAgcmVhZGVyLm9uZXJyb3IgPSAoKSA9PiB7XG4gICAgICAgIGNvbnN0IGVycm9yID0gJ0Vycm9yIGxleWVuZG8gYXJjaGl2byc7XG4gICAgICAgIGxvZygnXHUyNzRDJywgZXJyb3IpO1xuICAgICAgICByZXNvbHZlKHsgc3VjY2VzczogZmFsc2UsIGVycm9yIH0pO1xuICAgICAgfTtcbiAgICAgIFxuICAgICAgcmVhZGVyLnJlYWRBc1RleHQoZmlsZSk7XG4gICAgICBcbiAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgbG9nKCdcdTI3NEMgRXJyb3IgY2FyZ2FuZG8gcHJvZ3Jlc286JywgZXJyb3IpO1xuICAgICAgcmVzb2x2ZSh7IHN1Y2Nlc3M6IGZhbHNlLCBlcnJvcjogZXJyb3IubWVzc2FnZSB9KTtcbiAgICB9XG4gIH0pO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gY2xlYXJQcm9ncmVzcygpIHtcbiAgZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYSA9IG51bGw7XG4gIGd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMuY2xlYXIoKTtcbiAgZ3VhcmRTdGF0ZS5jaGFuZ2VzLmNsZWFyKCk7XG4gIGd1YXJkU3RhdGUudG90YWxSZXBhaXJlZCA9IDA7XG4gIGd1YXJkU3RhdGUubGFzdENoZWNrID0gMDtcbiAgXG4gIGlmIChndWFyZFN0YXRlLnVpKSB7XG4gICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVDb29yZGluYXRlcyh7IHgxOiAnJywgeTE6ICcnLCB4MjogJycsIHkyOiAnJyB9KTtcbiAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVByb2dyZXNzKDAsIDApO1xuICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHMoeyByZXBhaXJlZDogMCB9KTtcbiAgfVxuICBcbiAgbG9nKCdcdUQ4M0VcdURERjkgUHJvZ3Jlc28gbGltcGlhZG8nKTtcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGhhc1Byb2dyZXNzKCkge1xuICByZXR1cm4gZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYSAmJiBcbiAgICAgICAgIGd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMuc2l6ZSA+IDA7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBnZXRQcm9ncmVzc0luZm8oKSB7XG4gIHJldHVybiB7XG4gICAgaGFzUHJvZ3Jlc3M6IGhhc1Byb2dyZXNzKCksXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBndWFyZFN0YXRlLm9yaWdpbmFsUGl4ZWxzLnNpemUsXG4gICAgdG90YWxSZXBhaXJlZDogZ3VhcmRTdGF0ZS50b3RhbFJlcGFpcmVkLFxuICAgIGFyZWE6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEgPyB7XG4gICAgICB3aWR0aDogZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYS54MiAtIGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEueDEsXG4gICAgICBoZWlnaHQ6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEueTIgLSBndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhLnkxLFxuICAgICAgeDE6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEueDEsXG4gICAgICB5MTogZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYS55MSxcbiAgICAgIHgyOiBndWFyZFN0YXRlLnByb3RlY3Rpb25BcmVhLngyLFxuICAgICAgeTI6IGd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEueTJcbiAgICB9IDogbnVsbFxuICB9O1xufVxuXG4vLyBBbGlhcyBwYXJhIGNvbXBhdGliaWxpZGFkXG5leHBvcnQgY29uc3Qgc2F2ZUd1YXJkRGF0YSA9IHNhdmVQcm9ncmVzcztcbmV4cG9ydCBjb25zdCBsb2FkR3VhcmREYXRhID0gbG9hZFByb2dyZXNzO1xuZXhwb3J0IGNvbnN0IGNsZWFyR3VhcmREYXRhID0gY2xlYXJQcm9ncmVzcztcbmV4cG9ydCBjb25zdCBoYXNHdWFyZERhdGEgPSBoYXNQcm9ncmVzcztcbmV4cG9ydCBjb25zdCBnZXRHdWFyZERhdGFJbmZvID0gZ2V0UHJvZ3Jlc3NJbmZvO1xuIiwgImV4cG9ydCBjb25zdCBlcyA9IHtcbiAgLy8gTGF1bmNoZXJcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBBdXRvQk9UJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBBdXRvLUZhcm0nLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBBdXRvLUltYWdlJyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgQXV0by1HdWFyZCcsXG4gICAgc2VsZWN0aW9uOiAnU2VsZWNjaVx1MDBGM24nLFxuICAgIHVzZXI6ICdVc3VhcmlvJyxcbiAgICBjaGFyZ2VzOiAnQ2FyZ2FzJyxcbiAgICBiYWNrZW5kOiAnQmFja2VuZCcsXG4gICAgZGF0YWJhc2U6ICdEYXRhYmFzZScsXG4gICAgdXB0aW1lOiAnVXB0aW1lJyxcbiAgICBjbG9zZTogJ0NlcnJhcicsXG4gICAgbGF1bmNoOiAnTGFuemFyJyxcbiAgICBsb2FkaW5nOiAnQ2FyZ2FuZG9cdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ0VqZWN1dGFuZG9cdTIwMjYnLFxuICAgIGRvd25sb2FkaW5nOiAnRGVzY2FyZ2FuZG8gc2NyaXB0XHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdFbGlnZSB1biBib3QgeSBwcmVzaW9uYSBMYW56YXInLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdMaXN0byBwYXJhIGxhbnphcicsXG4gICAgbG9hZEVycm9yOiAnRXJyb3IgYWwgY2FyZ2FyJyxcbiAgICBsb2FkRXJyb3JNc2c6ICdObyBzZSBwdWRvIGNhcmdhciBlbCBib3Qgc2VsZWNjaW9uYWRvLiBSZXZpc2EgdHUgY29uZXhpXHUwMEYzbiBvIGludFx1MDBFOW50YWxvIGRlIG51ZXZvLicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgVmVyaWZpY2FuZG8uLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBPbmxpbmUnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgT2ZmbGluZScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgT0snLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IEVycm9yJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1JbWFnZVwiLFxuICAgIGluaXRCb3Q6IFwiSW5pY2lhciBBdXRvLUJPVFwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlN1YmlyIEltYWdlblwiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlJlZGltZW5zaW9uYXIgSW1hZ2VuXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU2VsZWNjaW9uYXIgUG9zaWNpXHUwMEYzblwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiSW5pY2lhciBQaW50dXJhXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIkRldGVuZXIgUGludHVyYVwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJHdWFyZGFyIFByb2dyZXNvXCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIkNhcmdhciBQcm9ncmVzb1wiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzRFx1REQwRCBWZXJpZmljYW5kbyBjb2xvcmVzIGRpc3BvbmlibGVzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHUwMEExQWJyZSBsYSBwYWxldGEgZGUgY29sb3JlcyBlbiBlbCBzaXRpbyBlIGludFx1MDBFOW50YWxvIGRlIG51ZXZvIVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSB7Y291bnR9IGNvbG9yZXMgZGlzcG9uaWJsZXMgZW5jb250cmFkb3NcIixcbiAgICBsb2FkaW5nSW1hZ2U6IFwiXHVEODNEXHVEREJDXHVGRTBGIENhcmdhbmRvIGltYWdlbi4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBJbWFnZW4gY2FyZ2FkYSBjb24ge2NvdW50fSBwXHUwMEVEeGVsZXMgdlx1MDBFMWxpZG9zXCIsXG4gICAgaW1hZ2VFcnJvcjogXCJcdTI3NEMgRXJyb3IgYWwgY2FyZ2FyIGxhIGltYWdlblwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHUwMEExUGludGEgZWwgcHJpbWVyIHBcdTAwRUR4ZWwgZW4gbGEgdWJpY2FjaVx1MDBGM24gZG9uZGUgcXVpZXJlcyBxdWUgY29taWVuY2UgZWwgYXJ0ZSFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBxdWUgcGludGVzIGVsIHBcdTAwRUR4ZWwgZGUgcmVmZXJlbmNpYS4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTAwQTFQb3NpY2lcdTAwRjNuIGVzdGFibGVjaWRhIGNvbiBcdTAwRTl4aXRvIVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgVGllbXBvIGFnb3RhZG8gcGFyYSBzZWxlY2Npb25hciBwb3NpY2lcdTAwRjNuXCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgUG9zaWNpXHUwMEYzbiBkZXRlY3RhZGEsIHByb2Nlc2FuZG8uLi5cIixcbiAgICBwb3NpdGlvbkVycm9yOiBcIlx1Mjc0QyBFcnJvciBkZXRlY3RhbmRvIHBvc2ljaVx1MDBGM24sIGludFx1MDBFOW50YWxvIGRlIG51ZXZvXCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggSW5pY2lhbmRvIHBpbnR1cmEuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBQcm9ncmVzbzoge3BhaW50ZWR9L3t0b3RhbH0gcFx1MDBFRHhlbGVzLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBTaW4gY2FyZ2FzLiBFc3BlcmFuZG8ge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQaW50dXJhIGRldGVuaWRhIHBvciBlbCB1c3VhcmlvXCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgXHUwMEExUGludHVyYSBjb21wbGV0YWRhISB7Y291bnR9IHBcdTAwRUR4ZWxlcyBwaW50YWRvcy5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBFcnJvciBkdXJhbnRlIGxhIHBpbnR1cmFcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBDYXJnYSB1bmEgaW1hZ2VuIHkgc2VsZWNjaW9uYSB1bmEgcG9zaWNpXHUwMEYzbiBwcmltZXJvXCIsXG4gICAgcHJvZ3Jlc3M6IFwiUHJvZ3Jlc29cIixcbiAgICB1c2VyTmFtZTogXCJVc3VhcmlvXCIsXG4gICAgcGl4ZWxzOiBcIlBcdTAwRUR4ZWxlc1wiLFxuICAgIGNoYXJnZXM6IFwiQ2FyZ2FzXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJUaWVtcG8gZXN0aW1hZG9cIixcbiAgICBpbml0TWVzc2FnZTogXCJIYXogY2xpYyBlbiAnSW5pY2lhciBBdXRvLUJPVCcgcGFyYSBjb21lbnphclwiLFxuICAgIHdhaXRpbmdJbml0OiBcIkVzcGVyYW5kbyBpbmljaWFsaXphY2lcdTAwRjNuLi4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgSW1hZ2VuIHJlZGltZW5zaW9uYWRhIGEge3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBQaW50dXJhIHBhdXNhZGEgZW4gbGEgcG9zaWNpXHUwMEYzbiBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlBcdTAwRUR4ZWxlcyBwb3IgbG90ZVwiLFxuICAgIGJhdGNoU2l6ZTogXCJUYW1hXHUwMEYxbyBkZWwgbG90ZVwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiU2lndWllbnRlIGxvdGUgZW5cIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlVzYXIgdG9kYXMgbGFzIGNhcmdhcyBkaXNwb25pYmxlc1wiLFxuICAgIHNob3dPdmVybGF5OiBcIk1vc3RyYXIgb3ZlcmxheVwiLFxuICAgIG1heENoYXJnZXM6IFwiQ2FyZ2FzIG1cdTAwRTF4aW1hcyBwb3IgbG90ZVwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBFc3BlcmFuZG8gY2FyZ2FzOiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlRpZW1wbyByZXN0YW50ZVwiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgRXNwZXJhbmRvIHt0aW1lfSBwYXJhIGNvbnRpbnVhci4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFByb2dyZXNvIGd1YXJkYWRvIGNvbW8ge2ZpbGVuYW1lfVwiLFxuICAgIHByb2dyZXNzTG9hZGVkOiBcIlx1MjcwNSBQcm9ncmVzbyBjYXJnYWRvOiB7cGFpbnRlZH0ve3RvdGFsfSBwXHUwMEVEeGVsZXMgcGludGFkb3NcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgRXJyb3IgYWwgY2FyZ2FyIHByb2dyZXNvOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGFsIGd1YXJkYXIgcHJvZ3Jlc286IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1MDBCRkRlc2VhcyBndWFyZGFyIGVsIHByb2dyZXNvIGFjdHVhbCBhbnRlcyBkZSBkZXRlbmVyP1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIkd1YXJkYXIgUHJvZ3Jlc29cIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiRGVzY2FydGFyXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbGFyXCIsXG4gICAgbWluaW1pemU6IFwiTWluaW1pemFyXCIsXG4gICAgd2lkdGg6IFwiQW5jaG9cIixcbiAgICBoZWlnaHQ6IFwiQWx0b1wiLCBcbiAgICBrZWVwQXNwZWN0OiBcIk1hbnRlbmVyIHByb3BvcmNpXHUwMEYzblwiLFxuICAgIGFwcGx5OiBcIkFwbGljYXJcIixcbiAgb3ZlcmxheU9uOiBcIk92ZXJsYXk6IE9OXCIsXG4gIG92ZXJsYXlPZmY6IFwiT3ZlcmxheTogT0ZGXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgUGFzYWRhIGNvbXBsZXRhZGE6IHtwYWludGVkfSBwXHUwMEVEeGVsZXMgcGludGFkb3MgfCBQcm9ncmVzbzoge3BlcmNlbnR9JSAoe2N1cnJlbnR9L3t0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgRXNwZXJhbmRvIHJlZ2VuZXJhY2lcdTAwRjNuIGRlIGNhcmdhczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gVGllbXBvOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgRXNwZXJhbmRvIGNhcmdhczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gUXVlZGFuOiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbmljaWFsaXphbmRvIGF1dG9tXHUwMEUxdGljYW1lbnRlLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBCb3QgaW5pY2lhZG8gYXV0b21cdTAwRTF0aWNhbWVudGVcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgTm8gc2UgcHVkbyBpbmljaWFyIGF1dG9tXHUwMEUxdGljYW1lbnRlLiBVc2EgZWwgYm90XHUwMEYzbiBtYW51YWwuXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBQYWxldGEgZGUgY29sb3JlcyBkZXRlY3RhZGFcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIEJ1c2NhbmRvIHBhbGV0YSBkZSBjb2xvcmVzLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgSGFjaWVuZG8gY2xpYyBlbiBlbCBib3RcdTAwRjNuIFBhaW50Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgQm90XHUwMEYzbiBQYWludCBubyBlbmNvbnRyYWRvXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbmljaW8gbWFudWFsIHJlcXVlcmlkb1wiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgUmVpbnRlbnRvIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IGVuIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgRXJyb3IgZW4gaW50ZW50byB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSwgcmVpbnRlbnRhbmRvIGVuIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIEZhbGxcdTAwRjMgZGVzcHVcdTAwRTlzIGRlIHttYXhBdHRlbXB0c30gaW50ZW50b3MuIENvbnRpbnVhbmRvIGNvbiBzaWd1aWVudGUgbG90ZS4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgRXJyb3IgZGUgcmVkLiBSZWludGVudGFuZG8uLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgRXJyb3IgZGVsIHNlcnZpZG9yLiBSZWludGVudGFuZG8uLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFRpbWVvdXQgZGVsIHNlcnZpZG9yLiBSZWludGVudGFuZG8uLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlIChwb3IgaW1wbGVtZW50YXIpXG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgRmFybSBCb3RcIixcbiAgICBzdGFydDogXCJJbmljaWFyXCIsXG4gICAgc3RvcDogXCJEZXRlbmVyXCIsIFxuICAgIHN0b3BwZWQ6IFwiQm90IGRldGVuaWRvXCIsXG4gICAgY2FsaWJyYXRlOiBcIkNhbGlicmFyXCIsXG4gICAgcGFpbnRPbmNlOiBcIlVuYSB2ZXpcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJWZXJpZmljYW5kbyBlc3RhZG8uLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIkNvbmZpZ3VyYWNpXHUwMEYzblwiLFxuICAgIGRlbGF5OiBcIkRlbGF5IChtcylcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQXHUwMEVEeGVsZXMvbG90ZVwiLFxuICAgIG1pbkNoYXJnZXM6IFwiQ2FyZ2FzIG1cdTAwRURuXCIsXG4gICAgY29sb3JNb2RlOiBcIk1vZG8gY29sb3JcIixcbiAgICByYW5kb206IFwiQWxlYXRvcmlvXCIsXG4gICAgZml4ZWQ6IFwiRmlqb1wiLFxuICAgIHJhbmdlOiBcIlJhbmdvXCIsXG4gICAgZml4ZWRDb2xvcjogXCJDb2xvciBmaWpvXCIsXG4gICAgYWR2YW5jZWQ6IFwiQXZhbnphZG9cIixcbiAgICB0aWxlWDogXCJUaWxlIFhcIixcbiAgICB0aWxlWTogXCJUaWxlIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlBhbGV0YSBwZXJzb25hbGl6YWRhXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiZWo6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJDYXB0dXJhclwiLFxuICAgIHBhaW50ZWQ6IFwiUGludGFkb3NcIixcbiAgICBjaGFyZ2VzOiBcIkNhcmdhc1wiLFxuICAgIHJldHJpZXM6IFwiRmFsbG9zXCIsXG4gICAgdGlsZTogXCJUaWxlXCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiQ29uZmlndXJhY2lcdTAwRjNuIGd1YXJkYWRhXCIsXG4gICAgY29uZmlnTG9hZGVkOiBcIkNvbmZpZ3VyYWNpXHUwMEYzbiBjYXJnYWRhXCIsXG4gICAgY29uZmlnUmVzZXQ6IFwiQ29uZmlndXJhY2lcdTAwRjNuIHJlaW5pY2lhZGFcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlBpbnRhIHVuIHBcdTAwRUR4ZWwgbWFudWFsbWVudGUgcGFyYSBjYXB0dXJhciBjb29yZGVuYWRhcy4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiQmFja2VuZCBPbmxpbmVcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJCYWNrZW5kIE9mZmxpbmVcIixcbiAgICBzdGFydGluZ0JvdDogXCJJbmljaWFuZG8gYm90Li4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiRGV0ZW5pZW5kbyBib3QuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJDYWxpYnJhbmRvLi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiQXV0by1GYXJtIHlhIGVzdFx1MDBFMSBjb3JyaWVuZG8uXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJBdXRvLUltYWdlIGVzdFx1MDBFMSBlamVjdXRcdTAwRTFuZG9zZS4gQ2lcdTAwRTlycmFsbyBhbnRlcyBkZSBpbmljaWFyIEF1dG8tRmFybS5cIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTZWxlY2Npb25hciBab25hXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgUGludGEgdW4gcFx1MDBFRHhlbCBlbiB1bmEgem9uYSBERVNQT0JMQURBIGRlbCBtYXBhIHBhcmEgZXN0YWJsZWNlciBlbCBcdTAwRTFyZWEgZGUgZmFybWluZ1wiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgRXNwZXJhbmRvIHF1ZSBwaW50ZXMgZWwgcFx1MDBFRHhlbCBkZSByZWZlcmVuY2lhLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1MDBBMVpvbmEgZXN0YWJsZWNpZGEhIFJhZGlvOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgVGllbXBvIGFnb3RhZG8gcGFyYSBzZWxlY2Npb25hciB6b25hXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBTZWxlY2Npb25hIHVuYSB6b25hIHByaW1lcm8gdXNhbmRvICdTZWxlY2Npb25hciBab25hJ1wiLFxuICAgIGZhcm1SYWRpdXM6IFwiUmFkaW8gZmFybVwiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJab25hIGFjdHVhbFwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgRmFybWluZyBlbiByYWRpbyB7cmFkaXVzfXB4IGRlc2RlICh7eH0se3l9KVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgSU1QT1JUQU5URTogU2VsZWNjaW9uYSB1bmEgem9uYSBERVNQT0JMQURBIHBhcmEgZXZpdGFyIGNvbmZsaWN0b3NcIixcbiAgICBub1Bvc2l0aW9uOiBcIlNpbiB6b25hXCIsXG4gICAgY3VycmVudFpvbmU6IFwiWm9uYTogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBTZWxlY2Npb25hIHVuYSB6b25hIHByaW1lcm8uIFBpbnRhIHVuIHBcdTAwRUR4ZWwgZW4gZWwgbWFwYSBwYXJhIGVzdGFibGVjZXIgbGEgem9uYSBkZSBmYXJtaW5nXCJcbiAgfSxcblxuICAvLyBDb21tb24vU2hhcmVkXG4gIGNvbW1vbjoge1xuICAgIHllczogXCJTXHUwMEVEXCIsXG4gICAgbm86IFwiTm9cIixcbiAgICBvazogXCJBY2VwdGFyXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbGFyXCIsXG4gICAgY2xvc2U6IFwiQ2VycmFyXCIsXG4gICAgc2F2ZTogXCJHdWFyZGFyXCIsXG4gICAgbG9hZDogXCJDYXJnYXJcIixcbiAgICBkZWxldGU6IFwiRWxpbWluYXJcIixcbiAgICBlZGl0OiBcIkVkaXRhclwiLFxuICAgIHN0YXJ0OiBcIkluaWNpYXJcIixcbiAgICBzdG9wOiBcIkRldGVuZXJcIixcbiAgICBwYXVzZTogXCJQYXVzYXJcIixcbiAgICByZXN1bWU6IFwiUmVhbnVkYXJcIixcbiAgICByZXNldDogXCJSZWluaWNpYXJcIixcbiAgICBzZXR0aW5nczogXCJDb25maWd1cmFjaVx1MDBGM25cIixcbiAgICBoZWxwOiBcIkF5dWRhXCIsXG4gICAgYWJvdXQ6IFwiQWNlcmNhIGRlXCIsXG4gICAgbGFuZ3VhZ2U6IFwiSWRpb21hXCIsXG4gICAgbG9hZGluZzogXCJDYXJnYW5kby4uLlwiLFxuICAgIGVycm9yOiBcIkVycm9yXCIsXG4gICAgc3VjY2VzczogXCJcdTAwQzl4aXRvXCIsXG4gICAgd2FybmluZzogXCJBZHZlcnRlbmNpYVwiLFxuICAgIGluZm86IFwiSW5mb3JtYWNpXHUwMEYzblwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJJZGlvbWEgY2FtYmlhZG8gYSB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1HdWFyZFwiLFxuICAgIGluaXRCb3Q6IFwiSW5pY2lhbGl6YXIgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJTZWxlY2Npb25hciBcdTAwQzFyZWFcIixcbiAgICBjYXB0dXJlQXJlYTogXCJDYXB0dXJhciBcdTAwQzFyZWFcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiSW5pY2lhciBQcm90ZWNjaVx1MDBGM25cIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJEZXRlbmVyIFByb3RlY2NpXHUwMEYzblwiLFxuICAgIHVwcGVyTGVmdDogXCJFc3F1aW5hIFN1cGVyaW9yIEl6cXVpZXJkYVwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiRXNxdWluYSBJbmZlcmlvciBEZXJlY2hhXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlBcdTAwRUR4ZWxlcyBQcm90ZWdpZG9zXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIkNhbWJpb3MgRGV0ZWN0YWRvc1wiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlBcdTAwRUR4ZWxlcyBSZXBhcmFkb3NcIixcbiAgICBjaGFyZ2VzOiBcIkNhcmdhc1wiLFxuICAgIHdhaXRpbmdJbml0OiBcIkVzcGVyYW5kbyBpbmljaWFsaXphY2lcdTAwRjNuLi4uXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNDXHVERkE4IFZlcmlmaWNhbmRvIGNvbG9yZXMgZGlzcG9uaWJsZXMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBObyBzZSBlbmNvbnRyYXJvbiBjb2xvcmVzLiBBYnJlIGxhIHBhbGV0YSBkZSBjb2xvcmVzIGVuIGVsIHNpdGlvLlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSB7Y291bnR9IGNvbG9yZXMgZGlzcG9uaWJsZXMgZW5jb250cmFkb3NcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaWNpYWxpemFkbyBjb3JyZWN0YW1lbnRlXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBFcnJvciBpbmljaWFsaXphbmRvIEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIENvb3JkZW5hZGFzIGludlx1MDBFMWxpZGFzXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIEVsIFx1MDBFMXJlYSBkZWJlIHRlbmVyIGVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhIG1lbm9yIHF1ZSBpbmZlcmlvciBkZXJlY2hhXCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBcdTAwQzFyZWEgZGVtYXNpYWRvIGdyYW5kZToge3NpemV9IHBcdTAwRUR4ZWxlcyAobVx1MDBFMXhpbW86IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IENhcHR1cmFuZG8gXHUwMEUxcmVhIGRlIHByb3RlY2NpXHUwMEYzbi4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHUwMEMxcmVhIGNhcHR1cmFkYToge2NvdW50fSBwXHUwMEVEeGVsZXMgYmFqbyBwcm90ZWNjaVx1MDBGM25cIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGNhcHR1cmFuZG8gXHUwMEUxcmVhOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBQcmltZXJvIGNhcHR1cmEgdW4gXHUwMEUxcmVhIGRlIHByb3RlY2NpXHUwMEYzblwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBQcm90ZWNjaVx1MDBGM24gaW5pY2lhZGEgLSBtb25pdG9yZWFuZG8gXHUwMEUxcmVhXCIsXG4gICAgcHJvdGVjdGlvblN0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFByb3RlY2NpXHUwMEYzbiBkZXRlbmlkYVwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHUwMEMxcmVhIHByb3RlZ2lkYSAtIHNpbiBjYW1iaW9zIGRldGVjdGFkb3NcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gY2FtYmlvcyBkZXRlY3RhZG9zIGVuIGVsIFx1MDBFMXJlYSBwcm90ZWdpZGFcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFJlcGFyYW5kbyB7Y291bnR9IHBcdTAwRUR4ZWxlcyBhbHRlcmFkb3MuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFJlcGFyYWRvcyB7Y291bnR9IHBcdTAwRUR4ZWxlcyBjb3JyZWN0YW1lbnRlXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIEVycm9yIHJlcGFyYW5kbyBwXHUwMEVEeGVsZXM6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIFNpbiBjYXJnYXMgc3VmaWNpZW50ZXMgcGFyYSByZXBhcmFyIGNhbWJpb3NcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFZlcmlmaWNhbmRvIGNhbWJpb3MgZW4gXHUwMEUxcmVhIHByb3RlZ2lkYS4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIEVycm9yIHZlcmlmaWNhbmRvIGNhbWJpb3M6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgR3VhcmRpXHUwMEUxbiBhY3Rpdm8gLSBcdTAwRTFyZWEgYmFqbyBwcm90ZWNjaVx1MDBGM25cIixcbiAgICBsYXN0Q2hlY2s6IFwiXHUwMERBbHRpbWEgdmVyaWZpY2FjaVx1MDBGM246IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJQclx1MDBGM3hpbWEgdmVyaWZpY2FjaVx1MDBGM24gZW46IHt0aW1lfXNcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbmljaWFsaXphbmRvIGF1dG9tXHUwMEUxdGljYW1lbnRlLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgaW5pY2lhZG8gYXV0b21cdTAwRTF0aWNhbWVudGVcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgTm8gc2UgcHVkbyBpbmljaWFyIGF1dG9tXHUwMEUxdGljYW1lbnRlLiBVc2EgZWwgYm90XHUwMEYzbiBtYW51YWwuXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbmljaW8gbWFudWFsIHJlcXVlcmlkb1wiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXRhIGRlIGNvbG9yZXMgZGV0ZWN0YWRhXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBCdXNjYW5kbyBwYWxldGEgZGUgY29sb3Jlcy4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IEhhY2llbmRvIGNsaWMgZW4gZWwgYm90XHUwMEYzbiBQYWludC4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkb1wiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgUGludGEgdW4gcFx1MDBFRHhlbCBlbiBsYSBlc3F1aW5hIFNVUEVSSU9SIElaUVVJRVJEQSBkZWwgXHUwMEUxcmVhIGEgcHJvdGVnZXJcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBBaG9yYSBwaW50YSB1biBwXHUwMEVEeGVsIGVuIGxhIGVzcXVpbmEgSU5GRVJJT1IgREVSRUNIQSBkZWwgXHUwMEUxcmVhXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgRXNwZXJhbmRvIHNlbGVjY2lcdTAwRjNuIGRlIGVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBzZWxlY2NpXHUwMEYzbiBkZSBlc3F1aW5hIGluZmVyaW9yIGRlcmVjaGEuLi5cIixcbiAgICB1cHBlckxlZnRDYXB0dXJlZDogXCJcdTI3MDUgRXNxdWluYSBzdXBlcmlvciBpenF1aWVyZGEgY2FwdHVyYWRhOiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBFc3F1aW5hIGluZmVyaW9yIGRlcmVjaGEgY2FwdHVyYWRhOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgVGllbXBvIGFnb3RhZG8gcGFyYSBzZWxlY2NpXHUwMEYzblwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBFcnJvciBlbiBzZWxlY2NpXHUwMEYzbiwgaW50XHUwMEU5bnRhbG8gZGUgbnVldm9cIlxuICB9XG59O1xuIiwgImV4cG9ydCBjb25zdCBlbiA9IHtcbiAgLy8gTGF1bmNoZXJcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBBdXRvQk9UJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBBdXRvLUZhcm0nLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBBdXRvLUltYWdlJyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgQXV0by1HdWFyZCcsXG4gICAgc2VsZWN0aW9uOiAnU2VsZWN0aW9uJyxcbiAgICB1c2VyOiAnVXNlcicsXG4gICAgY2hhcmdlczogJ0NoYXJnZXMnLFxuICAgIGJhY2tlbmQ6ICdCYWNrZW5kJyxcbiAgICBkYXRhYmFzZTogJ0RhdGFiYXNlJyxcbiAgICB1cHRpbWU6ICdVcHRpbWUnLFxuICAgIGNsb3NlOiAnQ2xvc2UnLFxuICAgIGxhdW5jaDogJ0xhdW5jaCcsXG4gICAgbG9hZGluZzogJ0xvYWRpbmdcdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ0V4ZWN1dGluZ1x1MjAyNicsXG4gICAgZG93bmxvYWRpbmc6ICdEb3dubG9hZGluZyBzY3JpcHRcdTIwMjYnLFxuICAgIGNob29zZUJvdDogJ0Nob29zZSBhIGJvdCBhbmQgcHJlc3MgTGF1bmNoJyxcbiAgICByZWFkeVRvTGF1bmNoOiAnUmVhZHkgdG8gbGF1bmNoJyxcbiAgICBsb2FkRXJyb3I6ICdMb2FkIGVycm9yJyxcbiAgICBsb2FkRXJyb3JNc2c6ICdDb3VsZCBub3QgbG9hZCB0aGUgc2VsZWN0ZWQgYm90LiBDaGVjayB5b3VyIGNvbm5lY3Rpb24gb3IgdHJ5IGFnYWluLicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgQ2hlY2tpbmcuLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBPbmxpbmUnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgT2ZmbGluZScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgT0snLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IEVycm9yJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1JbWFnZVwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGl6ZSBBdXRvLUJPVFwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlVwbG9hZCBJbWFnZVwiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlJlc2l6ZSBJbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNlbGVjdCBQb3NpdGlvblwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiU3RhcnQgUGFpbnRpbmdcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiU3RvcCBQYWludGluZ1wiLFxuICAgIHNhdmVQcm9ncmVzczogXCJTYXZlIFByb2dyZXNzXCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIkxvYWQgUHJvZ3Jlc3NcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgQ2hlY2tpbmcgYXZhaWxhYmxlIGNvbG9ycy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIE9wZW4gdGhlIGNvbG9yIHBhbGV0dGUgb24gdGhlIHNpdGUgYW5kIHRyeSBhZ2FpbiFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgRm91bmQge2NvdW50fSBhdmFpbGFibGUgY29sb3JzXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBMb2FkaW5nIGltYWdlLi4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IEltYWdlIGxvYWRlZCB3aXRoIHtjb3VudH0gdmFsaWQgcGl4ZWxzXCIsXG4gICAgaW1hZ2VFcnJvcjogXCJcdTI3NEMgRXJyb3IgbG9hZGluZyBpbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiUGFpbnQgdGhlIGZpcnN0IHBpeGVsIGF0IHRoZSBsb2NhdGlvbiB3aGVyZSB5b3Ugd2FudCB0aGUgYXJ0IHRvIHN0YXJ0IVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgV2FpdGluZyBmb3IgeW91IHRvIHBhaW50IHRoZSByZWZlcmVuY2UgcGl4ZWwuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgUG9zaXRpb24gc2V0IHN1Y2Nlc3NmdWxseSFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpbWVvdXQgZm9yIHBvc2l0aW9uIHNlbGVjdGlvblwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFBvc2l0aW9uIGRldGVjdGVkLCBwcm9jZXNzaW5nLi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgRXJyb3IgZGV0ZWN0aW5nIHBvc2l0aW9uLCBwbGVhc2UgdHJ5IGFnYWluXCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggU3RhcnRpbmcgcGFpbnRpbmcuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBQcm9ncmVzczoge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBObyBjaGFyZ2VzLiBXYWl0aW5nIHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUGFpbnRpbmcgc3RvcHBlZCBieSB1c2VyXCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgUGFpbnRpbmcgY29tcGxldGVkISB7Y291bnR9IHBpeGVscyBwYWludGVkLlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIEVycm9yIGR1cmluZyBwYWludGluZ1wiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIExvYWQgYW4gaW1hZ2UgYW5kIHNlbGVjdCBhIHBvc2l0aW9uIGZpcnN0XCIsXG4gICAgcHJvZ3Jlc3M6IFwiUHJvZ3Jlc3NcIixcbiAgICB1c2VyTmFtZTogXCJVc2VyXCIsXG4gICAgcGl4ZWxzOiBcIlBpeGVsc1wiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiRXN0aW1hdGVkIHRpbWVcIixcbiAgICBpbml0TWVzc2FnZTogXCJDbGljayAnSW5pdGlhbGl6ZSBBdXRvLUJPVCcgdG8gYmVnaW5cIixcbiAgICB3YWl0aW5nSW5pdDogXCJXYWl0aW5nIGZvciBpbml0aWFsaXphdGlvbi4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IEltYWdlIHJlc2l6ZWQgdG8ge3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBQYWludGluZyBwYXVzZWQgYXQgcG9zaXRpb24gWDoge3h9LCBZOiB7eX1cIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQaXhlbHMgcGVyIGJhdGNoXCIsXG4gICAgYmF0Y2hTaXplOiBcIkJhdGNoIHNpemVcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIk5leHQgYmF0Y2ggaW5cIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlVzZSBhbGwgYXZhaWxhYmxlIGNoYXJnZXNcIixcbiAgICBzaG93T3ZlcmxheTogXCJTaG93IG92ZXJsYXlcIixcbiAgICBtYXhDaGFyZ2VzOiBcIk1heCBjaGFyZ2VzIHBlciBiYXRjaFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBXYWl0aW5nIGZvciBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlRpbWUgcmVtYWluaW5nXCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBXYWl0aW5nIHt0aW1lfSB0byBjb250aW51ZS4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFByb2dyZXNzIHNhdmVkIGFzIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgUHJvZ3Jlc3MgbG9hZGVkOiB7cGFpbnRlZH0ve3RvdGFsfSBwaXhlbHMgcGFpbnRlZFwiLFxuICAgIHByb2dyZXNzTG9hZEVycm9yOiBcIlx1Mjc0QyBFcnJvciBsb2FkaW5nIHByb2dyZXNzOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIEVycm9yIHNhdmluZyBwcm9ncmVzczoge2Vycm9yfVwiLFxuICAgIGNvbmZpcm1TYXZlUHJvZ3Jlc3M6IFwiRG8geW91IHdhbnQgdG8gc2F2ZSB0aGUgY3VycmVudCBwcm9ncmVzcyBiZWZvcmUgc3RvcHBpbmc/XCIsXG4gICAgc2F2ZVByb2dyZXNzVGl0bGU6IFwiU2F2ZSBQcm9ncmVzc1wiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJEaXNjYXJkXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbFwiLFxuICAgIG1pbmltaXplOiBcIk1pbmltaXplXCIsXG4gICAgd2lkdGg6IFwiV2lkdGhcIixcbiAgICBoZWlnaHQ6IFwiSGVpZ2h0XCIsIFxuICAgIGtlZXBBc3BlY3Q6IFwiS2VlcCBhc3BlY3QgcmF0aW9cIixcbiAgICBhcHBseTogXCJBcHBseVwiLFxuICBvdmVybGF5T246IFwiT3ZlcmxheTogT05cIixcbiAgb3ZlcmxheU9mZjogXCJPdmVybGF5OiBPRkZcIixcbiAgICBwYXNzQ29tcGxldGVkOiBcIlx1MjcwNSBQYXNzIGNvbXBsZXRlZDoge3BhaW50ZWR9IHBpeGVscyBwYWludGVkIHwgUHJvZ3Jlc3M6IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFdhaXRpbmcgZm9yIGNoYXJnZSByZWdlbmVyYXRpb246IHtjdXJyZW50fS97bmVlZGVkfSAtIFRpbWU6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBXYWl0aW5nIGZvciBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH0gLSBSZW1haW5pbmc6IHt0aW1lfVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IEF1dG8taW5pdGlhbGl6aW5nLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBCb3QgYXV0by1zdGFydGVkIHN1Y2Nlc3NmdWxseVwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBDb3VsZCBub3QgYXV0by1zdGFydC4gVXNlIG1hbnVhbCBidXR0b24uXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBDb2xvciBwYWxldHRlIGRldGVjdGVkXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBTZWFyY2hpbmcgZm9yIGNvbG9yIHBhbGV0dGUuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBDbGlja2luZyBQYWludCBidXR0b24uLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBQYWludCBidXR0b24gbm90IGZvdW5kXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBNYW51YWwgaW5pdGlhbGl6YXRpb24gcmVxdWlyZWRcIixcbiAgICByZXRyeUF0dGVtcHQ6IFwiXHVEODNEXHVERDA0IFJldHJ5IHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IGluIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgRXJyb3IgaW4gYXR0ZW1wdCB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSwgcmV0cnlpbmcgaW4ge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgRmFpbGVkIGFmdGVyIHttYXhBdHRlbXB0c30gYXR0ZW1wdHMuIENvbnRpbnVpbmcgd2l0aCBuZXh0IGJhdGNoLi4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBOZXR3b3JrIGVycm9yLiBSZXRyeWluZy4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBTZXJ2ZXIgZXJyb3IuIFJldHJ5aW5nLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBTZXJ2ZXIgdGltZW91dC4gUmV0cnlpbmcuLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlICh0byBiZSBpbXBsZW1lbnRlZClcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBGYXJtIEJvdFwiLFxuICAgIHN0YXJ0OiBcIlN0YXJ0XCIsXG4gICAgc3RvcDogXCJTdG9wXCIsXG4gICAgc3RvcHBlZDogXCJCb3Qgc3RvcHBlZFwiLFxuICAgIGNhbGlicmF0ZTogXCJDYWxpYnJhdGVcIixcbiAgICBwYWludE9uY2U6IFwiT25jZVwiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIkNoZWNraW5nIHN0YXR1cy4uLlwiLFxuICAgIGNvbmZpZ3VyYXRpb246IFwiQ29uZmlndXJhdGlvblwiLFxuICAgIGRlbGF5OiBcIkRlbGF5IChtcylcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQaXhlbHMvYmF0Y2hcIixcbiAgICBtaW5DaGFyZ2VzOiBcIk1pbiBjaGFyZ2VzXCIsXG4gICAgY29sb3JNb2RlOiBcIkNvbG9yIG1vZGVcIixcbiAgICByYW5kb206IFwiUmFuZG9tXCIsXG4gICAgZml4ZWQ6IFwiRml4ZWRcIixcbiAgICByYW5nZTogXCJSYW5nZVwiLFxuICAgIGZpeGVkQ29sb3I6IFwiRml4ZWQgY29sb3JcIixcbiAgICBhZHZhbmNlZDogXCJBZHZhbmNlZFwiLFxuICAgIHRpbGVYOiBcIlRpbGUgWFwiLFxuICAgIHRpbGVZOiBcIlRpbGUgWVwiLFxuICAgIGN1c3RvbVBhbGV0dGU6IFwiQ3VzdG9tIHBhbGV0dGVcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJlLmc6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJDYXB0dXJlXCIsXG4gICAgcGFpbnRlZDogXCJQYWludGVkXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgcmV0cmllczogXCJSZXRyaWVzXCIsXG4gICAgdGlsZTogXCJUaWxlXCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiQ29uZmlndXJhdGlvbiBzYXZlZFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJDb25maWd1cmF0aW9uIGxvYWRlZFwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIkNvbmZpZ3VyYXRpb24gcmVzZXRcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlBhaW50IGEgcGl4ZWwgbWFudWFsbHkgdG8gY2FwdHVyZSBjb29yZGluYXRlcy4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiQmFja2VuZCBPbmxpbmVcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJCYWNrZW5kIE9mZmxpbmVcIixcbiAgICBzdGFydGluZ0JvdDogXCJTdGFydGluZyBib3QuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJTdG9wcGluZyBib3QuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJDYWxpYnJhdGluZy4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIkF1dG8tRmFybSBpcyBhbHJlYWR5IHJ1bm5pbmcuXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJBdXRvLUltYWdlIGlzIHJ1bm5pbmcuIENsb3NlIGl0IGJlZm9yZSBzdGFydGluZyBBdXRvLUZhcm0uXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU2VsZWN0IEFyZWFcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1RDgzQ1x1REZBRiBQYWludCBhIHBpeGVsIGluIGFuIEVNUFRZIGFyZWEgb2YgdGhlIG1hcCB0byBzZXQgdGhlIGZhcm1pbmcgem9uZVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgV2FpdGluZyBmb3IgeW91IHRvIHBhaW50IHRoZSByZWZlcmVuY2UgcGl4ZWwuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgQXJlYSBzZXQhIFJhZGl1czogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpbWVvdXQgZm9yIGFyZWEgc2VsZWN0aW9uXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBTZWxlY3QgYW4gYXJlYSBmaXJzdCB1c2luZyAnU2VsZWN0IEFyZWEnXCIsXG4gICAgZmFybVJhZGl1czogXCJGYXJtIHJhZGl1c1wiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJDdXJyZW50IGFyZWFcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIEZhcm1pbmcgaW4ge3JhZGl1c31weCByYWRpdXMgZnJvbSAoe3h9LHt5fSlcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIElNUE9SVEFOVDogU2VsZWN0IGFuIEVNUFRZIGFyZWEgdG8gYXZvaWQgY29uZmxpY3RzXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJObyBhcmVhXCIsXG4gICAgY3VycmVudFpvbmU6IFwiWm9uZTogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBTZWxlY3QgYW4gYXJlYSBmaXJzdC4gUGFpbnQgYSBwaXhlbCBvbiB0aGUgbWFwIHRvIHNldCB0aGUgZmFybWluZyB6b25lXCJcbiAgfSxcblxuICAvLyBDb21tb24vU2hhcmVkXG4gIGNvbW1vbjoge1xuICAgIHllczogXCJZZXNcIixcbiAgICBubzogXCJOb1wiLFxuICAgIG9rOiBcIk9LXCIsXG4gICAgY2FuY2VsOiBcIkNhbmNlbFwiLFxuICAgIGNsb3NlOiBcIkNsb3NlXCIsXG4gICAgc2F2ZTogXCJTYXZlXCIsXG4gICAgbG9hZDogXCJMb2FkXCIsXG4gICAgZGVsZXRlOiBcIkRlbGV0ZVwiLFxuICAgIGVkaXQ6IFwiRWRpdFwiLFxuICAgIHN0YXJ0OiBcIlN0YXJ0XCIsXG4gICAgc3RvcDogXCJTdG9wXCIsXG4gICAgcGF1c2U6IFwiUGF1c2VcIixcbiAgICByZXN1bWU6IFwiUmVzdW1lXCIsXG4gICAgcmVzZXQ6IFwiUmVzZXRcIixcbiAgICBzZXR0aW5nczogXCJTZXR0aW5nc1wiLFxuICAgIGhlbHA6IFwiSGVscFwiLFxuICAgIGFib3V0OiBcIkFib3V0XCIsXG4gICAgbGFuZ3VhZ2U6IFwiTGFuZ3VhZ2VcIixcbiAgICBsb2FkaW5nOiBcIkxvYWRpbmcuLi5cIixcbiAgICBlcnJvcjogXCJFcnJvclwiLFxuICAgIHN1Y2Nlc3M6IFwiU3VjY2Vzc1wiLFxuICAgIHdhcm5pbmc6IFwiV2FybmluZ1wiLFxuICAgIGluZm86IFwiSW5mb3JtYXRpb25cIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiTGFuZ3VhZ2UgY2hhbmdlZCB0byB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1HdWFyZFwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGl6ZSBHdWFyZC1CT1RcIixcbiAgICBzZWxlY3RBcmVhOiBcIlNlbGVjdCBBcmVhXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiQ2FwdHVyZSBBcmVhXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIlN0YXJ0IFByb3RlY3Rpb25cIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJTdG9wIFByb3RlY3Rpb25cIixcbiAgICB1cHBlckxlZnQ6IFwiVXBwZXIgTGVmdCBDb3JuZXJcIixcbiAgICBsb3dlclJpZ2h0OiBcIkxvd2VyIFJpZ2h0IENvcm5lclwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJQcm90ZWN0ZWQgUGl4ZWxzXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIkRldGVjdGVkIENoYW5nZXNcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJSZXBhaXJlZCBQaXhlbHNcIixcbiAgICBjaGFyZ2VzOiBcIkNoYXJnZXNcIixcbiAgICB3YWl0aW5nSW5pdDogXCJXYWl0aW5nIGZvciBpbml0aWFsaXphdGlvbi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBDaGVja2luZyBhdmFpbGFibGUgY29sb3JzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgTm8gY29sb3JzIGZvdW5kLiBPcGVuIHRoZSBjb2xvciBwYWxldHRlIG9uIHRoZSBzaXRlLlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBGb3VuZCB7Y291bnR9IGF2YWlsYWJsZSBjb2xvcnNcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaXRpYWxpemVkIHN1Y2Nlc3NmdWxseVwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgRXJyb3IgaW5pdGlhbGl6aW5nIEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIEludmFsaWQgY29vcmRpbmF0ZXNcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgQXJlYSBtdXN0IGhhdmUgdXBwZXIgbGVmdCBjb3JuZXIgbGVzcyB0aGFuIGxvd2VyIHJpZ2h0IGNvcm5lclwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgQXJlYSB0b28gbGFyZ2U6IHtzaXplfSBwaXhlbHMgKG1heGltdW06IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IENhcHR1cmluZyBwcm90ZWN0aW9uIGFyZWEuLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IEFyZWEgY2FwdHVyZWQ6IHtjb3VudH0gcGl4ZWxzIHVuZGVyIHByb3RlY3Rpb25cIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGNhcHR1cmluZyBhcmVhOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBGaXJzdCBjYXB0dXJlIGEgcHJvdGVjdGlvbiBhcmVhXCIsXG4gICAgcHJvdGVjdGlvblN0YXJ0ZWQ6IFwiXHVEODNEXHVERUUxXHVGRTBGIFByb3RlY3Rpb24gc3RhcnRlZCAtIG1vbml0b3JpbmcgYXJlYVwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQcm90ZWN0aW9uIHN0b3BwZWRcIixcbiAgICBub0NoYW5nZXM6IFwiXHUyNzA1IFByb3RlY3RlZCBhcmVhIC0gbm8gY2hhbmdlcyBkZXRlY3RlZFwiLFxuICAgIGNoYW5nZXNEZXRlY3RlZDogXCJcdUQ4M0RcdURFQTgge2NvdW50fSBjaGFuZ2VzIGRldGVjdGVkIGluIHByb3RlY3RlZCBhcmVhXCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBSZXBhaXJpbmcge2NvdW50fSBhbHRlcmVkIHBpeGVscy4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgU3VjY2Vzc2Z1bGx5IHJlcGFpcmVkIHtjb3VudH0gcGl4ZWxzXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIEVycm9yIHJlcGFpcmluZyBwaXhlbHM6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIEluc3VmZmljaWVudCBjaGFyZ2VzIHRvIHJlcGFpciBjaGFuZ2VzXCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBDaGVja2luZyBjaGFuZ2VzIGluIHByb3RlY3RlZCBhcmVhLi4uXCIsXG4gICAgZXJyb3JDaGVja2luZzogXCJcdTI3NEMgRXJyb3IgY2hlY2tpbmcgY2hhbmdlczoge2Vycm9yfVwiLFxuICAgIGd1YXJkQWN0aXZlOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBHdWFyZGlhbiBhY3RpdmUgLSBhcmVhIHVuZGVyIHByb3RlY3Rpb25cIixcbiAgICBsYXN0Q2hlY2s6IFwiTGFzdCBjaGVjazoge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIk5leHQgY2hlY2sgaW46IHt0aW1lfXNcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBBdXRvLWluaXRpYWxpemluZy4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGF1dG8tc3RhcnRlZCBzdWNjZXNzZnVsbHlcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgQ291bGQgbm90IGF1dG8tc3RhcnQuIFVzZSBtYW51YWwgYnV0dG9uLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgTWFudWFsIGluaXRpYWxpemF0aW9uIHJlcXVpcmVkXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBDb2xvciBwYWxldHRlIGRldGVjdGVkXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBTZWFyY2hpbmcgZm9yIGNvbG9yIHBhbGV0dGUuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBDbGlja2luZyBQYWludCBidXR0b24uLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBQYWludCBidXR0b24gbm90IGZvdW5kXCIsXG4gICAgc2VsZWN0VXBwZXJMZWZ0OiBcIlx1RDgzQ1x1REZBRiBQYWludCBhIHBpeGVsIGF0IHRoZSBVUFBFUiBMRUZUIGNvcm5lciBvZiB0aGUgYXJlYSB0byBwcm90ZWN0XCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgTm93IHBhaW50IGEgcGl4ZWwgYXQgdGhlIExPV0VSIFJJR0hUIGNvcm5lciBvZiB0aGUgYXJlYVwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IFdhaXRpbmcgZm9yIHVwcGVyIGxlZnQgY29ybmVyIHNlbGVjdGlvbi4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBXYWl0aW5nIGZvciBsb3dlciByaWdodCBjb3JuZXIgc2VsZWN0aW9uLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IFVwcGVyIGxlZnQgY29ybmVyIGNhcHR1cmVkOiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBMb3dlciByaWdodCBjb3JuZXIgY2FwdHVyZWQ6ICh7eH0sIHt5fSlcIixcbiAgICBzZWxlY3Rpb25UaW1lb3V0OiBcIlx1Mjc0QyBTZWxlY3Rpb24gdGltZW91dFwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBTZWxlY3Rpb24gZXJyb3IsIHBsZWFzZSB0cnkgYWdhaW5cIlxuICB9XG59O1xuIiwgImV4cG9ydCBjb25zdCBmciA9IHtcbiAgLy8gTGF1bmNoZXJcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBBdXRvQk9UJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBBdXRvLUZhcm0nLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBBdXRvLUltYWdlJyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgQXV0by1HdWFyZCcsXG4gICAgc2VsZWN0aW9uOiAnU1x1MDBFOWxlY3Rpb24nLFxuICAgIHVzZXI6ICdVdGlsaXNhdGV1cicsXG4gICAgY2hhcmdlczogJ0NoYXJnZXMnLFxuICAgIGJhY2tlbmQ6ICdCYWNrZW5kJyxcbiAgICBkYXRhYmFzZTogJ0Jhc2UgZGUgZG9ublx1MDBFOWVzJyxcbiAgICB1cHRpbWU6ICdUZW1wcyBhY3RpZicsXG4gICAgY2xvc2U6ICdGZXJtZXInLFxuICAgIGxhdW5jaDogJ0xhbmNlcicsXG4gICAgbG9hZGluZzogJ0NoYXJnZW1lbnRcdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ0V4XHUwMEU5Y3V0aW9uXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ1RcdTAwRTlsXHUwMEU5Y2hhcmdlbWVudCBkdSBzY3JpcHRcdTIwMjYnLFxuICAgIGNob29zZUJvdDogJ0Nob2lzaXNzZXogdW4gYm90IGV0IGFwcHV5ZXogc3VyIExhbmNlcicsXG4gICAgcmVhZHlUb0xhdW5jaDogJ1ByXHUwMEVBdCBcdTAwRTAgbGFuY2VyJyxcbiAgICBsb2FkRXJyb3I6ICdFcnJldXIgZGUgY2hhcmdlbWVudCcsXG4gICAgbG9hZEVycm9yTXNnOiAnSW1wb3NzaWJsZSBkZSBjaGFyZ2VyIGxlIGJvdCBzXHUwMEU5bGVjdGlvbm5cdTAwRTkuIFZcdTAwRTlyaWZpZXogdm90cmUgY29ubmV4aW9uIG91IHJcdTAwRTllc3NheWV6LicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgVlx1MDBFOXJpZmljYXRpb24uLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBFbiBsaWduZScsXG4gICAgb2ZmbGluZTogJ1x1RDgzRFx1REQzNCBIb3JzIGxpZ25lJyxcbiAgICBvazogJ1x1RDgzRFx1REZFMiBPSycsXG4gICAgZXJyb3I6ICdcdUQ4M0RcdUREMzQgRXJyZXVyJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1JbWFnZVwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGlzZXIgQXV0by1CT1RcIixcbiAgICB1cGxvYWRJbWFnZTogXCJUXHUwMEU5bFx1MDBFOWNoYXJnZXIgSW1hZ2VcIixcbiAgICByZXNpemVJbWFnZTogXCJSZWRpbWVuc2lvbm5lciBJbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNcdTAwRTlsZWN0aW9ubmVyIFBvc2l0aW9uXCIsXG4gICAgc3RhcnRQYWludGluZzogXCJDb21tZW5jZXIgUGVpbnR1cmVcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiQXJyXHUwMEVBdGVyIFBlaW50dXJlXCIsXG4gICAgc2F2ZVByb2dyZXNzOiBcIlNhdXZlZ2FyZGVyIFByb2dyXHUwMEU4c1wiLFxuICAgIGxvYWRQcm9ncmVzczogXCJDaGFyZ2VyIFByb2dyXHUwMEU4c1wiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzRFx1REQwRCBWXHUwMEU5cmlmaWNhdGlvbiBkZXMgY291bGV1cnMgZGlzcG9uaWJsZXMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBPdXZyZXogbGEgcGFsZXR0ZSBkZSBjb3VsZXVycyBzdXIgbGUgc2l0ZSBldCByXHUwMEU5ZXNzYXlleiFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUge2NvdW50fSBjb3VsZXVycyBkaXNwb25pYmxlcyB0cm91dlx1MDBFOWVzXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBDaGFyZ2VtZW50IGRlIGwnaW1hZ2UuLi5cIixcbiAgICBpbWFnZUxvYWRlZDogXCJcdTI3MDUgSW1hZ2UgY2hhcmdcdTAwRTllIGF2ZWMge2NvdW50fSBwaXhlbHMgdmFsaWRlc1wiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGR1IGNoYXJnZW1lbnQgZGUgbCdpbWFnZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiUGVpZ25leiBsZSBwcmVtaWVyIHBpeGVsIFx1MDBFMCBsJ2VtcGxhY2VtZW50IG9cdTAwRjkgdm91cyB2b3VsZXogcXVlIGwnYXJ0IGNvbW1lbmNlIVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgRW4gYXR0ZW50ZSBxdWUgdm91cyBwZWlnbmlleiBsZSBwaXhlbCBkZSByXHUwMEU5Zlx1MDBFOXJlbmNlLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFBvc2l0aW9uIGRcdTAwRTlmaW5pZSBhdmVjIHN1Y2NcdTAwRThzIVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgRFx1MDBFOWxhaSBkXHUwMEU5cGFzc1x1MDBFOSBwb3VyIGxhIHNcdTAwRTlsZWN0aW9uIGRlIHBvc2l0aW9uXCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgUG9zaXRpb24gZFx1MDBFOXRlY3RcdTAwRTllLCB0cmFpdGVtZW50Li4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgRXJyZXVyIGRcdTAwRTl0ZWN0YW50IGxhIHBvc2l0aW9uLCBlc3NheWV6IFx1MDBFMCBub3V2ZWF1XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggRFx1MDBFOWJ1dCBkZSBsYSBwZWludHVyZS4uLlwiLFxuICAgIHBhaW50aW5nUHJvZ3Jlc3M6IFwiXHVEODNFXHVEREYxIFByb2dyXHUwMEU4czoge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBBdWN1bmUgY2hhcmdlLiBBdHRlbmRyZSB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFBlaW50dXJlIGFyclx1MDBFQXRcdTAwRTllIHBhciBsJ3V0aWxpc2F0ZXVyXCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgUGVpbnR1cmUgdGVybWluXHUwMEU5ZSEge2NvdW50fSBwaXhlbHMgcGVpbnRzLlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBwZW5kYW50IGxhIHBlaW50dXJlXCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgQ2hhcmdleiB1bmUgaW1hZ2UgZXQgc1x1MDBFOWxlY3Rpb25uZXogdW5lIHBvc2l0aW9uIGQnYWJvcmRcIixcbiAgICBwcm9ncmVzczogXCJQcm9nclx1MDBFOHNcIixcbiAgICB1c2VyTmFtZTogXCJVc2FnZXJcIixcbiAgICBwaXhlbHM6IFwiUGl4ZWxzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJUZW1wcyBlc3RpbVx1MDBFOVwiLFxuICAgIGluaXRNZXNzYWdlOiBcIkNsaXF1ZXogc3VyICdJbml0aWFsaXNlciBBdXRvLUJPVCcgcG91ciBjb21tZW5jZXJcIixcbiAgICB3YWl0aW5nSW5pdDogXCJFbiBhdHRlbnRlIGQnaW5pdGlhbGlzYXRpb24uLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBJbWFnZSByZWRpbWVuc2lvbm5cdTAwRTllIFx1MDBFMCB7d2lkdGh9eHtoZWlnaHR9XCIsXG4gICAgcGFpbnRpbmdQYXVzZWQ6IFwiXHUyM0Y4XHVGRTBGIFBlaW50dXJlIG1pc2UgZW4gcGF1c2UgXHUwMEUwIGxhIHBvc2l0aW9uIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUGl4ZWxzIHBhciBsb3RcIixcbiAgICBiYXRjaFNpemU6IFwiVGFpbGxlIGR1IGxvdFwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiUHJvY2hhaW4gbG90IGRhbnNcIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlV0aWxpc2VyIHRvdXRlcyBsZXMgY2hhcmdlcyBkaXNwb25pYmxlc1wiLFxuICAgIHNob3dPdmVybGF5OiBcIkFmZmljaGVyIGwnb3ZlcmxheVwiLFxuICAgIG1heENoYXJnZXM6IFwiQ2hhcmdlcyBtYXggcGFyIGxvdFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBFbiBhdHRlbnRlIGRlIGNoYXJnZXM6IHtjdXJyZW50fS97bmVlZGVkfVwiLFxuICAgIHRpbWVSZW1haW5pbmc6IFwiVGVtcHMgcmVzdGFudFwiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgQXR0ZW5kcmUge3RpbWV9IHBvdXIgY29udGludWVyLi4uXCIsXG4gICAgcHJvZ3Jlc3NTYXZlZDogXCJcdTI3MDUgUHJvZ3JcdTAwRThzIHNhdXZlZ2FyZFx1MDBFOSBzb3VzIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgUHJvZ3JcdTAwRThzIGNoYXJnXHUwMEU5OiB7cGFpbnRlZH0ve3RvdGFsfSBwaXhlbHMgcGVpbnRzXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGR1IGNoYXJnZW1lbnQgZHUgcHJvZ3JcdTAwRThzOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGRlIGxhIHNhdXZlZ2FyZGUgZHUgcHJvZ3JcdTAwRThzOiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJWb3VsZXotdm91cyBzYXV2ZWdhcmRlciBsZSBwcm9nclx1MDBFOHMgYWN0dWVsIGF2YW50IGQnYXJyXHUwMEVBdGVyP1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlNhdXZlZ2FyZGVyIFByb2dyXHUwMEU4c1wiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJBYmFuZG9ubmVyXCIsXG4gICAgY2FuY2VsOiBcIkFubnVsZXJcIixcbiAgICBtaW5pbWl6ZTogXCJNaW5pbWlzZXJcIixcbiAgICB3aWR0aDogXCJMYXJnZXVyXCIsXG4gICAgaGVpZ2h0OiBcIkhhdXRldXJcIiwgXG4gICAga2VlcEFzcGVjdDogXCJHYXJkZXIgbGVzIHByb3BvcnRpb25zXCIsXG4gICAgYXBwbHk6IFwiQXBwbGlxdWVyXCIsXG4gIG92ZXJsYXlPbjogXCJPdmVybGF5IDogT05cIixcbiAgb3ZlcmxheU9mZjogXCJPdmVybGF5IDogT0ZGXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgUGFzc2FnZSB0ZXJtaW5cdTAwRTk6IHtwYWludGVkfSBwaXhlbHMgcGVpbnRzIHwgUHJvZ3JcdTAwRThzOiB7cGVyY2VudH0lICh7Y3VycmVudH0ve3RvdGFsfSlcIixcbiAgICB3YWl0aW5nQ2hhcmdlc1JlZ2VuOiBcIlx1MjNGMyBBdHRlbnRlIGRlIHJcdTAwRTlnXHUwMEU5blx1MDBFOXJhdGlvbiBkZXMgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gVGVtcHM6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBBdHRlbnRlIGRlcyBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH0gLSBSZXN0YW50OiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbml0aWFsaXNhdGlvbiBhdXRvbWF0aXF1ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgQm90IGRcdTAwRTltYXJyXHUwMEU5IGF1dG9tYXRpcXVlbWVudFwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBJbXBvc3NpYmxlIGRlIGRcdTAwRTltYXJyZXIgYXV0b21hdGlxdWVtZW50LiBVdGlsaXNleiBsZSBib3V0b24gbWFudWVsLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXR0ZSBkZSBjb3VsZXVycyBkXHUwMEU5dGVjdFx1MDBFOWVcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFJlY2hlcmNoZSBkZSBsYSBwYWxldHRlIGRlIGNvdWxldXJzLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpYyBzdXIgbGUgYm91dG9uIFBhaW50Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgQm91dG9uIFBhaW50IGludHJvdXZhYmxlXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbml0aWFsaXNhdGlvbiBtYW51ZWxsZSByZXF1aXNlXCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBUZW50YXRpdmUge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30gZGFucyB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IEVycmV1ciBkYW5zIHRlbnRhdGl2ZSB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSwgbm91dmVsIGVzc2FpIGRhbnMge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgXHUwMEM5Y2hlYyBhcHJcdTAwRThzIHttYXhBdHRlbXB0c30gdGVudGF0aXZlcy4gQ29udGludWFudCBhdmVjIGxlIGxvdCBzdWl2YW50Li4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBFcnJldXIgclx1MDBFOXNlYXUuIE5vdXZlbCBlc3NhaS4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBFcnJldXIgc2VydmV1ci4gTm91dmVsIGVzc2FpLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBUaW1lb3V0IHNlcnZldXIuIE5vdXZlbCBlc3NhaS4uLlwiXG4gIH0sXG5cbiAgLy8gRmFybSBNb2R1bGUgKHRvIGJlIGltcGxlbWVudGVkKVxuICBmYXJtOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEZhcm0gQm90XCIsXG4gICAgc3RhcnQ6IFwiRFx1MDBFOW1hcnJlclwiLFxuICAgIHN0b3A6IFwiQXJyXHUwMEVBdGVyXCIsXG4gICAgc3RvcHBlZDogXCJCb3QgYXJyXHUwMEVBdFx1MDBFOVwiLFxuICAgIGNhbGlicmF0ZTogXCJDYWxpYnJlclwiLFxuICAgIHBhaW50T25jZTogXCJVbmUgZm9pc1wiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIlZcdTAwRTlyaWZpY2F0aW9uIGR1IHN0YXR1dC4uLlwiLFxuICAgIGNvbmZpZ3VyYXRpb246IFwiQ29uZmlndXJhdGlvblwiLFxuICAgIGRlbGF5OiBcIkRcdTAwRTlsYWkgKG1zKVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlBpeGVscy9sb3RcIixcbiAgICBtaW5DaGFyZ2VzOiBcIkNoYXJnZXMgbWluXCIsXG4gICAgY29sb3JNb2RlOiBcIk1vZGUgY291bGV1clwiLFxuICAgIHJhbmRvbTogXCJBbFx1MDBFOWF0b2lyZVwiLFxuICAgIGZpeGVkOiBcIkZpeGVcIixcbiAgICByYW5nZTogXCJQbGFnZVwiLFxuICAgIGZpeGVkQ29sb3I6IFwiQ291bGV1ciBmaXhlXCIsXG4gICAgYWR2YW5jZWQ6IFwiQXZhbmNcdTAwRTlcIixcbiAgICB0aWxlWDogXCJUdWlsZSBYXCIsXG4gICAgdGlsZVk6IFwiVHVpbGUgWVwiLFxuICAgIGN1c3RvbVBhbGV0dGU6IFwiUGFsZXR0ZSBwZXJzb25uYWxpc1x1MDBFOWVcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJleDogI0ZGMDAwMCwjMDBGRjAwLCMwMDAwRkZcIixcbiAgICBjYXB0dXJlOiBcIkNhcHR1cmVyXCIsXG4gICAgcGFpbnRlZDogXCJQZWludHNcIixcbiAgICBjaGFyZ2VzOiBcIkNoYXJnZXNcIixcbiAgICByZXRyaWVzOiBcIlx1MDBDOWNoZWNzXCIsXG4gICAgdGlsZTogXCJUdWlsZVwiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIkNvbmZpZ3VyYXRpb24gc2F1dmVnYXJkXHUwMEU5ZVwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJDb25maWd1cmF0aW9uIGNoYXJnXHUwMEU5ZVwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIkNvbmZpZ3VyYXRpb24gclx1MDBFOWluaXRpYWxpc1x1MDBFOWVcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlBlaW5kcmUgdW4gcGl4ZWwgbWFudWVsbGVtZW50IHBvdXIgY2FwdHVyZXIgbGVzIGNvb3Jkb25uXHUwMEU5ZXMuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIkJhY2tlbmQgRW4gbGlnbmVcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJCYWNrZW5kIEhvcnMgbGlnbmVcIixcbiAgICBzdGFydGluZ0JvdDogXCJEXHUwMEU5bWFycmFnZSBkdSBib3QuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJBcnJcdTAwRUF0IGR1IGJvdC4uLlwiLFxuICAgIGNhbGlicmF0aW5nOiBcIkNhbGlicmFnZS4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIkF1dG8tRmFybSBlc3QgZFx1MDBFOWpcdTAwRTAgZW4gY291cnMgZCdleFx1MDBFOWN1dGlvbi5cIixcbiAgICBpbWFnZVJ1bm5pbmdXYXJuaW5nOiBcIkF1dG8tSW1hZ2UgZXN0IGVuIGNvdXJzIGQnZXhcdTAwRTljdXRpb24uIEZlcm1lei1sZSBhdmFudCBkZSBkXHUwMEU5bWFycmVyIEF1dG8tRmFybS5cIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTXHUwMEU5bGVjdGlvbm5lciBab25lXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgUGVpZ25leiB1biBwaXhlbCBkYW5zIHVuZSB6b25lIFZJREUgZGUgbGEgY2FydGUgcG91ciBkXHUwMEU5ZmluaXIgbGEgem9uZSBkZSBmYXJtaW5nXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBFbiBhdHRlbnRlIHF1ZSB2b3VzIHBlaWduaWV6IGxlIHBpeGVsIGRlIHJcdTAwRTlmXHUwMEU5cmVuY2UuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgWm9uZSBkXHUwMEU5ZmluaWUhIFJheW9uOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgRFx1MDBFOWxhaSBkXHUwMEU5cGFzc1x1MDBFOSBwb3VyIGxhIHNcdTAwRTlsZWN0aW9uIGRlIHpvbmVcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFNcdTAwRTlsZWN0aW9ubmV6IHVuZSB6b25lIGQnYWJvcmQgZW4gdXRpbGlzYW50ICdTXHUwMEU5bGVjdGlvbm5lciBab25lJ1wiLFxuICAgIGZhcm1SYWRpdXM6IFwiUmF5b24gZmFybVwiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJab25lIGFjdHVlbGxlXCIsXG4gICAgZmFybWluZ0luUmFkaXVzOiBcIlx1RDgzQ1x1REYzRSBGYXJtaW5nIGRhbnMgdW4gcmF5b24gZGUge3JhZGl1c31weCBkZXB1aXMgKHt4fSx7eX0pXCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBJTVBPUlRBTlQ6IFNcdTAwRTlsZWN0aW9ubmV6IHVuZSB6b25lIFZJREUgcG91ciBcdTAwRTl2aXRlciBsZXMgY29uZmxpdHNcIixcbiAgICBub1Bvc2l0aW9uOiBcIkF1Y3VuZSB6b25lXCIsXG4gICAgY3VycmVudFpvbmU6IFwiWm9uZTogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBTXHUwMEU5bGVjdGlvbm5leiB1bmUgem9uZSBkJ2Fib3JkLiBQZWlnbmV6IHVuIHBpeGVsIHN1ciBsYSBjYXJ0ZSBwb3VyIGRcdTAwRTlmaW5pciBsYSB6b25lIGRlIGZhcm1pbmdcIlxuICB9LFxuXG4gICAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiT3VpXCIsXG4gICAgbm86IFwiTm9uXCIsXG4gICAgb2s6IFwiT0tcIixcbiAgICBjYW5jZWw6IFwiQW5udWxlclwiLFxuICAgIGNsb3NlOiBcIkZlcm1lclwiLFxuICAgIHNhdmU6IFwiU2F1dmVnYXJkZXJcIixcbiAgICBsb2FkOiBcIkNoYXJnZXJcIixcbiAgICBkZWxldGU6IFwiU3VwcHJpbWVyXCIsXG4gICAgZWRpdDogXCJNb2RpZmllclwiLFxuICAgIHN0YXJ0OiBcIkRcdTAwRTltYXJyZXJcIixcbiAgICBzdG9wOiBcIkFyclx1MDBFQXRlclwiLFxuICAgIHBhdXNlOiBcIlBhdXNlXCIsXG4gICAgcmVzdW1lOiBcIlJlcHJlbmRyZVwiLFxuICAgIHJlc2V0OiBcIlJcdTAwRTlpbml0aWFsaXNlclwiLFxuICAgIHNldHRpbmdzOiBcIlBhcmFtXHUwMEU4dHJlc1wiLFxuICAgIGhlbHA6IFwiQWlkZVwiLFxuICAgIGFib3V0OiBcIlx1MDBDMCBwcm9wb3NcIixcbiAgICBsYW5ndWFnZTogXCJMYW5ndWVcIixcbiAgICBsb2FkaW5nOiBcIkNoYXJnZW1lbnQuLi5cIixcbiAgICBlcnJvcjogXCJFcnJldXJcIixcbiAgICBzdWNjZXNzOiBcIlN1Y2NcdTAwRThzXCIsXG4gICAgd2FybmluZzogXCJBdmVydGlzc2VtZW50XCIsXG4gICAgaW5mbzogXCJJbmZvcm1hdGlvblwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJMYW5ndWUgY2hhbmdcdTAwRTllIGVuIHtsYW5ndWFnZX1cIlxuICB9LFxuXG4gIC8vIEd1YXJkIE1vZHVsZVxuICBndWFyZDoge1xuICAgIHRpdGxlOiBcIldQbGFjZSBBdXRvLUd1YXJkXCIsXG4gICAgaW5pdEJvdDogXCJJbml0aWFsaXNlciBHdWFyZC1CT1RcIixcbiAgICBzZWxlY3RBcmVhOiBcIlNcdTAwRTlsZWN0aW9ubmVyIFpvbmVcIixcbiAgICBjYXB0dXJlQXJlYTogXCJDYXB0dXJlciBab25lXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIkRcdTAwRTltYXJyZXIgUHJvdGVjdGlvblwiLFxuICAgIHN0b3BQcm90ZWN0aW9uOiBcIkFyclx1MDBFQXRlciBQcm90ZWN0aW9uXCIsXG4gICAgdXBwZXJMZWZ0OiBcIkNvaW4gU3VwXHUwMEU5cmlldXIgR2F1Y2hlXCIsXG4gICAgbG93ZXJSaWdodDogXCJDb2luIEluZlx1MDBFOXJpZXVyIERyb2l0XCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlBpeGVscyBQcm90XHUwMEU5Z1x1MDBFOXNcIixcbiAgICBkZXRlY3RlZENoYW5nZXM6IFwiQ2hhbmdlbWVudHMgRFx1MDBFOXRlY3RcdTAwRTlzXCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiUGl4ZWxzIFJcdTAwRTlwYXJcdTAwRTlzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiRW4gYXR0ZW50ZSBkJ2luaXRpYWxpc2F0aW9uLi4uXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNDXHVERkE4IFZcdTAwRTlyaWZpY2F0aW9uIGRlcyBjb3VsZXVycyBkaXNwb25pYmxlcy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIEF1Y3VuZSBjb3VsZXVyIHRyb3V2XHUwMEU5ZS4gT3V2cmV6IGxhIHBhbGV0dGUgZGUgY291bGV1cnMgc3VyIGxlIHNpdGUuXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IHtjb3VudH0gY291bGV1cnMgZGlzcG9uaWJsZXMgdHJvdXZcdTAwRTllc1wiLFxuICAgIGluaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgaW5pdGlhbGlzXHUwMEU5IGF2ZWMgc3VjY1x1MDBFOHNcIixcbiAgICBpbml0RXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGRlIGwnaW5pdGlhbGlzYXRpb24gZGUgR3VhcmQtQk9UXCIsXG4gICAgaW52YWxpZENvb3JkczogXCJcdTI3NEMgQ29vcmRvbm5cdTAwRTllcyBpbnZhbGlkZXNcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgTGEgem9uZSBkb2l0IGF2b2lyIGxlIGNvaW4gc3VwXHUwMEU5cmlldXIgZ2F1Y2hlIGluZlx1MDBFOXJpZXVyIGF1IGNvaW4gaW5mXHUwMEU5cmlldXIgZHJvaXRcIixcbiAgICBhcmVhVG9vTGFyZ2U6IFwiXHUyNzRDIFpvbmUgdHJvcCBncmFuZGU6IHtzaXplfSBwaXhlbHMgKG1heGltdW06IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IENhcHR1cmUgZGUgbGEgem9uZSBkZSBwcm90ZWN0aW9uLi4uXCIsXG4gICAgYXJlYUNhcHR1cmVkOiBcIlx1MjcwNSBab25lIGNhcHR1clx1MDBFOWU6IHtjb3VudH0gcGl4ZWxzIHNvdXMgcHJvdGVjdGlvblwiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgRXJyZXVyIGxvcnMgZGUgbGEgY2FwdHVyZSBkZSB6b25lOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBDYXB0dXJleiBkJ2Fib3JkIHVuZSB6b25lIGRlIHByb3RlY3Rpb25cIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgUHJvdGVjdGlvbiBkXHUwMEU5bWFyclx1MDBFOWUgLSBzdXJ2ZWlsbGFuY2UgZGUgbGEgem9uZVwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQcm90ZWN0aW9uIGFyclx1MDBFQXRcdTAwRTllXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBab25lIHByb3RcdTAwRTlnXHUwMEU5ZSAtIGF1Y3VuIGNoYW5nZW1lbnQgZFx1MDBFOXRlY3RcdTAwRTlcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gY2hhbmdlbWVudHMgZFx1MDBFOXRlY3RcdTAwRTlzIGRhbnMgbGEgem9uZSBwcm90XHUwMEU5Z1x1MDBFOWVcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFJcdTAwRTlwYXJhdGlvbiBkZSB7Y291bnR9IHBpeGVscyBhbHRcdTAwRTlyXHUwMEU5cy4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUge2NvdW50fSBwaXhlbHMgclx1MDBFOXBhclx1MDBFOXMgYXZlYyBzdWNjXHUwMEU4c1wiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsYSByXHUwMEU5cGFyYXRpb24gZGVzIHBpeGVsczoge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgQ2hhcmdlcyBpbnN1ZmZpc2FudGVzIHBvdXIgclx1MDBFOXBhcmVyIGxlcyBjaGFuZ2VtZW50c1wiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgVlx1MDBFOXJpZmljYXRpb24gZGVzIGNoYW5nZW1lbnRzIGRhbnMgbGEgem9uZSBwcm90XHUwMEU5Z1x1MDBFOWUuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsYSB2XHUwMEU5cmlmaWNhdGlvbiBkZXMgY2hhbmdlbWVudHM6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgR2FyZGllbiBhY3RpZiAtIHpvbmUgc291cyBwcm90ZWN0aW9uXCIsXG4gICAgbGFzdENoZWNrOiBcIkRlcm5pXHUwMEU4cmUgdlx1MDBFOXJpZmljYXRpb246IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJQcm9jaGFpbmUgdlx1MDBFOXJpZmljYXRpb24gZGFuczoge3RpbWV9c1wiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IEluaXRpYWxpc2F0aW9uIGF1dG9tYXRpcXVlLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgZFx1MDBFOW1hcnJcdTAwRTkgYXV0b21hdGlxdWVtZW50XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIEltcG9zc2libGUgZGUgZFx1MDBFOW1hcnJlciBhdXRvbWF0aXF1ZW1lbnQuIFV0aWxpc2V6IGxlIGJvdXRvbiBtYW51ZWwuXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBJbml0aWFsaXNhdGlvbiBtYW51ZWxsZSByZXF1aXNlXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBQYWxldHRlIGRlIGNvdWxldXJzIGRcdTAwRTl0ZWN0XHUwMEU5ZVwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgUmVjaGVyY2hlIGRlIGxhIHBhbGV0dGUgZGUgY291bGV1cnMuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBDbGljIHN1ciBsZSBib3V0b24gUGFpbnQuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBCb3V0b24gUGFpbnQgaW50cm91dmFibGVcIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFBlaWduZXogdW4gcGl4ZWwgYXUgY29pbiBTVVBcdTAwQzlSSUVVUiBHQVVDSEUgZGUgbGEgem9uZSBcdTAwRTAgcHJvdFx1MDBFOWdlclwiLFxuICAgIHNlbGVjdExvd2VyUmlnaHQ6IFwiXHVEODNDXHVERkFGIE1haW50ZW5hbnQgcGVpZ25leiB1biBwaXhlbCBhdSBjb2luIElORlx1MDBDOVJJRVVSIERST0lUIGRlIGxhIHpvbmVcIixcbiAgICB3YWl0aW5nVXBwZXJMZWZ0OiBcIlx1RDgzRFx1REM0NiBFbiBhdHRlbnRlIGRlIGxhIHNcdTAwRTlsZWN0aW9uIGR1IGNvaW4gc3VwXHUwMEU5cmlldXIgZ2F1Y2hlLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IEVuIGF0dGVudGUgZGUgbGEgc1x1MDBFOWxlY3Rpb24gZHUgY29pbiBpbmZcdTAwRTlyaWV1ciBkcm9pdC4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBDb2luIHN1cFx1MDBFOXJpZXVyIGdhdWNoZSBjYXB0dXJcdTAwRTk6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IENvaW4gaW5mXHUwMEU5cmlldXIgZHJvaXQgY2FwdHVyXHUwMEU5OiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgRFx1MDBFOWxhaSBkZSBzXHUwMEU5bGVjdGlvbiBkXHUwMEU5cGFzc1x1MDBFOVwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBFcnJldXIgZGUgc1x1MDBFOWxlY3Rpb24sIHZldWlsbGV6IHJcdTAwRTllc3NheWVyXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgcnUgPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQycsXG4gICAgYXV0b0ltYWdlOiAnXHVEODNDXHVERkE4IFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUnLFxuICAgIGF1dG9HdWFyZDogJ1x1RDgzRFx1REVFMVx1RkUwRiBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwJyxcbiAgICBzZWxlY3Rpb246ICdcdTA0MTJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0M0RcdTA0M0UnLFxuICAgIHVzZXI6ICdcdTA0MUZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NEMnLFxuICAgIGNoYXJnZXM6ICdcdTA0MThcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYnLFxuICAgIGJhY2tlbmQ6ICdcdTA0MTFcdTA0NERcdTA0M0FcdTA0MzVcdTA0M0RcdTA0MzQnLFxuICAgIGRhdGFiYXNlOiAnXHUwNDExXHUwNDMwXHUwNDM3XHUwNDMwIFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQ0NScsXG4gICAgdXB0aW1lOiAnXHUwNDEyXHUwNDQwXHUwNDM1XHUwNDNDXHUwNDRGIFx1MDQ0MFx1MDQzMFx1MDQzMVx1MDQzRVx1MDQ0Mlx1MDQ0QicsXG4gICAgY2xvc2U6ICdcdTA0MTdcdTA0MzBcdTA0M0FcdTA0NDBcdTA0NEJcdTA0NDJcdTA0NEMnLFxuICAgIGxhdW5jaDogJ1x1MDQxN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QycsXG4gICAgbG9hZGluZzogJ1x1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzMCcsXG4gICAgZXhlY3V0aW5nOiAnXHUwNDEyXHUwNDRCXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1JyxcbiAgICBkb3dubG9hZGluZzogJ1x1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzMCBcdTA0NDFcdTA0M0FcdTA0NDBcdTA0MzhcdTA0M0ZcdTA0NDJcdTA0MzAuLi4nLFxuICAgIGNob29zZUJvdDogJ1x1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0MzAgXHUwNDM4IFx1MDQzRFx1MDQzMFx1MDQzNlx1MDQzQ1x1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MTdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzhcdTA0NDJcdTA0NEMnLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdcdTA0MTNcdTA0M0VcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0UgXHUwNDNBIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQVx1MDQ0MycsXG4gICAgbG9hZEVycm9yOiAnXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzOCcsXG4gICAgbG9hZEVycm9yTXNnOiAnXHUwNDFEXHUwNDM1XHUwNDMyXHUwNDNFXHUwNDM3XHUwNDNDXHUwNDNFXHUwNDM2XHUwNDNEXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0M0RcdTA0M0RcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwLiBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NENcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDNFXHUwNDM0XHUwNDNBXHUwNDNCXHUwNDRFXHUwNDQ3XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzOFx1MDQzQlx1MDQzOCBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDM1XHUwNDQ5XHUwNDM1IFx1MDQ0MFx1MDQzMFx1MDQzNy4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMC4uLicsXG4gICAgb25saW5lOiAnXHVEODNEXHVERkUyIFx1MDQxRVx1MDQzRFx1MDQzQlx1MDQzMFx1MDQzOVx1MDQzRCcsXG4gICAgb2ZmbGluZTogJ1x1RDgzRFx1REQzNCBcdTA0MUVcdTA0NDRcdTA0M0JcdTA0MzBcdTA0MzlcdTA0M0QnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIFx1MDQxRVx1MDQxQScsXG4gICAgZXJyb3I6ICdcdUQ4M0RcdUREMzQgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwJyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBJbWFnZSBNb2R1bGVcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIGluaXRCb3Q6IFwiXHUwNDE4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDIEF1dG8tQk9UXCIsXG4gICAgdXBsb2FkSW1hZ2U6IFwiXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlx1MDQxOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0NDBcdTA0MzBcdTA0MzdcdTA0M0NcdTA0MzVcdTA0NDAgXHUwNDM4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQzQ1x1MDQzNVx1MDQ0MVx1MDQ0Mlx1MDQzRSBcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0MzBcIixcbiAgICBzdGFydFBhaW50aW5nOiBcIlx1MDQxRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0NENcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJcdTA0MjFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIlx1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwIFx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQ0M1x1MDQzRlx1MDQzRFx1MDQ0Qlx1MDQ0NSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDJcdTA0M0FcdTA0NDBcdTA0M0VcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDQzIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMiBcdTA0M0RcdTA0MzAgXHUwNDQxXHUwNDMwXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzOCBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDQxXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDMwIVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTA0MURcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0M0Uge2NvdW50fSBcdTA0MzRcdTA0M0VcdTA0NDFcdTA0NDJcdTA0NDNcdTA0M0ZcdTA0M0RcdTA0NEJcdTA0NDUgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzAgXHUwNDM4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IFx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDQxIHtjb3VudH0gXHUwNDM0XHUwNDM1XHUwNDM5XHUwNDQxXHUwNDQyXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDM1XHUwNDNCXHUwNDRDXHUwNDNEXHUwNDRCXHUwNDNDXHUwNDM4IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0Rlx1MDQzQ1x1MDQzOFwiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzggXHUwNDM4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdTA0MURcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQwXHUwNDQyXHUwNDNFXHUwNDMyXHUwNDRCXHUwNDM5IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDQyXHUwNDNFXHUwNDNDIFx1MDQzQ1x1MDQzNVx1MDQ0MVx1MDQ0Mlx1MDQzNSwgXHUwNDMzXHUwNDM0XHUwNDM1IFx1MDQzMlx1MDQ0QiBcdTA0NDVcdTA0M0VcdTA0NDJcdTA0MzhcdTA0NDJcdTA0MzUsIFx1MDQ0N1x1MDQ0Mlx1MDQzRVx1MDQzMVx1MDQ0QiBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0M0RcdTA0M0VcdTA0M0EgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDM4XHUwNDNEXHUwNDMwXHUwNDNCXHUwNDQxXHUwNDRGIVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQ0MFx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzRVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEYuLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQzRVx1MDQzN1x1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQ0RiBcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcdTA0MzAgXHUwNDQzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHUwNDIyXHUwNDMwXHUwNDM5XHUwNDNDXHUwNDMwXHUwNDQzXHUwNDQyIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0ZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzhcIixcbiAgICBwb3NpdGlvbkRldGVjdGVkOiBcIlx1RDgzQ1x1REZBRiBcdTA0MUZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDNEXHUwNDMwLCBcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0M0FcdTA0MzAuLi5cIixcbiAgICBwb3NpdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwIFx1MDQzRlx1MDQzRVx1MDQzN1x1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzOCwgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzNVx1MDQ0OVx1MDQzNSBcdTA0NDBcdTA0MzBcdTA0MzdcIixcbiAgICBzdGFydFBhaW50aW5nTXNnOiBcIlx1RDgzQ1x1REZBOCBcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0M0UgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxOiB7cGFpbnRlZH0gXHUwNDM4XHUwNDM3IHt0b3RhbH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5Li4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBcdTA0MURcdTA0MzVcdTA0NDIgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDNFXHUwNDMyLiBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTA0MjBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQzRlx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQzN1x1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzQ1wiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1MDQyMFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NDhcdTA0MzVcdTA0M0RcdTA0M0UhIHtjb3VudH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRS5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0Nlx1MDQzNVx1MDQ0MVx1MDQ0MVx1MDQzNSBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NEZcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBcdTA0MjFcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0MzJcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzggXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDM1XHUwNDQwXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzQ1x1MDQzNVx1MDQ0MVx1MDQ0Mlx1MDQzRSBcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0MzBcIixcbiAgICBwcm9ncmVzczogXCJcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICB1c2VyTmFtZTogXCJcdTA0MUZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NENcIixcbiAgICBwaXhlbHM6IFwiXHUwNDFGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM4XCIsXG4gICAgY2hhcmdlczogXCJcdTA0MTdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0NEJcIixcbiAgICBlc3RpbWF0ZWRUaW1lOiBcIlx1MDQxRlx1MDQ0MFx1MDQzNVx1MDQzNFx1MDQzRlx1MDQzRVx1MDQzQlx1MDQzRVx1MDQzNlx1MDQzOFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQzRVx1MDQzNSBcdTA0MzJcdTA0NDBcdTA0MzVcdTA0M0NcdTA0NEZcIixcbiAgICBpbml0TWVzc2FnZTogXCJcdTA0MURcdTA0MzBcdTA0MzZcdTA0M0NcdTA0MzhcdTA0NDJcdTA0MzUgXHUwMEFCXHUwNDE3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDIEF1dG8tQk9UXHUwMEJCLCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOC4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IFx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDM0XHUwNDNFIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgXHUwNDIwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzRlx1MDQ0MFx1MDQzOFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0M0RcdTA0MzAgXHUwNDNGXHUwNDNFXHUwNDM3XHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDM4IFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHUwNDFGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzMiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDVcdTA0M0VcdTA0MzRcdTA0MzVcIixcbiAgICBiYXRjaFNpemU6IFwiXHUwNDIwXHUwNDMwXHUwNDM3XHUwNDNDXHUwNDM1XHUwNDQwIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFx1MDQzMFwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiXHUwNDIxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDQzXHUwNDRFXHUwNDQ5XHUwNDM4XHUwNDM5IFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNCBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0MzdcIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlx1MDQxOFx1MDQ0MVx1MDQzRlx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQzN1x1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0MzJcdTA0NDFcdTA0MzUgXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQ0QlwiLFxuICAgIHNob3dPdmVybGF5OiBcIlx1MDQxRlx1MDQzRVx1MDQzQVx1MDQzMFx1MDQzN1x1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0RcdTA0MzBcdTA0M0JcdTA0M0VcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBtYXhDaGFyZ2VzOiBcIlx1MDQxQ1x1MDQzMFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQzQ1x1MDQzMFx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQzRVx1MDQzNSBcdTA0M0FcdTA0M0VcdTA0M0ItXHUwNDMyXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMiBcdTA0MzdcdTA0MzAgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XCIsXG4gICAgd2FpdGluZ0ZvckNoYXJnZXM6IFwiXHUyM0YzIFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0M0VcdTA0MzI6IHtjdXJyZW50fSBcdTA0MzhcdTA0Mzcge25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlx1MDQxMlx1MDQ0MFx1MDQzNVx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOCBcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0JcdTA0M0VcdTA0NDFcdTA0NENcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSB7dGltZX0gXHUwNDM0XHUwNDNCXHUwNDRGIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzNFx1MDQzRVx1MDQzQlx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0NDFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzVcdTA0M0QgXHUwNDNBXHUwNDMwXHUwNDNBIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRDoge3BhaW50ZWR9IFx1MDQzOFx1MDQzNyB7dG90YWx9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0M0RcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0M0VcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzOCBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcdTA0MzA6IHtlcnJvcn1cIixcbiAgICBwcm9ncmVzc1NhdmVFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQ0MVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcdTA0MzA6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1MDQyMVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0NDJcdTA0MzVcdTA0M0FcdTA0NDNcdTA0NDlcdTA0MzhcdTA0MzkgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxIFx1MDQzRlx1MDQzNVx1MDQ0MFx1MDQzNVx1MDQzNCBcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0FcdTA0M0VcdTA0Mzk/XCIsXG4gICAgc2F2ZVByb2dyZXNzVGl0bGU6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MVwiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJcdTA0MURcdTA0MzUgXHUwNDQxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDRGXHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MVwiLFxuICAgIGNhbmNlbDogXCJcdTA0MUVcdTA0NDJcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBtaW5pbWl6ZTogXCJcdTA0MjFcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0RcdTA0NDNcdTA0NDJcdTA0NENcIixcbiAgICB3aWR0aDogXCJcdTA0MjhcdTA0MzhcdTA0NDBcdTA0MzhcdTA0M0RcdTA0MzBcIixcbiAgICBoZWlnaHQ6IFwiXHUwNDEyXHUwNDRCXHUwNDQxXHUwNDNFXHUwNDQyXHUwNDMwXCIsXG4gICAga2VlcEFzcGVjdDogXCJcdTA0MjFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDQxXHUwNDNFXHUwNDNFXHUwNDQyXHUwNDNEXHUwNDNFXHUwNDQ4XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQ0MVx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzRVx1MDQzRFwiLFxuICAgIGFwcGx5OiBcIlx1MDQxRlx1MDQ0MFx1MDQzOFx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQ0Nlx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0MzdcdTA0MzBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NDhcdTA0MzVcdTA0M0Q6IHtwYWludGVkfSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDNFIHwgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxOiB7cGVyY2VudH0lICh7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHt0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQzRlx1MDQzRVx1MDQzQlx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0MzA6IHtjdXJyZW50fSBcdTA0MzhcdTA0Mzcge25lZWRlZH0gLSBcdTA0MTJcdTA0NDBcdTA0MzVcdTA0M0NcdTA0NEY6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDNFXHUwNDMyOiB7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHtuZWVkZWR9IC0gXHUwNDIyXHUwNDQwXHUwNDM1XHUwNDMxXHUwNDQzXHUwNDM1XHUwNDQyXHUwNDQxXHUwNDRGOiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTA0MTFcdTA0M0VcdTA0NDIgXHUwNDQzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQzQlx1MDQ0MVx1MDQ0RiBcdTA0MzBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzhcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgXHUwNDFEXHUwNDM1IFx1MDQ0M1x1MDQzNFx1MDQzMFx1MDQzQlx1MDQzRVx1MDQ0MVx1MDQ0QyBcdTA0MzJcdTA0NEJcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDMwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBLiBcdTA0MThcdTA0NDFcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDQzIFx1MDQ0MFx1MDQ0M1x1MDQ0N1x1MDQzRFx1MDQzRVx1MDQzM1x1MDQzRSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0M0FcdTA0MzAuXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTA0MjZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDMwIFx1MDQzRVx1MDQzMVx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDNFXHUwNDM4XHUwNDQxXHUwNDNBIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzRVx1MDQzOSBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0NEIuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTA0MURcdTA0MzBcdTA0MzZcdTA0MzBcdTA0NDJcdTA0MzhcdTA0MzUgXHUwNDNBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDM4IFx1MDBBQlBhaW50XHUwMEJCLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHUwNDFBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDMwIFx1MDBBQlBhaW50XHUwMEJCIFx1MDQzRFx1MDQzNSBcdTA0M0RcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1MDQyMlx1MDQ0MFx1MDQzNVx1MDQzMVx1MDQ0M1x1MDQzNVx1MDQ0Mlx1MDQ0MVx1MDQ0RiBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGXCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwIHthdHRlbXB0fSBcdTA0MzhcdTA0Mzcge21heEF0dGVtcHRzfSBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0Mzcge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUVycm9yOiBcIlx1RDgzRFx1RENBNSBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzNSB7YXR0ZW1wdH0gXHUwNDM4XHUwNDM3IHttYXhBdHRlbXB0c30sIFx1MDQzRlx1MDQzRVx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0Mzcge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQ0MVx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQ0RiB7bWF4QXR0ZW1wdHN9IFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzRVx1MDQzQS4gXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDM0XHUwNDNFXHUwNDNCXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMiBcdTA0NDFcdTA0M0JcdTA0MzVcdTA0MzRcdTA0NDNcdTA0NEVcdTA0NDlcdTA0MzVcdTA0M0MgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XHUwNDM1Li4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDM1XHUwNDQyXHUwNDM4LiBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgc2VydmVyRXJyb3I6IFwiXHVEODNEXHVERDI1IFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0NDFcdTA0MzVcdTA0NDBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0MzAuIFx1MDQxRlx1MDQzRVx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzRFx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0FcdTA0MzAuLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFx1MDQyMlx1MDQzMFx1MDQzOVx1MDQzQ1x1MDQzMFx1MDQ0M1x1MDQ0MiBcdTA0NDFcdTA0MzVcdTA0NDBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0MzAuIFx1MDQxRlx1MDQzRVx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzRFx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0FcdTA0MzAuLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlICh0byBiZSBpbXBsZW1lbnRlZClcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDI0XHUwNDMwXHUwNDQwXHUwNDNDXCIsXG4gICAgc3RhcnQ6IFwiXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcDogXCJcdTA0MUVcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBzdG9wcGVkOiBcIlx1MDQxMVx1MDQzRVx1MDQ0MiBcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcIixcbiAgICBjYWxpYnJhdGU6IFwiXHUwNDFBXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDMxXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgcGFpbnRPbmNlOiBcIlx1MDQxNVx1MDQzNFx1MDQzOFx1MDQzRFx1MDQzRVx1MDQ0MFx1MDQzMFx1MDQzN1x1MDQzRVx1MDQzMlx1MDQzRVwiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIlx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0NDFcdTA0NDJcdTA0MzBcdTA0NDJcdTA0NDNcdTA0NDFcdTA0MzAuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIlx1MDQxQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzOFx1MDQzM1x1MDQ0M1x1MDQ0MFx1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIGRlbGF5OiBcIlx1MDQxN1x1MDQzMFx1MDQzNFx1MDQzNVx1MDQ0MFx1MDQzNlx1MDQzQVx1MDQzMCAoXHUwNDNDXHUwNDQxKVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0MzdcdTA0MzAgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XCIsXG4gICAgbWluQ2hhcmdlczogXCJcdTA0MUNcdTA0MzhcdTA0M0RcdTA0MzhcdTA0M0NcdTA0MzBcdTA0M0JcdTA0NENcdTA0M0RcdTA0M0VcdTA0MzUgXHUwNDNBXHUwNDNFXHUwNDNCLVx1MDQzMlx1MDQzRVwiLFxuICAgIGNvbG9yTW9kZTogXCJcdTA0MjBcdTA0MzVcdTA0MzZcdTA0MzhcdTA0M0MgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXCIsXG4gICAgcmFuZG9tOiBcIlx1MDQyMVx1MDQzQlx1MDQ0M1x1MDQ0N1x1MDQzMFx1MDQzOVx1MDQzRFx1MDQ0Qlx1MDQzOVwiLFxuICAgIGZpeGVkOiBcIlx1MDQyNFx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzOVwiLFxuICAgIHJhbmdlOiBcIlx1MDQxNFx1MDQzOFx1MDQzMFx1MDQzRlx1MDQzMFx1MDQzN1x1MDQzRVx1MDQzRFwiLFxuICAgIGZpeGVkQ29sb3I6IFwiXHUwNDI0XHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM5IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0MlwiLFxuICAgIGFkdmFuY2VkOiBcIlx1MDQyMFx1MDQzMFx1MDQ0MVx1MDQ0OFx1MDQzOFx1MDQ0MFx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzNVwiLFxuICAgIHRpbGVYOiBcIlx1MDQxRlx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQzQVx1MDQzMCBYXCIsXG4gICAgdGlsZVk6IFwiXHUwNDFGXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDNBXHUwNDMwIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlx1MDQyMVx1MDQzMlx1MDQzRVx1MDQ0RiBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0MzBcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJcdTA0M0ZcdTA0NDBcdTA0MzhcdTA0M0NcdTA0MzVcdTA0NDA6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJcdTA0MTdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDJcIixcbiAgICBwYWludGVkOiBcIlx1MDQxN1x1MDQzMFx1MDQzQVx1MDQ0MFx1MDQzMFx1MDQ0OFx1MDQzNVx1MDQzRFx1MDQzRVwiLFxuICAgIGNoYXJnZXM6IFwiXHUwNDE3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDRCXCIsXG4gICAgcmV0cmllczogXCJcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0NEJcdTA0MzUgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDM4XCIsXG4gICAgdGlsZTogXCJcdTA0MUZcdTA0M0JcdTA0MzhcdTA0NDJcdTA0M0FcdTA0MzBcIixcbiAgICBjb25maWdTYXZlZDogXCJcdTA0MUFcdTA0M0VcdTA0M0RcdTA0NDRcdTA0MzhcdTA0MzNcdTA0NDNcdTA0NDBcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDQxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgY29uZmlnTG9hZGVkOiBcIlx1MDQxQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzOFx1MDQzM1x1MDQ0M1x1MDQ0MFx1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RiBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBjb25maWdSZXNldDogXCJcdTA0MjFcdTA0MzFcdTA0NDBcdTA0M0VcdTA0NDEgXHUwNDNBXHUwNDNFXHUwNDNEXHUwNDQ0XHUwNDM4XHUwNDMzXHUwNDQzXHUwNDQwXHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDM4XCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJcdTA0MURcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRDIFx1MDQzMlx1MDQ0MFx1MDQ0M1x1MDQ0N1x1MDQzRFx1MDQ0M1x1MDQ0RSBcdTA0MzRcdTA0M0JcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXHUwNDMwIFx1MDQzQVx1MDQzRVx1MDQzRVx1MDQ0MFx1MDQzNFx1MDQzOFx1MDQzRFx1MDQzMFx1MDQ0Mi4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiXHUwNDExXHUwNDREXHUwNDNBXHUwNDREXHUwNDNEXHUwNDM0IFx1MDQxRVx1MDQzRFx1MDQzQlx1MDQzMFx1MDQzOVx1MDQzRFwiLFxuICAgIGJhY2tlbmRPZmZsaW5lOiBcIlx1MDQxMVx1MDQ0RFx1MDQzQVx1MDQ0RFx1MDQzRFx1MDQzNFwiLFxuICAgIHN0YXJ0aW5nQm90OiBcIlx1MDQxN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQSBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0MzAuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJcdTA0MUVcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0FcdTA0MzAgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwLi4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiXHUwNDFBXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDMxXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQyBcdTA0NDNcdTA0MzZcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQ5XHUwNDM1XHUwNDNEXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRS4gXHUwNDE3XHUwNDMwXHUwNDNBXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzNVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0MzVcdTA0MzQgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBXHUwNDNFXHUwNDNDIFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MjRcdTA0MzBcdTA0NDBcdTA0M0NcdTA0MzAuXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDFGXHUwNDIzXHUwNDIxXHUwNDIyXHUwNDFFXHUwNDE5IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOCBcdTA0M0FcdTA0MzBcdTA0NDBcdTA0NDJcdTA0NEIsIFx1MDQ0N1x1MDQ0Mlx1MDQzRVx1MDQzMVx1MDQ0QiBcdTA0M0VcdTA0MzFcdTA0M0VcdTA0MzdcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0NFx1MDQzMFx1MDQ0MFx1MDQzQ1x1MDQzMC5cIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDFcdTA0NDJcdTA0MzBcdTA0NDBcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRGLi4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDMwISBcdTA0MjBcdTA0MzBcdTA0MzRcdTA0MzhcdTA0NDNcdTA0NDE6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTA0MjJcdTA0MzBcdTA0MzlcdTA0M0NcdTA0MzBcdTA0NDNcdTA0NDIgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDM1XHUwNDQwXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0NDEgXHUwNDNGXHUwNDNFXHUwNDNDXHUwNDNFXHUwNDQ5XHUwNDRDXHUwNDRFIFx1MDBBQlx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NENcdTAwQkJcIixcbiAgICBmYXJtUmFkaXVzOiBcIlx1MDQyMFx1MDQzMFx1MDQzNFx1MDQzOFx1MDQ0M1x1MDQ0MSBcdTA0NDRcdTA0MzBcdTA0NDBcdTA0M0NcdTA0MzBcIixcbiAgICBwb3NpdGlvbkluZm86IFwiXHUwNDIyXHUwNDM1XHUwNDNBXHUwNDQzXHUwNDQ5XHUwNDMwXHUwNDRGIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgXHUwNDI0XHUwNDMwXHUwNDQwXHUwNDNDIFx1MDQzMiBcdTA0NDBcdTA0MzBcdTA0MzRcdTA0MzhcdTA0NDNcdTA0NDFcdTA0MzUge3JhZGl1c31weCBcdTA0M0VcdTA0NDIgKHt4fSx7eX0pXCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBcdTA0MTJcdTA0MTBcdTA0MTZcdTA0MURcdTA0MUU6IFx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MUZcdTA0MjNcdTA0MjFcdTA0MjJcdTA0MjNcdTA0MkUgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDLCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDM4XHUwNDM3XHUwNDMxXHUwNDM1XHUwNDM2XHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQzQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzQlx1MDQzOFx1MDQzQVx1MDQ0Mlx1MDQzRVx1MDQzMi5cIixcbiAgICBub1Bvc2l0aW9uOiBcIlx1MDQxRFx1MDQzNVx1MDQ0MiBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICBjdXJyZW50Wm9uZTogXCJcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEM6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgXHUwNDIxXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDMwIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMuIFx1MDQxRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDNEXHUwNDMwIFx1MDQzQVx1MDQzMFx1MDQ0MFx1MDQ0Mlx1MDQzNSwgXHUwNDQ3XHUwNDQyXHUwNDNFXHUwNDMxXHUwNDRCIFx1MDQzRVx1MDQzMVx1MDQzRVx1MDQzN1x1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQ0XHUwNDMwXHUwNDQwXHUwNDNDXHUwNDMwLlwiXG4gIH0sXG5cbiAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiXHUwNDE0XHUwNDMwXCIsXG4gICAgbm86IFwiXHUwNDFEXHUwNDM1XHUwNDQyXCIsXG4gICAgb2s6IFwiXHUwNDFFXHUwNDFBXCIsXG4gICAgY2FuY2VsOiBcIlx1MDQxRVx1MDQ0Mlx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGNsb3NlOiBcIlx1MDQxN1x1MDQzMFx1MDQzQVx1MDQ0MFx1MDQ0Qlx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHNhdmU6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgbG9hZDogXCJcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBkZWxldGU6IFwiXHUwNDIzXHUwNDM0XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgZWRpdDogXCJcdTA0MThcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBzdGFydDogXCJcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0NDJcdTA0NENcIixcbiAgICBzdG9wOiBcIlx1MDQxN1x1MDQzMFx1MDQzQVx1MDQzRVx1MDQzRFx1MDQ0N1x1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHBhdXNlOiBcIlx1MDQxRlx1MDQ0MFx1MDQzOFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHJlc3VtZTogXCJcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzRcdTA0M0VcdTA0M0JcdTA0MzZcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICByZXNldDogXCJcdTA0MjFcdTA0MzFcdTA0NDBcdTA0M0VcdTA0NDFcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBzZXR0aW5nczogXCJcdTA0MURcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NDBcdTA0M0VcdTA0MzlcdTA0M0FcdTA0MzhcIixcbiAgICBoZWxwOiBcIlx1MDQxRlx1MDQzRVx1MDQzQ1x1MDQzRVx1MDQ0OVx1MDQ0Q1wiLFxuICAgIGFib3V0OiBcIlx1MDQxOFx1MDQzRFx1MDQ0NFx1MDQzRVx1MDQ0MFx1MDQzQ1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIGxhbmd1YWdlOiBcIlx1MDQyRlx1MDQzN1x1MDQ0Qlx1MDQzQVwiLFxuICAgIGxvYWRpbmc6IFwiXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgZXJyb3I6IFwiXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwXCIsXG4gICAgc3VjY2VzczogXCJcdTA0MjNcdTA0NDFcdTA0M0ZcdTA0MzVcdTA0NDVcIixcbiAgICB3YXJuaW5nOiBcIlx1MDQxRlx1MDQ0MFx1MDQzNVx1MDQzNFx1MDQ0M1x1MDQzRlx1MDQ0MFx1MDQzNVx1MDQzNlx1MDQzNFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNVwiLFxuICAgIGluZm86IFwiXHUwNDE4XHUwNDNEXHUwNDQ0XHUwNDNFXHUwNDQwXHUwNDNDXHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGXCIsXG4gICAgbGFuZ3VhZ2VDaGFuZ2VkOiBcIlx1MDQyRlx1MDQzN1x1MDQ0Qlx1MDQzQSBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0QgXHUwNDNEXHUwNDMwIHtsYW5ndWFnZX1cIlxuICB9LFxuXG4gIC8vIEd1YXJkIE1vZHVsZVxuICBndWFyZDoge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwXCIsXG4gICAgaW5pdEJvdDogXCJcdTA0MThcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzhcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0NEMgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJcdTA0MTJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiXHUwNDE3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDQzXCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0M1wiLFxuICAgIHVwcGVyTGVmdDogXCJcdTA0MTJcdTA0MzVcdTA0NDBcdTA0NDVcdTA0M0RcdTA0MzhcdTA0MzkgXHUwNDFCXHUwNDM1XHUwNDMyXHUwNDRCXHUwNDM5IFx1MDQyM1x1MDQzM1x1MDQzRVx1MDQzQlwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiXHUwNDFEXHUwNDM4XHUwNDM2XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQxRlx1MDQ0MFx1MDQzMFx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0MjNcdTA0MzNcdTA0M0VcdTA0M0JcIixcbiAgICBwcm90ZWN0ZWRQaXhlbHM6IFwiXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzOFwiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJcdTA0MUVcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0RcdTA0NEJcdTA0MzUgXHUwNDE4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiXHUwNDEyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzOFwiLFxuICAgIGNoYXJnZXM6IFwiXHUwNDE3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDRCXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOC4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAgXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1MDQyNlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzMCBcdTA0M0RcdTA0MzUgXHUwNDNEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDRCLiBcdTA0MUVcdTA0NDJcdTA0M0FcdTA0NDBcdTA0M0VcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDQzIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMiBcdTA0M0RcdTA0MzAgXHUwNDQxXHUwNDMwXHUwNDM5XHUwNDQyXHUwNDM1LlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTA0MURcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0M0Uge2NvdW50fSBcdTA0MzRcdTA0M0VcdTA0NDFcdTA0NDJcdTA0NDNcdTA0M0ZcdTA0M0RcdTA0NEJcdTA0NDUgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBcdTA0NDNcdTA0NDFcdTA0M0ZcdTA0MzVcdTA0NDhcdTA0M0RcdTA0M0UgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDM4IEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIFx1MDQxRFx1MDQzNVx1MDQzNFx1MDQzNVx1MDQzOVx1MDQ0MVx1MDQ0Mlx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0M0FcdTA0M0VcdTA0M0VcdTA0NDBcdTA0MzRcdTA0MzhcdTA0M0RcdTA0MzBcdTA0NDJcdTA0NEJcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzNFx1MDQzRVx1MDQzQlx1MDQzNlx1MDQzRFx1MDQzMCBcdTA0MzhcdTA0M0NcdTA0MzVcdTA0NDJcdTA0NEMgXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzQlx1MDQzNVx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0NDNcdTA0MzNcdTA0M0VcdTA0M0IgXHUwNDNDXHUwNDM1XHUwNDNEXHUwNDRDXHUwNDQ4XHUwNDM1IFx1MDQzRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzNVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDMwXCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQxXHUwNDNCXHUwNDM4XHUwNDQ4XHUwNDNBXHUwNDNFXHUwNDNDIFx1MDQzMVx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQ0OFx1MDQzMFx1MDQ0Rjoge3NpemV9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSAoXHUwNDNDXHUwNDMwXHUwNDNBXHUwNDQxXHUwNDM4XHUwNDNDXHUwNDQzXHUwNDNDOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBcdTA0MTdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDIgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4IFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0Qi4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0N1x1MDQzNVx1MDQzRFx1MDQzMDoge2NvdW50fSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDNGXHUwNDNFXHUwNDM0IFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzRVx1MDQzOVwiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzMCBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0Mzg6IHtlcnJvcn1cIixcbiAgICBjYXB0dXJlRmlyc3Q6IFwiXHUyNzRDIFx1MDQyMVx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQzQlx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0QlwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDMwIC0gXHUwNDNDXHUwNDNFXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDNFXHUwNDQwXHUwNDM4XHUwNDNEXHUwNDMzIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0MzAgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDlcdTA0MzVcdTA0M0RcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIC0gXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzRFx1MDQzNSBcdTA0M0VcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0VcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzRVx1MDQzMVx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0MzIgXHUwNDM3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDNFXHUwNDM5IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIHJlcGFpcmluZzogXCJcdUQ4M0RcdURFRTBcdUZFMEYgXHUwNDEyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1IHtjb3VudH0gXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOS4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgXHUwNDIzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSB7Y291bnR9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOVwiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDMyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGIFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOToge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgXHUwNDFEXHUwNDM1XHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQyXHUwNDNFXHUwNDQ3XHUwNDNEXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMiBcdTA0MzRcdTA0M0JcdTA0NEYgXHUwNDMyXHUwNDNFXHUwNDQxXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGIFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOVwiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwIFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0MzIgXHUwNDM3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDNFXHUwNDM5IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOC4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzggXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM5OiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIFx1MDQyMVx1MDQ0Mlx1MDQ0MFx1MDQzMFx1MDQzNiBcdTA0MzBcdTA0M0FcdTA0NDJcdTA0MzhcdTA0MzJcdTA0MzVcdTA0M0QgLSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDNGXHUwNDNFXHUwNDM0IFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzRVx1MDQzOVwiLFxuICAgIGxhc3RDaGVjazogXCJcdTA0MUZcdTA0M0VcdTA0NDFcdTA0M0JcdTA0MzVcdTA0MzRcdTA0M0RcdTA0NEZcdTA0NEYgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwOiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiXHUwNDIxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDQzXHUwNDRFXHUwNDQ5XHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0NDdcdTA0MzVcdTA0NDBcdTA0MzVcdTA0Mzc6IHt0aW1lfVx1MDQ0MVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzQ1x1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0N1x1MDQzNVx1MDQ0MVx1MDQzQVx1MDQzMFx1MDQ0RiBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEYuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDlcdTA0MzVcdTA0M0QgXHUwNDMwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDNDXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQ3XHUwNDM1XHUwNDQxXHUwNDNBXHUwNDM4XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1MDQxRFx1MDQzNSBcdTA0NDNcdTA0MzRcdTA0MzBcdTA0M0JcdTA0M0VcdTA0NDFcdTA0NEMgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzQ1x1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0N1x1MDQzNVx1MDQ0MVx1MDQzQVx1MDQzOC4gXHUwNDE4XHUwNDQxXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQ0MyBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBXHUwNDMwLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHUwNDIyXHUwNDQwXHUwNDM1XHUwNDMxXHUwNDQzXHUwNDM1XHUwNDQyXHUwNDQxXHUwNDRGIFx1MDQ0MFx1MDQ0M1x1MDQ0N1x1MDQzRFx1MDQzMFx1MDQ0RiBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEZcIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFx1MDQyNlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0MzAgXHUwNDNFXHUwNDMxXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTA0MUZcdTA0M0VcdTA0MzhcdTA0NDFcdTA0M0EgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXHUwNDNFXHUwNDM5IFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQ0Qi4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1MDQxRFx1MDQzMFx1MDQzNlx1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQzNSBcdTA0M0FcdTA0M0RcdTA0M0VcdTA0M0ZcdTA0M0FcdTA0MzggXHUwMEFCUGFpbnRcdTAwQkIuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTA0MUFcdTA0M0RcdTA0M0VcdTA0M0ZcdTA0M0FcdTA0MzAgXHUwMEFCUGFpbnRcdTAwQkIgXHUwNDNEXHUwNDM1IFx1MDQzRFx1MDQzMFx1MDQzOVx1MDQzNFx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDEyXHUwNDE1XHUwNDIwXHUwNDI1XHUwNDFEXHUwNDE1XHUwNDFDIFx1MDQxQlx1MDQxNVx1MDQxMlx1MDQxRVx1MDQxQyBcdTA0NDNcdTA0MzNcdTA0M0JcdTA0NDMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4IFx1MDQzNFx1MDQzQlx1MDQ0RiBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NEJcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBcdTA0MjJcdTA0MzVcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0NEMgXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzIgXHUwNDFEXHUwNDE4XHUwNDE2XHUwNDFEXHUwNDE1XHUwNDFDIFx1MDQxRlx1MDQyMFx1MDQxMFx1MDQxMlx1MDQxRVx1MDQxQyBcdTA0NDNcdTA0MzNcdTA0M0JcdTA0NDMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4XCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0MzJcdTA0MzVcdTA0NDBcdTA0NDVcdTA0M0RcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNCXHUwNDM1XHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQ0M1x1MDQzM1x1MDQzQlx1MDQzMC4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwIFx1MDQzRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzNVx1MDQzM1x1MDQzRSBcdTA0M0ZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDMwLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDQxMlx1MDQzNVx1MDQ0MFx1MDQ0NVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0JcdTA0MzVcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDQzXHUwNDMzXHUwNDNFXHUwNDNCIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0N1x1MDQzNVx1MDQzRDogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgXHUwNDFEXHUwNDM4XHUwNDM2XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQzRlx1MDQ0MFx1MDQzMFx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0NDNcdTA0MzNcdTA0M0VcdTA0M0IgXHUwNDM3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQ3XHUwNDM1XHUwNDNEOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgXHUwNDIyXHUwNDMwXHUwNDM5XHUwNDNDLVx1MDQzMFx1MDQ0M1x1MDQ0MiBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzBcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCwgXHUwNDNGXHUwNDNFXHUwNDM2XHUwNDMwXHUwNDNCXHUwNDQzXHUwNDM5XHUwNDQxXHUwNDQyXHUwNDMwLCBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDQxXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDMwXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgemhIYW5zID0ge1xuICAvLyBcdTU0MkZcdTUyQThcdTU2NjhcbiAgbGF1bmNoZXI6IHtcbiAgICB0aXRsZTogJ1dQbGFjZSBcdTgxRUFcdTUyQThcdTY3M0FcdTU2NjhcdTRFQkEnLFxuICAgIGF1dG9GYXJtOiAnXHVEODNDXHVERjNFIFx1ODFFQVx1NTJBOFx1NTE5Q1x1NTczQScsXG4gICAgYXV0b0ltYWdlOiAnXHVEODNDXHVERkE4IFx1ODFFQVx1NTJBOFx1N0VEOFx1NTZGRScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIFx1ODFFQVx1NTJBOFx1NUI4OFx1NjJBNCcsXG4gICAgc2VsZWN0aW9uOiAnXHU5MDA5XHU2MkU5JyxcbiAgICB1c2VyOiAnXHU3NTI4XHU2MjM3JyxcbiAgICBjaGFyZ2VzOiAnXHU2QjIxXHU2NTcwJyxcbiAgICBiYWNrZW5kOiAnXHU1NDBFXHU3QUVGJyxcbiAgICBkYXRhYmFzZTogJ1x1NjU3MFx1NjM2RVx1NUU5MycsXG4gICAgdXB0aW1lOiAnXHU4RkQwXHU4ODRDXHU2NUY2XHU5NUY0JyxcbiAgICBjbG9zZTogJ1x1NTE3M1x1OTVFRCcsXG4gICAgbGF1bmNoOiAnXHU1NDJGXHU1MkE4JyxcbiAgICBsb2FkaW5nOiAnXHU1MkEwXHU4RjdEXHU0RTJEXHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdcdTYyNjdcdTg4NENcdTRFMkRcdTIwMjYnLFxuICAgIGRvd25sb2FkaW5nOiAnXHU2QjYzXHU1NzI4XHU0RTBCXHU4RjdEXHU4MTFBXHU2NzJDXHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdcdTkwMDlcdTYyRTlcdTRFMDBcdTRFMkFcdTY3M0FcdTU2NjhcdTRFQkFcdTVFNzZcdTcwQjlcdTUxRkJcdTU0MkZcdTUyQTgnLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdcdTUxQzZcdTU5MDdcdTU0MkZcdTUyQTgnLFxuICAgIGxvYWRFcnJvcjogJ1x1NTJBMFx1OEY3RFx1OTUxOVx1OEJFRicsXG4gICAgbG9hZEVycm9yTXNnOiAnXHU2NUUwXHU2Q0Q1XHU1MkEwXHU4RjdEXHU2MjQwXHU5MDA5XHU2NzNBXHU1NjY4XHU0RUJBXHUzMDAyXHU4QkY3XHU2OEMwXHU2N0U1XHU3RjUxXHU3RURDXHU4RkRFXHU2M0E1XHU2MjE2XHU5MUNEXHU4QkQ1XHUzMDAyJyxcbiAgICBjaGVja2luZzogJ1x1RDgzRFx1REQwNCBcdTY4QzBcdTY3RTVcdTRFMkQuLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBcdTU3MjhcdTdFQkYnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgXHU3OUJCXHU3RUJGJyxcbiAgICBvazogJ1x1RDgzRFx1REZFMiBcdTZCNjNcdTVFMzgnLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IFx1OTUxOVx1OEJFRicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gXHU3RUQ4XHU1NkZFXHU2QTIxXHU1NzU3XG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1ODFFQVx1NTJBOFx1N0VEOFx1NTZGRVwiLFxuICAgIGluaXRCb3Q6IFwiXHU1MjFEXHU1OUNCXHU1MzE2XHU4MUVBXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBXCIsXG4gICAgdXBsb2FkSW1hZ2U6IFwiXHU0RTBBXHU0RjIwXHU1NkZFXHU3MjQ3XCIsXG4gICAgcmVzaXplSW1hZ2U6IFwiXHU4QzAzXHU2NTc0XHU1NkZFXHU3MjQ3XHU1OTI3XHU1QzBGXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHU5MDA5XHU2MkU5XHU0RjREXHU3RjZFXCIsXG4gICAgc3RhcnRQYWludGluZzogXCJcdTVGMDBcdTU5Q0JcdTdFRDhcdTUyMzZcIixcbiAgICBzdG9wUGFpbnRpbmc6IFwiXHU1MDVDXHU2QjYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgc2F2ZVByb2dyZXNzOiBcIlx1NEZERFx1NUI1OFx1OEZEQlx1NUVBNlwiLFxuICAgIGxvYWRQcm9ncmVzczogXCJcdTUyQTBcdThGN0RcdThGREJcdTVFQTZcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgXHU2OEMwXHU2N0U1XHU1M0VGXHU3NTI4XHU5ODlDXHU4MjcyLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHU4QkY3XHU1NzI4XHU3RjUxXHU3QUQ5XHU0RTBBXHU2MjUzXHU1RjAwXHU4QzAzXHU4MjcyXHU2NzdGXHU1NDBFXHU5MUNEXHU4QkQ1XHVGRjAxXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IFx1NjI3RVx1NTIzMCB7Y291bnR9IFx1NzlDRFx1NTNFRlx1NzUyOFx1OTg5Q1x1ODI3MlwiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgXHU2QjYzXHU1NzI4XHU1MkEwXHU4RjdEXHU1NkZFXHU3MjQ3Li4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IFx1NTZGRVx1NzI0N1x1NURGMlx1NTJBMFx1OEY3RFx1RkYwQ1x1NjcwOVx1NjU0OFx1NTBDRlx1N0QyMCB7Y291bnR9IFx1NEUyQVwiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIFx1NTZGRVx1NzI0N1x1NTJBMFx1OEY3RFx1NTkzMVx1OEQyNVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHU4QkY3XHU1NzI4XHU0RjYwXHU2MEYzXHU1RjAwXHU1OUNCXHU3RUQ4XHU1MjM2XHU3Njg0XHU1NzMwXHU2NUI5XHU2RDgyXHU3QjJDXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXHVGRjAxXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTRGNjBcdTZEODJcdTUzQzJcdTgwMDNcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHU0RjREXHU3RjZFXHU4QkJFXHU3RjZFXHU2MjEwXHU1MjlGXHVGRjAxXCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTRGNERcdTdGNkVcdTkwMDlcdTYyRTlcdThEODVcdTY1RjZcIixcbiAgICBwb3NpdGlvbkRldGVjdGVkOiBcIlx1RDgzQ1x1REZBRiBcdTVERjJcdTY4QzBcdTZENEJcdTUyMzBcdTRGNERcdTdGNkVcdUZGMENcdTU5MDRcdTc0MDZcdTRFMkQuLi5cIixcbiAgICBwb3NpdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTRGNERcdTdGNkVcdTY4QzBcdTZENEJcdTU5MzFcdThEMjVcdUZGMENcdThCRjdcdTkxQ0RcdThCRDVcIixcbiAgICBzdGFydFBhaW50aW5nTXNnOiBcIlx1RDgzQ1x1REZBOCBcdTVGMDBcdTU5Q0JcdTdFRDhcdTUyMzYuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBcdThGREJcdTVFQTY6IHtwYWludGVkfS97dG90YWx9IFx1NTBDRlx1N0QyMC4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgXHU2Q0ExXHU2NzA5XHU2QjIxXHU2NTcwXHUzMDAyXHU3QjQ5XHU1Rjg1IHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHU3NTI4XHU2MjM3XHU1REYyXHU1MDVDXHU2QjYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgcGFpbnRpbmdDb21wbGV0ZTogXCJcdTI3MDUgXHU3RUQ4XHU1MjM2XHU1QjhDXHU2MjEwXHVGRjAxXHU1MTcxXHU3RUQ4XHU1MjM2IHtjb3VudH0gXHU0RTJBXHU1MENGXHU3RDIwXHUzMDAyXCIsXG4gICAgcGFpbnRpbmdFcnJvcjogXCJcdTI3NEMgXHU3RUQ4XHU1MjM2XHU4RkM3XHU3QTBCXHU0RTJEXHU1MUZBXHU5NTE5XCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgXHU4QkY3XHU1MTQ4XHU1MkEwXHU4RjdEXHU1NkZFXHU3MjQ3XHU1RTc2XHU5MDA5XHU2MkU5XHU0RjREXHU3RjZFXCIsXG4gICAgcHJvZ3Jlc3M6IFwiXHU4RkRCXHU1RUE2XCIsXG4gICAgdXNlck5hbWU6IFwiXHU3NTI4XHU2MjM3XCIsXG4gICAgcGl4ZWxzOiBcIlx1NTBDRlx1N0QyMFwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTcwXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJcdTk4ODRcdThCQTFcdTY1RjZcdTk1RjRcIixcbiAgICBpbml0TWVzc2FnZTogXCJcdTcwQjlcdTUxRkJcdTIwMUNcdTUyMURcdTU5Q0JcdTUzMTZcdTgxRUFcdTUyQThcdTY3M0FcdTU2NjhcdTRFQkFcdTIwMURcdTVGMDBcdTU5Q0JcIixcbiAgICB3YWl0aW5nSW5pdDogXCJcdTdCNDlcdTVGODVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBcdTU2RkVcdTcyNDdcdTVERjJcdThDMDNcdTY1NzRcdTRFM0Ege3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBcdTdFRDhcdTUyMzZcdTY2ODJcdTUwNUNcdTRFOEVcdTRGNERcdTdGNkUgWDoge3h9LCBZOiB7eX1cIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTZCQ0ZcdTYyNzlcdTUwQ0ZcdTdEMjBcdTY1NzBcIixcbiAgICBiYXRjaFNpemU6IFwiXHU2Mjc5XHU2QjIxXHU1OTI3XHU1QzBGXCIsXG4gICAgbmV4dEJhdGNoVGltZTogXCJcdTRFMEJcdTZCMjFcdTYyNzlcdTZCMjFcdTY1RjZcdTk1RjRcIixcbiAgICB1c2VBbGxDaGFyZ2VzOiBcIlx1NEY3Rlx1NzUyOFx1NjI0MFx1NjcwOVx1NTNFRlx1NzUyOFx1NkIyMVx1NjU3MFwiLFxuICAgIHNob3dPdmVybGF5OiBcIlx1NjYzRVx1NzkzQVx1ODk4Nlx1NzZENlx1NUM0MlwiLFxuICAgIG1heENoYXJnZXM6IFwiXHU2QkNGXHU2Mjc5XHU2NzAwXHU1OTI3XHU2QjIxXHU2NTcwXCIsXG4gICAgd2FpdGluZ0ZvckNoYXJnZXM6IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3MDoge2N1cnJlbnR9L3tuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJcdTUyNjlcdTRGNTlcdTY1RjZcdTk1RjRcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIFx1N0I0OVx1NUY4NSB7dGltZX0gXHU1NDBFXHU3RUU3XHU3RUVELi4uXCIsXG4gICAgcHJvZ3Jlc3NTYXZlZDogXCJcdTI3MDUgXHU4RkRCXHU1RUE2XHU1REYyXHU0RkREXHU1QjU4XHU0RTNBIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgXHU1REYyXHU1MkEwXHU4RjdEXHU4RkRCXHU1RUE2OiB7cGFpbnRlZH0ve3RvdGFsfSBcdTUwQ0ZcdTdEMjBcdTVERjJcdTdFRDhcdTUyMzZcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgXHU1MkEwXHU4RjdEXHU4RkRCXHU1RUE2XHU1OTMxXHU4RDI1OiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIFx1NEZERFx1NUI1OFx1OEZEQlx1NUVBNlx1NTkzMVx1OEQyNToge2Vycm9yfVwiLFxuICAgIGNvbmZpcm1TYXZlUHJvZ3Jlc3M6IFwiXHU1NzI4XHU1MDVDXHU2QjYyXHU0RTRCXHU1MjREXHU4OTgxXHU0RkREXHU1QjU4XHU1RjUzXHU1MjREXHU4RkRCXHU1RUE2XHU1NDE3XHVGRjFGXCIsXG4gICAgc2F2ZVByb2dyZXNzVGl0bGU6IFwiXHU0RkREXHU1QjU4XHU4RkRCXHU1RUE2XCIsXG4gICAgZGlzY2FyZFByb2dyZXNzOiBcIlx1NjUzRVx1NUYwM1wiLFxuICAgIGNhbmNlbDogXCJcdTUzRDZcdTZEODhcIixcbiAgICBtaW5pbWl6ZTogXCJcdTY3MDBcdTVDMEZcdTUzMTZcIixcbiAgICB3aWR0aDogXCJcdTVCQkRcdTVFQTZcIixcbiAgICBoZWlnaHQ6IFwiXHU5QUQ4XHU1RUE2XCIsXG4gICAga2VlcEFzcGVjdDogXCJcdTRGRERcdTYzMDFcdTdFQjVcdTZBMkFcdTZCRDRcIixcbiAgICBhcHBseTogXCJcdTVFOTRcdTc1MjhcIixcbiAgICBvdmVybGF5T246IFwiXHU4OTg2XHU3NkQ2XHU1QzQyOiBcdTVGMDBcdTU0MkZcIixcbiAgICBvdmVybGF5T2ZmOiBcIlx1ODk4Nlx1NzZENlx1NUM0MjogXHU1MTczXHU5NUVEXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgXHU2Mjc5XHU2QjIxXHU1QjhDXHU2MjEwOiBcdTVERjJcdTdFRDhcdTUyMzYge3BhaW50ZWR9IFx1NTBDRlx1N0QyMCB8IFx1OEZEQlx1NUVBNjoge3BlcmNlbnR9JSAoe2N1cnJlbnR9L3t0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTcwXHU2MDYyXHU1OTBEOiB7Y3VycmVudH0ve25lZWRlZH0gLSBcdTY1RjZcdTk1RjQ6IHt0aW1lfVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzQ291bnRkb3duOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1NzA6IHtjdXJyZW50fS97bmVlZGVkfSAtIFx1NTI2OVx1NEY1OToge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgXHU2QjYzXHU1NzI4XHU4MUVBXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTgxRUFcdTUyQThcdTU0MkZcdTUyQThcdTYyMTBcdTUyOUZcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgXHU2NUUwXHU2Q0Q1XHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHVGRjBDXHU4QkY3XHU2MjRCXHU1MkE4XHU2NENEXHU0RjVDXHUzMDAyXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTVERjJcdTY4QzBcdTZENEJcdTUyMzBcdThDMDNcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjQxQ1x1N0QyMlx1OEMwM1x1ODI3Mlx1Njc3Ri4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1NkI2M1x1NTcyOFx1NzBCOVx1NTFGQlx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRS4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRVwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHU5NzAwXHU4OTgxXHU2MjRCXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2XCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBcdTkxQ0RcdThCRDUge2F0dGVtcHR9L3ttYXhBdHRlbXB0c31cdUZGMENcdTdCNDlcdTVGODUge2RlbGF5fSBcdTc5RDIuLi5cIixcbiAgICByZXRyeUVycm9yOiBcIlx1RDgzRFx1RENBNSBcdTdCMkMge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30gXHU2QjIxXHU1QzFEXHU4QkQ1XHU1MUZBXHU5NTE5XHVGRjBDXHU1QzA2XHU1NzI4IHtkZWxheX0gXHU3OUQyXHU1NDBFXHU5MUNEXHU4QkQ1Li4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIFx1OEQ4NVx1OEZDNyB7bWF4QXR0ZW1wdHN9IFx1NkIyMVx1NUMxRFx1OEJENVx1NTkzMVx1OEQyNVx1MzAwMlx1N0VFN1x1N0VFRFx1NEUwQlx1NEUwMFx1NjI3OS4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgXHU3RjUxXHU3RURDXHU5NTE5XHU4QkVGXHVGRjBDXHU2QjYzXHU1NzI4XHU5MUNEXHU4QkQ1Li4uXCIsXG4gICAgc2VydmVyRXJyb3I6IFwiXHVEODNEXHVERDI1IFx1NjcwRFx1NTJBMVx1NTY2OFx1OTUxOVx1OEJFRlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEJENS4uLlwiLFxuICAgIHRpbWVvdXRFcnJvcjogXCJcdTIzRjAgXHU2NzBEXHU1MkExXHU1NjY4XHU4RDg1XHU2NUY2XHVGRjBDXHU2QjYzXHU1NzI4XHU5MUNEXHU4QkQ1Li4uXCJcbiAgfSxcblxuICAvLyBcdTUxOUNcdTU3M0FcdTZBMjFcdTU3NTdcdUZGMDhcdTVGODVcdTVCOUVcdTczQjBcdUZGMDlcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTUxOUNcdTU3M0FcdTY3M0FcdTU2NjhcdTRFQkFcIixcbiAgICBzdGFydDogXCJcdTVGMDBcdTU5Q0JcIixcbiAgICBzdG9wOiBcIlx1NTA1Q1x1NkI2MlwiLFxuICAgIHN0b3BwZWQ6IFwiXHU2NzNBXHU1NjY4XHU0RUJBXHU1REYyXHU1MDVDXHU2QjYyXCIsXG4gICAgY2FsaWJyYXRlOiBcIlx1NjgyMVx1NTFDNlwiLFxuICAgIHBhaW50T25jZTogXCJcdTRFMDBcdTZCMjFcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJcdTY4QzBcdTY3RTVcdTcyQjZcdTYwMDFcdTRFMkQuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIlx1OTE0RFx1N0Y2RVwiLFxuICAgIGRlbGF5OiBcIlx1NUVGNlx1OEZERiAoXHU2QkVCXHU3OUQyKVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1NkJDRlx1NjI3OVx1NTBDRlx1N0QyMFwiLFxuICAgIG1pbkNoYXJnZXM6IFwiXHU2NzAwXHU1QzExXHU2QjIxXHU2NTcwXCIsXG4gICAgY29sb3JNb2RlOiBcIlx1OTg5Q1x1ODI3Mlx1NkEyMVx1NUYwRlwiLFxuICAgIHJhbmRvbTogXCJcdTk2OEZcdTY3M0FcIixcbiAgICBmaXhlZDogXCJcdTU2RkFcdTVCOUFcIixcbiAgICByYW5nZTogXCJcdTgzMDNcdTU2RjRcIixcbiAgICBmaXhlZENvbG9yOiBcIlx1NTZGQVx1NUI5QVx1OTg5Q1x1ODI3MlwiLFxuICAgIGFkdmFuY2VkOiBcIlx1OUFEOFx1N0VBN1wiLFxuICAgIHRpbGVYOiBcIlx1NzRFNlx1NzI0NyBYXCIsXG4gICAgdGlsZVk6IFwiXHU3NEU2XHU3MjQ3IFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlx1ODFFQVx1NUI5QVx1NEU0OVx1OEMwM1x1ODI3Mlx1Njc3RlwiLFxuICAgIHBhbGV0dGVFeGFtcGxlOiBcIlx1NEY4Qlx1NTk4MjogI0ZGMDAwMCwjMDBGRjAwLCMwMDAwRkZcIixcbiAgICBjYXB0dXJlOiBcIlx1NjM1NVx1ODNCN1wiLFxuICAgIHBhaW50ZWQ6IFwiXHU1REYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgY2hhcmdlczogXCJcdTZCMjFcdTY1NzBcIixcbiAgICByZXRyaWVzOiBcIlx1OTFDRFx1OEJENVwiLFxuICAgIHRpbGU6IFwiXHU3NEU2XHU3MjQ3XCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiXHU5MTREXHU3RjZFXHU1REYyXHU0RkREXHU1QjU4XCIsXG4gICAgY29uZmlnTG9hZGVkOiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1NTJBMFx1OEY3RFwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1OTFDRFx1N0Y2RVwiLFxuICAgIGNhcHR1cmVJbnN0cnVjdGlvbnM6IFwiXHU4QkY3XHU2MjRCXHU1MkE4XHU3RUQ4XHU1MjM2XHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXHU0RUU1XHU2MzU1XHU4M0I3XHU1NzUwXHU2ODA3Li4uXCIsXG4gICAgYmFja2VuZE9ubGluZTogXCJcdTU0MEVcdTdBRUZcdTU3MjhcdTdFQkZcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJcdTU0MEVcdTdBRUZcdTc5QkJcdTdFQkZcIixcbiAgICBzdGFydGluZ0JvdDogXCJcdTZCNjNcdTU3MjhcdTU0MkZcdTUyQThcdTY3M0FcdTU2NjhcdTRFQkEuLi5cIixcbiAgICBzdG9wcGluZ0JvdDogXCJcdTZCNjNcdTU3MjhcdTUwNUNcdTZCNjJcdTY3M0FcdTU2NjhcdTRFQkEuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJcdTY4MjFcdTUxQzZcdTRFMkQuLi5cIixcbiAgICBhbHJlYWR5UnVubmluZzogXCJcdTgxRUFcdTUyQThcdTUxOUNcdTU3M0FcdTVERjJcdTU3MjhcdThGRDBcdTg4NENcdTMwMDJcIixcbiAgICBpbWFnZVJ1bm5pbmdXYXJuaW5nOiBcIlx1ODFFQVx1NTJBOFx1N0VEOFx1NTZGRVx1NkI2M1x1NTcyOFx1OEZEMFx1ODg0Q1x1RkYwQ1x1OEJGN1x1NTE0OFx1NTE3M1x1OTVFRFx1NTE4RFx1NTQyRlx1NTJBOFx1ODFFQVx1NTJBOFx1NTE5Q1x1NTczQVx1MzAwMlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFx1NTcyOFx1NTczMFx1NTZGRVx1NzY4NFx1N0E3QVx1NzY3RFx1NTMzQVx1NTdERlx1NkQ4Mlx1NEUwMFx1NEUyQVx1NTBDRlx1N0QyMFx1NEVFNVx1OEJCRVx1N0Y2RVx1NTE5Q1x1NTczQVx1NTMzQVx1NTdERlwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU0RjYwXHU2RDgyXHU1M0MyXHU4MDAzXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1NTMzQVx1NTdERlx1OEJCRVx1N0Y2RVx1NjIxMFx1NTI5Rlx1RkYwMVx1NTM0QVx1NUY4NDogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1NTMzQVx1NTdERlx1OTAwOVx1NjJFOVx1OEQ4NVx1NjVGNlwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgXHU4QkY3XHU1MTQ4XHU5MDA5XHU2MkU5XHU1MzNBXHU1N0RGXHVGRjA4XHU0RjdGXHU3NTI4XHUyMDFDXHU5MDA5XHU2MkU5XHU1MzNBXHU1N0RGXHUyMDFEXHU2MzA5XHU5NEFFXHVGRjA5XCIsXG4gICAgZmFybVJhZGl1czogXCJcdTUxOUNcdTU3M0FcdTUzNEFcdTVGODRcIixcbiAgICBwb3NpdGlvbkluZm86IFwiXHU1RjUzXHU1MjREXHU1MzNBXHU1N0RGXCIsXG4gICAgZmFybWluZ0luUmFkaXVzOiBcIlx1RDgzQ1x1REYzRSBcdTZCNjNcdTU3MjhcdTRFRTVcdTUzNEFcdTVGODQge3JhZGl1c31weCBcdTU3MjggKHt4fSx7eX0pIFx1NTE5Q1x1NTczQVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgXHU5MUNEXHU4OTgxOiBcdThCRjdcdTkwMDlcdTYyRTlcdTdBN0FcdTc2N0RcdTUzM0FcdTU3REZcdTRFRTVcdTkwN0ZcdTUxNERcdTUxQjJcdTdBODFcIixcbiAgICBub1Bvc2l0aW9uOiBcIlx1NjcyQVx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlwiLFxuICAgIGN1cnJlbnRab25lOiBcIlx1NTMzQVx1NTdERjogKHt4fSx7eX0pXCIsXG4gICAgYXV0b1NlbGVjdFBvc2l0aW9uOiBcIlx1RDgzQ1x1REZBRiBcdThCRjdcdTUxNDhcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcdUZGMENcdTU3MjhcdTU3MzBcdTU2RkVcdTRFMEFcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcdTRFRTVcdThCQkVcdTdGNkVcdTUxOUNcdTU3M0FcdTUzM0FcdTU3REZcIlxuICB9LFxuXG4gIC8vIFx1NTE2Q1x1NTE3MVxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiXHU2NjJGXCIsXG4gICAgbm86IFwiXHU1NDI2XCIsXG4gICAgb2s6IFwiXHU3ODZFXHU4QkE0XCIsXG4gICAgY2FuY2VsOiBcIlx1NTNENlx1NkQ4OFwiLFxuICAgIGNsb3NlOiBcIlx1NTE3M1x1OTVFRFwiLFxuICAgIHNhdmU6IFwiXHU0RkREXHU1QjU4XCIsXG4gICAgbG9hZDogXCJcdTUyQTBcdThGN0RcIixcbiAgICBkZWxldGU6IFwiXHU1MjIwXHU5NjY0XCIsXG4gICAgZWRpdDogXCJcdTdGMTZcdThGOTFcIixcbiAgICBzdGFydDogXCJcdTVGMDBcdTU5Q0JcIixcbiAgICBzdG9wOiBcIlx1NTA1Q1x1NkI2MlwiLFxuICAgIHBhdXNlOiBcIlx1NjY4Mlx1NTA1Q1wiLFxuICAgIHJlc3VtZTogXCJcdTdFRTdcdTdFRURcIixcbiAgICByZXNldDogXCJcdTkxQ0RcdTdGNkVcIixcbiAgICBzZXR0aW5nczogXCJcdThCQkVcdTdGNkVcIixcbiAgICBoZWxwOiBcIlx1NUUyRVx1NTJBOVwiLFxuICAgIGFib3V0OiBcIlx1NTE3M1x1NEU4RVwiLFxuICAgIGxhbmd1YWdlOiBcIlx1OEJFRFx1OEEwMFwiLFxuICAgIGxvYWRpbmc6IFwiXHU1MkEwXHU4RjdEXHU0RTJELi4uXCIsXG4gICAgZXJyb3I6IFwiXHU5NTE5XHU4QkVGXCIsXG4gICAgc3VjY2VzczogXCJcdTYyMTBcdTUyOUZcIixcbiAgICB3YXJuaW5nOiBcIlx1OEI2Nlx1NTQ0QVwiLFxuICAgIGluZm86IFwiXHU0RkUxXHU2MDZGXCIsXG4gICAgbGFuZ3VhZ2VDaGFuZ2VkOiBcIlx1OEJFRFx1OEEwMFx1NURGMlx1NTIwN1x1NjM2Mlx1NEUzQSB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBcdTVCODhcdTYyQTRcdTZBMjFcdTU3NTdcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU4MUVBXHU1MkE4XHU1Qjg4XHU2MkE0XCIsXG4gICAgaW5pdEJvdDogXCJcdTUyMURcdTU5Q0JcdTUzMTZcdTVCODhcdTYyQTRcdTY3M0FcdTU2NjhcdTRFQkFcIixcbiAgICBzZWxlY3RBcmVhOiBcIlx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlwiLFxuICAgIGNhcHR1cmVBcmVhOiBcIlx1NjM1NVx1ODNCN1x1NTMzQVx1NTdERlwiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJcdTVGMDBcdTU5Q0JcdTVCODhcdTYyQTRcIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJcdTUwNUNcdTZCNjJcdTVCODhcdTYyQTRcIixcbiAgICB1cHBlckxlZnQ6IFwiXHU1REU2XHU0RTBBXHU4OUQyXCIsXG4gICAgbG93ZXJSaWdodDogXCJcdTUzRjNcdTRFMEJcdTg5RDJcIixcbiAgICBwcm90ZWN0ZWRQaXhlbHM6IFwiXHU1M0Q3XHU0RkREXHU2MkE0XHU1MENGXHU3RDIwXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIlx1NjhDMFx1NkQ0Qlx1NTIzMFx1NzY4NFx1NTNEOFx1NTMxNlwiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlx1NEZFRVx1NTkwRFx1NzY4NFx1NTBDRlx1N0QyMFwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTcwXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHU3QjQ5XHU1Rjg1XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNDXHVERkE4IFx1NjhDMFx1NjdFNVx1NTNFRlx1NzUyOFx1OTg5Q1x1ODI3Mi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1OTg5Q1x1ODI3Mlx1RkYwQ1x1OEJGN1x1NTcyOFx1N0Y1MVx1N0FEOVx1NEUwQVx1NjI1M1x1NUYwMFx1OEMwM1x1ODI3Mlx1Njc3Rlx1MzAwMlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTYyN0VcdTUyMzAge2NvdW50fSBcdTc5Q0RcdTUzRUZcdTc1MjhcdTk4OUNcdTgyNzJcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgXHU1Qjg4XHU2MkE0XHU2NzNBXHU1NjY4XHU0RUJBXHU1MjFEXHU1OUNCXHU1MzE2XHU2MjEwXHU1MjlGXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBcdTVCODhcdTYyQTRcdTY3M0FcdTU2NjhcdTRFQkFcdTUyMURcdTU5Q0JcdTUzMTZcdTU5MzFcdThEMjVcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBcdTU3NTBcdTY4MDdcdTY1RTBcdTY1NDhcIixcbiAgICBpbnZhbGlkQXJlYTogXCJcdTI3NEMgXHU1MzNBXHU1N0RGXHU2NUUwXHU2NTQ4XHVGRjBDXHU1REU2XHU0RTBBXHU4OUQyXHU1RkM1XHU5ODdCXHU1QzBGXHU0RThFXHU1M0YzXHU0RTBCXHU4OUQyXCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBcdTUzM0FcdTU3REZcdThGQzdcdTU5Mjc6IHtzaXplfSBcdTUwQ0ZcdTdEMjAgKFx1NjcwMFx1NTkyNzoge21heH0pXCIsXG4gICAgY2FwdHVyaW5nQXJlYTogXCJcdUQ4M0RcdURDRjggXHU2MzU1XHU4M0I3XHU1Qjg4XHU2MkE0XHU1MzNBXHU1N0RGXHU0RTJELi4uXCIsXG4gICAgYXJlYUNhcHR1cmVkOiBcIlx1MjcwNSBcdTUzM0FcdTU3REZcdTYzNTVcdTgzQjdcdTYyMTBcdTUyOUY6IHtjb3VudH0gXHU1MENGXHU3RDIwXHU1M0Q3XHU0RkREXHU2MkE0XCIsXG4gICAgY2FwdHVyZUVycm9yOiBcIlx1Mjc0QyBcdTYzNTVcdTgzQjdcdTUzM0FcdTU3REZcdTUxRkFcdTk1MTk6IHtlcnJvcn1cIixcbiAgICBjYXB0dXJlRmlyc3Q6IFwiXHUyNzRDIFx1OEJGN1x1NTE0OFx1NjM1NVx1ODNCN1x1NEUwMFx1NEUyQVx1NUI4OFx1NjJBNFx1NTMzQVx1NTdERlwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTVCODhcdTYyQTRcdTVERjJcdTU0MkZcdTUyQTggLSBcdTUzM0FcdTU3REZcdTc2RDFcdTYzQTdcdTRFMkRcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHU1Qjg4XHU2MkE0XHU1REYyXHU1MDVDXHU2QjYyXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBcdTUzM0FcdTU3REZcdTVCODlcdTUxNjggLSBcdTY3MkFcdTY4QzBcdTZENEJcdTUyMzBcdTUzRDhcdTUzMTZcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IFx1NjhDMFx1NkQ0Qlx1NTIzMCB7Y291bnR9IFx1NEUyQVx1NTNEOFx1NTMxNlwiLFxuICAgIHJlcGFpcmluZzogXCJcdUQ4M0RcdURFRTBcdUZFMEYgXHU2QjYzXHU1NzI4XHU0RkVFXHU1OTBEIHtjb3VudH0gXHU0RTJBXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcmVwYWlyZWRTdWNjZXNzOiBcIlx1MjcwNSBcdTVERjJcdTYyMTBcdTUyOUZcdTRGRUVcdTU5MEQge2NvdW50fSBcdTRFMkFcdTUwQ0ZcdTdEMjBcIixcbiAgICByZXBhaXJFcnJvcjogXCJcdTI3NEMgXHU0RkVFXHU1OTBEXHU1MUZBXHU5NTE5OiB7ZXJyb3J9XCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjZBMFx1RkUwRiBcdTZCMjFcdTY1NzBcdTRFMERcdThEQjNcdUZGMENcdTY1RTBcdTZDRDVcdTRGRUVcdTU5MERcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjhDMFx1NjdFNVx1NTMzQVx1NTdERlx1NTNEOFx1NTMxNi4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIFx1NjhDMFx1NjdFNVx1NTFGQVx1OTUxOToge2Vycm9yfVwiLFxuICAgIGd1YXJkQWN0aXZlOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTVCODhcdTYyQTRcdTRFMkQgLSBcdTUzM0FcdTU3REZcdTUzRDdcdTRGRERcdTYyQTRcIixcbiAgICBsYXN0Q2hlY2s6IFwiXHU0RTBBXHU2QjIxXHU2OEMwXHU2N0U1OiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiXHU0RTBCXHU2QjIxXHU2OEMwXHU2N0U1OiB7dGltZX0gXHU3OUQyXHU1NDBFXCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgXHU2QjYzXHU1NzI4XHU4MUVBXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTgxRUFcdTUyQThcdTU0MkZcdTUyQThcdTYyMTBcdTUyOUZcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgXHU2NUUwXHU2Q0Q1XHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHVGRjBDXHU4QkY3XHU2MjRCXHU1MkE4XHU2NENEXHU0RjVDXHUzMDAyXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBcdTk3MDBcdTg5ODFcdTYyNEJcdTUyQThcdTUyMURcdTU5Q0JcdTUzMTZcIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFx1NURGMlx1NjhDMFx1NkQ0Qlx1NTIzMFx1OEMwM1x1ODI3Mlx1Njc3RlwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHU2QjYzXHU1NzI4XHU2NDFDXHU3RDIyXHU4QzAzXHU4MjcyXHU2NzdGLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgXHU2QjYzXHU1NzI4XHU3MEI5XHU1MUZCXHU3RUQ4XHU1MjM2XHU2MzA5XHU5NEFFLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHU2NzJBXHU2MjdFXHU1MjMwXHU3RUQ4XHU1MjM2XHU2MzA5XHU5NEFFXCIsXG4gICAgc2VsZWN0VXBwZXJMZWZ0OiBcIlx1RDgzQ1x1REZBRiBcdTU3MjhcdTk3MDBcdTg5ODFcdTRGRERcdTYyQTRcdTUzM0FcdTU3REZcdTc2ODRcdTVERTZcdTRFMEFcdTg5RDJcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBcdTczQjBcdTU3MjhcdTU3MjhcdTUzRjNcdTRFMEJcdTg5RDJcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcIixcbiAgICB3YWl0aW5nVXBwZXJMZWZ0OiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTkwMDlcdTYyRTlcdTVERTZcdTRFMEFcdTg5RDIuLi5cIixcbiAgICB3YWl0aW5nTG93ZXJSaWdodDogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU5MDA5XHU2MkU5XHU1M0YzXHU0RTBCXHU4OUQyLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1NURGMlx1NjM1NVx1ODNCN1x1NURFNlx1NEUwQVx1ODlEMjogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgXHU1REYyXHU2MzU1XHU4M0I3XHU1M0YzXHU0RTBCXHU4OUQyOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgXHU5MDA5XHU2MkU5XHU4RDg1XHU2NUY2XCIsXG4gICAgc2VsZWN0aW9uRXJyb3I6IFwiXHUyNzRDIFx1OTAwOVx1NjJFOVx1NTFGQVx1OTUxOVx1RkYwQ1x1OEJGN1x1OTFDRFx1OEJENVwiXG4gIH1cbn07XG4iLCAiZXhwb3J0IGNvbnN0IHpoSGFudCA9IHtcbiAgLy8gXHU1NTUzXHU1MkQ1XHU1NjY4XG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgXHU4MUVBXHU1MkQ1XHU2QTVGXHU1NjY4XHU0RUJBJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBcdTgxRUFcdTUyRDVcdThGQjJcdTU4MzQnLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBcdTgxRUFcdTUyRDVcdTdFNkFcdTU3MTYnLFxuICAgIGF1dG9HdWFyZDogJ1x1RDgzRFx1REVFMVx1RkUwRiBcdTgxRUFcdTUyRDVcdTVCODhcdThCNzcnLFxuICAgIHNlbGVjdGlvbjogJ1x1OTA3OFx1NjRDNycsXG4gICAgdXNlcjogJ1x1NzUyOFx1NjIzNycsXG4gICAgY2hhcmdlczogJ1x1NkIyMVx1NjU3OCcsXG4gICAgYmFja2VuZDogJ1x1NUY4Q1x1N0FFRicsXG4gICAgZGF0YWJhc2U6ICdcdTY1NzhcdTY0REFcdTVFQUInLFxuICAgIHVwdGltZTogJ1x1OTA0Qlx1ODg0Q1x1NjY0Mlx1OTU5MycsXG4gICAgY2xvc2U6ICdcdTk1RENcdTk1ODknLFxuICAgIGxhdW5jaDogJ1x1NTU1M1x1NTJENScsXG4gICAgbG9hZGluZzogJ1x1NTJBMFx1OEYwOVx1NEUyRFx1MjAyNicsXG4gICAgZXhlY3V0aW5nOiAnXHU1N0Y3XHU4ODRDXHU0RTJEXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ1x1NkI2M1x1NTcyOFx1NEUwQlx1OEYwOVx1ODE3M1x1NjcyQ1x1MjAyNicsXG4gICAgY2hvb3NlQm90OiAnXHU5MDc4XHU2NEM3XHU0RTAwXHU1MDBCXHU2QTVGXHU1NjY4XHU0RUJBXHU0RTI2XHU5RURFXHU2NENBXHU1NTUzXHU1MkQ1JyxcbiAgICByZWFkeVRvTGF1bmNoOiAnXHU2RTk2XHU1MDk5XHU1NTUzXHU1MkQ1JyxcbiAgICBsb2FkRXJyb3I6ICdcdTUyQTBcdThGMDlcdTkzMkZcdThBQTQnLFxuICAgIGxvYWRFcnJvck1zZzogJ1x1NzEyMVx1NkNENVx1NTJBMFx1OEYwOVx1NjI0MFx1OTA3OFx1NkE1Rlx1NTY2OFx1NEVCQVx1MzAwMlx1OEFDQlx1NkFBMlx1NjdFNVx1N0RCMlx1N0Q2MVx1OTAyM1x1NjNBNVx1NjIxNlx1OTFDRFx1OEE2Nlx1MzAwMicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgXHU2QUEyXHU2N0U1XHU0RTJELi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgXHU1NzI4XHU3RERBJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IFx1OTZFMlx1N0REQScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgXHU2QjYzXHU1RTM4JyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBcdTkzMkZcdThBQTQnLFxuICAgIHVua25vd246ICctJ1xuICB9LFxuXG4gIC8vIFx1N0U2QVx1NTcxNlx1NkEyMVx1NTg0QVxuICBpbWFnZToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTgxRUFcdTUyRDVcdTdFNkFcdTU3MTZcIixcbiAgICBpbml0Qm90OiBcIlx1NTIxRFx1NTlDQlx1NTMxNlx1ODFFQVx1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQVwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlx1NEUwQVx1NTBCM1x1NTcxNlx1NzI0N1wiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlx1OEFCRlx1NjU3NFx1NTcxNlx1NzI0N1x1NTkyN1x1NUMwRlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1OTA3OFx1NjRDN1x1NEY0RFx1N0Y2RVwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiXHU5NThCXHU1OUNCXHU3RTZBXHU4OEZEXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlx1NTA1Q1x1NkI2Mlx1N0U2QVx1ODhGRFwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJcdTRGRERcdTVCNThcdTkwMzJcdTVFQTZcIixcbiAgICBsb2FkUHJvZ3Jlc3M6IFwiXHU1MkEwXHU4RjA5XHU5MDMyXHU1RUE2XCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIFx1NkFBMlx1NjdFNVx1NTNFRlx1NzUyOFx1OTg0Rlx1ODI3Mi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1OEFDQlx1NTcyOFx1N0RCMlx1N0FEOVx1NEUwQVx1NjI1M1x1OTU4Qlx1OEFCRlx1ODI3Mlx1Njc3Rlx1NUY4Q1x1OTFDRFx1OEE2Nlx1RkYwMVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTYyN0VcdTUyMzAge2NvdW50fSBcdTdBMkVcdTUzRUZcdTc1MjhcdTk4NEZcdTgyNzJcIixcbiAgICBsb2FkaW5nSW1hZ2U6IFwiXHVEODNEXHVEREJDXHVGRTBGIFx1NkI2M1x1NTcyOFx1NTJBMFx1OEYwOVx1NTcxNlx1NzI0Ny4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBcdTU3MTZcdTcyNDdcdTVERjJcdTUyQTBcdThGMDlcdUZGMENcdTY3MDlcdTY1NDhcdTUwQ0ZcdTdEMjAge2NvdW50fSBcdTUwMEJcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBcdTU3MTZcdTcyNDdcdTUyQTBcdThGMDlcdTU5MzFcdTY1NTdcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1OEFDQlx1NTcyOFx1NEY2MFx1NjBGM1x1OTU4Qlx1NTlDQlx1N0U2QVx1ODhGRFx1NzY4NFx1NTczMFx1NjVCOVx1NTg1N1x1N0IyQ1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFx1RkYwMVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU0RjYwXHU1ODU3XHU1M0MzXHU4MDAzXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1NEY0RFx1N0Y2RVx1OEEyRFx1N0Y2RVx1NjIxMFx1NTI5Rlx1RkYwMVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU5MDc4XHU2NEM3XHU4RDg1XHU2NjQyXCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgXHU1REYyXHU2QUEyXHU2RTJDXHU1MjMwXHU0RjREXHU3RjZFXHVGRjBDXHU4NjU1XHU3NDA2XHU0RTJELi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU2QUEyXHU2RTJDXHU1OTMxXHU2NTU3XHVGRjBDXHU4QUNCXHU5MUNEXHU4QTY2XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggXHU5NThCXHU1OUNCXHU3RTZBXHU4OEZELi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgXHU5MDMyXHU1RUE2OiB7cGFpbnRlZH0ve3RvdGFsfSBcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyMzFCIFx1NkM5Mlx1NjcwOVx1NkIyMVx1NjU3OFx1MzAwMlx1N0I0OVx1NUY4NSB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NzUyOFx1NjIzN1x1NURGMlx1NTA1Q1x1NkI2Mlx1N0U2QVx1ODhGRFwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1N0U2QVx1ODhGRFx1NUI4Q1x1NjIxMFx1RkYwMVx1NTE3MVx1N0U2QVx1ODhGRCB7Y291bnR9IFx1NTAwQlx1NTBDRlx1N0QyMFx1MzAwMlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIFx1N0U2QVx1ODhGRFx1OTA0RVx1N0EwQlx1NEUyRFx1NTFGQVx1OTMyRlwiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIFx1OEFDQlx1NTE0OFx1NTJBMFx1OEYwOVx1NTcxNlx1NzI0N1x1NEUyNlx1OTA3OFx1NjRDN1x1NEY0RFx1N0Y2RVwiLFxuICAgIHByb2dyZXNzOiBcIlx1OTAzMlx1NUVBNlwiLFxuICAgIHVzZXJOYW1lOiBcIlx1NzUyOFx1NjIzN1wiLFxuICAgIHBpeGVsczogXCJcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3OFwiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiXHU5ODEwXHU4QTA4XHU2NjQyXHU5NTkzXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiXHU5RURFXHU2NENBXHUyMDFDXHU1MjFEXHU1OUNCXHU1MzE2XHU4MUVBXHU1MkQ1XHU2QTVGXHU1NjY4XHU0RUJBXHUyMDFEXHU5NThCXHU1OUNCXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHU3QjQ5XHU1Rjg1XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgXHU1NzE2XHU3MjQ3XHU1REYyXHU4QUJGXHU2NTc0XHU3MEJBIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgXHU3RTZBXHU4OEZEXHU2NkFCXHU1MDVDXHU2NUJDXHU0RjREXHU3RjZFIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHU2QkNGXHU2Mjc5XHU1MENGXHU3RDIwXHU2NTc4XCIsXG4gICAgYmF0Y2hTaXplOiBcIlx1NjI3OVx1NkIyMVx1NTkyN1x1NUMwRlwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiXHU0RTBCXHU2QjIxXHU2Mjc5XHU2QjIxXHU2NjQyXHU5NTkzXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJcdTRGN0ZcdTc1MjhcdTYyNDBcdTY3MDlcdTUzRUZcdTc1MjhcdTZCMjFcdTY1NzhcIixcbiAgICBzaG93T3ZlcmxheTogXCJcdTk4NkZcdTc5M0FcdTg5ODZcdTg0Q0JcdTVDNjRcIixcbiAgICBtYXhDaGFyZ2VzOiBcIlx1NkJDRlx1NjI3OVx1NjcwMFx1NTkyN1x1NkIyMVx1NjU3OFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1Nzg6IHtjdXJyZW50fS97bmVlZGVkfVwiLFxuICAgIHRpbWVSZW1haW5pbmc6IFwiXHU1MjY5XHU5OTE4XHU2NjQyXHU5NTkzXCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBcdTdCNDlcdTVGODUge3RpbWV9IFx1NUY4Q1x1N0U3Q1x1N0U4Qy4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFx1OTAzMlx1NUVBNlx1NURGMlx1NEZERFx1NUI1OFx1NzBCQSB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFx1NURGMlx1NTJBMFx1OEYwOVx1OTAzMlx1NUVBNjoge3BhaW50ZWR9L3t0b3RhbH0gXHU1MENGXHU3RDIwXHU1REYyXHU3RTZBXHU4OEZEXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIFx1NTJBMFx1OEYwOVx1OTAzMlx1NUVBNlx1NTkzMVx1NjU1Nzoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBcdTRGRERcdTVCNThcdTkwMzJcdTVFQTZcdTU5MzFcdTY1NTc6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1NTcyOFx1NTA1Q1x1NkI2Mlx1NEU0Qlx1NTI0RFx1ODk4MVx1NEZERFx1NUI1OFx1NzU3Nlx1NTI0RFx1OTAzMlx1NUVBNlx1NTVDRVx1RkYxRlwiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlx1NEZERFx1NUI1OFx1OTAzMlx1NUVBNlwiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJcdTY1M0VcdTY4QzRcIixcbiAgICBjYW5jZWw6IFwiXHU1M0Q2XHU2RDg4XCIsXG4gICAgbWluaW1pemU6IFwiXHU2NzAwXHU1QzBGXHU1MzE2XCIsXG4gICAgd2lkdGg6IFwiXHU1QkVDXHU1RUE2XCIsXG4gICAgaGVpZ2h0OiBcIlx1OUFEOFx1NUVBNlwiLFxuICAgIGtlZXBBc3BlY3Q6IFwiXHU0RkREXHU2MzAxXHU3RTMxXHU2QTZCXHU2QkQ0XCIsXG4gICAgYXBwbHk6IFwiXHU2MUM5XHU3NTI4XCIsXG4gICAgb3ZlcmxheU9uOiBcIlx1ODk4Nlx1ODRDQlx1NUM2NDogXHU5NThCXHU1NTUzXCIsXG4gICAgb3ZlcmxheU9mZjogXCJcdTg5ODZcdTg0Q0JcdTVDNjQ6IFx1OTVEQ1x1OTU4OVwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFx1NjI3OVx1NkIyMVx1NUI4Q1x1NjIxMDogXHU1REYyXHU3RTZBXHU4OEZEIHtwYWludGVkfSBcdTUwQ0ZcdTdEMjAgfCBcdTkwMzJcdTVFQTY6IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3OFx1NjA2Mlx1NUZBOToge2N1cnJlbnR9L3tuZWVkZWR9IC0gXHU2NjQyXHU5NTkzOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTc4OiB7Y3VycmVudH0ve25lZWRlZH0gLSBcdTUyNjlcdTk5MTg6IHt0aW1lfVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkQ1XHU1NTUzXHU1MkQ1XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NzEyMVx1NkNENVx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1RkYwQ1x1OEFDQlx1NjI0Qlx1NTJENVx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHU1REYyXHU2QUEyXHU2RTJDXHU1MjMwXHU4QUJGXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY0MUNcdTdEMjJcdThBQkZcdTgyNzJcdTY3N0YuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTZCNjNcdTU3MjhcdTlFREVcdTY0Q0FcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTUuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTVcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1OTcwMFx1ODk4MVx1NjI0Qlx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNlwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgXHU5MUNEXHU4QTY2IHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9XHVGRjBDXHU3QjQ5XHU1Rjg1IHtkZWxheX0gXHU3OUQyLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgXHU3QjJDIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IFx1NkIyMVx1NTYxN1x1OEE2Nlx1NTFGQVx1OTMyRlx1RkYwQ1x1NUMwN1x1NTcyOCB7ZGVsYXl9IFx1NzlEMlx1NUY4Q1x1OTFDRFx1OEE2Ni4uLlwiLFxuICAgIHJldHJ5RmFpbGVkOiBcIlx1Mjc0QyBcdThEODVcdTkwNEUge21heEF0dGVtcHRzfSBcdTZCMjFcdTU2MTdcdThBNjZcdTU5MzFcdTY1NTdcdTMwMDJcdTdFN0NcdTdFOENcdTRFMEJcdTRFMDBcdTYyNzkuLi5cIixcbiAgICBuZXR3b3JrRXJyb3I6IFwiXHVEODNDXHVERjEwIFx1N0RCMlx1N0Q2MVx1OTMyRlx1OEFBNFx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEE2Ni4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBcdTY3MERcdTUyRDlcdTU2NjhcdTkzMkZcdThBQTRcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThBNjYuLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFx1NjcwRFx1NTJEOVx1NTY2OFx1OEQ4NVx1NjY0Mlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEE2Ni4uLlwiXG4gIH0sXG5cbiAgLy8gXHU4RkIyXHU1ODM0XHU2QTIxXHU1ODRBXHVGRjA4XHU1Rjg1XHU1QkU2XHU3M0ZFXHVGRjA5XG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU4RkIyXHU1ODM0XHU2QTVGXHU1NjY4XHU0RUJBXCIsXG4gICAgc3RhcnQ6IFwiXHU5NThCXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBzdG9wcGVkOiBcIlx1NkE1Rlx1NTY2OFx1NEVCQVx1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIGNhbGlicmF0ZTogXCJcdTY4MjFcdTZFOTZcIixcbiAgICBwYWludE9uY2U6IFwiXHU0RTAwXHU2QjIxXCIsXG4gICAgY2hlY2tpbmdTdGF0dXM6IFwiXHU2QUEyXHU2N0U1XHU3MkMwXHU2MTRCXHU0RTJELi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJcdTkxNERcdTdGNkVcIixcbiAgICBkZWxheTogXCJcdTVFRjZcdTkwNzIgKFx1NkJFQlx1NzlEMilcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTZCQ0ZcdTYyNzlcdTUwQ0ZcdTdEMjBcIixcbiAgICBtaW5DaGFyZ2VzOiBcIlx1NjcwMFx1NUMxMVx1NkIyMVx1NjU3OFwiLFxuICAgIGNvbG9yTW9kZTogXCJcdTk4NEZcdTgyNzJcdTZBMjFcdTVGMEZcIixcbiAgICByYW5kb206IFwiXHU5NkE4XHU2QTVGXCIsXG4gICAgZml4ZWQ6IFwiXHU1NkZBXHU1QjlBXCIsXG4gICAgcmFuZ2U6IFwiXHU3QkM0XHU1NzBEXCIsXG4gICAgZml4ZWRDb2xvcjogXCJcdTU2RkFcdTVCOUFcdTk4NEZcdTgyNzJcIixcbiAgICBhZHZhbmNlZDogXCJcdTlBRDhcdTdEMUFcIixcbiAgICB0aWxlWDogXCJcdTc0RTZcdTcyNDcgWFwiLFxuICAgIHRpbGVZOiBcIlx1NzRFNlx1NzI0NyBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJcdTgxRUFcdTVCOUFcdTdGQTlcdThBQkZcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJcdTRGOEJcdTU5ODI6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJcdTYzNTVcdTczNzJcIixcbiAgICBwYWludGVkOiBcIlx1NURGMlx1N0U2QVx1ODhGRFwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTc4XCIsXG4gICAgcmV0cmllczogXCJcdTkxQ0RcdThBNjZcIixcbiAgICB0aWxlOiBcIlx1NzRFNlx1NzI0N1wiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1NEZERFx1NUI1OFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTUyQTBcdThGMDlcIixcbiAgICBjb25maWdSZXNldDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTkxQ0RcdTdGNkVcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlx1OEFDQlx1NjI0Qlx1NTJENVx1N0U2QVx1ODhGRFx1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFx1NEVFNVx1NjM1NVx1NzM3Mlx1NUVBN1x1NkExOS4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiXHU1RjhDXHU3QUVGXHU1NzI4XHU3RERBXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiXHU1RjhDXHU3QUVGXHU5NkUyXHU3RERBXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1NTUzXHU1MkQ1XHU2QTVGXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1MDVDXHU2QjYyXHU2QTVGXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiXHU2ODIxXHU2RTk2XHU0RTJELi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiXHU4MUVBXHU1MkQ1XHU4RkIyXHU1ODM0XHU1REYyXHU1NzI4XHU5MDRCXHU4ODRDXHUzMDAyXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJcdTgxRUFcdTUyRDVcdTdFNkFcdTU3MTZcdTZCNjNcdTU3MjhcdTkwNEJcdTg4NENcdUZGMENcdThBQ0JcdTUxNDhcdTk1RENcdTk1ODlcdTUxOERcdTU1NTNcdTUyRDVcdTgxRUFcdTUyRDVcdThGQjJcdTU4MzRcdTMwMDJcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1RDgzQ1x1REZBRiBcdTU3MjhcdTU3MzBcdTU3MTZcdTc2ODRcdTdBN0FcdTc2N0RcdTUzNDBcdTU3REZcdTU4NTdcdTRFMDBcdTUwMEJcdTUwQ0ZcdTdEMjBcdTRFRTVcdThBMkRcdTdGNkVcdThGQjJcdTU4MzRcdTUzNDBcdTU3REZcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1NEY2MFx1NTg1N1x1NTNDM1x1ODAwM1x1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTUzNDBcdTU3REZcdThBMkRcdTdGNkVcdTYyMTBcdTUyOUZcdUZGMDFcdTUzNEFcdTVGOTE6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTUzNDBcdTU3REZcdTkwNzhcdTY0QzdcdThEODVcdTY2NDJcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFx1OEFDQlx1NTE0OFx1OTA3OFx1NjRDN1x1NTM0MFx1NTdERlx1RkYwOFx1NEY3Rlx1NzUyOFx1MjAxQ1x1OTA3OFx1NjRDN1x1NTM0MFx1NTdERlx1MjAxRFx1NjMwOVx1OTIxNVx1RkYwOVwiLFxuICAgIGZhcm1SYWRpdXM6IFwiXHU4RkIyXHU1ODM0XHU1MzRBXHU1RjkxXCIsXG4gICAgcG9zaXRpb25JbmZvOiBcIlx1NzU3Nlx1NTI0RFx1NTM0MFx1NTdERlwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgXHU2QjYzXHU1NzI4XHU0RUU1XHU1MzRBXHU1RjkxIHtyYWRpdXN9cHggXHU1NzI4ICh7eH0se3l9KSBcdThGQjJcdTU4MzRcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIFx1OTFDRFx1ODk4MTogXHU4QUNCXHU5MDc4XHU2NEM3XHU3QTdBXHU3NjdEXHU1MzQwXHU1N0RGXHU0RUU1XHU5MDdGXHU1MTREXHU4ODVEXHU3QTgxXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJcdTY3MkFcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcIixcbiAgICBjdXJyZW50Wm9uZTogXCJcdTUzNDBcdTU3REY6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgXHU4QUNCXHU1MTQ4XHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXHVGRjBDXHU1NzI4XHU1NzMwXHU1NzE2XHU0RTBBXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXHU0RUU1XHU4QTJEXHU3RjZFXHU4RkIyXHU1ODM0XHU1MzQwXHU1N0RGXCJcbiAgfSxcblxuICAvLyBcdTUxNkNcdTUxNzFcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIlx1NjYyRlwiLFxuICAgIG5vOiBcIlx1NTQyNlwiLFxuICAgIG9rOiBcIlx1NzhCQVx1OEE4RFwiLFxuICAgIGNhbmNlbDogXCJcdTUzRDZcdTZEODhcIixcbiAgICBjbG9zZTogXCJcdTk1RENcdTk1ODlcIixcbiAgICBzYXZlOiBcIlx1NEZERFx1NUI1OFwiLFxuICAgIGxvYWQ6IFwiXHU1MkEwXHU4RjA5XCIsXG4gICAgZGVsZXRlOiBcIlx1NTIyQVx1OTY2NFwiLFxuICAgIGVkaXQ6IFwiXHU3REU4XHU4RjJGXCIsXG4gICAgc3RhcnQ6IFwiXHU5NThCXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBwYXVzZTogXCJcdTY2QUJcdTUwNUNcIixcbiAgICByZXN1bWU6IFwiXHU3RTdDXHU3RThDXCIsXG4gICAgcmVzZXQ6IFwiXHU5MUNEXHU3RjZFXCIsXG4gICAgc2V0dGluZ3M6IFwiXHU4QTJEXHU3RjZFXCIsXG4gICAgaGVscDogXCJcdTVFNkJcdTUyQTlcIixcbiAgICBhYm91dDogXCJcdTk1RENcdTY1QkNcIixcbiAgICBsYW5ndWFnZTogXCJcdThBOUVcdThBMDBcIixcbiAgICBsb2FkaW5nOiBcIlx1NTJBMFx1OEYwOVx1NEUyRC4uLlwiLFxuICAgIGVycm9yOiBcIlx1OTMyRlx1OEFBNFwiLFxuICAgIHN1Y2Nlc3M6IFwiXHU2MjEwXHU1MjlGXCIsXG4gICAgd2FybmluZzogXCJcdThCNjZcdTU0NEFcIixcbiAgICBpbmZvOiBcIlx1NEZFMVx1NjA2RlwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJcdThBOUVcdThBMDBcdTVERjJcdTUyMDdcdTYzREJcdTcwQkEge2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gXHU1Qjg4XHU4Qjc3XHU2QTIxXHU1ODRBXG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1ODFFQVx1NTJENVx1NUI4OFx1OEI3N1wiLFxuICAgIGluaXRCb3Q6IFwiXHU1MjFEXHU1OUNCXHU1MzE2XHU1Qjg4XHU4Qjc3XHU2QTVGXHU1NjY4XHU0RUJBXCIsXG4gICAgc2VsZWN0QXJlYTogXCJcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcIixcbiAgICBjYXB0dXJlQXJlYTogXCJcdTYzNTVcdTczNzJcdTUzNDBcdTU3REZcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiXHU5NThCXHU1OUNCXHU1Qjg4XHU4Qjc3XCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiXHU1MDVDXHU2QjYyXHU1Qjg4XHU4Qjc3XCIsXG4gICAgdXBwZXJMZWZ0OiBcIlx1NURFNlx1NEUwQVx1ODlEMlwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiXHU1M0YzXHU0RTBCXHU4OUQyXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlx1NTNEN1x1NEZERFx1OEI3N1x1NTBDRlx1N0QyMFwiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJcdTZBQTJcdTZFMkNcdTUyMzBcdTc2ODRcdThCOEFcdTUzMTZcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJcdTRGRUVcdTVGQTlcdTc2ODRcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3OFwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1N0I0OVx1NUY4NVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBcdTZBQTJcdTY3RTVcdTUzRUZcdTc1MjhcdTk4NEZcdTgyNzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTk4NEZcdTgyNzJcdUZGMENcdThBQ0JcdTU3MjhcdTdEQjJcdTdBRDlcdTRFMEFcdTYyNTNcdTk1OEJcdThBQkZcdTgyNzJcdTY3N0ZcdTMwMDJcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHU2MjdFXHU1MjMwIHtjb3VudH0gXHU3QTJFXHU1M0VGXHU3NTI4XHU5ODRGXHU4MjcyXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1NUI4OFx1OEI3N1x1NkE1Rlx1NTY2OFx1NEVCQVx1NTIxRFx1NTlDQlx1NTMxNlx1NjIxMFx1NTI5RlwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgXHU1Qjg4XHU4Qjc3XHU2QTVGXHU1NjY4XHU0RUJBXHU1MjFEXHU1OUNCXHU1MzE2XHU1OTMxXHU2NTU3XCIsXG4gICAgaW52YWxpZENvb3JkczogXCJcdTI3NEMgXHU1RUE3XHU2QTE5XHU3MTIxXHU2NTQ4XCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIFx1NTM0MFx1NTdERlx1NzEyMVx1NjU0OFx1RkYwQ1x1NURFNlx1NEUwQVx1ODlEMlx1NUZDNVx1OTgwOFx1NUMwRlx1NjVCQ1x1NTNGM1x1NEUwQlx1ODlEMlwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHU1MzQwXHU1N0RGXHU5MDRFXHU1OTI3OiB7c2l6ZX0gXHU1MENGXHU3RDIwIChcdTY3MDBcdTU5Mjc6IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IFx1NjM1NVx1NzM3Mlx1NUI4OFx1OEI3N1x1NTM0MFx1NTdERlx1NEUyRC4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHU1MzQwXHU1N0RGXHU2MzU1XHU3MzcyXHU2MjEwXHU1MjlGOiB7Y291bnR9IFx1NTBDRlx1N0QyMFx1NTNEN1x1NEZERFx1OEI3N1wiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgXHU2MzU1XHU3MzcyXHU1MzQwXHU1N0RGXHU1MUZBXHU5MzJGOiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBcdThBQ0JcdTUxNDhcdTYzNTVcdTczNzJcdTRFMDBcdTUwMEJcdTVCODhcdThCNzdcdTUzNDBcdTU3REZcIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU4Qjc3XHU1REYyXHU1NTUzXHU1MkQ1IC0gXHU1MzQwXHU1N0RGXHU3NkUzXHU2M0E3XHU0RTJEXCIsXG4gICAgcHJvdGVjdGlvblN0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NUI4OFx1OEI3N1x1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHU1MzQwXHU1N0RGXHU1Qjg5XHU1MTY4IC0gXHU2NzJBXHU2QUEyXHU2RTJDXHU1MjMwXHU4QjhBXHU1MzE2XCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCBcdTZBQTJcdTZFMkNcdTUyMzAge2NvdW50fSBcdTUwMEJcdThCOEFcdTUzMTZcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFx1NkI2M1x1NTcyOFx1NEZFRVx1NUZBOSB7Y291bnR9IFx1NTAwQlx1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgXHU1REYyXHU2MjEwXHU1MjlGXHU0RkVFXHU1RkE5IHtjb3VudH0gXHU1MDBCXHU1MENGXHU3RDIwXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIFx1NEZFRVx1NUZBOVx1NTFGQVx1OTMyRjoge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgXHU2QjIxXHU2NTc4XHU0RTBEXHU4REIzXHVGRjBDXHU3MTIxXHU2Q0Q1XHU0RkVFXHU1RkE5XCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTZBQTJcdTY3RTVcdTUzNDBcdTU3REZcdThCOEFcdTUzMTYuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBcdTZBQTJcdTY3RTVcdTUxRkFcdTkzMkY6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU4Qjc3XHU0RTJEIC0gXHU1MzQwXHU1N0RGXHU1M0Q3XHU0RkREXHU4Qjc3XCIsXG4gICAgbGFzdENoZWNrOiBcIlx1NEUwQVx1NkIyMVx1NkFBMlx1NjdFNToge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIlx1NEUwQlx1NkIyMVx1NkFBMlx1NjdFNToge3RpbWV9IFx1NzlEMlx1NUY4Q1wiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkQ1XHU1NTUzXHU1MkQ1XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NzEyMVx1NkNENVx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1RkYwQ1x1OEFDQlx1NjI0Qlx1NTJENVx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHU5NzAwXHU4OTgxXHU2MjRCXHU1MkQ1XHU1MjFEXHU1OUNCXHU1MzE2XCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTVERjJcdTZBQTJcdTZFMkNcdTUyMzBcdThBQkZcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjQxQ1x1N0QyMlx1OEFCRlx1ODI3Mlx1Njc3Ri4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1NkI2M1x1NTcyOFx1OUVERVx1NjRDQVx1N0U2QVx1ODhGRFx1NjMwOVx1OTIxNS4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1N0U2QVx1ODhGRFx1NjMwOVx1OTIxNVwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgXHU1NzI4XHU5NzAwXHU4OTgxXHU0RkREXHU4Qjc3XHU1MzQwXHU1N0RGXHU3Njg0XHU1REU2XHU0RTBBXHU4OUQyXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgXHU3M0ZFXHU1NzI4XHU1NzI4XHU1M0YzXHU0RTBCXHU4OUQyXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU5MDc4XHU2NEM3XHU1REU2XHU0RTBBXHU4OUQyLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1OTA3OFx1NjRDN1x1NTNGM1x1NEUwQlx1ODlEMi4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBcdTVERjJcdTYzNTVcdTczNzJcdTVERTZcdTRFMEFcdTg5RDI6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1NURGMlx1NjM1NVx1NzM3Mlx1NTNGM1x1NEUwQlx1ODlEMjogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1OTA3OFx1NjRDN1x1OEQ4NVx1NjY0MlwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTkwNzhcdTY0QzdcdTUxRkFcdTkzMkZcdUZGMENcdThBQ0JcdTkxQ0RcdThBNjZcIlxuICB9XG59OyIsICJpbXBvcnQgeyBlcyB9IGZyb20gJy4vZXMuanMnO1xuaW1wb3J0IHsgZW4gfSBmcm9tICcuL2VuLmpzJztcbmltcG9ydCB7IGZyIH0gZnJvbSAnLi9mci5qcyc7XG5pbXBvcnQgeyBydSB9IGZyb20gJy4vcnUuanMnO1xuaW1wb3J0IHsgemhIYW5zIH0gZnJvbSAnLi96aC1IYW5zLmpzJztcbmltcG9ydCB7IHpoSGFudCB9IGZyb20gJy4vemgtSGFudC5qcyc7XG5cbi8vIElkaW9tYXMgZGlzcG9uaWJsZXNcbmV4cG9ydCBjb25zdCBBVkFJTEFCTEVfTEFOR1VBR0VTID0ge1xuICBlczogeyBuYW1lOiAnRXNwYVx1MDBGMW9sJywgZmxhZzogJ1x1RDgzQ1x1RERFQVx1RDgzQ1x1RERGOCcsIGNvZGU6ICdlcycgfSxcbiAgZW46IHsgbmFtZTogJ0VuZ2xpc2gnLCBmbGFnOiAnXHVEODNDXHVEREZBXHVEODNDXHVEREY4JywgY29kZTogJ2VuJyB9LFxuICBmcjogeyBuYW1lOiAnRnJhblx1MDBFN2FpcycsIGZsYWc6ICdcdUQ4M0NcdURERUJcdUQ4M0NcdURERjcnLCBjb2RlOiAnZnInIH0sXG4gIHJ1OiB7IG5hbWU6ICdcdTA0MjBcdTA0NDNcdTA0NDFcdTA0NDFcdTA0M0FcdTA0MzhcdTA0MzknLCBmbGFnOiAnXHVEODNDXHVEREY3XHVEODNDXHVEREZBJywgY29kZTogJ3J1JyB9LFxuICB6aEhhbnM6IHsgbmFtZTogJ1x1N0I4MFx1NEY1M1x1NEUyRFx1NjU4NycsIGZsYWc6ICdcdUQ4M0NcdURERThcdUQ4M0NcdURERjMnLCBjb2RlOiAnemgtSGFucycgfSxcbiAgemhIYW50OiB7IG5hbWU6ICdcdTdFNDFcdTlBRDRcdTRFMkRcdTY1ODcnLCBmbGFnOiAnXHVEODNDXHVEREU4XHVEODNDXHVEREYzJywgY29kZTogJ3poLUhhbnQnIH1cbn07XG5cbi8vIFRvZGFzIGxhcyB0cmFkdWNjaW9uZXNcbmNvbnN0IHRyYW5zbGF0aW9ucyA9IHtcbiAgZXMsXG4gIGVuLFxuICBmcixcbiAgcnUsXG4gIHpoSGFucyxcbiAgemhIYW50XG59O1xuXG4vLyBFc3RhZG8gZGVsIGlkaW9tYSBhY3R1YWxcbmxldCBjdXJyZW50TGFuZ3VhZ2UgPSAnZXMnO1xubGV0IGN1cnJlbnRUcmFuc2xhdGlvbnMgPSB0cmFuc2xhdGlvbnNbY3VycmVudExhbmd1YWdlXTtcblxuLyoqXG4gKiBEZXRlY3RhIGVsIGlkaW9tYSBkZWwgbmF2ZWdhZG9yXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hIGRldGVjdGFkb1xuICovXG5leHBvcnQgZnVuY3Rpb24gZGV0ZWN0QnJvd3Nlckxhbmd1YWdlKCkge1xuICBjb25zdCBicm93c2VyTGFuZyA9IHdpbmRvdy5uYXZpZ2F0b3IubGFuZ3VhZ2UgfHwgd2luZG93Lm5hdmlnYXRvci51c2VyTGFuZ3VhZ2UgfHwgJ2VzJztcblxuICAvLyBFeHRyYWVyIHNvbG8gZWwgY1x1MDBGM2RpZ28gZGVsIGlkaW9tYSAoZWo6ICdlcy1FUycgLT4gJ2VzJylcbiAgY29uc3QgbGFuZ0NvZGUgPSBicm93c2VyTGFuZy5zcGxpdCgnLScpWzBdLnRvTG93ZXJDYXNlKCk7XG5cbiAgLy8gVmVyaWZpY2FyIHNpIHRlbmVtb3Mgc29wb3J0ZSBwYXJhIGVzdGUgaWRpb21hXG4gIGlmICh0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdKSB7XG4gICAgcmV0dXJuIGxhbmdDb2RlO1xuICB9XG5cbiAgLy8gRmFsbGJhY2sgYSBlc3BhXHUwMEYxb2wgcG9yIGRlZmVjdG9cbiAgcmV0dXJuICdlcyc7XG59XG5cbi8qKlxuICogT2J0aWVuZSBlbCBpZGlvbWEgZ3VhcmRhZG8gKGRlc2hhYmlsaXRhZG8gLSBubyB1c2FyIGxvY2FsU3RvcmFnZSlcbiAqIEByZXR1cm5zIHtzdHJpbmd9IFNpZW1wcmUgcmV0b3JuYSBudWxsXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRTYXZlZExhbmd1YWdlKCkge1xuICAvLyBObyB1c2FyIGxvY2FsU3RvcmFnZSAtIHNpZW1wcmUgcmV0b3JuYXIgbnVsbFxuICByZXR1cm4gbnVsbDtcbn1cblxuLyoqXG4gKiBHdWFyZGEgZWwgaWRpb21hIChkZXNoYWJpbGl0YWRvIC0gbm8gdXNhciBsb2NhbFN0b3JhZ2UpXG4gKiBAcGFyYW0ge3N0cmluZ30gbGFuZ0NvZGUgLSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBzYXZlTGFuZ3VhZ2UobGFuZ0NvZGUpIHtcbiAgLy8gTm8gZ3VhcmRhciBlbiBsb2NhbFN0b3JhZ2UgLSBmdW5jaVx1MDBGM24gZGVzaGFiaWxpdGFkYVxuICByZXR1cm47XG59XG5cbi8qKlxuICogSW5pY2lhbGl6YSBlbCBzaXN0ZW1hIGRlIGlkaW9tYXNcbiAqIEByZXR1cm5zIHtzdHJpbmd9IENcdTAwRjNkaWdvIGRlbCBpZGlvbWEgaW5pY2lhbGl6YWRvXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBpbml0aWFsaXplTGFuZ3VhZ2UoKSB7XG4gIC8vIFByaW9yaWRhZDogZ3VhcmRhZG8gPiBuYXZlZ2Fkb3IgPiBlc3BhXHUwMEYxb2xcbiAgY29uc3Qgc2F2ZWRMYW5nID0gZ2V0U2F2ZWRMYW5ndWFnZSgpO1xuICBjb25zdCBicm93c2VyTGFuZyA9IGRldGVjdEJyb3dzZXJMYW5ndWFnZSgpO1xuXG4gIGxldCBzZWxlY3RlZExhbmcgPSAnZXMnOyAvLyBmYWxsYmFjayBwb3IgZGVmZWN0b1xuXG4gIGlmIChzYXZlZExhbmcgJiYgdHJhbnNsYXRpb25zW3NhdmVkTGFuZ10pIHtcbiAgICBzZWxlY3RlZExhbmcgPSBzYXZlZExhbmc7XG4gIH0gZWxzZSBpZiAoYnJvd3NlckxhbmcgJiYgdHJhbnNsYXRpb25zW2Jyb3dzZXJMYW5nXSkge1xuICAgIHNlbGVjdGVkTGFuZyA9IGJyb3dzZXJMYW5nO1xuICB9XG5cbiAgc2V0TGFuZ3VhZ2Uoc2VsZWN0ZWRMYW5nKTtcbiAgcmV0dXJuIHNlbGVjdGVkTGFuZztcbn1cblxuLyoqXG4gKiBDYW1iaWEgZWwgaWRpb21hIGFjdHVhbFxuICogQHBhcmFtIHtzdHJpbmd9IGxhbmdDb2RlIC0gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYVxuICovXG5leHBvcnQgZnVuY3Rpb24gc2V0TGFuZ3VhZ2UobGFuZ0NvZGUpIHtcbiAgaWYgKCF0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdKSB7XG4gICAgY29uc29sZS53YXJuKGBJZGlvbWEgJyR7bGFuZ0NvZGV9JyBubyBkaXNwb25pYmxlLiBVc2FuZG8gJyR7Y3VycmVudExhbmd1YWdlfSdgKTtcbiAgICByZXR1cm47XG4gIH1cblxuICBjdXJyZW50TGFuZ3VhZ2UgPSBsYW5nQ29kZTtcbiAgY3VycmVudFRyYW5zbGF0aW9ucyA9IHRyYW5zbGF0aW9uc1tsYW5nQ29kZV07XG4gIHNhdmVMYW5ndWFnZShsYW5nQ29kZSk7XG5cbiAgLy8gRW1pdGlyIGV2ZW50byBwZXJzb25hbGl6YWRvIHBhcmEgcXVlIGxvcyBtXHUwMEYzZHVsb3MgcHVlZGFuIHJlYWNjaW9uYXJcbiAgaWYgKHR5cGVvZiB3aW5kb3cgIT09ICd1bmRlZmluZWQnICYmIHdpbmRvdy5DdXN0b21FdmVudCkge1xuICAgIHdpbmRvdy5kaXNwYXRjaEV2ZW50KG5ldyB3aW5kb3cuQ3VzdG9tRXZlbnQoJ2xhbmd1YWdlQ2hhbmdlZCcsIHtcbiAgICAgIGRldGFpbDogeyBsYW5ndWFnZTogbGFuZ0NvZGUsIHRyYW5zbGF0aW9uczogY3VycmVudFRyYW5zbGF0aW9ucyB9XG4gICAgfSkpO1xuICB9XG59XG5cbi8qKlxuICogT2J0aWVuZSBlbCBpZGlvbWEgYWN0dWFsXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hIGFjdHVhbFxuICovXG5leHBvcnQgZnVuY3Rpb24gZ2V0Q3VycmVudExhbmd1YWdlKCkge1xuICByZXR1cm4gY3VycmVudExhbmd1YWdlO1xufVxuXG4vKipcbiAqIE9idGllbmUgbGFzIHRyYWR1Y2Npb25lcyBhY3R1YWxlc1xuICogQHJldHVybnMge29iamVjdH0gT2JqZXRvIGNvbiB0b2RhcyBsYXMgdHJhZHVjY2lvbmVzIGRlbCBpZGlvbWEgYWN0dWFsXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRDdXJyZW50VHJhbnNsYXRpb25zKCkge1xuICByZXR1cm4gY3VycmVudFRyYW5zbGF0aW9ucztcbn1cblxuLyoqXG4gKiBPYnRpZW5lIHVuIHRleHRvIHRyYWR1Y2lkbyB1c2FuZG8gbm90YWNpXHUwMEYzbiBkZSBwdW50b1xuICogQHBhcmFtIHtzdHJpbmd9IGtleSAtIENsYXZlIGRlbCB0ZXh0byAoZWo6ICdpbWFnZS50aXRsZScsICdjb21tb24uY2FuY2VsJylcbiAqIEBwYXJhbSB7b2JqZWN0fSBwYXJhbXMgLSBQYXJcdTAwRTFtZXRyb3MgcGFyYSBpbnRlcnBvbGFjaVx1MDBGM24gKGVqOiB7Y291bnQ6IDV9KVxuICogQHJldHVybnMge3N0cmluZ30gVGV4dG8gdHJhZHVjaWRvXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiB0KGtleSwgcGFyYW1zID0ge30pIHtcbiAgY29uc3Qga2V5cyA9IGtleS5zcGxpdCgnLicpO1xuICBsZXQgdmFsdWUgPSBjdXJyZW50VHJhbnNsYXRpb25zO1xuXG4gIC8vIE5hdmVnYXIgcG9yIGxhIGVzdHJ1Y3R1cmEgZGUgb2JqZXRvc1xuICBmb3IgKGNvbnN0IGsgb2Yga2V5cykge1xuICAgIGlmICh2YWx1ZSAmJiB0eXBlb2YgdmFsdWUgPT09ICdvYmplY3QnICYmIGsgaW4gdmFsdWUpIHtcbiAgICAgIHZhbHVlID0gdmFsdWVba107XG4gICAgfSBlbHNlIHtcbiAgICAgIGNvbnNvbGUud2FybihgQ2xhdmUgZGUgdHJhZHVjY2lcdTAwRjNuIG5vIGVuY29udHJhZGE6ICcke2tleX0nYCk7XG4gICAgICByZXR1cm4ga2V5OyAvLyBSZXRvcm5hciBsYSBjbGF2ZSBjb21vIGZhbGxiYWNrXG4gICAgfVxuICB9XG5cbiAgaWYgKHR5cGVvZiB2YWx1ZSAhPT0gJ3N0cmluZycpIHtcbiAgICBjb25zb2xlLndhcm4oYENsYXZlIGRlIHRyYWR1Y2NpXHUwMEYzbiBubyBlcyBzdHJpbmc6ICcke2tleX0nYCk7XG4gICAgcmV0dXJuIGtleTtcbiAgfVxuXG4gIC8vIEludGVycG9sYXIgcGFyXHUwMEUxbWV0cm9zXG4gIHJldHVybiBpbnRlcnBvbGF0ZSh2YWx1ZSwgcGFyYW1zKTtcbn1cblxuLyoqXG4gKiBJbnRlcnBvbGEgcGFyXHUwMEUxbWV0cm9zIGVuIHVuIHN0cmluZ1xuICogQHBhcmFtIHtzdHJpbmd9IHRleHQgLSBUZXh0byBjb24gbWFyY2Fkb3JlcyB7a2V5fVxuICogQHBhcmFtIHtvYmplY3R9IHBhcmFtcyAtIFBhclx1MDBFMW1ldHJvcyBhIGludGVycG9sYXJcbiAqIEByZXR1cm5zIHtzdHJpbmd9IFRleHRvIGNvbiBwYXJcdTAwRTFtZXRyb3MgaW50ZXJwb2xhZG9zXG4gKi9cbmZ1bmN0aW9uIGludGVycG9sYXRlKHRleHQsIHBhcmFtcykge1xuICBpZiAoIXBhcmFtcyB8fCBPYmplY3Qua2V5cyhwYXJhbXMpLmxlbmd0aCA9PT0gMCkge1xuICAgIHJldHVybiB0ZXh0O1xuICB9XG5cbiAgcmV0dXJuIHRleHQucmVwbGFjZSgvXFx7KFxcdyspXFx9L2csIChtYXRjaCwga2V5KSA9PiB7XG4gICAgcmV0dXJuIHBhcmFtc1trZXldICE9PSB1bmRlZmluZWQgPyBwYXJhbXNba2V5XSA6IG1hdGNoO1xuICB9KTtcbn1cblxuLyoqXG4gKiBPYnRpZW5lIHRyYWR1Y2Npb25lcyBkZSB1bmEgc2VjY2lcdTAwRjNuIGVzcGVjXHUwMEVEZmljYVxuICogQHBhcmFtIHtzdHJpbmd9IHNlY3Rpb24gLSBTZWNjaVx1MDBGM24gKGVqOiAnaW1hZ2UnLCAnbGF1bmNoZXInLCAnY29tbW9uJylcbiAqIEByZXR1cm5zIHtvYmplY3R9IE9iamV0byBjb24gbGFzIHRyYWR1Y2Npb25lcyBkZSBsYSBzZWNjaVx1MDBGM25cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGdldFNlY3Rpb24oc2VjdGlvbikge1xuICBpZiAoY3VycmVudFRyYW5zbGF0aW9uc1tzZWN0aW9uXSkge1xuICAgIHJldHVybiBjdXJyZW50VHJhbnNsYXRpb25zW3NlY3Rpb25dO1xuICB9XG5cbiAgY29uc29sZS53YXJuKGBTZWNjaVx1MDBGM24gZGUgdHJhZHVjY2lcdTAwRjNuIG5vIGVuY29udHJhZGE6ICcke3NlY3Rpb259J2ApO1xuICByZXR1cm4ge307XG59XG5cbi8qKlxuICogVmVyaWZpY2Egc2kgdW4gaWRpb21hIGVzdFx1MDBFMSBkaXNwb25pYmxlXG4gKiBAcGFyYW0ge3N0cmluZ30gbGFuZ0NvZGUgLSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hXG4gKiBAcmV0dXJucyB7Ym9vbGVhbn0gVHJ1ZSBzaSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICovXG5leHBvcnQgZnVuY3Rpb24gaXNMYW5ndWFnZUF2YWlsYWJsZShsYW5nQ29kZSkge1xuICByZXR1cm4gISF0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdO1xufVxuXG4vLyBJbmljaWFsaXphciBhdXRvbVx1MDBFMXRpY2FtZW50ZSBhbCBjYXJnYXIgZWwgbVx1MDBGM2R1bG9cbmluaXRpYWxpemVMYW5ndWFnZSgpO1xuIiwgImV4cG9ydCBjb25zdCAkID0gKHNlbCwgcm9vdCA9IGRvY3VtZW50KSA9PiByb290LnF1ZXJ5U2VsZWN0b3Ioc2VsKTtcblxuZXhwb3J0IGZ1bmN0aW9uIGNyZWF0ZVN0eWxlKGNzcykge1xuICBjb25zdCBzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudChcInN0eWxlXCIpO1xuICBzLnRleHRDb250ZW50ID0gY3NzOyBkb2N1bWVudC5oZWFkLmFwcGVuZENoaWxkKHMpOyByZXR1cm4gcztcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIG1vdW50U2hhZG93KGNvbnRhaW5lciA9IGRvY3VtZW50LmJvZHkpIHtcbiAgY29uc3QgaG9zdCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoXCJkaXZcIik7XG4gIGhvc3QuaWQgPSBcIndwbGFjZS1ib3Qtcm9vdFwiO1xuICBjb250YWluZXIuYXBwZW5kQ2hpbGQoaG9zdCk7XG4gIGNvbnN0IHJvb3QgPSBob3N0LmF0dGFjaFNoYWRvdyA/IGhvc3QuYXR0YWNoU2hhZG93KHsgbW9kZTogXCJvcGVuXCIgfSkgOiBob3N0O1xuICByZXR1cm4geyBob3N0LCByb290IH07XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIGRldGVjdGFyIHNpIGxhIHBhbGV0YSBkZSBjb2xvcmVzIGVzdFx1MDBFMSBhYmllcnRhXG5leHBvcnQgZnVuY3Rpb24gaXNQYWxldHRlT3BlbihkZWJ1ZyA9IGZhbHNlKSB7XG4gIC8vIEJ1c2NhciBlbGVtZW50b3MgY29tdW5lcyBkZSBsYSBwYWxldGEgZGUgY29sb3JlcyAobVx1MDBFOXRvZG8gb3JpZ2luYWwpXG4gIGNvbnN0IHBhbGV0dGVTZWxlY3RvcnMgPSBbXG4gICAgJ1tkYXRhLXRlc3RpZD1cImNvbG9yLXBpY2tlclwiXScsXG4gICAgJy5jb2xvci1waWNrZXInLFxuICAgICcucGFsZXR0ZScsXG4gICAgJ1tjbGFzcyo9XCJjb2xvclwiXVtjbGFzcyo9XCJwaWNrZXJcIl0nLFxuICAgICdbY2xhc3MqPVwicGFsZXR0ZVwiXSdcbiAgXTtcbiAgXG4gIGZvciAoY29uc3Qgc2VsZWN0b3Igb2YgcGFsZXR0ZVNlbGVjdG9ycykge1xuICAgIGNvbnN0IGVsZW1lbnQgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKHNlbGVjdG9yKTtcbiAgICBpZiAoZWxlbWVudCAmJiBlbGVtZW50Lm9mZnNldFBhcmVudCAhPT0gbnVsbCkge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkE4IFBhbGV0YSBkZXRlY3RhZGEgcG9yIHNlbGVjdG9yOiAke3NlbGVjdG9yfWApO1xuICAgICAgcmV0dXJuIHRydWU7XG4gICAgfVxuICB9XG4gIFxuICAvLyBCdXNjYXIgcG9yIGNvbG9yZXMgZW4gdW4gZ3JpZCBvIGxpc3RhIChtXHUwMEU5dG9kbyBvcmlnaW5hbClcbiAgY29uc3QgY29sb3JFbGVtZW50cyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ1tzdHlsZSo9XCJiYWNrZ3JvdW5kLWNvbG9yXCJdLCBbc3R5bGUqPVwiYmFja2dyb3VuZDpcIl0sIC5jb2xvciwgW2NsYXNzKj1cImNvbG9yXCJdJyk7XG4gIGxldCB2aXNpYmxlQ29sb3JzID0gMDtcbiAgZm9yIChjb25zdCBlbCBvZiBjb2xvckVsZW1lbnRzKSB7XG4gICAgaWYgKGVsLm9mZnNldFBhcmVudCAhPT0gbnVsbCAmJiBlbC5vZmZzZXRXaWR0aCA+IDEwICYmIGVsLm9mZnNldEhlaWdodCA+IDEwKSB7XG4gICAgICB2aXNpYmxlQ29sb3JzKys7XG4gICAgICBpZiAodmlzaWJsZUNvbG9ycyA+PSA1KSB7XG4gICAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzQ1x1REZBOCBQYWxldGEgZGV0ZWN0YWRhIHBvciBjb2xvcmVzIHZpc2libGVzOiAke3Zpc2libGVDb2xvcnN9YCk7XG4gICAgICAgIHJldHVybiB0cnVlOyAvLyBTaSBoYXkgNSsgZWxlbWVudG9zIGRlIGNvbG9yIHZpc2libGVzXG4gICAgICB9XG4gICAgfVxuICB9XG4gIFxuICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0RcdUREMEQgUGFsZXRhIG5vIGRldGVjdGFkYS4gQ29sb3JlcyB2aXNpYmxlczogJHt2aXNpYmxlQ29sb3JzfWApO1xuICByZXR1cm4gZmFsc2U7XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIGVuY29udHJhciB5IGhhY2VyIGNsaWMgZW4gZWwgYm90XHUwMEYzbiBkZSBQYWludFxuZXhwb3J0IGZ1bmN0aW9uIGZpbmRBbmRDbGlja1BhaW50QnV0dG9uKGRlYnVnID0gZmFsc2UsIGRvdWJsZUNsaWNrID0gZmFsc2UpIHtcbiAgLy8gTVx1MDBFOXRvZG8gMTogQlx1MDBGQXNxdWVkYSBlc3BlY1x1MDBFRGZpY2EgcG9yIGNsYXNlcyAobVx1MDBFOXRvZG8gb3JpZ2luYWwsIG1cdTAwRTFzIGNvbmZpYWJsZSlcbiAgY29uc3Qgc3BlY2lmaWNCdXR0b24gPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKCdidXR0b24uYnRuLmJ0bi1wcmltYXJ5LmJ0bi1sZywgYnV0dG9uLmJ0bi5idG4tcHJpbWFyeS5zbVxcXFw6YnRuLXhsJyk7XG4gIFxuICBpZiAoc3BlY2lmaWNCdXR0b24pIHtcbiAgICBjb25zdCBidXR0b25UZXh0ID0gc3BlY2lmaWNCdXR0b24udGV4dENvbnRlbnQudG9Mb3dlckNhc2UoKTtcbiAgICBjb25zdCBoYXNQYWludFRleHQgPSBidXR0b25UZXh0LmluY2x1ZGVzKCdwYWludCcpIHx8IGJ1dHRvblRleHQuaW5jbHVkZXMoJ3BpbnRhcicpO1xuICAgIGNvbnN0IGhhc1BhaW50SWNvbiA9IHNwZWNpZmljQnV0dG9uLnF1ZXJ5U2VsZWN0b3IoJ3N2ZyBwYXRoW2QqPVwiMjQwLTEyMFwiXScpIHx8IFxuICAgICAgICAgICAgICAgICAgICAgICAgc3BlY2lmaWNCdXR0b24ucXVlcnlTZWxlY3Rvcignc3ZnIHBhdGhbZCo9XCJNMTVcIl0nKTtcbiAgICBcbiAgICBpZiAoaGFzUGFpbnRUZXh0IHx8IGhhc1BhaW50SWNvbikge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkFGIEJvdFx1MDBGM24gUGFpbnQgZW5jb250cmFkbyBwb3Igc2VsZWN0b3IgZXNwZWNcdTAwRURmaWNvOiBcIiR7YnV0dG9uVGV4dH1cImApO1xuICAgICAgc3BlY2lmaWNCdXR0b24uY2xpY2soKTtcbiAgICAgIFxuICAgICAgLy8gU2kgc2UgcmVxdWllcmUgZG9ibGUgY2xpYywgaGFjZXIgc2VndW5kbyBjbGljIGRlc3B1XHUwMEU5cyBkZSB1biBkZWxheVxuICAgICAgaWYgKGRvdWJsZUNsaWNrKSB7XG4gICAgICAgIHNldFRpbWVvdXQoKCkgPT4ge1xuICAgICAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzQ1x1REZBRiBTZWd1bmRvIGNsaWMgZW4gYm90XHUwMEYzbiBQYWludGApO1xuICAgICAgICAgIHNwZWNpZmljQnV0dG9uLmNsaWNrKCk7XG4gICAgICAgIH0sIDUwMCk7XG4gICAgICB9XG4gICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIE1cdTAwRTl0b2RvIDI6IEJcdTAwRkFzcXVlZGEgc2ltcGxlIHBvciB0ZXh0byAobVx1MDBFOXRvZG8gb3JpZ2luYWwpXG4gIGNvbnN0IGJ1dHRvbnMgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKCdidXR0b24nKTtcbiAgZm9yIChjb25zdCBidXR0b24gb2YgYnV0dG9ucykge1xuICAgIGNvbnN0IGJ1dHRvblRleHQgPSBidXR0b24udGV4dENvbnRlbnQudG9Mb3dlckNhc2UoKTtcbiAgICBpZiAoKGJ1dHRvblRleHQuaW5jbHVkZXMoJ3BhaW50JykgfHwgYnV0dG9uVGV4dC5pbmNsdWRlcygncGludGFyJykpICYmIFxuICAgICAgICBidXR0b24ub2Zmc2V0UGFyZW50ICE9PSBudWxsICYmXG4gICAgICAgICFidXR0b24uZGlzYWJsZWQpIHtcbiAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzQ1x1REZBRiBCb3RcdTAwRjNuIFBhaW50IGVuY29udHJhZG8gcG9yIHRleHRvOiBcIiR7YnV0dG9uLnRleHRDb250ZW50LnRyaW0oKX1cImApO1xuICAgICAgYnV0dG9uLmNsaWNrKCk7XG4gICAgICBcbiAgICAgIC8vIFNpIHNlIHJlcXVpZXJlIGRvYmxlIGNsaWMsIGhhY2VyIHNlZ3VuZG8gY2xpYyBkZXNwdVx1MDBFOXMgZGUgdW4gZGVsYXlcbiAgICAgIGlmIChkb3VibGVDbGljaykge1xuICAgICAgICBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQUYgU2VndW5kbyBjbGljIGVuIGJvdFx1MDBGM24gUGFpbnRgKTtcbiAgICAgICAgICBidXR0b24uY2xpY2soKTtcbiAgICAgICAgfSwgNTAwKTtcbiAgICAgIH1cbiAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbiAgfVxuICBcbiAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkb2ApO1xuICByZXR1cm4gZmFsc2U7XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBwYXJhIHJlYWxpemFyIGF1dG8tY2xpY2sgZGVsIGJvdFx1MDBGM24gUGFpbnQgY29uIHNlY3VlbmNpYSBjb3JyZWN0YVxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGF1dG9DbGlja1BhaW50QnV0dG9uKG1heEF0dGVtcHRzID0gMywgZGVidWcgPSB0cnVlKSB7XG4gIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzRVx1REQxNiBJbmljaWFuZG8gYXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludCAobVx1MDBFMXhpbW8gJHttYXhBdHRlbXB0c30gaW50ZW50b3MpYCk7XG4gIFxuICBmb3IgKGxldCBhdHRlbXB0ID0gMTsgYXR0ZW1wdCA8PSBtYXhBdHRlbXB0czsgYXR0ZW1wdCsrKSB7XG4gICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkFGIEludGVudG8gJHthdHRlbXB0fS8ke21heEF0dGVtcHRzfSAtIEJ1c2NhbmRvIGJvdFx1MDBGM24gUGFpbnQuLi5gKTtcbiAgICBcbiAgICAvLyBWZXJpZmljYXIgc2kgbGEgcGFsZXRhIHlhIGVzdFx1MDBFMSBhYmllcnRhXG4gICAgaWYgKGlzUGFsZXR0ZU9wZW4oKSkge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHUyNzA1IFBhbGV0YSB5YSBlc3RcdTAwRTEgYWJpZXJ0YSwgYXV0by1jbGljayBjb21wbGV0YWRvYCk7XG4gICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG4gICAgXG4gICAgLy8gQ0xJQyBcdTAwREFOSUNPOiBQcmVzaW9uYXIgUGFpbnQgdW5hIHNvbGEgdmV6IChzb2xvIHBhcmEgbW9zdHJhciBwYWxldGEvZGV0ZWN0YXIgY29sb3JlcylcbiAgICBpZiAoZmluZEFuZENsaWNrUGFpbnRCdXR0b24oZGVidWcsIGZhbHNlKSkge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNEXHVEQzQ2IENsaWMgZW4gYm90XHUwMEYzbiBQYWludCByZWFsaXphZG8gKHNpbiBzZWd1bmRvIGNsaWMpYCk7XG4gICAgICBcbiAgICAgIC8vIEVzcGVyYXIgdW4gcG9jbyBwYXJhIHF1ZSBsYSBVSS9wYWxldGEgYXBhcmV6Y2EgZW4gcGFudGFsbGFcbiAgICAgIGF3YWl0IG5ldyBQcm9taXNlKHJlc29sdmUgPT4gc2V0VGltZW91dChyZXNvbHZlLCAxNTAwKSk7XG4gICAgICBcbiAgICAgIC8vIFZlcmlmaWNhciBzaSBsYSBwYWxldGEgc2UgYWJyaVx1MDBGM1xuICAgICAgaWYgKGlzUGFsZXR0ZU9wZW4oKSkge1xuICAgICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3MDUgUGFsZXRhIGFiaWVydGEgZXhpdG9zYW1lbnRlIGRlc3B1XHUwMEU5cyBkZWwgaW50ZW50byAke2F0dGVtcHR9YCk7XG4gICAgICAgIHJldHVybiB0cnVlO1xuICAgICAgfSBlbHNlIHtcbiAgICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHUyNkEwXHVGRTBGIFBhbGV0YSBubyBkZXRlY3RhZGEgdHJhcyBlbCBjbGljIGVuIGludGVudG8gJHthdHRlbXB0fS4gUmVpbnRlbnRhclx1MDBFMS5gKTtcbiAgICAgIH1cbiAgICB9IGVsc2Uge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkbyBwYXJhIGNsaWMgZW4gaW50ZW50byAke2F0dGVtcHR9YCk7XG4gICAgfVxuICAgIFxuICAgIC8vIEVzcGVyYXIgYW50ZXMgZGVsIHNpZ3VpZW50ZSBpbnRlbnRvXG4gICAgaWYgKGF0dGVtcHQgPCBtYXhBdHRlbXB0cykge1xuICAgICAgYXdhaXQgbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIDEwMDApKTtcbiAgICB9XG4gIH1cbiAgXG4gIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1Mjc0QyBBdXRvLWNsaWNrIGZhbGxcdTAwRjMgZGVzcHVcdTAwRTlzIGRlICR7bWF4QXR0ZW1wdHN9IGludGVudG9zYCk7XG4gIHJldHVybiBmYWxzZTtcbn1cbiIsICJpbXBvcnQgeyBsb2cgfSBmcm9tIFwiLi4vY29yZS9sb2dnZXIuanNcIjtcbmltcG9ydCB7IGdldFNlc3Npb24gfSBmcm9tIFwiLi4vY29yZS93cGxhY2UtYXBpLmpzXCI7XG5pbXBvcnQgeyBndWFyZFN0YXRlLCBHVUFSRF9ERUZBVUxUUyB9IGZyb20gXCIuL2NvbmZpZy5qc1wiO1xuaW1wb3J0IHsgZGV0ZWN0QXZhaWxhYmxlQ29sb3JzLCBhbmFseXplQXJlYVBpeGVscywgY2hlY2tGb3JDaGFuZ2VzIH0gZnJvbSBcIi4vcHJvY2Vzc29yLmpzXCI7XG5pbXBvcnQgeyBjcmVhdGVHdWFyZFVJLCBzaG93Q29uZmlybURpYWxvZyB9IGZyb20gXCIuL3VpLmpzXCI7XG5pbXBvcnQgeyBzYXZlUHJvZ3Jlc3MsIGxvYWRQcm9ncmVzcywgaGFzUHJvZ3Jlc3MgfSBmcm9tIFwiLi9zYXZlLWxvYWQuanNcIjtcbmltcG9ydCB7IGluaXRpYWxpemVMYW5ndWFnZSwgZ2V0U2VjdGlvbiwgdCB9IGZyb20gXCIuLi9sb2NhbGVzL2luZGV4LmpzXCI7XG5pbXBvcnQgeyBpc1BhbGV0dGVPcGVuLCBmaW5kQW5kQ2xpY2tQYWludEJ1dHRvbiB9IGZyb20gXCIuLi9jb3JlL2RvbS5qc1wiO1xuaW1wb3J0IHsgc2xlZXAgfSBmcm9tIFwiLi4vY29yZS90aW1pbmcuanNcIjtcblxuLy8gR2xvYmFscyBkZWwgbmF2ZWdhZG9yXG5jb25zdCB7IHNldEludGVydmFsLCBjbGVhckludGVydmFsIH0gPSB3aW5kb3c7XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBydW5HdWFyZCgpIHtcbiAgbG9nKCdcdUQ4M0RcdURFRTFcdUZFMEYgSW5pY2lhbmRvIFdQbGFjZSBBdXRvLUd1YXJkJyk7XG4gIFxuICAvLyBJbmljaWFsaXphciBzaXN0ZW1hIGRlIGlkaW9tYXNcbiAgaW5pdGlhbGl6ZUxhbmd1YWdlKCk7XG4gIFxuICAvLyBWZXJpZmljYXIgY29uZmxpY3RvcyBjb24gb3Ryb3MgYm90c1xuICBpZiAoIWNoZWNrRXhpc3RpbmdCb3RzKCkpIHtcbiAgICByZXR1cm47XG4gIH1cbiAgXG4gIC8vIE1hcmNhciBjb21vIGVqZWN1dFx1MDBFMW5kb3NlXG4gIHdpbmRvdy5fX3dwbGFjZUJvdCA9IHsgXG4gICAgLi4ud2luZG93Ll9fd3BsYWNlQm90LCBcbiAgICBndWFyZFJ1bm5pbmc6IHRydWUgXG4gIH07XG4gIFxuICB0cnkge1xuICAgIC8vIE9idGVuZXIgdGV4dG9zIGVuIGVsIGlkaW9tYSBhY3R1YWxcbiAgICBjb25zdCB0ZXh0cyA9IGdldFNlY3Rpb24oJ2d1YXJkJyk7XG4gICAgXG4gICAgLy8gQ3JlYXIgVUlcbiAgICBndWFyZFN0YXRlLnVpID0gY3JlYXRlR3VhcmRVSSh0ZXh0cyk7XG4gICAgXG4gICAgLy8gQ29uZmlndXJhciBldmVudCBsaXN0ZW5lcnNcbiAgICBzZXR1cEV2ZW50TGlzdGVuZXJzKCk7XG4gICAgXG4gICAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgYXV0by1pbmljaW8gZGVsIGJvdCAocm9idXN0YSk6IHZhbGlkYSBjb2xvcmVzIHJlYWxlcyB5IGhhY2UgZmFsbGJhY2sgYSBjbGljIGRlIFBhaW50XG4gICAgYXN5bmMgZnVuY3Rpb24gdHJ5QXV0b0luaXQoKSB7XG4gICAgICBsb2coJ1x1RDgzRVx1REQxNiBJbnRlbnRhbmRvIGF1dG8taW5pY2lvIGRlbCBHdWFyZC4uLicpO1xuICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQucGFsZXR0ZU5vdEZvdW5kJyksICdpbmZvJyk7XG5cbiAgICAgIC8vIDEpIFNpIHBhcmVjZSBhYmllcnRhLCB2YWxpZGFyIHF1ZSBoYXlhIGNvbG9yZXMgcmVhbGVzXG4gICAgICBpZiAoaXNQYWxldHRlT3BlbigpKSB7XG4gICAgICAgIGxvZygnXHVEODNDXHVERkE4IFBhbGV0YSBwYXJlY2UgYWJpZXJ0YS4gVmFsaWRhbmRvIGNvbG9yZXMuLi4nKTtcbiAgICAgICAgY29uc3QgY29sb3JzTm93ID0gZGV0ZWN0QXZhaWxhYmxlQ29sb3JzKCk7XG4gICAgICAgIGlmIChjb2xvcnNOb3cubGVuZ3RoID4gMCkge1xuICAgICAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLnBhbGV0dGVEZXRlY3RlZCcpLCAnc3VjY2VzcycpO1xuICAgICAgICAgIHJldHVybiB0cnVlO1xuICAgICAgICB9XG4gICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIFBhbGV0YSBcImFiaWVydGFcIiBwZXJvIHNpbiBjb2xvcmVzIGRldGVjdGFkb3MuIEludGVudGFuZG8gcHJlc2lvbmFyIFBhaW50Li4uJyk7XG4gICAgICB9XG5cbiAgICAgIC8vIDIpIEludGVudGFyIGhhY2VyIGNsaWMgZW4gZWwgYm90XHUwMEYzbiBQYWludFxuICAgICAgbG9nKCdcdUQ4M0RcdUREMEQgQnVzY2FuZG8gYm90XHUwMEYzbiBQYWludC4uLicpO1xuICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQuY2xpY2tpbmdQYWludEJ1dHRvbicpLCAnaW5mbycpO1xuICAgICAgaWYgKGZpbmRBbmRDbGlja1BhaW50QnV0dG9uKCkpIHtcbiAgICAgICAgbG9nKCdcdUQ4M0RcdURDNDYgQm90XHUwMEYzbiBQYWludCBlbmNvbnRyYWRvIHkgcHJlc2lvbmFkbycpO1xuICAgICAgICBhd2FpdCBzbGVlcCgzMDAwKTsgLy8gRXNwZXJhciBhIHF1ZSBjYXJndWVcblxuICAgICAgICAvLyBSZXZhbGlkYXI6IHByaW1lcm8gY29sb3JlcyByZWFsZXMsIGx1ZWdvIGZhbGxiYWNrIGEgaGV1clx1MDBFRHN0aWNhIGRlIHBhbGV0YVxuICAgICAgICBjb25zdCBjb2xvcnNBZnRlciA9IGRldGVjdEF2YWlsYWJsZUNvbG9ycygpO1xuICAgICAgICBpZiAoY29sb3JzQWZ0ZXIubGVuZ3RoID4gMCkge1xuICAgICAgICAgIGxvZygnXHUyNzA1IENvbG9yZXMgZGV0ZWN0YWRvcyB0cmFzIHByZXNpb25hciBQYWludCcpO1xuICAgICAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLnBhbGV0dGVEZXRlY3RlZCcpLCAnc3VjY2VzcycpO1xuICAgICAgICAgIHJldHVybiB0cnVlO1xuICAgICAgICB9XG4gICAgICAgIGlmIChpc1BhbGV0dGVPcGVuKCkpIHtcbiAgICAgICAgICBsb2coJ1x1MjcwNSBQYWxldGEgYWJpZXJ0YSwgcGVybyBzaW4gY29sb3JlcyBhY2Nlc2libGVzIGFcdTAwRkFuJyk7XG4gICAgICAgICAgLy8gQVx1MDBGQW4gY29uc2lkZXJhbW9zIGZhbGxpZG8gcGFyYSBmb3J6YXIgaW5pY2lvIG1hbnVhbFxuICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgIGxvZygnXHUyNzRDIExhIHBhbGV0YSBubyBzZSBhYnJpXHUwMEYzIGRlc3B1XHUwMEU5cyBkZSBoYWNlciBjbGljJyk7XG4gICAgICAgIH1cbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIGxvZygnXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkbycpO1xuICAgICAgfVxuXG4gICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5hdXRvSW5pdEZhaWxlZCcpLCAnd2FybmluZycpO1xuICAgICAgcmV0dXJuIGZhbHNlO1xuICAgIH1cbiAgICBcbiAgICAvLyBJbnRlbnRhciBhdXRvLWluaWNpbyBkZXNwdVx1MDBFOXMgZGUgcXVlIGxhIFVJIGVzdFx1MDBFOSBsaXN0YVxuICAgIHNldFRpbWVvdXQoYXN5bmMgKCkgPT4ge1xuICAgICAgdHJ5IHtcbiAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQuYXV0b0luaXRpYWxpemluZycpLCAnaW5mbycpO1xuICAgICAgICBsb2coJ1x1RDgzRVx1REQxNiBJbnRlbnRhbmRvIGF1dG8taW5pY2lvLi4uJyk7XG4gICAgICAgIFxuICAgICAgICBjb25zdCBhdXRvSW5pdFN1Y2Nlc3MgPSBhd2FpdCB0cnlBdXRvSW5pdCgpO1xuICAgICAgICBcbiAgICAgICAgaWYgKGF1dG9Jbml0U3VjY2Vzcykge1xuICAgICAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLmF1dG9Jbml0U3VjY2VzcycpLCAnc3VjY2VzcycpO1xuICAgICAgICAgIGxvZygnXHUyNzA1IEF1dG8taW5pY2lvIGV4aXRvc28nKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBPY3VsdGFyIGVsIGJvdFx1MDBGM24gZGUgaW5pY2lhbGl6YWNpXHUwMEYzbiBtYW51YWxcbiAgICAgICAgICBndWFyZFN0YXRlLnVpLnNldEluaXRCdXR0b25WaXNpYmxlKGZhbHNlKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBFamVjdXRhciBsYSBsXHUwMEYzZ2ljYSBkZSBpbmljaWFsaXphY2lcdTAwRjNuIGRlbCBib3RcbiAgICAgICAgICBjb25zdCBpbml0UmVzdWx0ID0gYXdhaXQgaW5pdGlhbGl6ZUd1YXJkKHRydWUpOyAvLyB0cnVlID0gZXMgYXV0by1pbmljaW9cbiAgICAgICAgICBpZiAoaW5pdFJlc3VsdCkge1xuICAgICAgICAgICAgbG9nKCdcdUQ4M0RcdURFODAgR3VhcmQtQk9UIGF1dG8taW5pY2lhZG8gY29tcGxldGFtZW50ZScpO1xuICAgICAgICAgIH1cbiAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5hdXRvSW5pdEZhaWxlZCcpLCAnd2FybmluZycpO1xuICAgICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIEF1dG8taW5pY2lvIGZhbGxcdTAwRjMsIHNlIHJlcXVpZXJlIGluaWNpbyBtYW51YWwnKTtcbiAgICAgICAgICAvLyBBc2VndXJhciBxdWUgZWwgYm90XHUwMEYzbiBkZSBpbmljaW8gbWFudWFsIGVzdFx1MDBFOSB2aXNpYmxlXG4gICAgICAgICAgZ3VhcmRTdGF0ZS51aS5zZXRJbml0QnV0dG9uVmlzaWJsZSh0cnVlKTtcbiAgICAgICAgfVxuICAgICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgICAgbG9nKCdcdTI3NEMgRXJyb3IgZW4gYXV0by1pbmljaW86JywgZXJyb3IpO1xuICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5tYW51YWxJbml0UmVxdWlyZWQnKSwgJ3dhcm5pbmcnKTtcbiAgICAgIH1cbiAgfSwgMTAwMCk7IC8vIDFzLCBjb25zaXN0ZW50ZSBjb24gQXV0by1JbWFnZVxuICAgIFxuICAgIC8vIENsZWFudXAgYWwgY2VycmFyXG4gICAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2JlZm9yZXVubG9hZCcsICgpID0+IHtcbiAgICAgIHN0b3BHdWFyZCgpO1xuICAgICAgaWYgKHdpbmRvdy5fX3dwbGFjZUJvdCkge1xuICAgICAgICB3aW5kb3cuX193cGxhY2VCb3QuZ3VhcmRSdW5uaW5nID0gZmFsc2U7XG4gICAgICB9XG4gICAgfSk7XG4gICAgXG4gICAgbG9nKCdcdTI3MDUgQXV0by1HdWFyZCBjYXJnYWRvIGNvcnJlY3RhbWVudGUnKTtcbiAgICBcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1Mjc0QyBFcnJvciBpbmljaWFsaXphbmRvIEF1dG8tR3VhcmQ6JywgZXJyb3IpO1xuICAgIGlmICh3aW5kb3cuX193cGxhY2VCb3QpIHtcbiAgICAgIHdpbmRvdy5fX3dwbGFjZUJvdC5ndWFyZFJ1bm5pbmcgPSBmYWxzZTtcbiAgICB9XG4gICAgdGhyb3cgZXJyb3I7XG4gIH1cbn1cblxuZnVuY3Rpb24gY2hlY2tFeGlzdGluZ0JvdHMoKSB7XG4gIGlmICh3aW5kb3cuX193cGxhY2VCb3Q/LmltYWdlUnVubmluZykge1xuICAgIGFsZXJ0KCdBdXRvLUltYWdlIGVzdFx1MDBFMSBlamVjdXRcdTAwRTFuZG9zZS4gQ2lcdTAwRTlycmFsbyBhbnRlcyBkZSBpbmljaWFyIEF1dG8tR3VhcmQuJyk7XG4gICAgcmV0dXJuIGZhbHNlO1xuICB9XG4gIGlmICh3aW5kb3cuX193cGxhY2VCb3Q/LmZhcm1SdW5uaW5nKSB7XG4gICAgYWxlcnQoJ0F1dG8tRmFybSBlc3RcdTAwRTEgZWplY3V0XHUwMEUxbmRvc2UuIENpXHUwMEU5cnJhbG8gYW50ZXMgZGUgaW5pY2lhciBBdXRvLUd1YXJkLicpO1xuICAgIHJldHVybiBmYWxzZTtcbiAgfVxuICByZXR1cm4gdHJ1ZTtcbn1cblxuZnVuY3Rpb24gc2V0dXBFdmVudExpc3RlbmVycygpIHtcbiAgY29uc3QgeyBlbGVtZW50cyB9ID0gZ3VhcmRTdGF0ZS51aTtcbiAgXG4gIGVsZW1lbnRzLmNsb3NlQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIHN0b3BHdWFyZCgpO1xuICAgIGd1YXJkU3RhdGUudWkuZGVzdHJveSgpO1xuICAgIGlmICh3aW5kb3cuX193cGxhY2VCb3QpIHtcbiAgICAgIHdpbmRvdy5fX3dwbGFjZUJvdC5ndWFyZFJ1bm5pbmcgPSBmYWxzZTtcbiAgICB9XG4gIH0pO1xuXG4gIGVsZW1lbnRzLmluaXRCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiBpbml0aWFsaXplR3VhcmQoKSk7XG4gIGVsZW1lbnRzLnNlbGVjdEFyZWFCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCBzZWxlY3RBcmVhU3RlcEJ5U3RlcCk7XG4gIGVsZW1lbnRzLmxvYWRBcmVhQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIGVsZW1lbnRzLmFyZWFGaWxlSW5wdXQuY2xpY2soKTtcbiAgfSk7XG4gIFxuICBlbGVtZW50cy5hcmVhRmlsZUlucHV0LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIGFzeW5jICgpID0+IHtcbiAgICBpZiAoZWxlbWVudHMuYXJlYUZpbGVJbnB1dC5maWxlcy5sZW5ndGggPiAwKSB7XG4gICAgICBjb25zdCByZXN1bHQgPSBhd2FpdCBsb2FkUHJvZ3Jlc3MoZWxlbWVudHMuYXJlYUZpbGVJbnB1dC5maWxlc1swXSk7XG4gICAgICBpZiAocmVzdWx0LnN1Y2Nlc3MpIHtcbiAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoYFx1MjcwNSBQcm90ZWNjaVx1MDBGM24gY2FyZ2FkYTogJHtyZXN1bHQucHJvdGVjdGVkUGl4ZWxzfSBwXHUwMEVEeGVsZXMgcHJvdGVnaWRvc2AsICdzdWNjZXNzJyk7XG4gICAgICAgIGxvZyhgXHUyNzA1IFx1MDBDMXJlYSBkZSBwcm90ZWNjaVx1MDBGM24gY2FyZ2FkYSBkZXNkZSBhcmNoaXZvYCk7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyhgXHUyNzRDIEVycm9yIGFsIGNhcmdhciBwcm90ZWNjaVx1MDBGM246ICR7cmVzdWx0LmVycm9yfWAsICdlcnJvcicpO1xuICAgICAgICBsb2coYFx1Mjc0QyBFcnJvciBjYXJnYW5kbyBhcmNoaXZvOiAke3Jlc3VsdC5lcnJvcn1gKTtcbiAgICAgIH1cbiAgICB9XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuc3RhcnRCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCBzdGFydEd1YXJkKTtcbiAgZWxlbWVudHMuc3RvcEJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIGFzeW5jICgpID0+IHtcbiAgICAvLyBTaW1wbGVtZW50ZSBkZXRlbmVyIGxhIHByb3RlY2NpXHUwMEYzbiBzaW4gb3BjaW9uZXMgZGUgZ3VhcmRhZG9cbiAgICBndWFyZFN0YXRlLnJ1bm5pbmcgPSBmYWxzZTtcbiAgICBndWFyZFN0YXRlLmxvb3BJZCA9IG51bGw7XG4gICAgZ3VhcmRTdGF0ZS51aS5zZXRSdW5uaW5nU3RhdGUoZmFsc2UpO1xuICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKCdcdTIzRjlcdUZFMEYgUHJvdGVjY2lcdTAwRjNuIGRldGVuaWRhJywgJ3dhcm5pbmcnKTtcbiAgICBcbiAgICBpZiAoZ3VhcmRTdGF0ZS5jaGVja0ludGVydmFsKSB7XG4gICAgICBjbGVhckludGVydmFsKGd1YXJkU3RhdGUuY2hlY2tJbnRlcnZhbCk7XG4gICAgICBndWFyZFN0YXRlLmNoZWNrSW50ZXJ2YWwgPSBudWxsO1xuICAgIH1cbiAgfSk7XG4gIFxuICAvLyBFdmVudG9zIHBhcmEgc2F2ZS9sb2FkL2RlbGV0ZVxuICBlbGVtZW50cy5zYXZlQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgYXN5bmMgKCkgPT4ge1xuICAgIGlmICghaGFzUHJvZ3Jlc3MoKSkge1xuICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoJ1x1Mjc0QyBObyBoYXkgXHUwMEUxcmVhIHByb3RlZ2lkYSBwYXJhIGd1YXJkYXInLCAnZXJyb3InKTtcbiAgICAgIHJldHVybjtcbiAgICB9XG4gICAgXG4gICAgLy8gTW9zdHJhciBkaVx1MDBFMWxvZ28gZGUgc3BsaXRcbiAgICBjb25zdCBzcGxpdENvbmZpcm0gPSBhd2FpdCBzaG93Q29uZmlybURpYWxvZyhcbiAgICAgICdcdTAwQkZEZXNlYXMgZGl2aWRpciBlbCBcdTAwRTFyZWEgcHJvdGVnaWRhIGVuIHBhcnRlcyBwYXJhIG1cdTAwRkFsdGlwbGVzIHVzdWFyaW9zPzxicj48YnI+JyArXG4gICAgICAnPGxhYmVsIGZvcj1cInNwbGl0Q291bnRJbnB1dFwiPk5cdTAwRkFtZXJvIGRlIHBhcnRlcyAoMSA9IHNpbiBkaXZpZGlyKTo8L2xhYmVsPjxicj4nICtcbiAgICAgICc8aW5wdXQgdHlwZT1cIm51bWJlclwiIGlkPVwic3BsaXRDb3VudElucHV0XCIgbWluPVwiMVwiIG1heD1cIjIwXCIgdmFsdWU9XCIxXCIgc3R5bGU9XCJtYXJnaW46IDVweCAwOyBwYWRkaW5nOiA1cHg7IHdpZHRoOiAxMDBweDsgYmFja2dyb3VuZDogIzM3NDE1MTsgYm9yZGVyOiAxcHggc29saWQgIzRiNTU2MzsgYm9yZGVyLXJhZGl1czogNHB4OyBjb2xvcjogI2QxZDVkYjtcIj4nLFxuICAgICAgJ09wY2lvbmVzIGRlIEd1YXJkYWRvJyxcbiAgICAgIHtcbiAgICAgICAgc2F2ZTogXCJHdWFyZGFyXCIsXG4gICAgICAgIGNhbmNlbDogXCJDYW5jZWxhclwiXG4gICAgICB9XG4gICAgKTtcbiAgICBcbiAgICBpZiAoc3BsaXRDb25maXJtID09PSAnc2F2ZScpIHtcbiAgICAgIGNvbnN0IHNwbGl0SW5wdXQgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKCcjc3BsaXRDb3VudElucHV0Jyk7XG4gICAgICBjb25zdCBzcGxpdENvdW50ID0gcGFyc2VJbnQoc3BsaXRJbnB1dD8udmFsdWUpIHx8IDE7XG4gICAgICBjb25zdCByZXN1bHQgPSBhd2FpdCBzYXZlUHJvZ3Jlc3MobnVsbCwgc3BsaXRDb3VudCk7XG4gICAgICBpZiAocmVzdWx0LnN1Y2Nlc3MpIHtcbiAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXMoYFx1MjcwNSBQcm90ZWNjaVx1MDBGM24gZ3VhcmRhZGEke3NwbGl0Q291bnQgPiAxID8gYCAoZGl2aWRpZGEgZW4gJHtzcGxpdENvdW50fSBwYXJ0ZXMpYCA6ICcnfWAsICdzdWNjZXNzJyk7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyhgXHUyNzRDIEVycm9yIGFsIGd1YXJkYXI6ICR7cmVzdWx0LmVycm9yfWAsICdlcnJvcicpO1xuICAgICAgfVxuICAgIH1cbiAgfSk7XG5cbiAgLy8gRXZlbnRvcyBwYXJhIGNvbmZpZ3VyYWNpXHUwMEYzbiBlZGl0YWJsZVxuICBlbGVtZW50cy5waXhlbHNQZXJCYXRjaElucHV0LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIChlKSA9PiB7XG4gICAgZ3VhcmRTdGF0ZS5waXhlbHNQZXJCYXRjaCA9IE1hdGgubWF4KDEsIE1hdGgubWluKDUwLCBwYXJzZUludChlLnRhcmdldC52YWx1ZSkgfHwgMTApKTtcbiAgICBlLnRhcmdldC52YWx1ZSA9IGd1YXJkU3RhdGUucGl4ZWxzUGVyQmF0Y2g7XG4gIH0pO1xuXG4gIGVsZW1lbnRzLm1pbkNoYXJnZXNJbnB1dC5hZGRFdmVudExpc3RlbmVyKCdjaGFuZ2UnLCAoZSkgPT4ge1xuICAgIGd1YXJkU3RhdGUubWluQ2hhcmdlc1RvV2FpdCA9IE1hdGgubWF4KDEsIE1hdGgubWluKDEwMCwgcGFyc2VJbnQoZS50YXJnZXQudmFsdWUpIHx8IDIwKSk7XG4gICAgZS50YXJnZXQudmFsdWUgPSBndWFyZFN0YXRlLm1pbkNoYXJnZXNUb1dhaXQ7XG4gIH0pO1xuXG4gIC8vIEFjdHVhbGl6YXIgaW5wdXRzIGNvbiB2YWxvcmVzIGRlbCBlc3RhZG9cbiAgZWxlbWVudHMucGl4ZWxzUGVyQmF0Y2hJbnB1dC52YWx1ZSA9IGd1YXJkU3RhdGUucGl4ZWxzUGVyQmF0Y2g7XG4gIGVsZW1lbnRzLm1pbkNoYXJnZXNJbnB1dC52YWx1ZSA9IGd1YXJkU3RhdGUubWluQ2hhcmdlc1RvV2FpdDtcbn1cblxuYXN5bmMgZnVuY3Rpb24gaW5pdGlhbGl6ZUd1YXJkKGlzQXV0b0luaXQgPSBmYWxzZSkge1xuICB0cnkge1xuICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLmNoZWNraW5nQ29sb3JzJyksICdpbmZvJyk7XG4gICAgXG4gICAgLy8gRGV0ZWN0YXIgY29sb3JlcyBkaXNwb25pYmxlc1xuICAgIGxldCBjb2xvcnMgPSBkZXRlY3RBdmFpbGFibGVDb2xvcnMoKTtcbiAgICBpZiAoY29sb3JzLmxlbmd0aCA9PT0gMCkge1xuICAgICAgLy8gRmFsbGJhY2s6IGludGVudGFyIGFicmlyIGxhIHBhbGV0YSBhdXRvbVx1MDBFMXRpY2FtZW50ZSBzaSBhXHUwMEZBbiBubyBoYXkgY29sb3Jlc1xuICAgICAgbG9nKCdcdTI2QTBcdUZFMEYgMCBjb2xvcmVzIGRldGVjdGFkb3MuIEludGVudGFuZG8gYWJyaXIgcGFsZXRhIChmYWxsYmFjaykuLi4nKTtcbiAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLmNsaWNraW5nUGFpbnRCdXR0b24nKSwgJ2luZm8nKTtcbiAgICAgIGlmIChmaW5kQW5kQ2xpY2tQYWludEJ1dHRvbigpKSB7XG4gICAgICAgIGF3YWl0IHNsZWVwKDI1MDApO1xuICAgICAgICBjb2xvcnMgPSBkZXRlY3RBdmFpbGFibGVDb2xvcnMoKTtcbiAgICAgIH1cbiAgICB9XG4gICAgaWYgKGNvbG9ycy5sZW5ndGggPT09IDApIHtcbiAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLm5vQ29sb3JzRm91bmQnKSwgJ2Vycm9yJyk7XG4gICAgICByZXR1cm4gZmFsc2U7XG4gICAgfVxuICAgIFxuICAgIGd1YXJkU3RhdGUuYXZhaWxhYmxlQ29sb3JzID0gY29sb3JzO1xuICAgIGd1YXJkU3RhdGUuY29sb3JzQ2hlY2tlZCA9IHRydWU7XG4gICAgXG4gICAgLy8gT2J0ZW5lciBpbmZvcm1hY2lcdTAwRjNuIGRlIHNlc2lcdTAwRjNuXG4gICAgY29uc3Qgc2Vzc2lvbiA9IGF3YWl0IGdldFNlc3Npb24oKTtcbiAgICBpZiAoc2Vzc2lvbi5zdWNjZXNzKSB7XG4gICAgICBndWFyZFN0YXRlLmN1cnJlbnRDaGFyZ2VzID0gc2Vzc2lvbi5kYXRhLmNoYXJnZXM7XG4gICAgICBndWFyZFN0YXRlLm1heENoYXJnZXMgPSBzZXNzaW9uLmRhdGEubWF4Q2hhcmdlcztcbiAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHMoeyBjaGFyZ2VzOiBNYXRoLmZsb29yKGd1YXJkU3RhdGUuY3VycmVudENoYXJnZXMpIH0pO1xuICAgICAgbG9nKGBcdUQ4M0RcdURDNjQgVXN1YXJpbzogJHtzZXNzaW9uLmRhdGEudXNlcj8ubmFtZSB8fCAnQW5cdTAwRjNuaW1vJ30gLSBDYXJnYXM6ICR7Z3VhcmRTdGF0ZS5jdXJyZW50Q2hhcmdlc31gKTtcbiAgICB9XG4gICAgXG4gICAgZ3VhcmRTdGF0ZS5pbml0aWFsaXplZCA9IHRydWU7XG4gICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQuY29sb3JzRm91bmQnLCB7IGNvdW50OiBjb2xvcnMubGVuZ3RoIH0pLCAnc3VjY2VzcycpO1xuICAgIGd1YXJkU3RhdGUudWkuc2hvd0FyZWFTZWN0aW9uKCk7XG4gICAgXG4gICAgLy8gU29sbyBtb3N0cmFyIGxvZyB1bmEgdmV6IChldml0YXIgZHVwbGljYWRvIGVuIGF1dG8taW5pY2lvKVxuICAgIGlmICghaXNBdXRvSW5pdCkge1xuICAgICAgbG9nKGBcdTI3MDUgJHtjb2xvcnMubGVuZ3RofSBjb2xvcmVzIGRpc3BvbmlibGVzIGRldGVjdGFkb3NgKTtcbiAgICB9XG4gICAgXG4gICAgLy8gTWFyY2FyIGNvbW8gaW5pY2lhbGl6YWRvIGV4aXRvc2FtZW50ZSBwYXJhIGRlc2hhYmlsaXRhciBlbCBib3RcdTAwRjNuXG4gICAgZ3VhcmRTdGF0ZS51aS5zZXRJbml0aWFsaXplZCh0cnVlKTtcbiAgICBcbiAgICByZXR1cm4gdHJ1ZTtcbiAgICBcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1Mjc0QyBFcnJvciBpbmljaWFsaXphbmRvOicsIGVycm9yKTtcbiAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5pbml0RXJyb3InKSwgJ2Vycm9yJyk7XG4gICAgcmV0dXJuIGZhbHNlO1xuICB9XG59XG5cbi8vIFZhcmlhYmxlIHBhcmEgYWxtYWNlbmFyIGZldGNoIG9yaWdpbmFsXG5sZXQgb3JpZ2luYWxGZXRjaCA9IHdpbmRvdy5mZXRjaDtcblxuYXN5bmMgZnVuY3Rpb24gc2VsZWN0QXJlYVN0ZXBCeVN0ZXAoKSB7XG4gIGxvZygnXHVEODNDXHVERkFGIEluaWNpYW5kbyBzZWxlY2NpXHUwMEYzbiBwYXNvIGEgcGFzbyBkZWwgXHUwMEUxcmVhJyk7XG4gIFxuICAvLyBFc3RhZG8gcGFyYSBsYSBzZWxlY2NpXHUwMEYzblxuICBsZXQgdXBwZXJMZWZ0Q29ybmVyID0gbnVsbDtcbiAgbGV0IGxvd2VyUmlnaHRDb3JuZXIgPSBudWxsO1xuICBsZXQgc2VsZWN0aW9uUGhhc2UgPSAndXBwZXJMZWZ0JzsgLy8gJ3VwcGVyTGVmdCcgfCAnbG93ZXJSaWdodCdcbiAgbGV0IHBvc2l0aW9uQ2FwdHVyZWQgPSBmYWxzZTtcbiAgXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIHJlc3RhdXJhciBmZXRjaCBvcmlnaW5hbFxuICBjb25zdCByZXN0b3JlRmV0Y2ggPSAoKSA9PiB7XG4gICAgaWYgKHdpbmRvdy5mZXRjaCAhPT0gb3JpZ2luYWxGZXRjaCkge1xuICAgICAgd2luZG93LmZldGNoID0gb3JpZ2luYWxGZXRjaDtcbiAgICAgIGxvZygnXHVEODNEXHVERDA0IEZldGNoIG9yaWdpbmFsIHJlc3RhdXJhZG8nKTtcbiAgICB9XG4gIH07XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBpbnRlcmNlcHRhciBwaW50YWRvIHkgY2FwdHVyYXIgY29vcmRlbmFkYXNcbiAgY29uc3Qgc2V0dXBGZXRjaEludGVyY2VwdGlvbiA9ICgpID0+IHtcbiAgICB3aW5kb3cuZmV0Y2ggPSBhc3luYyAodXJsLCBvcHRpb25zKSA9PiB7XG4gICAgICAvLyBTb2xvIGludGVyY2VwdGFyIHJlcXVlc3RzIGVzcGVjXHUwMEVEZmljb3MgZGUgcGludGFkbyBkdXJhbnRlIHNlbGVjY2lcdTAwRjNuXG4gICAgICBpZiAoIXBvc2l0aW9uQ2FwdHVyZWQgJiZcbiAgICAgICAgICB0eXBlb2YgdXJsID09PSAnc3RyaW5nJyAmJiBcbiAgICAgICAgICB1cmwuaW5jbHVkZXMoJy9zMC9waXhlbC8nKSAmJiBcbiAgICAgICAgICBvcHRpb25zICYmIFxuICAgICAgICAgIG9wdGlvbnMubWV0aG9kID09PSAnUE9TVCcpIHtcbiAgICAgICAgXG4gICAgICAgIHRyeSB7XG4gICAgICAgICAgbG9nKGBcdUQ4M0NcdURGQUYgSW50ZXJjZXB0YW5kbyByZXF1ZXN0IGRlIHBpbnRhZG86ICR7dXJsfWApO1xuICAgICAgICAgIFxuICAgICAgICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgb3JpZ2luYWxGZXRjaCh1cmwsIG9wdGlvbnMpO1xuICAgICAgICAgIFxuICAgICAgICAgIGlmIChyZXNwb25zZS5vayAmJiBvcHRpb25zLmJvZHkpIHtcbiAgICAgICAgICAgIGxldCBib2R5RGF0YTtcbiAgICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICAgIGJvZHlEYXRhID0gSlNPTi5wYXJzZShvcHRpb25zLmJvZHkpO1xuICAgICAgICAgICAgfSBjYXRjaCAocGFyc2VFcnJvcikge1xuICAgICAgICAgICAgICBsb2coJ0Vycm9yIHBhcnNlYW5kbyBib2R5IGRlbCByZXF1ZXN0OicsIHBhcnNlRXJyb3IpO1xuICAgICAgICAgICAgICByZXR1cm4gcmVzcG9uc2U7XG4gICAgICAgICAgICB9XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIGlmIChib2R5RGF0YS5jb29yZHMgJiYgQXJyYXkuaXNBcnJheShib2R5RGF0YS5jb29yZHMpICYmIGJvZHlEYXRhLmNvb3Jkcy5sZW5ndGggPj0gMikge1xuICAgICAgICAgICAgICBjb25zdCBsb2NhbFggPSBib2R5RGF0YS5jb29yZHNbMF07XG4gICAgICAgICAgICAgIGNvbnN0IGxvY2FsWSA9IGJvZHlEYXRhLmNvb3Jkc1sxXTtcbiAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgIC8vIEV4dHJhZXIgdGlsZSBkZSBsYSBVUkxcbiAgICAgICAgICAgICAgY29uc3QgdGlsZU1hdGNoID0gdXJsLm1hdGNoKC9cXC9zMFxcL3BpeGVsXFwvKC0/XFxkKylcXC8oLT9cXGQrKS8pO1xuICAgICAgICAgICAgICBpZiAodGlsZU1hdGNoKSB7XG4gICAgICAgICAgICAgICAgY29uc3QgdGlsZVggPSBwYXJzZUludCh0aWxlTWF0Y2hbMV0pO1xuICAgICAgICAgICAgICAgIGNvbnN0IHRpbGVZID0gcGFyc2VJbnQodGlsZU1hdGNoWzJdKTtcbiAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAvLyBDYWxjdWxhciBjb29yZGVuYWRhcyBnbG9iYWxlc1xuICAgICAgICAgICAgICAgIGNvbnN0IGdsb2JhbFggPSB0aWxlWCAqIDMwMDAgKyBsb2NhbFg7XG4gICAgICAgICAgICAgICAgY29uc3QgZ2xvYmFsWSA9IHRpbGVZICogMzAwMCArIGxvY2FsWTtcbiAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICBpZiAoc2VsZWN0aW9uUGhhc2UgPT09ICd1cHBlckxlZnQnKSB7XG4gICAgICAgICAgICAgICAgICAvLyBDYXB0dXJhciBlc3F1aW5hIHN1cGVyaW9yIGl6cXVpZXJkYVxuICAgICAgICAgICAgICAgICAgdXBwZXJMZWZ0Q29ybmVyID0geyB4OiBnbG9iYWxYLCB5OiBnbG9iYWxZIH07XG4gICAgICAgICAgICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZUNvb3JkaW5hdGVzKHsgeDE6IGdsb2JhbFgsIHkxOiBnbG9iYWxZIH0pO1xuICAgICAgICAgICAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQudXBwZXJMZWZ0Q2FwdHVyZWQnLCB7IHg6IGdsb2JhbFgsIHk6IGdsb2JhbFkgfSksICdzdWNjZXNzJyk7XG4gICAgICAgICAgICAgICAgICBsb2coYFx1MjcwNSBFc3F1aW5hIHN1cGVyaW9yIGl6cXVpZXJkYSBjYXB0dXJhZGE6ICgke2dsb2JhbFh9LCAke2dsb2JhbFl9KWApO1xuICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAvLyBDYW1iaWFyIGEgZmFzZSBkZSBlc3F1aW5hIGluZmVyaW9yIGRlcmVjaGFcbiAgICAgICAgICAgICAgICAgIHNlbGVjdGlvblBoYXNlID0gJ2xvd2VyUmlnaHQnO1xuICAgICAgICAgICAgICAgICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICAgICAgICAgICAgICAgIGlmIChzZWxlY3Rpb25QaGFzZSA9PT0gJ2xvd2VyUmlnaHQnKSB7XG4gICAgICAgICAgICAgICAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQuc2VsZWN0TG93ZXJSaWdodCcpLCAnaW5mbycpO1xuICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICB9LCAxNTAwKTtcbiAgICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgIH0gZWxzZSBpZiAoc2VsZWN0aW9uUGhhc2UgPT09ICdsb3dlclJpZ2h0Jykge1xuICAgICAgICAgICAgICAgICAgLy8gQ2FwdHVyYXIgZXNxdWluYSBpbmZlcmlvciBkZXJlY2hhXG4gICAgICAgICAgICAgICAgICBsb3dlclJpZ2h0Q29ybmVyID0geyB4OiBnbG9iYWxYLCB5OiBnbG9iYWxZIH07XG4gICAgICAgICAgICAgICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZUNvb3JkaW5hdGVzKHsgeDI6IGdsb2JhbFgsIHkyOiBnbG9iYWxZIH0pO1xuICAgICAgICAgICAgICAgICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQubG93ZXJSaWdodENhcHR1cmVkJywgeyB4OiBnbG9iYWxYLCB5OiBnbG9iYWxZIH0pLCAnc3VjY2VzcycpO1xuICAgICAgICAgICAgICAgICAgbG9nKGBcdTI3MDUgRXNxdWluYSBpbmZlcmlvciBkZXJlY2hhIGNhcHR1cmFkYTogKCR7Z2xvYmFsWH0sICR7Z2xvYmFsWX0pYCk7XG4gICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgIC8vIENvbXBsZXRhciBzZWxlY2NpXHUwMEYzblxuICAgICAgICAgICAgICAgICAgcG9zaXRpb25DYXB0dXJlZCA9IHRydWU7XG4gICAgICAgICAgICAgICAgICByZXN0b3JlRmV0Y2goKTtcbiAgICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgICAgLy8gVmFsaWRhciBcdTAwRTFyZWFcbiAgICAgICAgICAgICAgICAgIGlmICh1cHBlckxlZnRDb3JuZXIueCA+PSBsb3dlclJpZ2h0Q29ybmVyLnggfHwgdXBwZXJMZWZ0Q29ybmVyLnkgPj0gbG93ZXJSaWdodENvcm5lci55KSB7XG4gICAgICAgICAgICAgICAgICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLmludmFsaWRBcmVhJyksICdlcnJvcicpO1xuICAgICAgICAgICAgICAgICAgICByZXR1cm4gcmVzcG9uc2U7XG4gICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgIC8vIENhcHR1cmFyIFx1MDBFMXJlYSBhdXRvbVx1MDBFMXRpY2FtZW50ZVxuICAgICAgICAgICAgICAgICAgc2V0VGltZW91dChhc3luYyAoKSA9PiB7XG4gICAgICAgICAgICAgICAgICAgIGF3YWl0IGNhcHR1cmVBcmVhRnJvbUNvb3JkaW5hdGVzKHVwcGVyTGVmdENvcm5lciwgbG93ZXJSaWdodENvcm5lcik7XG4gICAgICAgICAgICAgICAgICB9LCAxMDAwKTtcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH1cbiAgICAgICAgICB9XG4gICAgICAgICAgXG4gICAgICAgICAgcmV0dXJuIHJlc3BvbnNlO1xuICAgICAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgICAgIGxvZygnXHUyNzRDIEVycm9yIGludGVyY2VwdGFuZG8gcGl4ZWw6JywgZXJyb3IpO1xuICAgICAgICAgIHJlc3RvcmVGZXRjaCgpO1xuICAgICAgICAgIHJldHVybiBvcmlnaW5hbEZldGNoKHVybCwgb3B0aW9ucyk7XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICAgIFxuICAgICAgLy8gUGFyYSB0b2RvcyBsb3MgZGVtXHUwMEUxcyByZXF1ZXN0cywgdXNhciBmZXRjaCBvcmlnaW5hbFxuICAgICAgcmV0dXJuIG9yaWdpbmFsRmV0Y2godXJsLCBvcHRpb25zKTtcbiAgICB9O1xuICB9O1xuICBcbiAgLy8gQ29uZmlndXJhciBpbnRlcmNlcHRhY2lcdTAwRjNuXG4gIHNldHVwRmV0Y2hJbnRlcmNlcHRpb24oKTtcbiAgXG4gIC8vIEluaWNpYXIgY29uIGVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhXG4gIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLnNlbGVjdFVwcGVyTGVmdCcpLCAnaW5mbycpO1xuICBcbiAgLy8gVGltZW91dCBwYXJhIHNlbGVjY2lcdTAwRjNuICgyIG1pbnV0b3MpXG4gIHNldFRpbWVvdXQoKCkgPT4ge1xuICAgIGlmICghcG9zaXRpb25DYXB0dXJlZCkge1xuICAgICAgcmVzdG9yZUZldGNoKCk7XG4gICAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5zZWxlY3Rpb25UaW1lb3V0JyksICdlcnJvcicpO1xuICAgICAgbG9nKCdcdTIzRjAgVGltZW91dCBlbiBzZWxlY2NpXHUwMEYzbiBkZSBcdTAwRTFyZWEnKTtcbiAgICB9XG4gIH0sIDEyMDAwMCk7XG59XG5cbmFzeW5jIGZ1bmN0aW9uIGNhcHR1cmVBcmVhRnJvbUNvb3JkaW5hdGVzKHVwcGVyTGVmdCwgbG93ZXJSaWdodCkge1xuICB0cnkge1xuICAgIGNvbnN0IGFyZWEgPSB7XG4gICAgICB4MTogdXBwZXJMZWZ0LngsXG4gICAgICB5MTogdXBwZXJMZWZ0LnksXG4gICAgICB4MjogbG93ZXJSaWdodC54LFxuICAgICAgeTI6IGxvd2VyUmlnaHQueVxuICAgIH07XG4gICAgXG4gICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQuY2FwdHVyaW5nQXJlYScpLCAnaW5mbycpO1xuICAgIFxuICAgIGNvbnN0IHBpeGVsTWFwID0gYXdhaXQgYW5hbHl6ZUFyZWFQaXhlbHMoYXJlYSk7XG4gICAgXG4gICAgZ3VhcmRTdGF0ZS5wcm90ZWN0aW9uQXJlYSA9IGFyZWE7XG4gICAgZ3VhcmRTdGF0ZS5vcmlnaW5hbFBpeGVscyA9IHBpeGVsTWFwO1xuICAgIGd1YXJkU3RhdGUuY2hhbmdlcy5jbGVhcigpO1xuICAgIFxuICAgIGd1YXJkU3RhdGUudWkudXBkYXRlUHJvZ3Jlc3MoMCwgcGl4ZWxNYXAuc2l6ZSk7XG4gICAgZ3VhcmRTdGF0ZS51aS51cGRhdGVTdGF0dXModCgnZ3VhcmQuYXJlYUNhcHR1cmVkJywgeyBjb3VudDogcGl4ZWxNYXAuc2l6ZSB9KSwgJ3N1Y2Nlc3MnKTtcbiAgICBndWFyZFN0YXRlLnVpLmVuYWJsZVN0YXJ0QnRuKCk7XG4gICAgXG4gICAgbG9nKGBcdTI3MDUgXHUwMEMxcmVhIGNhcHR1cmFkYTogJHtwaXhlbE1hcC5zaXplfSBwXHUwMEVEeGVsZXMgcHJvdGVnaWRvc2ApO1xuICAgIFxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZygnXHUyNzRDIEVycm9yIGNhcHR1cmFuZG8gXHUwMEUxcmVhOicsIGVycm9yKTtcbiAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5jYXB0dXJlRXJyb3InLCB7IGVycm9yOiBlcnJvci5tZXNzYWdlIH0pLCAnZXJyb3InKTtcbiAgfVxufVxuXG5hc3luYyBmdW5jdGlvbiBzdGFydEd1YXJkKCkge1xuICBpZiAoIWd1YXJkU3RhdGUucHJvdGVjdGlvbkFyZWEgfHwgIWd1YXJkU3RhdGUub3JpZ2luYWxQaXhlbHMuc2l6ZSkge1xuICAgIGd1YXJkU3RhdGUudWkudXBkYXRlU3RhdHVzKHQoJ2d1YXJkLmNhcHR1cmVGaXJzdCcpLCAnZXJyb3InKTtcbiAgICByZXR1cm47XG4gIH1cbiAgXG4gIGd1YXJkU3RhdGUucnVubmluZyA9IHRydWU7XG4gIGd1YXJkU3RhdGUudWkuc2V0UnVubmluZ1N0YXRlKHRydWUpO1xuICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5wcm90ZWN0aW9uU3RhcnRlZCcpLCAnc3VjY2VzcycpO1xuICBcbiAgbG9nKCdcdUQ4M0RcdURFRTFcdUZFMEYgSW5pY2lhbmRvIHByb3RlY2NpXHUwMEYzbiBkZWwgXHUwMEUxcmVhJyk7XG4gIFxuICAvLyBDb25maWd1cmFyIGludGVydmFsbyBkZSB2ZXJpZmljYWNpXHUwMEYzblxuICBndWFyZFN0YXRlLmNoZWNrSW50ZXJ2YWwgPSBzZXRJbnRlcnZhbChjaGVja0ZvckNoYW5nZXMsIEdVQVJEX0RFRkFVTFRTLkNIRUNLX0lOVEVSVkFMKTtcbiAgXG4gIC8vIFByaW1lcmEgdmVyaWZpY2FjaVx1MDBGM24gaW5tZWRpYXRhXG4gIGF3YWl0IGNoZWNrRm9yQ2hhbmdlcygpO1xufVxuXG5mdW5jdGlvbiBzdG9wR3VhcmQoKSB7XG4gIGd1YXJkU3RhdGUucnVubmluZyA9IGZhbHNlO1xuICBcbiAgaWYgKGd1YXJkU3RhdGUuY2hlY2tJbnRlcnZhbCkge1xuICAgIGNsZWFySW50ZXJ2YWwoZ3VhcmRTdGF0ZS5jaGVja0ludGVydmFsKTtcbiAgICBndWFyZFN0YXRlLmNoZWNrSW50ZXJ2YWwgPSBudWxsO1xuICB9XG4gIFxuICBpZiAoZ3VhcmRTdGF0ZS51aSkge1xuICAgIGd1YXJkU3RhdGUudWkuc2V0UnVubmluZ1N0YXRlKGZhbHNlKTtcbiAgICBndWFyZFN0YXRlLnVpLnVwZGF0ZVN0YXR1cyh0KCdndWFyZC5wcm90ZWN0aW9uU3RvcHBlZCcpLCAnd2FybmluZycpO1xuICB9XG4gIFxuICBsb2coJ1x1MjNGOVx1RkUwRiBQcm90ZWNjaVx1MDBGM24gZGV0ZW5pZGEnKTtcbn1cbiIsICJpbXBvcnQgeyBydW5HdWFyZCB9IGZyb20gXCIuLi9ndWFyZC9pbmRleC5qc1wiO1xuaW1wb3J0IHsgYXV0b0NsaWNrUGFpbnRCdXR0b24gfSBmcm9tIFwiLi4vY29yZS9kb20uanNcIjtcblxuLy8gQXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludCBhbCBpbmljaW9cbihhc3luYyBmdW5jdGlvbigpIHtcbiAgdHJ5IHtcbiAgICBjb25zb2xlLmxvZygnW1dQQS1HdWFyZF0gXHVEODNFXHVERDE2IEluaWNpYW5kbyBhdXRvLWNsaWNrIGRlbCBib3RcdTAwRjNuIFBhaW50Li4uJyk7XG4gICAgYXdhaXQgYXV0b0NsaWNrUGFpbnRCdXR0b24oMywgdHJ1ZSk7XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgY29uc29sZS5sb2coJ1tXUEEtR3VhcmRdIFx1MjZBMFx1RkUwRiBFcnJvciBlbiBhdXRvLWNsaWNrIGRlbCBib3RcdTAwRjNuIFBhaW50OicsIGVycm9yKTtcbiAgfVxuICBcbiAgLy8gVmVyaWZpY2FyIHNpIHlhIGhheSB1biBib3QgR3VhcmQgY29ycmllbmRvXG4gIGlmICh3aW5kb3cuX193cGxhY2VCb3Q/Lmd1YXJkUnVubmluZykge1xuICAgIGFsZXJ0KCdBdXRvLUd1YXJkIHlhIGVzdFx1MDBFMSBjb3JyaWVuZG8uJyk7XG4gIH0gZWxzZSB7XG4gICAgLy8gRWplY3V0YXIgZWwgYm90XG4gICAgcnVuR3VhcmQoKS5jYXRjaChlcnJvciA9PiB7XG4gICAgICBjb25zb2xlLmVycm9yKCdbV1BBLUdVQVJEXSBFcnJvciBlbiBBdXRvLUd1YXJkOicsIGVycm9yKTtcbiAgICAgIGlmICh3aW5kb3cuX193cGxhY2VCb3QpIHtcbiAgICAgICAgd2luZG93Ll9fd3BsYWNlQm90Lmd1YXJkUnVubmluZyA9IGZhbHNlO1xuICAgICAgfVxuICAgICAgYWxlcnQoJ0F1dG8tR3VhcmQ6IGVycm9yIGluZXNwZXJhZG8uIFJldmlzYSBjb25zb2xhLicpO1xuICAgIH0pO1xuICB9XG59KSgpO1xuIl0sCiAgIm1hcHBpbmdzIjogIjs7O0FBVU8sTUFBTSxNQUFNLElBQUksTUFBTSxRQUFRLElBQUksWUFBWSxHQUFHLENBQUM7OztBQ1J6RCxNQUFNLE9BQU87QUFFYixpQkFBc0IsYUFBYTtBQUpuQztBQUtFLFFBQUk7QUFDRixZQUFNLEtBQUssTUFBTSxNQUFNLEdBQUcsSUFBSSxPQUFPLEVBQUUsYUFBYSxVQUFVLENBQUMsRUFBRSxLQUFLLE9BQUssRUFBRSxLQUFLLENBQUM7QUFDbkYsWUFBTSxPQUFPLE1BQU07QUFDbkIsWUFBTSxLQUFJLHlCQUFJLFlBQVcsQ0FBQztBQUMxQixZQUFNLFVBQVU7QUFBQSxRQUNkLFFBQU8sT0FBRSxVQUFGLFlBQVc7QUFBQTtBQUFBLFFBQ2xCLE1BQUssT0FBRSxRQUFGLFlBQVM7QUFBQTtBQUFBLFFBQ2QsYUFBWSxPQUFFLGVBQUYsWUFBZ0I7QUFBQSxNQUM5QjtBQUVBLGFBQU87QUFBQSxRQUNMLFNBQVM7QUFBQSxRQUNULE1BQU07QUFBQSxVQUNKO0FBQUEsVUFDQSxTQUFTLFFBQVE7QUFBQSxVQUNqQixZQUFZLFFBQVE7QUFBQSxVQUNwQixhQUFhLFFBQVE7QUFBQSxRQUN2QjtBQUFBLE1BQ0Y7QUFBQSxJQUNGLFNBQVMsT0FBTztBQUNkLGFBQU87QUFBQSxRQUNMLFNBQVM7QUFBQSxRQUNULE9BQU8sTUFBTTtBQUFBLFFBQ2IsTUFBTTtBQUFBLFVBQ0osTUFBTTtBQUFBLFVBQ04sU0FBUztBQUFBLFVBQ1QsWUFBWTtBQUFBLFVBQ1osYUFBYTtBQUFBLFFBQ2Y7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUFBLEVBQ0Y7QUFrSUEsaUJBQXNCLG9CQUFvQixPQUFPLE9BQU8sUUFBUSxRQUFRLGdCQUFnQjtBQUN0RixRQUFJO0FBQ0YsWUFBTSxPQUFPLEtBQUssVUFBVTtBQUFBLFFBQzFCO0FBQUEsUUFDQTtBQUFBLFFBQ0EsR0FBRztBQUFBLE1BQ0wsQ0FBQztBQUVELFlBQU0sV0FBVyxNQUFNLE1BQU0sR0FBRyxJQUFJLGFBQWEsS0FBSyxJQUFJLEtBQUssSUFBSTtBQUFBLFFBQ2pFLFFBQVE7QUFBQSxRQUNSLGFBQWE7QUFBQSxRQUNiLFNBQVMsRUFBRSxnQkFBZ0IsMkJBQTJCO0FBQUEsUUFDdEQ7QUFBQSxNQUNGLENBQUM7QUFFRCxVQUFJLGVBQWU7QUFDbkIsVUFBSTtBQUNGLHVCQUFlLE1BQU0sU0FBUyxLQUFLO0FBQUEsTUFDckMsUUFBUTtBQUNOLHVCQUFlLENBQUM7QUFBQSxNQUNsQjtBQUVBLGFBQU87QUFBQSxRQUNMLFFBQVEsU0FBUztBQUFBLFFBQ2pCLE1BQU07QUFBQSxRQUNOLFNBQVMsU0FBUztBQUFBLFFBQ2xCLFVBQVMsNkNBQWMsWUFBVztBQUFBLE1BQ3BDO0FBQUEsSUFDRixTQUFTLE9BQU87QUFDZCxhQUFPO0FBQUEsUUFDTCxRQUFRO0FBQUEsUUFDUixNQUFNLEVBQUUsT0FBTyxNQUFNLFFBQVE7QUFBQSxRQUM3QixTQUFTO0FBQUEsUUFDVCxTQUFTO0FBQUEsTUFDWDtBQUFBLElBQ0Y7QUFBQSxFQUNGOzs7QUN6TU8sTUFBTSxpQkFBaUI7QUFBQSxJQUM1QixTQUFTO0FBQUEsSUFDVCxrQkFBa0I7QUFBQSxJQUNsQixXQUFXO0FBQUEsSUFDWCxnQkFBZ0I7QUFBQTtBQUFBLElBQ2hCLHFCQUFxQjtBQUFBO0FBQUEsSUFDckIsa0JBQWtCO0FBQUE7QUFBQSxJQUNsQixxQkFBcUI7QUFBQTtBQUFBLElBQ3JCLGFBQWE7QUFBQSxFQUNmO0FBR08sTUFBTSxhQUFhO0FBQUEsSUFDeEIsU0FBUztBQUFBLElBQ1QsYUFBYTtBQUFBLElBQ2IsZ0JBQWdCO0FBQUE7QUFBQSxJQUNoQixnQkFBZ0Isb0JBQUksSUFBSTtBQUFBO0FBQUEsSUFDeEIsU0FBUyxvQkFBSSxJQUFJO0FBQUE7QUFBQSxJQUNqQixnQkFBZ0I7QUFBQSxJQUNoQixZQUFZO0FBQUEsSUFDWixXQUFXO0FBQUEsSUFDWCxlQUFlO0FBQUEsSUFDZixpQkFBaUIsQ0FBQztBQUFBLElBQ2xCLGVBQWU7QUFBQSxJQUNmLElBQUk7QUFBQSxJQUNKLGVBQWU7QUFBQTtBQUFBLElBRWYsZ0JBQWdCLGVBQWU7QUFBQSxJQUMvQixrQkFBa0IsZUFBZTtBQUFBLEVBQ25DOzs7QUM5QkEsTUFBSSxTQUFTO0FBRWIsaUJBQXNCLGdCQUFnQjtBQUNwQyxRQUFJLFVBQVUsT0FBTyxVQUFXO0FBRWhDLFdBQU8sSUFBSSxRQUFRLENBQUMsU0FBUyxXQUFXO0FBQ3RDLFlBQU0sSUFBSSxTQUFTLGNBQWMsUUFBUTtBQUN6QyxRQUFFLE1BQU07QUFDUixRQUFFLFFBQVE7QUFDVixRQUFFLFFBQVE7QUFDVixRQUFFLFNBQVMsTUFBTTtBQUNmLGlCQUFTO0FBQ1QsZ0JBQVE7QUFBQSxNQUNWO0FBQ0EsUUFBRSxVQUFVLE1BQU0sT0FBTyxJQUFJLE1BQU0sNkJBQTZCLENBQUM7QUFDakUsZUFBUyxLQUFLLFlBQVksQ0FBQztBQUFBLElBQzdCLENBQUM7QUFBQSxFQUNIO0FBRUEsaUJBQXNCLGlCQUFpQixTQUFTLFNBQVMsU0FBUztBQW5CbEU7QUFvQkUsVUFBTSxjQUFjO0FBRXBCLFFBQUksU0FBTyxZQUFPLGNBQVAsbUJBQWtCLGFBQVksWUFBWTtBQUNuRCxVQUFJO0FBQ0YsY0FBTSxRQUFRLE1BQU0sT0FBTyxVQUFVLFFBQVEsU0FBUyxFQUFFLE9BQU8sQ0FBQztBQUNoRSxZQUFJLFNBQVMsTUFBTSxTQUFTLEdBQUksUUFBTztBQUFBLE1BQ3pDLFFBQVE7QUFBQSxNQUVSO0FBQUEsSUFDRjtBQUdBLFdBQU8sTUFBTSxJQUFJLFFBQVEsQ0FBQyxZQUFZO0FBQ3BDLFlBQU0sT0FBTyxTQUFTLGNBQWMsS0FBSztBQUN6QyxXQUFLLE1BQU0sV0FBVztBQUN0QixXQUFLLE1BQU0sT0FBTztBQUNsQixlQUFTLEtBQUssWUFBWSxJQUFJO0FBQzlCLGFBQU8sVUFBVSxPQUFPLE1BQU07QUFBQSxRQUM1QixTQUFTO0FBQUEsUUFDVCxVQUFVLENBQUNBLE9BQU07QUFDZixtQkFBUyxLQUFLLFlBQVksSUFBSTtBQUM5QixrQkFBUUEsRUFBQztBQUFBLFFBQ1g7QUFBQSxNQUNGLENBQUM7QUFBQSxJQUNILENBQUM7QUFBQSxFQUNIO0FBR0EsaUJBQXNCLGtCQUFrQixTQUFTO0FBQy9DLFdBQU8saUJBQWlCLFNBQVMsT0FBTztBQUFBLEVBQzFDOzs7QUNsRE8sTUFBTSxRQUFRLENBQUMsT0FBTyxJQUFJLFFBQVEsT0FBSyxXQUFXLEdBQUcsRUFBRSxDQUFDOzs7QUNPL0QsTUFBTSxFQUFFLE9BQU8sSUFBSSxJQUFJO0FBR3ZCLGlCQUFzQixhQUFhLE9BQU8sT0FBTztBQUMvQyxRQUFJO0FBQ0YsWUFBTSxNQUFNLEdBQUcsZUFBZSxXQUFXLG1CQUFtQixLQUFLLElBQUksS0FBSztBQUMxRSxZQUFNLFdBQVcsTUFBTSxNQUFNLEdBQUc7QUFFaEMsVUFBSSxDQUFDLFNBQVMsSUFBSTtBQUNoQixjQUFNLElBQUksTUFBTSxRQUFRLFNBQVMsTUFBTSxFQUFFO0FBQUEsTUFDM0M7QUFFQSxhQUFPLE1BQU0sU0FBUyxLQUFLO0FBQUEsSUFDN0IsU0FBUyxPQUFPO0FBQ2QsVUFBSSx5QkFBeUIsS0FBSyxJQUFJLEtBQUssS0FBSyxLQUFLO0FBQ3JELGFBQU87QUFBQSxJQUNUO0FBQUEsRUFDRjtBQUdPLFdBQVMsd0JBQXdCO0FBQ3RDLFFBQUksNkNBQXNDO0FBQzFDLFVBQU0sZ0JBQWdCLFNBQVMsaUJBQWlCLGdCQUFnQjtBQUNoRSxVQUFNLFNBQVMsQ0FBQztBQUVoQixlQUFXLFdBQVcsZUFBZTtBQUNuQyxVQUFJLFFBQVEsY0FBYyxLQUFLLEVBQUc7QUFFbEMsWUFBTSxVQUFVLFNBQVMsUUFBUSxHQUFHLFFBQVEsVUFBVSxFQUFFLENBQUM7QUFDekQsVUFBSSxZQUFZLEtBQUssWUFBWSxFQUFHO0FBRXBDLFlBQU0sVUFBVSxRQUFRLE1BQU07QUFDOUIsVUFBSSxTQUFTO0FBQ1gsY0FBTSxXQUFXLFFBQVEsTUFBTSxNQUFNO0FBQ3JDLFlBQUksWUFBWSxTQUFTLFVBQVUsR0FBRztBQUNwQyxpQkFBTyxLQUFLO0FBQUEsWUFDVixJQUFJO0FBQUEsWUFDSixHQUFHLFNBQVMsU0FBUyxDQUFDLENBQUM7QUFBQSxZQUN2QixHQUFHLFNBQVMsU0FBUyxDQUFDLENBQUM7QUFBQSxZQUN2QixHQUFHLFNBQVMsU0FBUyxDQUFDLENBQUM7QUFBQSxZQUN2QjtBQUFBLFVBQ0YsQ0FBQztBQUFBLFFBQ0g7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUVBLFFBQUksVUFBSyxPQUFPLE1BQU0scUJBQXFCO0FBQzNDLFdBQU87QUFBQSxFQUNUO0FBR08sV0FBUyxpQkFBaUIsR0FBRyxHQUFHLEdBQUcsaUJBQWlCO0FBQ3pELFFBQUksY0FBYztBQUNsQixRQUFJLGVBQWU7QUFFbkIsZUFBVyxTQUFTLGlCQUFpQjtBQUNuQyxZQUFNLFdBQVcsS0FBSztBQUFBLFFBQ3BCLEtBQUssSUFBSSxJQUFJLE1BQU0sR0FBRyxDQUFDLElBQ3ZCLEtBQUssSUFBSSxJQUFJLE1BQU0sR0FBRyxDQUFDLElBQ3ZCLEtBQUssSUFBSSxJQUFJLE1BQU0sR0FBRyxDQUFDO0FBQUEsTUFDekI7QUFFQSxVQUFJLFdBQVcsYUFBYTtBQUMxQixzQkFBYztBQUNkLHVCQUFlO0FBQUEsTUFDakI7QUFBQSxJQUNGO0FBRUEsV0FBTztBQUFBLEVBQ1Q7QUFHQSxpQkFBc0Isa0JBQWtCLE1BQU07QUFDNUMsVUFBTSxFQUFFLElBQUksSUFBSSxJQUFJLEdBQUcsSUFBSTtBQUMzQixVQUFNLFFBQVEsS0FBSztBQUNuQixVQUFNLFNBQVMsS0FBSztBQUVwQixRQUFJLGdDQUFzQixLQUFLLElBQUksTUFBTSxXQUFXLEVBQUUsSUFBSSxFQUFFLFlBQVksRUFBRSxJQUFJLEVBQUUsR0FBRztBQUVuRixVQUFNLFdBQVcsb0JBQUksSUFBSTtBQUd6QixVQUFNLGFBQWEsS0FBSyxNQUFNLEtBQUssZUFBZSxTQUFTO0FBQzNELFVBQU0sYUFBYSxLQUFLLE1BQU0sS0FBSyxlQUFlLFNBQVM7QUFDM0QsVUFBTSxXQUFXLEtBQUssTUFBTSxLQUFLLGVBQWUsU0FBUztBQUN6RCxVQUFNLFdBQVcsS0FBSyxNQUFNLEtBQUssZUFBZSxTQUFTO0FBR3pELGFBQVMsUUFBUSxZQUFZLFNBQVMsVUFBVSxTQUFTO0FBQ3ZELGVBQVMsUUFBUSxZQUFZLFNBQVMsVUFBVSxTQUFTO0FBQ3ZELFlBQUk7QUFDRixnQkFBTSxXQUFXLE1BQU0sYUFBYSxPQUFPLEtBQUs7QUFDaEQsY0FBSSxDQUFDLFVBQVU7QUFDYixnQkFBSSx3Q0FBOEIsS0FBSyxJQUFJLEtBQUssa0JBQWtCO0FBQ2xFO0FBQUEsVUFDRjtBQUdBLGdCQUFNLE1BQU0sSUFBSSxNQUFNO0FBQ3RCLGdCQUFNLFNBQVMsU0FBUyxjQUFjLFFBQVE7QUFDOUMsZ0JBQU0sTUFBTSxPQUFPLFdBQVcsSUFBSTtBQUVsQyxnQkFBTSxJQUFJLFFBQVEsQ0FBQyxTQUFTLFdBQVc7QUFDckMsZ0JBQUksU0FBUztBQUNiLGdCQUFJLFVBQVU7QUFDZCxnQkFBSSxNQUFNLElBQUksZ0JBQWdCLFFBQVE7QUFBQSxVQUN4QyxDQUFDO0FBRUQsaUJBQU8sUUFBUSxJQUFJO0FBQ25CLGlCQUFPLFNBQVMsSUFBSTtBQUNwQixjQUFJLFVBQVUsS0FBSyxHQUFHLENBQUM7QUFFdkIsZ0JBQU0sWUFBWSxJQUFJLGFBQWEsR0FBRyxHQUFHLE9BQU8sT0FBTyxPQUFPLE1BQU07QUFDcEUsZ0JBQU0sT0FBTyxVQUFVO0FBR3ZCLGdCQUFNLGFBQWEsUUFBUSxlQUFlO0FBQzFDLGdCQUFNLGFBQWEsUUFBUSxlQUFlO0FBQzFDLGdCQUFNLFdBQVcsYUFBYSxlQUFlO0FBQzdDLGdCQUFNLFdBQVcsYUFBYSxlQUFlO0FBRzdDLGdCQUFNLGdCQUFnQixLQUFLLElBQUksSUFBSSxVQUFVO0FBQzdDLGdCQUFNLGdCQUFnQixLQUFLLElBQUksSUFBSSxVQUFVO0FBQzdDLGdCQUFNLGNBQWMsS0FBSyxJQUFJLElBQUksUUFBUTtBQUN6QyxnQkFBTSxjQUFjLEtBQUssSUFBSSxJQUFJLFFBQVE7QUFFekMsbUJBQVMsVUFBVSxlQUFlLFVBQVUsYUFBYSxXQUFXO0FBQ2xFLHFCQUFTLFVBQVUsZUFBZSxVQUFVLGFBQWEsV0FBVztBQUNsRSxvQkFBTSxTQUFTLFVBQVU7QUFDekIsb0JBQU0sU0FBUyxVQUFVO0FBR3pCLGtCQUFJLFVBQVUsS0FBSyxTQUFTLGVBQWUsYUFDdkMsVUFBVSxLQUFLLFNBQVMsZUFBZSxXQUFXO0FBR3BELG9CQUFJLFNBQVMsT0FBTyxTQUFTLFNBQVMsT0FBTyxRQUFRO0FBQ25ELHdCQUFNLGNBQWMsU0FBUyxPQUFPLFFBQVEsVUFBVTtBQUN0RCx3QkFBTSxJQUFJLEtBQUssVUFBVTtBQUN6Qix3QkFBTSxJQUFJLEtBQUssYUFBYSxDQUFDO0FBQzdCLHdCQUFNLElBQUksS0FBSyxhQUFhLENBQUM7QUFDN0Isd0JBQU0sSUFBSSxLQUFLLGFBQWEsQ0FBQztBQUU3QixzQkFBSSxJQUFJLEdBQUc7QUFDVCwwQkFBTSxlQUFlLGlCQUFpQixHQUFHLEdBQUcsR0FBRyxXQUFXLGVBQWU7QUFDekUsd0JBQUksY0FBYztBQUNoQiwrQkFBUyxJQUFJLEdBQUcsT0FBTyxJQUFJLE9BQU8sSUFBSTtBQUFBLHdCQUNwQztBQUFBLHdCQUFHO0FBQUEsd0JBQUc7QUFBQSx3QkFDTixTQUFTLGFBQWE7QUFBQSx3QkFDdEI7QUFBQSx3QkFDQTtBQUFBLHdCQUNBO0FBQUEsd0JBQ0E7QUFBQSx3QkFDQTtBQUFBLHdCQUNBO0FBQUEsc0JBQ0YsQ0FBQztBQUFBLG9CQUNIO0FBQUEsa0JBQ0Y7QUFBQSxnQkFDRjtBQUFBLGNBQ0Y7QUFBQSxZQUNGO0FBQUEsVUFDRjtBQUVBLGNBQUksZ0JBQWdCLElBQUksR0FBRztBQUFBLFFBQzdCLFNBQVMsT0FBTztBQUNkLGNBQUksZ0NBQTJCLEtBQUssSUFBSSxLQUFLLEtBQUssS0FBSztBQUFBLFFBQ3pEO0FBQUEsTUFDRjtBQUFBLElBQ0Y7QUFFQSxRQUFJLGtDQUEwQixTQUFTLElBQUksd0JBQXFCO0FBR2hFLFFBQUksU0FBUyxTQUFTLEdBQUc7QUFDdkIsVUFBSSxrR0FBK0U7QUFHbkYsZUFBUyxVQUFVLElBQUksVUFBVSxJQUFJLFdBQVc7QUFDOUMsaUJBQVMsVUFBVSxJQUFJLFVBQVUsSUFBSSxXQUFXO0FBQzlDLGdCQUFNLFFBQVEsS0FBSyxNQUFNLFVBQVUsZUFBZSxTQUFTO0FBQzNELGdCQUFNLFFBQVEsS0FBSyxNQUFNLFVBQVUsZUFBZSxTQUFTO0FBQzNELGdCQUFNLFNBQVMsVUFBVyxRQUFRLGVBQWU7QUFDakQsZ0JBQU0sU0FBUyxVQUFXLFFBQVEsZUFBZTtBQUdqRCxtQkFBUyxJQUFJLEdBQUcsT0FBTyxJQUFJLE9BQU8sSUFBSTtBQUFBLFlBQ3BDLEdBQUc7QUFBQSxZQUFLLEdBQUc7QUFBQSxZQUFLLEdBQUc7QUFBQTtBQUFBLFlBQ25CLFNBQVM7QUFBQTtBQUFBLFlBQ1Q7QUFBQSxZQUNBO0FBQUEsWUFDQTtBQUFBLFlBQ0E7QUFBQSxZQUNBO0FBQUEsWUFDQTtBQUFBLFVBQ0YsQ0FBQztBQUFBLFFBQ0g7QUFBQSxNQUNGO0FBRUEsVUFBSSxrQ0FBMEIsU0FBUyxJQUFJLDJCQUF3QjtBQUFBLElBQ3JFO0FBRUEsV0FBTztBQUFBLEVBQ1Q7QUFHQSxpQkFBc0Isa0JBQWtCO0FBQ3RDLFFBQUksQ0FBQyxXQUFXLGtCQUFrQixDQUFDLFdBQVcsZUFBZSxNQUFNO0FBQ2pFO0FBQUEsSUFDRjtBQUVBLFFBQUk7QUFDRixZQUFNLGdCQUFnQixNQUFNLGtCQUFrQixXQUFXLGNBQWM7QUFDdkUsWUFBTSxVQUFVLG9CQUFJLElBQUk7QUFDeEIsVUFBSSxlQUFlO0FBR25CLGlCQUFXLENBQUMsS0FBSyxhQUFhLEtBQUssV0FBVyxnQkFBZ0I7QUFDNUQsY0FBTSxlQUFlLGNBQWMsSUFBSSxHQUFHO0FBRTFDLFlBQUksQ0FBQyxjQUFjO0FBRWpCLGtCQUFRLElBQUksS0FBSztBQUFBLFlBQ2YsV0FBVyxLQUFLLElBQUk7QUFBQSxZQUNwQixNQUFNO0FBQUEsWUFDTixVQUFVO0FBQUEsWUFDVixTQUFTO0FBQUEsVUFDWCxDQUFDO0FBQ0Q7QUFBQSxRQUNGLFdBQVcsYUFBYSxZQUFZLGNBQWMsU0FBUztBQUV6RCxrQkFBUSxJQUFJLEtBQUs7QUFBQSxZQUNmLFdBQVcsS0FBSyxJQUFJO0FBQUEsWUFDcEIsTUFBTTtBQUFBLFlBQ04sVUFBVTtBQUFBLFlBQ1YsU0FBUztBQUFBLFVBQ1gsQ0FBQztBQUNEO0FBQUEsUUFDRjtBQUFBLE1BQ0Y7QUFFQSxVQUFJLGVBQWUsR0FBRztBQUNwQixZQUFJLHdCQUFpQixZQUFZLGtDQUErQjtBQUNoRSxtQkFBVyxVQUFVO0FBR3JCLFlBQUksV0FBVyxJQUFJO0FBQ2pCLHFCQUFXLEdBQUcsYUFBYSxhQUFNLFlBQVksdUJBQXVCLFNBQVM7QUFDN0UscUJBQVcsR0FBRyxlQUFlLFFBQVEsTUFBTSxXQUFXLGVBQWUsSUFBSTtBQUFBLFFBQzNFO0FBR0EsWUFBSSxXQUFXLFNBQVM7QUFDdEIsZ0JBQU0sY0FBYyxPQUFPO0FBQUEsUUFDN0I7QUFBQSxNQUNGLE9BQU87QUFFTCxtQkFBVyxZQUFZLEtBQUssSUFBSTtBQUNoQyxZQUFJLFdBQVcsSUFBSTtBQUNqQixxQkFBVyxHQUFHLGFBQWEsMENBQWtDLFNBQVM7QUFBQSxRQUN4RTtBQUFBLE1BQ0Y7QUFBQSxJQUVGLFNBQVMsT0FBTztBQUNkLFVBQUkscUNBQWdDLEtBQUs7QUFDekMsVUFBSSxXQUFXLElBQUk7QUFDakIsbUJBQVcsR0FBRyxhQUFhLDZCQUF3QixNQUFNLE9BQU8sSUFBSSxPQUFPO0FBQUEsTUFDN0U7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUdBLGlCQUFzQixjQUFjLFNBQVM7QUFDM0MsUUFBSSxRQUFRLFNBQVMsR0FBRztBQUN0QjtBQUFBLElBQ0Y7QUFFQSxVQUFNLGVBQWUsTUFBTSxLQUFLLFFBQVEsT0FBTyxDQUFDO0FBQ2hELFVBQU0sbUJBQW1CLEtBQUssTUFBTSxXQUFXLGNBQWM7QUFHN0QsUUFBSSxxQkFBcUIsR0FBRztBQUMxQixVQUFJLDJEQUFpRDtBQUNyRCxVQUFJLFdBQVcsSUFBSTtBQUNqQixtQkFBVyxHQUFHLGFBQWEsMkNBQXNDLFNBQVM7QUFBQSxNQUM1RTtBQUNBO0FBQUEsSUFDRjtBQUdBLFVBQU0sa0JBQWtCLG1CQUFtQixXQUFXO0FBQ3RELFVBQU0sYUFBYSxrQkFDZixtQkFDQSxLQUFLLElBQUksYUFBYSxRQUFRLFdBQVcsY0FBYztBQUUzRCxRQUFJLDJCQUFlLGdCQUFnQixnQkFBYSxXQUFXLGdCQUFnQixnQkFBZ0IsVUFBVSxhQUFVO0FBRS9HLFFBQUksV0FBVyxJQUFJO0FBQ2pCLFlBQU0sYUFBYSxrQkFBa0IsaUNBQWlDO0FBQ3RFLGlCQUFXLEdBQUcsYUFBYSw2QkFBaUIsVUFBVSxjQUFXLFVBQVUsT0FBTyxNQUFNO0FBQUEsSUFDMUY7QUFHQSxVQUFNLGlCQUFpQixhQUFhLE1BQU0sR0FBRyxVQUFVO0FBR3ZELFVBQU0sZ0JBQWdCLG9CQUFJLElBQUk7QUFFOUIsZUFBVyxVQUFVLGdCQUFnQjtBQUNuQyxZQUFNLFdBQVcsT0FBTztBQUN4QixZQUFNLFVBQVUsR0FBRyxTQUFTLEtBQUssSUFBSSxTQUFTLEtBQUs7QUFFbkQsVUFBSSxDQUFDLGNBQWMsSUFBSSxPQUFPLEdBQUc7QUFDL0Isc0JBQWMsSUFBSSxTQUFTLENBQUMsQ0FBQztBQUFBLE1BQy9CO0FBRUEsb0JBQWMsSUFBSSxPQUFPLEVBQUUsS0FBSztBQUFBLFFBQzlCLFFBQVEsU0FBUztBQUFBLFFBQ2pCLFFBQVEsU0FBUztBQUFBLFFBQ2pCLFNBQVMsU0FBUztBQUFBLFFBQ2xCLFNBQVMsU0FBUztBQUFBLFFBQ2xCLFNBQVMsU0FBUztBQUFBLE1BQ3BCLENBQUM7QUFBQSxJQUNIO0FBRUEsUUFBSSxnQkFBZ0I7QUFHcEIsZUFBVyxDQUFDLFNBQVMsV0FBVyxLQUFLLGVBQWU7QUFDbEQsWUFBTSxDQUFDLE9BQU8sS0FBSyxJQUFJLFFBQVEsTUFBTSxHQUFHLEVBQUUsSUFBSSxNQUFNO0FBRXBELFVBQUk7QUFDRixjQUFNLFNBQVMsQ0FBQztBQUNoQixjQUFNLFNBQVMsQ0FBQztBQUVoQixtQkFBVyxVQUFVLGFBQWE7QUFDaEMsaUJBQU8sS0FBSyxPQUFPLFFBQVEsT0FBTyxNQUFNO0FBQ3hDLGlCQUFPLEtBQUssT0FBTyxPQUFPO0FBQUEsUUFDNUI7QUFFQSxjQUFNLFNBQVMsTUFBTSxnQkFBZ0IsT0FBTyxPQUFPLFFBQVEsTUFBTTtBQUVqRSxZQUFJLE9BQU8sV0FBVyxPQUFPLFVBQVUsR0FBRztBQUN4QywyQkFBaUIsT0FBTztBQUN4QixxQkFBVyxpQkFBaUIsS0FBSyxJQUFJLEdBQUcsV0FBVyxpQkFBaUIsT0FBTyxPQUFPO0FBQ2xGLHFCQUFXLGlCQUFpQixPQUFPO0FBR25DLG1CQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sV0FBVyxJQUFJLFlBQVksUUFBUSxLQUFLO0FBQ2pFLGtCQUFNLFNBQVMsWUFBWSxDQUFDO0FBQzVCLGtCQUFNLE1BQU0sR0FBRyxPQUFPLE9BQU8sSUFBSSxPQUFPLE9BQU87QUFDL0MsdUJBQVcsUUFBUSxPQUFPLEdBQUc7QUFBQSxVQUMvQjtBQUVBLGNBQUksb0JBQWUsT0FBTyxPQUFPLHdCQUFxQixLQUFLLElBQUksS0FBSyxHQUFHO0FBQUEsUUFDekUsT0FBTztBQUNMLGNBQUksZ0NBQTJCLEtBQUssSUFBSSxLQUFLLE1BQU0sT0FBTyxLQUFLO0FBQUEsUUFDakU7QUFBQSxNQUVGLFNBQVMsT0FBTztBQUNkLFlBQUksZ0NBQTJCLEtBQUssSUFBSSxLQUFLLE1BQU0sS0FBSztBQUFBLE1BQzFEO0FBR0EsVUFBSSxjQUFjLE9BQU8sR0FBRztBQUMxQixjQUFNLE1BQU0sR0FBRztBQUFBLE1BQ2pCO0FBQUEsSUFDRjtBQUVBLFVBQU0sbUJBQW1CLEtBQUssTUFBTSxXQUFXLGNBQWM7QUFDN0QsVUFBTSxtQkFBbUIsV0FBVyxRQUFRO0FBRTVDLFFBQUksNkNBQThCLGFBQWEsMEJBQXVCLGdCQUFnQixtQkFBbUI7QUFFekcsUUFBSSxXQUFXLElBQUk7QUFDakIsVUFBSSxtQkFBbUIsS0FBSyxtQkFBbUIsV0FBVyxrQkFBa0I7QUFDMUUsbUJBQVcsR0FBRyxhQUFhLG9CQUFlLFdBQVcsZ0JBQWdCLDJCQUEyQixnQkFBZ0IsY0FBYyxTQUFTO0FBQUEsTUFDekksT0FBTztBQUNMLG1CQUFXLEdBQUcsYUFBYSxvQkFBZSxhQUFhLDZCQUEwQixTQUFTO0FBQUEsTUFDNUY7QUFFQSxpQkFBVyxHQUFHLFlBQVk7QUFBQSxRQUN4QixTQUFTO0FBQUEsUUFDVCxVQUFVLFdBQVc7QUFBQSxRQUNyQixTQUFTO0FBQUEsTUFDWCxDQUFDO0FBQUEsSUFDSDtBQUFBLEVBQ0Y7QUFHQSxpQkFBZSxnQkFBZ0IsT0FBTyxPQUFPLFFBQVEsUUFBUTtBQTdZN0Q7QUE4WUUsUUFBSTtBQUNGLFlBQU0sUUFBUSxNQUFNLGtCQUFrQixlQUFlLE9BQU87QUFFNUQsWUFBTSxXQUFXLE1BQU07QUFBQSxRQUNyQjtBQUFBLFFBQ0E7QUFBQSxRQUNBO0FBQUEsUUFDQTtBQUFBLFFBQ0E7QUFBQSxNQUNGO0FBRUEsYUFBTztBQUFBLFFBQ0wsU0FBUyxTQUFTO0FBQUEsUUFDbEIsU0FBUyxTQUFTO0FBQUEsUUFDbEIsUUFBUSxTQUFTO0FBQUEsUUFDakIsT0FBTyxTQUFTLFVBQVUsU0FBUSxjQUFTLFNBQVQsbUJBQWUsWUFBVztBQUFBLE1BQzlEO0FBQUEsSUFDRixTQUFTLE9BQU87QUFDZCxhQUFPO0FBQUEsUUFDTCxTQUFTO0FBQUEsUUFDVCxTQUFTO0FBQUEsUUFDVCxPQUFPLE1BQU07QUFBQSxNQUNmO0FBQUEsSUFDRjtBQUFBLEVBQ0Y7OztBQ3RhTyxXQUFTLGNBQWMsT0FBTztBQUVuQyxVQUFNLFlBQVksU0FBUyxjQUFjLEtBQUs7QUFDOUMsY0FBVSxNQUFNLFVBQVU7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFjMUIsY0FBVSxZQUFZO0FBQUE7QUFBQTtBQUFBLGdDQUdKLE1BQU0sS0FBSztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxzQkFTaEIsTUFBTSxPQUFPO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLHdCQVNYLE1BQU0sVUFBVTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsb0dBV21FLE1BQU0sU0FBUztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLG9HQVVmLE1BQU0sVUFBVTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLHlCQVVyRyxNQUFNLGVBQWU7QUFBQTtBQUFBO0FBQUE7QUFBQSx5QkFJckIsTUFBTSxjQUFjO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsNEJBT2QsTUFBTSxlQUFlO0FBQUE7QUFBQTtBQUFBLDRCQUdyQixNQUFNLGVBQWU7QUFBQTtBQUFBO0FBQUEseUJBR3RCLE1BQU0sT0FBTztBQUFBO0FBQUE7QUFBQSxrQ0FHWCxNQUFNLGNBQWM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLGlCQTZCOUIsTUFBTSxXQUFXO0FBQUE7QUFBQTtBQUFBO0FBSzNCLGFBQVMsS0FBSyxZQUFZLFNBQVM7QUFHbkMsVUFBTSxnQkFBZ0IsU0FBUyxjQUFjLE9BQU87QUFDcEQsa0JBQWMsT0FBTztBQUNyQixrQkFBYyxTQUFTO0FBQ3ZCLGtCQUFjLE1BQU0sVUFBVTtBQUM5QixhQUFTLEtBQUssWUFBWSxhQUFhO0FBR3ZDLGtCQUFjLFNBQVM7QUFHdkIsVUFBTSxXQUFXO0FBQUEsTUFDZixTQUFTLFVBQVUsY0FBYyxVQUFVO0FBQUEsTUFDM0MsZUFBZSxVQUFVLGNBQWMsZ0JBQWdCO0FBQUEsTUFDdkQsYUFBYSxVQUFVLGNBQWMsY0FBYztBQUFBLE1BQ25ELFNBQVMsVUFBVSxjQUFjLFVBQVU7QUFBQSxNQUMzQyxTQUFTLFVBQVUsY0FBYyxVQUFVO0FBQUEsTUFDM0MsU0FBUyxVQUFVLGNBQWMsVUFBVTtBQUFBLE1BQzNDLFNBQVMsVUFBVSxjQUFjLFVBQVU7QUFBQSxNQUMzQyxVQUFVLFVBQVUsY0FBYyxXQUFXO0FBQUEsTUFDN0MsU0FBUyxVQUFVLGNBQWMsVUFBVTtBQUFBLE1BQzNDLFVBQVUsVUFBVSxjQUFjLFdBQVc7QUFBQSxNQUM3QyxhQUFhLFVBQVUsY0FBYyxjQUFjO0FBQUEsTUFDbkQsYUFBYSxVQUFVLGNBQWMsY0FBYztBQUFBLE1BQ25ELGdCQUFnQixVQUFVLGNBQWMsaUJBQWlCO0FBQUEsTUFDekQsY0FBYyxVQUFVLGNBQWMsZUFBZTtBQUFBLE1BQ3JELGNBQWMsVUFBVSxjQUFjLGVBQWU7QUFBQSxNQUNyRCxlQUFlLFVBQVUsY0FBYyxnQkFBZ0I7QUFBQSxNQUN2RCxXQUFXLFVBQVUsY0FBYyxZQUFZO0FBQUEsTUFDL0M7QUFBQSxNQUNBLHFCQUFxQixVQUFVLGNBQWMsc0JBQXNCO0FBQUEsTUFDbkUsaUJBQWlCLFVBQVUsY0FBYyxrQkFBa0I7QUFBQSxNQUMzRCxTQUFTLFVBQVUsY0FBYyxVQUFVO0FBQUEsSUFDN0M7QUFHQSxVQUFNLEtBQUs7QUFBQSxNQUNUO0FBQUEsTUFFQSxjQUFjLENBQUMsU0FBUyxPQUFPLFdBQVc7QUFDeEMsaUJBQVMsVUFBVSxjQUFjO0FBQ2pDLGNBQU0sU0FBUztBQUFBLFVBQ2IsTUFBTTtBQUFBLFVBQ04sU0FBUztBQUFBLFVBQ1QsU0FBUztBQUFBLFVBQ1QsT0FBTztBQUFBLFFBQ1Q7QUFDQSxpQkFBUyxVQUFVLE1BQU0sUUFBUSxPQUFPLElBQUksS0FBSyxPQUFPO0FBQUEsTUFDMUQ7QUFBQSxNQUVBLGdCQUFnQixDQUFDLFNBQVMsVUFBVTtBQUNsQyxpQkFBUyxhQUFhLGNBQWM7QUFDcEMsaUJBQVMsZUFBZSxjQUFjO0FBQUEsTUFDeEM7QUFBQSxNQUVBLGFBQWEsQ0FBQyxVQUFVO0FBQ3RCLFlBQUksTUFBTSxZQUFZLE9BQVcsVUFBUyxhQUFhLGNBQWMsTUFBTTtBQUMzRSxZQUFJLE1BQU0sYUFBYSxPQUFXLFVBQVMsY0FBYyxjQUFjLE1BQU07QUFDN0UsWUFBSSxNQUFNLFlBQVksT0FBVyxVQUFTLGFBQWEsY0FBYyxNQUFNO0FBQUEsTUFDN0U7QUFBQSxNQUVBLGlCQUFpQixNQUFNO0FBQ3JCLGlCQUFTLFlBQVksTUFBTSxVQUFVO0FBQ3JDLGlCQUFTLFlBQVksTUFBTSxVQUFVO0FBQUEsTUFDdkM7QUFBQSxNQUVBLHNCQUFzQixDQUFDLFlBQVk7QUFDakMsaUJBQVMsWUFBWSxNQUFNLFVBQVUsVUFBVSxVQUFVO0FBQUEsTUFDM0Q7QUFBQSxNQUVBLGdCQUFnQixDQUFDLGdCQUFnQjtBQUMvQixpQkFBUyxRQUFRLFdBQVc7QUFDNUIsWUFBSSxhQUFhO0FBQ2YsbUJBQVMsUUFBUSxNQUFNLFVBQVU7QUFDakMsbUJBQVMsUUFBUSxNQUFNLFNBQVM7QUFBQSxRQUNsQztBQUFBLE1BQ0Y7QUFBQSxNQUVBLGdCQUFnQixNQUFNO0FBQ3BCLGlCQUFTLFNBQVMsV0FBVztBQUFBLE1BQy9CO0FBQUEsTUFFQSxpQkFBaUIsQ0FBQyxZQUFZO0FBQzVCLGlCQUFTLFNBQVMsV0FBVztBQUM3QixpQkFBUyxRQUFRLFdBQVcsQ0FBQztBQUM3QixpQkFBUyxjQUFjLFdBQVc7QUFBQSxNQUNwQztBQUFBLE1BRUEsbUJBQW1CLENBQUMsV0FBVztBQUM3QixZQUFJLE9BQU8sT0FBTyxPQUFXLFVBQVMsUUFBUSxRQUFRLE9BQU87QUFDN0QsWUFBSSxPQUFPLE9BQU8sT0FBVyxVQUFTLFFBQVEsUUFBUSxPQUFPO0FBQzdELFlBQUksT0FBTyxPQUFPLE9BQVcsVUFBUyxRQUFRLFFBQVEsT0FBTztBQUM3RCxZQUFJLE9BQU8sT0FBTyxPQUFXLFVBQVMsUUFBUSxRQUFRLE9BQU87QUFBQSxNQUMvRDtBQUFBLE1BRUEsU0FBUyxNQUFNO0FBQ2Isa0JBQVUsT0FBTztBQUNqQixzQkFBYyxPQUFPO0FBQUEsTUFDdkI7QUFBQSxJQUNGO0FBRUEsV0FBTztBQUFBLEVBQ1Q7QUFFTyxXQUFTLGtCQUFrQixTQUFTLE9BQU8sVUFBVSxDQUFDLEdBQUc7QUFDOUQsV0FBTyxJQUFJLFFBQVEsQ0FBQyxZQUFZO0FBQzlCLFlBQU0sVUFBVSxTQUFTLGNBQWMsS0FBSztBQUM1QyxjQUFRLFlBQVk7QUFDcEIsY0FBUSxNQUFNLFdBQVc7QUFDekIsY0FBUSxNQUFNLE1BQU07QUFDcEIsY0FBUSxNQUFNLE9BQU87QUFDckIsY0FBUSxNQUFNLFFBQVE7QUFDdEIsY0FBUSxNQUFNLFNBQVM7QUFDdkIsY0FBUSxNQUFNLGFBQWE7QUFDM0IsY0FBUSxNQUFNLFNBQVM7QUFDdkIsY0FBUSxNQUFNLFVBQVU7QUFDeEIsY0FBUSxNQUFNLGFBQWE7QUFDM0IsY0FBUSxNQUFNLGlCQUFpQjtBQUUvQixZQUFNLFFBQVEsU0FBUyxjQUFjLEtBQUs7QUFDMUMsWUFBTSxNQUFNLGFBQWE7QUFDekIsWUFBTSxNQUFNLFNBQVM7QUFDckIsWUFBTSxNQUFNLGVBQWU7QUFDM0IsWUFBTSxNQUFNLFVBQVU7QUFDdEIsWUFBTSxNQUFNLFFBQVE7QUFDcEIsWUFBTSxNQUFNLFdBQVc7QUFDdkIsWUFBTSxNQUFNLFdBQVc7QUFDdkIsWUFBTSxNQUFNLFlBQVk7QUFDeEIsWUFBTSxNQUFNLGFBQWE7QUFFekIsWUFBTSxZQUFZO0FBQUEsNkVBQ3VELEtBQUs7QUFBQSw2RUFDTCxPQUFPO0FBQUE7QUFBQSxVQUUxRSxRQUFRLE9BQU8sb01BQW9NLFFBQVEsSUFBSSxjQUFjLEVBQUU7QUFBQSxVQUMvTyxRQUFRLFVBQVUsdU1BQXVNLFFBQVEsT0FBTyxjQUFjLEVBQUU7QUFBQSxVQUN4UCxRQUFRLFNBQVMsc01BQXNNLFFBQVEsTUFBTSxjQUFjLEVBQUU7QUFBQTtBQUFBO0FBSTNQLGNBQVEsWUFBWSxLQUFLO0FBQ3pCLGVBQVMsS0FBSyxZQUFZLE9BQU87QUFHakMsWUFBTSxVQUFVLE1BQU0sY0FBYyxXQUFXO0FBQy9DLFlBQU0sYUFBYSxNQUFNLGNBQWMsY0FBYztBQUNyRCxZQUFNLFlBQVksTUFBTSxjQUFjLGFBQWE7QUFFbkQsWUFBTSxVQUFVLE1BQU07QUFDcEIsaUJBQVMsS0FBSyxZQUFZLE9BQU87QUFBQSxNQUNuQztBQUVBLFVBQUksU0FBUztBQUNYLGdCQUFRLGlCQUFpQixTQUFTLE1BQU07QUFDdEMsa0JBQVE7QUFDUixrQkFBUSxNQUFNO0FBQUEsUUFDaEIsQ0FBQztBQUFBLE1BQ0g7QUFFQSxVQUFJLFlBQVk7QUFDZCxtQkFBVyxpQkFBaUIsU0FBUyxNQUFNO0FBQ3pDLGtCQUFRO0FBQ1Isa0JBQVEsU0FBUztBQUFBLFFBQ25CLENBQUM7QUFBQSxNQUNIO0FBRUEsVUFBSSxXQUFXO0FBQ2Isa0JBQVUsaUJBQWlCLFNBQVMsTUFBTTtBQUN4QyxrQkFBUTtBQUNSLGtCQUFRLFFBQVE7QUFBQSxRQUNsQixDQUFDO0FBQUEsTUFDSDtBQUdBLGNBQVEsaUJBQWlCLFNBQVMsQ0FBQyxNQUFNO0FBQ3ZDLFlBQUksRUFBRSxXQUFXLFNBQVM7QUFDeEIsa0JBQVE7QUFDUixrQkFBUSxRQUFRO0FBQUEsUUFDbEI7QUFBQSxNQUNGLENBQUM7QUFBQSxJQUNILENBQUM7QUFBQSxFQUNIO0FBRUEsV0FBUyxjQUFjLFNBQVM7QUFDOUIsUUFBSSxhQUFhO0FBQ2pCLFFBQUksUUFBUSxRQUFRLFdBQVc7QUFFL0IsVUFBTSxTQUFTLFFBQVEsY0FBYyxlQUFlO0FBQ3BELFdBQU8saUJBQWlCLGFBQWEsQ0FBQyxNQUFNO0FBQzFDLFVBQUksRUFBRSxPQUFPLE9BQU8sV0FBWTtBQUVoQyxtQkFBYTtBQUNiLGVBQVMsRUFBRTtBQUNYLGVBQVMsRUFBRTtBQUNYLGtCQUFZLFNBQVMsT0FBTyxpQkFBaUIsT0FBTyxFQUFFLE1BQU0sRUFBRTtBQUM5RCxpQkFBVyxTQUFTLE9BQU8saUJBQWlCLE9BQU8sRUFBRSxLQUFLLEVBQUU7QUFFNUQsY0FBUSxNQUFNLFNBQVM7QUFBQSxJQUN6QixDQUFDO0FBRUQsYUFBUyxpQkFBaUIsYUFBYSxDQUFDLE1BQU07QUFDNUMsVUFBSSxDQUFDLFdBQVk7QUFFakIsWUFBTSxTQUFTLEVBQUUsVUFBVTtBQUMzQixZQUFNLFNBQVMsRUFBRSxVQUFVO0FBRTNCLGNBQVEsTUFBTSxPQUFPLEdBQUcsWUFBWSxNQUFNO0FBQzFDLGNBQVEsTUFBTSxNQUFNLEdBQUcsV0FBVyxNQUFNO0FBQ3hDLGNBQVEsTUFBTSxRQUFRO0FBQUEsSUFDeEIsQ0FBQztBQUVELGFBQVMsaUJBQWlCLFdBQVcsTUFBTTtBQUN6QyxVQUFJLFlBQVk7QUFDZCxxQkFBYTtBQUNiLGdCQUFRLE1BQU0sU0FBUztBQUFBLE1BQ3pCO0FBQUEsSUFDRixDQUFDO0FBQUEsRUFDSDs7O0FDbFZBLFdBQVMsb0JBQW9CLE1BQU0sWUFBWTtBQUM3QyxVQUFNLEVBQUUsSUFBSSxJQUFJLElBQUksR0FBRyxJQUFJO0FBQzNCLFVBQU0sUUFBUSxLQUFLO0FBQ25CLFVBQU0sU0FBUyxLQUFLO0FBQ3BCLFVBQU0sUUFBUSxDQUFDO0FBRWYsUUFBSSxjQUFjLEdBQUc7QUFDbkIsYUFBTyxDQUFDLElBQUk7QUFBQSxJQUNkO0FBR0EsVUFBTSxxQkFBcUIsU0FBUztBQUVwQyxRQUFJLG9CQUFvQjtBQUN0QixZQUFNLGVBQWUsS0FBSyxNQUFNLFFBQVEsVUFBVTtBQUNsRCxlQUFTLElBQUksR0FBRyxJQUFJLFlBQVksS0FBSztBQUNuQyxjQUFNLFNBQVMsS0FBTSxJQUFJO0FBQ3pCLGNBQU0sT0FBTyxNQUFNLGFBQWEsSUFBSSxLQUFLLFNBQVM7QUFDbEQsY0FBTSxLQUFLO0FBQUEsVUFDVCxJQUFJO0FBQUEsVUFDSjtBQUFBLFVBQ0EsSUFBSTtBQUFBLFVBQ0o7QUFBQSxRQUNGLENBQUM7QUFBQSxNQUNIO0FBQUEsSUFDRixPQUFPO0FBQ0wsWUFBTSxnQkFBZ0IsS0FBSyxNQUFNLFNBQVMsVUFBVTtBQUNwRCxlQUFTLElBQUksR0FBRyxJQUFJLFlBQVksS0FBSztBQUNuQyxjQUFNLFNBQVMsS0FBTSxJQUFJO0FBQ3pCLGNBQU0sT0FBTyxNQUFNLGFBQWEsSUFBSSxLQUFLLFNBQVM7QUFDbEQsY0FBTSxLQUFLO0FBQUEsVUFDVDtBQUFBLFVBQ0EsSUFBSTtBQUFBLFVBQ0o7QUFBQSxVQUNBLElBQUk7QUFBQSxRQUNOLENBQUM7QUFBQSxNQUNIO0FBQUEsSUFDRjtBQUVBLFdBQU87QUFBQSxFQUNUO0FBR0EsV0FBUyxnQkFBZ0IsTUFBTSxXQUFXO0FBQ3hDLFVBQU0sU0FBUyxDQUFDO0FBQ2hCLFVBQU0sRUFBRSxJQUFJLElBQUksSUFBSSxHQUFHLElBQUk7QUFFM0IsZUFBVyxDQUFDLEtBQUssS0FBSyxLQUFLLFVBQVUsUUFBUSxHQUFHO0FBQzlDLFlBQU0sQ0FBQyxHQUFHLENBQUMsSUFBSSxJQUFJLE1BQU0sR0FBRyxFQUFFLElBQUksTUFBTTtBQUN4QyxVQUFJLEtBQUssTUFBTSxLQUFLLE1BQU0sS0FBSyxNQUFNLEtBQUssSUFBSTtBQUM1QyxlQUFPLEtBQUssRUFBRSxLQUFLLEdBQUcsTUFBTSxDQUFDO0FBQUEsTUFDL0I7QUFBQSxJQUNGO0FBRUEsV0FBTztBQUFBLEVBQ1Q7QUFFTyxXQUFTLGFBQWEsV0FBVyxNQUFNLGFBQWEsTUFBTTtBQUMvRCxRQUFJO0FBQ0YsVUFBSSxDQUFDLFdBQVcsa0JBQWtCLENBQUMsV0FBVyxlQUFlLE1BQU07QUFDakUsY0FBTSxJQUFJLE1BQU0sOEJBQThCO0FBQUEsTUFDaEQ7QUFFQSxZQUFNLFFBQVEsY0FBYyxhQUFhLElBQ3ZDLG9CQUFvQixXQUFXLGdCQUFnQixVQUFVLElBQ3pELENBQUMsV0FBVyxjQUFjO0FBRTVCLFlBQU0sVUFBVSxDQUFDO0FBRWpCLGVBQVMsSUFBSSxHQUFHLElBQUksTUFBTSxRQUFRLEtBQUs7QUFDckMsY0FBTSxPQUFPLE1BQU0sQ0FBQztBQUNwQixjQUFNLGFBQWEsZ0JBQWdCLE1BQU0sV0FBVyxjQUFjO0FBRWxFLGNBQU0sZUFBZTtBQUFBLFVBQ25CLFNBQVM7QUFBQSxVQUNULFdBQVcsS0FBSyxJQUFJO0FBQUEsVUFDcEIsZ0JBQWdCO0FBQUEsWUFDZCxNQUFNLEVBQUUsR0FBRyxLQUFLO0FBQUEsWUFDaEIsaUJBQWlCLFdBQVc7QUFBQSxZQUM1QixXQUFXLGFBQWEsSUFBSTtBQUFBLGNBQzFCLE9BQU87QUFBQSxjQUNQLFNBQVMsSUFBSTtBQUFBLGNBQ2IsY0FBYyxFQUFFLEdBQUcsV0FBVyxlQUFlO0FBQUEsWUFDL0MsSUFBSTtBQUFBLFVBQ047QUFBQSxVQUNBLFVBQVU7QUFBQSxZQUNSLGVBQWUsV0FBVztBQUFBLFlBQzFCLFdBQVcsV0FBVztBQUFBLFVBQ3hCO0FBQUEsVUFDQSxRQUFRO0FBQUEsWUFDTixtQkFBbUI7QUFBQSxZQUNuQixnQkFBZ0I7QUFBQSxZQUNoQixlQUFlO0FBQUEsVUFDakI7QUFBQTtBQUFBLFVBRUEsUUFBUSxXQUFXLGdCQUFnQixJQUFJLFlBQVU7QUFBQSxZQUMvQyxJQUFJLE1BQU07QUFBQSxZQUNWLEdBQUcsTUFBTTtBQUFBLFlBQ1QsR0FBRyxNQUFNO0FBQUEsWUFDVCxHQUFHLE1BQU07QUFBQSxVQUNYLEVBQUU7QUFBQTtBQUFBLFVBRUYsZ0JBQWdCO0FBQUEsUUFDbEI7QUFFQSxjQUFNLFVBQVUsS0FBSyxVQUFVLGNBQWMsTUFBTSxDQUFDO0FBQ3BELGNBQU0sT0FBTyxJQUFJLE9BQU8sS0FBSyxDQUFDLE9BQU8sR0FBRyxFQUFFLE1BQU0sbUJBQW1CLENBQUM7QUFFcEUsY0FBTSxTQUFTLGFBQWEsSUFBSSxTQUFTLElBQUksQ0FBQyxLQUFLLFVBQVUsS0FBSztBQUNsRSxjQUFNLGdCQUFnQixZQUNwQixpQkFBZ0Isb0JBQUksS0FBSyxHQUFFLFlBQVksRUFBRSxNQUFNLEdBQUcsRUFBRSxFQUFFLFFBQVEsTUFBTSxHQUFHLENBQUMsR0FBRyxNQUFNO0FBR25GLGNBQU0sTUFBTSxPQUFPLElBQUksZ0JBQWdCLElBQUk7QUFDM0MsY0FBTSxPQUFPLFNBQVMsY0FBYyxHQUFHO0FBQ3ZDLGFBQUssT0FBTztBQUNaLGFBQUssV0FBVztBQUNoQixpQkFBUyxLQUFLLFlBQVksSUFBSTtBQUM5QixhQUFLLE1BQU07QUFDWCxpQkFBUyxLQUFLLFlBQVksSUFBSTtBQUM5QixlQUFPLElBQUksZ0JBQWdCLEdBQUc7QUFFOUIsZ0JBQVEsS0FBSyxFQUFFLFNBQVMsTUFBTSxVQUFVLGNBQWMsQ0FBQztBQUN2RCxZQUFJLDZCQUF3QixhQUFhLEVBQUU7QUFBQSxNQUM3QztBQUVBLGFBQU87QUFBQSxRQUNMLFNBQVM7QUFBQSxRQUNULFVBQVUsUUFBUSxXQUFXLElBQUksUUFBUSxDQUFDLEVBQUUsV0FBVyxHQUFHLFFBQVEsTUFBTTtBQUFBLFFBQ3hFLE9BQU87QUFBQSxNQUNUO0FBQUEsSUFFRixTQUFTLE9BQU87QUFDZCxVQUFJLG9DQUErQixLQUFLO0FBQ3hDLGFBQU8sRUFBRSxTQUFTLE9BQU8sT0FBTyxNQUFNLFFBQVE7QUFBQSxJQUNoRDtBQUFBLEVBQ0Y7QUFFQSxpQkFBc0IsYUFBYSxNQUFNO0FBQ3ZDLFdBQU8sSUFBSSxRQUFRLENBQUMsWUFBWTtBQUM5QixVQUFJO0FBQ0YsY0FBTSxTQUFTLElBQUksT0FBTyxXQUFXO0FBRXJDLGVBQU8sU0FBUyxPQUFPLE1BQU07QUFDM0IsY0FBSTtBQUNGLGtCQUFNLGVBQWUsS0FBSyxNQUFNLEVBQUUsT0FBTyxNQUFNO0FBRy9DLGtCQUFNLGlCQUFpQixDQUFDLGtCQUFrQixrQkFBa0IsUUFBUTtBQUNwRSxrQkFBTSxnQkFBZ0IsZUFBZSxPQUFPLFdBQVMsRUFBRSxTQUFTLGFBQWE7QUFFN0UsZ0JBQUksY0FBYyxTQUFTLEdBQUc7QUFDNUIsb0JBQU0sSUFBSSxNQUFNLGdDQUFnQyxjQUFjLEtBQUssSUFBSSxDQUFDLEVBQUU7QUFBQSxZQUM1RTtBQUdBLGdCQUFJLFdBQVcsZ0JBQWdCLFNBQVMsR0FBRztBQUN6QyxvQkFBTSxnQkFBZ0IsYUFBYSxPQUFPLElBQUksT0FBSyxFQUFFLEVBQUU7QUFDdkQsb0JBQU0sa0JBQWtCLFdBQVcsZ0JBQWdCLElBQUksT0FBSyxFQUFFLEVBQUU7QUFDaEUsb0JBQU0sZUFBZSxjQUFjLE9BQU8sUUFBTSxnQkFBZ0IsU0FBUyxFQUFFLENBQUM7QUFFNUUsa0JBQUksYUFBYSxTQUFTLGNBQWMsU0FBUyxLQUFLO0FBQ3BELG9CQUFJLGdGQUFzRTtBQUFBLGNBQzVFO0FBQUEsWUFDRjtBQUdBLGdCQUFJLGFBQWEsZ0JBQWdCO0FBQy9CLHlCQUFXLGlCQUFpQixhQUFhLGVBQWU7QUFBQSxZQUMxRCxXQUFXLGFBQWEsZ0JBQWdCO0FBRXRDLHlCQUFXLGlCQUFpQixhQUFhO0FBQUEsWUFDM0M7QUFHQSx1QkFBVyxpQkFBaUIsb0JBQUksSUFBSTtBQUNwQyx1QkFBVyxhQUFhLGFBQWEsZ0JBQWdCO0FBQ25ELG9CQUFNLEVBQUUsS0FBSyxHQUFHLFVBQVUsSUFBSTtBQUM5Qix5QkFBVyxlQUFlLElBQUksS0FBSyxTQUFTO0FBQUEsWUFDOUM7QUFHQSxnQkFBSSxhQUFhLFVBQVU7QUFDekIseUJBQVcsZ0JBQWdCLGFBQWEsU0FBUyxpQkFBaUI7QUFDbEUseUJBQVcsWUFBWSxhQUFhLFNBQVMsYUFBYTtBQUFBLFlBQzVELFdBQVcsYUFBYSxZQUFZO0FBRWxDLHlCQUFXLGdCQUFnQixhQUFhLFdBQVcsaUJBQWlCO0FBQ3BFLHlCQUFXLFlBQVksYUFBYSxXQUFXLGFBQWE7QUFBQSxZQUM5RDtBQUdBLHVCQUFXLFFBQVEsTUFBTTtBQUd6QixnQkFBSSxXQUFXLElBQUk7QUFDakIseUJBQVcsR0FBRyxrQkFBa0I7QUFBQSxnQkFDOUIsSUFBSSxXQUFXLGVBQWU7QUFBQSxnQkFDOUIsSUFBSSxXQUFXLGVBQWU7QUFBQSxnQkFDOUIsSUFBSSxXQUFXLGVBQWU7QUFBQSxnQkFDOUIsSUFBSSxXQUFXLGVBQWU7QUFBQSxjQUNoQyxDQUFDO0FBRUQseUJBQVcsR0FBRyxlQUFlLEdBQUcsV0FBVyxlQUFlLElBQUk7QUFDOUQseUJBQVcsR0FBRyxZQUFZO0FBQUEsZ0JBQ3hCLFVBQVUsV0FBVztBQUFBLGNBQ3ZCLENBQUM7QUFFRCx5QkFBVyxHQUFHLGVBQWU7QUFBQSxZQUMvQjtBQUVBLGdCQUFJLDRCQUF1QixXQUFXLGVBQWUsSUFBSSx3QkFBcUI7QUFFOUUsb0JBQVE7QUFBQSxjQUNOLFNBQVM7QUFBQSxjQUNULE1BQU07QUFBQSxjQUNOLGlCQUFpQixXQUFXLGVBQWU7QUFBQSxjQUMzQyxNQUFNLFdBQVc7QUFBQSxZQUNuQixDQUFDO0FBQUEsVUFFSCxTQUFTLFlBQVk7QUFDbkIsZ0JBQUksK0NBQTBDLFVBQVU7QUFDeEQsb0JBQVEsRUFBRSxTQUFTLE9BQU8sT0FBTyxXQUFXLFFBQVEsQ0FBQztBQUFBLFVBQ3ZEO0FBQUEsUUFDRjtBQUVBLGVBQU8sVUFBVSxNQUFNO0FBQ3JCLGdCQUFNLFFBQVE7QUFDZCxjQUFJLFVBQUssS0FBSztBQUNkLGtCQUFRLEVBQUUsU0FBUyxPQUFPLE1BQU0sQ0FBQztBQUFBLFFBQ25DO0FBRUEsZUFBTyxXQUFXLElBQUk7QUFBQSxNQUV4QixTQUFTLE9BQU87QUFDZCxZQUFJLG1DQUE4QixLQUFLO0FBQ3ZDLGdCQUFRLEVBQUUsU0FBUyxPQUFPLE9BQU8sTUFBTSxRQUFRLENBQUM7QUFBQSxNQUNsRDtBQUFBLElBQ0YsQ0FBQztBQUFBLEVBQ0g7QUFrQk8sV0FBUyxjQUFjO0FBQzVCLFdBQU8sV0FBVyxrQkFDWCxXQUFXLGVBQWUsT0FBTztBQUFBLEVBQzFDOzs7QUN4UU8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDVixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDVixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDVixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUN6UE8sTUFBTSxTQUFTO0FBQUE7QUFBQSxJQUVwQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDUCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxTQUFTO0FBQUE7QUFBQSxJQUVwQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDUCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUN6T0EsTUFBTSxlQUFlO0FBQUEsSUFDbkI7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLEVBQ0Y7QUFHQSxNQUFJLGtCQUFrQjtBQUN0QixNQUFJLHNCQUFzQixhQUFhLGVBQWU7QUFNL0MsV0FBUyx3QkFBd0I7QUFDdEMsVUFBTSxjQUFjLE9BQU8sVUFBVSxZQUFZLE9BQU8sVUFBVSxnQkFBZ0I7QUFHbEYsVUFBTSxXQUFXLFlBQVksTUFBTSxHQUFHLEVBQUUsQ0FBQyxFQUFFLFlBQVk7QUFHdkQsUUFBSSxhQUFhLFFBQVEsR0FBRztBQUMxQixhQUFPO0FBQUEsSUFDVDtBQUdBLFdBQU87QUFBQSxFQUNUO0FBTU8sV0FBUyxtQkFBbUI7QUFFakMsV0FBTztBQUFBLEVBQ1Q7QUFNTyxXQUFTLGFBQWEsVUFBVTtBQUVyQztBQUFBLEVBQ0Y7QUFNTyxXQUFTLHFCQUFxQjtBQUVuQyxVQUFNLFlBQVksaUJBQWlCO0FBQ25DLFVBQU0sY0FBYyxzQkFBc0I7QUFFMUMsUUFBSSxlQUFlO0FBRW5CLFFBQUksYUFBYSxhQUFhLFNBQVMsR0FBRztBQUN4QyxxQkFBZTtBQUFBLElBQ2pCLFdBQVcsZUFBZSxhQUFhLFdBQVcsR0FBRztBQUNuRCxxQkFBZTtBQUFBLElBQ2pCO0FBRUEsZ0JBQVksWUFBWTtBQUN4QixXQUFPO0FBQUEsRUFDVDtBQU1PLFdBQVMsWUFBWSxVQUFVO0FBQ3BDLFFBQUksQ0FBQyxhQUFhLFFBQVEsR0FBRztBQUMzQixjQUFRLEtBQUssV0FBVyxRQUFRLDRCQUE0QixlQUFlLEdBQUc7QUFDOUU7QUFBQSxJQUNGO0FBRUEsc0JBQWtCO0FBQ2xCLDBCQUFzQixhQUFhLFFBQVE7QUFDM0MsaUJBQWEsUUFBUTtBQUdyQixRQUFJLE9BQU8sV0FBVyxlQUFlLE9BQU8sYUFBYTtBQUN2RCxhQUFPLGNBQWMsSUFBSSxPQUFPLFlBQVksbUJBQW1CO0FBQUEsUUFDN0QsUUFBUSxFQUFFLFVBQVUsVUFBVSxjQUFjLG9CQUFvQjtBQUFBLE1BQ2xFLENBQUMsQ0FBQztBQUFBLElBQ0o7QUFBQSxFQUNGO0FBd0JPLFdBQVMsRUFBRSxLQUFLLFNBQVMsQ0FBQyxHQUFHO0FBQ2xDLFVBQU0sT0FBTyxJQUFJLE1BQU0sR0FBRztBQUMxQixRQUFJLFFBQVE7QUFHWixlQUFXLEtBQUssTUFBTTtBQUNwQixVQUFJLFNBQVMsT0FBTyxVQUFVLFlBQVksS0FBSyxPQUFPO0FBQ3BELGdCQUFRLE1BQU0sQ0FBQztBQUFBLE1BQ2pCLE9BQU87QUFDTCxnQkFBUSxLQUFLLDBDQUF1QyxHQUFHLEdBQUc7QUFDMUQsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBRUEsUUFBSSxPQUFPLFVBQVUsVUFBVTtBQUM3QixjQUFRLEtBQUsseUNBQXNDLEdBQUcsR0FBRztBQUN6RCxhQUFPO0FBQUEsSUFDVDtBQUdBLFdBQU8sWUFBWSxPQUFPLE1BQU07QUFBQSxFQUNsQztBQVFBLFdBQVMsWUFBWSxNQUFNLFFBQVE7QUFDakMsUUFBSSxDQUFDLFVBQVUsT0FBTyxLQUFLLE1BQU0sRUFBRSxXQUFXLEdBQUc7QUFDL0MsYUFBTztBQUFBLElBQ1Q7QUFFQSxXQUFPLEtBQUssUUFBUSxjQUFjLENBQUMsT0FBTyxRQUFRO0FBQ2hELGFBQU8sT0FBTyxHQUFHLE1BQU0sU0FBWSxPQUFPLEdBQUcsSUFBSTtBQUFBLElBQ25ELENBQUM7QUFBQSxFQUNIO0FBT08sV0FBUyxXQUFXLFNBQVM7QUFDbEMsUUFBSSxvQkFBb0IsT0FBTyxHQUFHO0FBQ2hDLGFBQU8sb0JBQW9CLE9BQU87QUFBQSxJQUNwQztBQUVBLFlBQVEsS0FBSywrQ0FBeUMsT0FBTyxHQUFHO0FBQ2hFLFdBQU8sQ0FBQztBQUFBLEVBQ1Y7QUFZQSxxQkFBbUI7OztBQ3BMWixXQUFTLGNBQWMsUUFBUSxPQUFPO0FBRTNDLFVBQU0sbUJBQW1CO0FBQUEsTUFDdkI7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsSUFDRjtBQUVBLGVBQVcsWUFBWSxrQkFBa0I7QUFDdkMsWUFBTSxVQUFVLFNBQVMsY0FBYyxRQUFRO0FBQy9DLFVBQUksV0FBVyxRQUFRLGlCQUFpQixNQUFNO0FBQzVDLFlBQUksTUFBTyxTQUFRLElBQUkscURBQThDLFFBQVEsRUFBRTtBQUMvRSxlQUFPO0FBQUEsTUFDVDtBQUFBLElBQ0Y7QUFHQSxVQUFNLGdCQUFnQixTQUFTLGlCQUFpQiwrRUFBK0U7QUFDL0gsUUFBSSxnQkFBZ0I7QUFDcEIsZUFBVyxNQUFNLGVBQWU7QUFDOUIsVUFBSSxHQUFHLGlCQUFpQixRQUFRLEdBQUcsY0FBYyxNQUFNLEdBQUcsZUFBZSxJQUFJO0FBQzNFO0FBQ0EsWUFBSSxpQkFBaUIsR0FBRztBQUN0QixjQUFJLE1BQU8sU0FBUSxJQUFJLDZEQUFzRCxhQUFhLEVBQUU7QUFDNUYsaUJBQU87QUFBQSxRQUNUO0FBQUEsTUFDRjtBQUFBLElBQ0Y7QUFFQSxRQUFJLE1BQU8sU0FBUSxJQUFJLDZEQUFzRCxhQUFhLEVBQUU7QUFDNUYsV0FBTztBQUFBLEVBQ1Q7QUFHTyxXQUFTLHdCQUF3QixRQUFRLE9BQU8sY0FBYyxPQUFPO0FBRTFFLFVBQU0saUJBQWlCLFNBQVMsY0FBYyxtRUFBbUU7QUFFakgsUUFBSSxnQkFBZ0I7QUFDbEIsWUFBTSxhQUFhLGVBQWUsWUFBWSxZQUFZO0FBQzFELFlBQU0sZUFBZSxXQUFXLFNBQVMsT0FBTyxLQUFLLFdBQVcsU0FBUyxRQUFRO0FBQ2pGLFlBQU0sZUFBZSxlQUFlLGNBQWMsd0JBQXdCLEtBQ3RELGVBQWUsY0FBYyxvQkFBb0I7QUFFckUsVUFBSSxnQkFBZ0IsY0FBYztBQUNoQyxZQUFJLE1BQU8sU0FBUSxJQUFJLDZFQUFnRSxVQUFVLEdBQUc7QUFDcEcsdUJBQWUsTUFBTTtBQUdyQixZQUFJLGFBQWE7QUFDZixxQkFBVyxNQUFNO0FBQ2YsZ0JBQUksTUFBTyxTQUFRLElBQUksbURBQXlDO0FBQ2hFLDJCQUFlLE1BQU07QUFBQSxVQUN2QixHQUFHLEdBQUc7QUFBQSxRQUNSO0FBQ0EsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBR0EsVUFBTSxVQUFVLFNBQVMsaUJBQWlCLFFBQVE7QUFDbEQsZUFBVyxVQUFVLFNBQVM7QUFDNUIsWUFBTSxhQUFhLE9BQU8sWUFBWSxZQUFZO0FBQ2xELFdBQUssV0FBVyxTQUFTLE9BQU8sS0FBSyxXQUFXLFNBQVMsUUFBUSxNQUM3RCxPQUFPLGlCQUFpQixRQUN4QixDQUFDLE9BQU8sVUFBVTtBQUNwQixZQUFJLE1BQU8sU0FBUSxJQUFJLDREQUFrRCxPQUFPLFlBQVksS0FBSyxDQUFDLEdBQUc7QUFDckcsZUFBTyxNQUFNO0FBR2IsWUFBSSxhQUFhO0FBQ2YscUJBQVcsTUFBTTtBQUNmLGdCQUFJLE1BQU8sU0FBUSxJQUFJLG1EQUF5QztBQUNoRSxtQkFBTyxNQUFNO0FBQUEsVUFDZixHQUFHLEdBQUc7QUFBQSxRQUNSO0FBQ0EsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBRUEsUUFBSSxNQUFPLFNBQVEsSUFBSSw4Q0FBc0M7QUFDN0QsV0FBTztBQUFBLEVBQ1Q7QUFHQSxpQkFBc0IscUJBQXFCLGNBQWMsR0FBRyxRQUFRLE1BQU07QUFDeEUsUUFBSSxNQUFPLFNBQVEsSUFBSSx5RUFBNEQsV0FBVyxZQUFZO0FBRTFHLGFBQVMsVUFBVSxHQUFHLFdBQVcsYUFBYSxXQUFXO0FBQ3ZELFVBQUksTUFBTyxTQUFRLElBQUksOEJBQXVCLE9BQU8sSUFBSSxXQUFXLCtCQUE0QjtBQUdoRyxVQUFJLGNBQWMsR0FBRztBQUNuQixZQUFJLE1BQU8sU0FBUSxJQUFJLGtFQUEwRDtBQUNqRixlQUFPO0FBQUEsTUFDVDtBQUdBLFVBQUksd0JBQXdCLE9BQU8sS0FBSyxHQUFHO0FBQ3pDLFlBQUksTUFBTyxTQUFRLElBQUksd0VBQThEO0FBR3JGLGNBQU0sSUFBSSxRQUFRLGFBQVcsV0FBVyxTQUFTLElBQUksQ0FBQztBQUd0RCxZQUFJLGNBQWMsR0FBRztBQUNuQixjQUFJLE1BQU8sU0FBUSxJQUFJLHNFQUE4RCxPQUFPLEVBQUU7QUFDOUYsaUJBQU87QUFBQSxRQUNULE9BQU87QUFDTCxjQUFJLE1BQU8sU0FBUSxJQUFJLHFFQUEyRCxPQUFPLG1CQUFnQjtBQUFBLFFBQzNHO0FBQUEsTUFDRixPQUFPO0FBQ0wsWUFBSSxNQUFPLFNBQVEsSUFBSSxxRUFBNkQsT0FBTyxFQUFFO0FBQUEsTUFDL0Y7QUFHQSxVQUFJLFVBQVUsYUFBYTtBQUN6QixjQUFNLElBQUksUUFBUSxhQUFXLFdBQVcsU0FBUyxHQUFJLENBQUM7QUFBQSxNQUN4RDtBQUFBLElBQ0Y7QUFFQSxRQUFJLE1BQU8sU0FBUSxJQUFJLHFEQUEwQyxXQUFXLFdBQVc7QUFDdkYsV0FBTztBQUFBLEVBQ1Q7OztBQ2xJQSxNQUFNLEVBQUUsYUFBYSxjQUFjLElBQUk7QUFFdkMsaUJBQXNCLFdBQVc7QUFDL0IsUUFBSSw2Q0FBaUM7QUFHckMsdUJBQW1CO0FBR25CLFFBQUksQ0FBQyxrQkFBa0IsR0FBRztBQUN4QjtBQUFBLElBQ0Y7QUFHQSxXQUFPLGNBQWM7QUFBQSxNQUNuQixHQUFHLE9BQU87QUFBQSxNQUNWLGNBQWM7QUFBQSxJQUNoQjtBQUVBLFFBQUk7QUFFRixZQUFNLFFBQVEsV0FBVyxPQUFPO0FBR2hDLGlCQUFXLEtBQUssY0FBYyxLQUFLO0FBR25DLDBCQUFvQjtBQUdwQixxQkFBZSxjQUFjO0FBQzNCLFlBQUksK0NBQXdDO0FBQzVDLG1CQUFXLEdBQUcsYUFBYSxFQUFFLHVCQUF1QixHQUFHLE1BQU07QUFHN0QsWUFBSSxjQUFjLEdBQUc7QUFDbkIsY0FBSSx1REFBZ0Q7QUFDcEQsZ0JBQU0sWUFBWSxzQkFBc0I7QUFDeEMsY0FBSSxVQUFVLFNBQVMsR0FBRztBQUN4Qix1QkFBVyxHQUFHLGFBQWEsRUFBRSx1QkFBdUIsR0FBRyxTQUFTO0FBQ2hFLG1CQUFPO0FBQUEsVUFDVDtBQUNBLGNBQUksMEZBQWdGO0FBQUEsUUFDdEY7QUFHQSxZQUFJLHNDQUE0QjtBQUNoQyxtQkFBVyxHQUFHLGFBQWEsRUFBRSwyQkFBMkIsR0FBRyxNQUFNO0FBQ2pFLFlBQUksd0JBQXdCLEdBQUc7QUFDN0IsY0FBSSxrREFBd0M7QUFDNUMsZ0JBQU0sTUFBTSxHQUFJO0FBR2hCLGdCQUFNLGNBQWMsc0JBQXNCO0FBQzFDLGNBQUksWUFBWSxTQUFTLEdBQUc7QUFDMUIsZ0JBQUksZ0RBQTJDO0FBQy9DLHVCQUFXLEdBQUcsYUFBYSxFQUFFLHVCQUF1QixHQUFHLFNBQVM7QUFDaEUsbUJBQU87QUFBQSxVQUNUO0FBQ0EsY0FBSSxjQUFjLEdBQUc7QUFDbkIsZ0JBQUksMkRBQW1EO0FBQUEsVUFFekQsT0FBTztBQUNMLGdCQUFJLDBEQUErQztBQUFBLFVBQ3JEO0FBQUEsUUFDRixPQUFPO0FBQ0wsY0FBSSxxQ0FBNkI7QUFBQSxRQUNuQztBQUVBLG1CQUFXLEdBQUcsYUFBYSxFQUFFLHNCQUFzQixHQUFHLFNBQVM7QUFDL0QsZUFBTztBQUFBLE1BQ1Q7QUFHQSxpQkFBVyxZQUFZO0FBQ3JCLFlBQUk7QUFDRixxQkFBVyxHQUFHLGFBQWEsRUFBRSx3QkFBd0IsR0FBRyxNQUFNO0FBQzlELGNBQUkscUNBQThCO0FBRWxDLGdCQUFNLGtCQUFrQixNQUFNLFlBQVk7QUFFMUMsY0FBSSxpQkFBaUI7QUFDbkIsdUJBQVcsR0FBRyxhQUFhLEVBQUUsdUJBQXVCLEdBQUcsU0FBUztBQUNoRSxnQkFBSSw0QkFBdUI7QUFHM0IsdUJBQVcsR0FBRyxxQkFBcUIsS0FBSztBQUd4QyxrQkFBTSxhQUFhLE1BQU0sZ0JBQWdCLElBQUk7QUFDN0MsZ0JBQUksWUFBWTtBQUNkLGtCQUFJLGlEQUEwQztBQUFBLFlBQ2hEO0FBQUEsVUFDRixPQUFPO0FBQ0wsdUJBQVcsR0FBRyxhQUFhLEVBQUUsc0JBQXNCLEdBQUcsU0FBUztBQUMvRCxnQkFBSSw4REFBaUQ7QUFFckQsdUJBQVcsR0FBRyxxQkFBcUIsSUFBSTtBQUFBLFVBQ3pDO0FBQUEsUUFDRixTQUFTLE9BQU87QUFDZCxjQUFJLGdDQUEyQixLQUFLO0FBQ3BDLHFCQUFXLEdBQUcsYUFBYSxFQUFFLDBCQUEwQixHQUFHLFNBQVM7QUFBQSxRQUNyRTtBQUFBLE1BQ0osR0FBRyxHQUFJO0FBR0wsYUFBTyxpQkFBaUIsZ0JBQWdCLE1BQU07QUFDNUMsa0JBQVU7QUFDVixZQUFJLE9BQU8sYUFBYTtBQUN0QixpQkFBTyxZQUFZLGVBQWU7QUFBQSxRQUNwQztBQUFBLE1BQ0YsQ0FBQztBQUVELFVBQUkseUNBQW9DO0FBQUEsSUFFMUMsU0FBUyxPQUFPO0FBQ2QsVUFBSSwwQ0FBcUMsS0FBSztBQUM5QyxVQUFJLE9BQU8sYUFBYTtBQUN0QixlQUFPLFlBQVksZUFBZTtBQUFBLE1BQ3BDO0FBQ0EsWUFBTTtBQUFBLElBQ1I7QUFBQSxFQUNGO0FBRUEsV0FBUyxvQkFBb0I7QUF2STdCO0FBd0lFLFNBQUksWUFBTyxnQkFBUCxtQkFBb0IsY0FBYztBQUNwQyxZQUFNLDhFQUFxRTtBQUMzRSxhQUFPO0FBQUEsSUFDVDtBQUNBLFNBQUksWUFBTyxnQkFBUCxtQkFBb0IsYUFBYTtBQUNuQyxZQUFNLDZFQUFvRTtBQUMxRSxhQUFPO0FBQUEsSUFDVDtBQUNBLFdBQU87QUFBQSxFQUNUO0FBRUEsV0FBUyxzQkFBc0I7QUFDN0IsVUFBTSxFQUFFLFNBQVMsSUFBSSxXQUFXO0FBRWhDLGFBQVMsU0FBUyxpQkFBaUIsU0FBUyxNQUFNO0FBQ2hELGdCQUFVO0FBQ1YsaUJBQVcsR0FBRyxRQUFRO0FBQ3RCLFVBQUksT0FBTyxhQUFhO0FBQ3RCLGVBQU8sWUFBWSxlQUFlO0FBQUEsTUFDcEM7QUFBQSxJQUNGLENBQUM7QUFFRCxhQUFTLFFBQVEsaUJBQWlCLFNBQVMsTUFBTSxnQkFBZ0IsQ0FBQztBQUNsRSxhQUFTLGNBQWMsaUJBQWlCLFNBQVMsb0JBQW9CO0FBQ3JFLGFBQVMsWUFBWSxpQkFBaUIsU0FBUyxNQUFNO0FBQ25ELGVBQVMsY0FBYyxNQUFNO0FBQUEsSUFDL0IsQ0FBQztBQUVELGFBQVMsY0FBYyxpQkFBaUIsVUFBVSxZQUFZO0FBQzVELFVBQUksU0FBUyxjQUFjLE1BQU0sU0FBUyxHQUFHO0FBQzNDLGNBQU0sU0FBUyxNQUFNLGFBQWEsU0FBUyxjQUFjLE1BQU0sQ0FBQyxDQUFDO0FBQ2pFLFlBQUksT0FBTyxTQUFTO0FBQ2xCLHFCQUFXLEdBQUcsYUFBYSxpQ0FBeUIsT0FBTyxlQUFlLDBCQUF1QixTQUFTO0FBQzFHLGNBQUksdURBQTRDO0FBQUEsUUFDbEQsT0FBTztBQUNMLHFCQUFXLEdBQUcsYUFBYSx5Q0FBaUMsT0FBTyxLQUFLLElBQUksT0FBTztBQUNuRixjQUFJLGtDQUE2QixPQUFPLEtBQUssRUFBRTtBQUFBLFFBQ2pEO0FBQUEsTUFDRjtBQUFBLElBQ0YsQ0FBQztBQUVELGFBQVMsU0FBUyxpQkFBaUIsU0FBUyxVQUFVO0FBQ3RELGFBQVMsUUFBUSxpQkFBaUIsU0FBUyxZQUFZO0FBRXJELGlCQUFXLFVBQVU7QUFDckIsaUJBQVcsU0FBUztBQUNwQixpQkFBVyxHQUFHLGdCQUFnQixLQUFLO0FBQ25DLGlCQUFXLEdBQUcsYUFBYSx1Q0FBMEIsU0FBUztBQUU5RCxVQUFJLFdBQVcsZUFBZTtBQUM1QixzQkFBYyxXQUFXLGFBQWE7QUFDdEMsbUJBQVcsZ0JBQWdCO0FBQUEsTUFDN0I7QUFBQSxJQUNGLENBQUM7QUFHRCxhQUFTLFFBQVEsaUJBQWlCLFNBQVMsWUFBWTtBQUNyRCxVQUFJLENBQUMsWUFBWSxHQUFHO0FBQ2xCLG1CQUFXLEdBQUcsYUFBYSxnREFBd0MsT0FBTztBQUMxRTtBQUFBLE1BQ0Y7QUFHQSxZQUFNLGVBQWUsTUFBTTtBQUFBLFFBQ3pCO0FBQUEsUUFHQTtBQUFBLFFBQ0E7QUFBQSxVQUNFLE1BQU07QUFBQSxVQUNOLFFBQVE7QUFBQSxRQUNWO0FBQUEsTUFDRjtBQUVBLFVBQUksaUJBQWlCLFFBQVE7QUFDM0IsY0FBTSxhQUFhLFNBQVMsY0FBYyxrQkFBa0I7QUFDNUQsY0FBTSxhQUFhLFNBQVMseUNBQVksS0FBSyxLQUFLO0FBQ2xELGNBQU0sU0FBUyxNQUFNLGFBQWEsTUFBTSxVQUFVO0FBQ2xELFlBQUksT0FBTyxTQUFTO0FBQ2xCLHFCQUFXLEdBQUcsYUFBYSxnQ0FBd0IsYUFBYSxJQUFJLGlCQUFpQixVQUFVLGFBQWEsRUFBRSxJQUFJLFNBQVM7QUFBQSxRQUM3SCxPQUFPO0FBQ0wscUJBQVcsR0FBRyxhQUFhLDRCQUF1QixPQUFPLEtBQUssSUFBSSxPQUFPO0FBQUEsUUFDM0U7QUFBQSxNQUNGO0FBQUEsSUFDRixDQUFDO0FBR0QsYUFBUyxvQkFBb0IsaUJBQWlCLFVBQVUsQ0FBQyxNQUFNO0FBQzdELGlCQUFXLGlCQUFpQixLQUFLLElBQUksR0FBRyxLQUFLLElBQUksSUFBSSxTQUFTLEVBQUUsT0FBTyxLQUFLLEtBQUssRUFBRSxDQUFDO0FBQ3BGLFFBQUUsT0FBTyxRQUFRLFdBQVc7QUFBQSxJQUM5QixDQUFDO0FBRUQsYUFBUyxnQkFBZ0IsaUJBQWlCLFVBQVUsQ0FBQyxNQUFNO0FBQ3pELGlCQUFXLG1CQUFtQixLQUFLLElBQUksR0FBRyxLQUFLLElBQUksS0FBSyxTQUFTLEVBQUUsT0FBTyxLQUFLLEtBQUssRUFBRSxDQUFDO0FBQ3ZGLFFBQUUsT0FBTyxRQUFRLFdBQVc7QUFBQSxJQUM5QixDQUFDO0FBR0QsYUFBUyxvQkFBb0IsUUFBUSxXQUFXO0FBQ2hELGFBQVMsZ0JBQWdCLFFBQVEsV0FBVztBQUFBLEVBQzlDO0FBRUEsaUJBQWUsZ0JBQWdCLGFBQWEsT0FBTztBQTlPbkQ7QUErT0UsUUFBSTtBQUNGLGlCQUFXLEdBQUcsYUFBYSxFQUFFLHNCQUFzQixHQUFHLE1BQU07QUFHNUQsVUFBSSxTQUFTLHNCQUFzQjtBQUNuQyxVQUFJLE9BQU8sV0FBVyxHQUFHO0FBRXZCLFlBQUksMEVBQWdFO0FBQ3BFLG1CQUFXLEdBQUcsYUFBYSxFQUFFLDJCQUEyQixHQUFHLE1BQU07QUFDakUsWUFBSSx3QkFBd0IsR0FBRztBQUM3QixnQkFBTSxNQUFNLElBQUk7QUFDaEIsbUJBQVMsc0JBQXNCO0FBQUEsUUFDakM7QUFBQSxNQUNGO0FBQ0EsVUFBSSxPQUFPLFdBQVcsR0FBRztBQUN2QixtQkFBVyxHQUFHLGFBQWEsRUFBRSxxQkFBcUIsR0FBRyxPQUFPO0FBQzVELGVBQU87QUFBQSxNQUNUO0FBRUEsaUJBQVcsa0JBQWtCO0FBQzdCLGlCQUFXLGdCQUFnQjtBQUczQixZQUFNLFVBQVUsTUFBTSxXQUFXO0FBQ2pDLFVBQUksUUFBUSxTQUFTO0FBQ25CLG1CQUFXLGlCQUFpQixRQUFRLEtBQUs7QUFDekMsbUJBQVcsYUFBYSxRQUFRLEtBQUs7QUFDckMsbUJBQVcsR0FBRyxZQUFZLEVBQUUsU0FBUyxLQUFLLE1BQU0sV0FBVyxjQUFjLEVBQUUsQ0FBQztBQUM1RSxZQUFJLHdCQUFlLGFBQVEsS0FBSyxTQUFiLG1CQUFtQixTQUFRLFlBQVMsY0FBYyxXQUFXLGNBQWMsRUFBRTtBQUFBLE1BQ2xHO0FBRUEsaUJBQVcsY0FBYztBQUN6QixpQkFBVyxHQUFHLGFBQWEsRUFBRSxxQkFBcUIsRUFBRSxPQUFPLE9BQU8sT0FBTyxDQUFDLEdBQUcsU0FBUztBQUN0RixpQkFBVyxHQUFHLGdCQUFnQjtBQUc5QixVQUFJLENBQUMsWUFBWTtBQUNmLFlBQUksVUFBSyxPQUFPLE1BQU0saUNBQWlDO0FBQUEsTUFDekQ7QUFHQSxpQkFBVyxHQUFHLGVBQWUsSUFBSTtBQUVqQyxhQUFPO0FBQUEsSUFFVCxTQUFTLE9BQU87QUFDZCxVQUFJLCtCQUEwQixLQUFLO0FBQ25DLGlCQUFXLEdBQUcsYUFBYSxFQUFFLGlCQUFpQixHQUFHLE9BQU87QUFDeEQsYUFBTztBQUFBLElBQ1Q7QUFBQSxFQUNGO0FBR0EsTUFBSSxnQkFBZ0IsT0FBTztBQUUzQixpQkFBZSx1QkFBdUI7QUFDcEMsUUFBSSwwREFBNkM7QUFHakQsUUFBSSxrQkFBa0I7QUFDdEIsUUFBSSxtQkFBbUI7QUFDdkIsUUFBSSxpQkFBaUI7QUFDckIsUUFBSSxtQkFBbUI7QUFHdkIsVUFBTSxlQUFlLE1BQU07QUFDekIsVUFBSSxPQUFPLFVBQVUsZUFBZTtBQUNsQyxlQUFPLFFBQVE7QUFDZixZQUFJLHFDQUE4QjtBQUFBLE1BQ3BDO0FBQUEsSUFDRjtBQUdBLFVBQU0seUJBQXlCLE1BQU07QUFDbkMsYUFBTyxRQUFRLE9BQU8sS0FBSyxZQUFZO0FBRXJDLFlBQUksQ0FBQyxvQkFDRCxPQUFPLFFBQVEsWUFDZixJQUFJLFNBQVMsWUFBWSxLQUN6QixXQUNBLFFBQVEsV0FBVyxRQUFRO0FBRTdCLGNBQUk7QUFDRixnQkFBSSwrQ0FBd0MsR0FBRyxFQUFFO0FBRWpELGtCQUFNLFdBQVcsTUFBTSxjQUFjLEtBQUssT0FBTztBQUVqRCxnQkFBSSxTQUFTLE1BQU0sUUFBUSxNQUFNO0FBQy9CLGtCQUFJO0FBQ0osa0JBQUk7QUFDRiwyQkFBVyxLQUFLLE1BQU0sUUFBUSxJQUFJO0FBQUEsY0FDcEMsU0FBUyxZQUFZO0FBQ25CLG9CQUFJLHFDQUFxQyxVQUFVO0FBQ25ELHVCQUFPO0FBQUEsY0FDVDtBQUVBLGtCQUFJLFNBQVMsVUFBVSxNQUFNLFFBQVEsU0FBUyxNQUFNLEtBQUssU0FBUyxPQUFPLFVBQVUsR0FBRztBQUNwRixzQkFBTSxTQUFTLFNBQVMsT0FBTyxDQUFDO0FBQ2hDLHNCQUFNLFNBQVMsU0FBUyxPQUFPLENBQUM7QUFHaEMsc0JBQU0sWUFBWSxJQUFJLE1BQU0sK0JBQStCO0FBQzNELG9CQUFJLFdBQVc7QUFDYix3QkFBTSxRQUFRLFNBQVMsVUFBVSxDQUFDLENBQUM7QUFDbkMsd0JBQU0sUUFBUSxTQUFTLFVBQVUsQ0FBQyxDQUFDO0FBR25DLHdCQUFNLFVBQVUsUUFBUSxNQUFPO0FBQy9CLHdCQUFNLFVBQVUsUUFBUSxNQUFPO0FBRS9CLHNCQUFJLG1CQUFtQixhQUFhO0FBRWxDLHNDQUFrQixFQUFFLEdBQUcsU0FBUyxHQUFHLFFBQVE7QUFDM0MsK0JBQVcsR0FBRyxrQkFBa0IsRUFBRSxJQUFJLFNBQVMsSUFBSSxRQUFRLENBQUM7QUFDNUQsK0JBQVcsR0FBRyxhQUFhLEVBQUUsMkJBQTJCLEVBQUUsR0FBRyxTQUFTLEdBQUcsUUFBUSxDQUFDLEdBQUcsU0FBUztBQUM5Rix3QkFBSSxpREFBNEMsT0FBTyxLQUFLLE9BQU8sR0FBRztBQUd0RSxxQ0FBaUI7QUFDakIsK0JBQVcsTUFBTTtBQUNmLDBCQUFJLG1CQUFtQixjQUFjO0FBQ25DLG1DQUFXLEdBQUcsYUFBYSxFQUFFLHdCQUF3QixHQUFHLE1BQU07QUFBQSxzQkFDaEU7QUFBQSxvQkFDRixHQUFHLElBQUk7QUFBQSxrQkFFVCxXQUFXLG1CQUFtQixjQUFjO0FBRTFDLHVDQUFtQixFQUFFLEdBQUcsU0FBUyxHQUFHLFFBQVE7QUFDNUMsK0JBQVcsR0FBRyxrQkFBa0IsRUFBRSxJQUFJLFNBQVMsSUFBSSxRQUFRLENBQUM7QUFDNUQsK0JBQVcsR0FBRyxhQUFhLEVBQUUsNEJBQTRCLEVBQUUsR0FBRyxTQUFTLEdBQUcsUUFBUSxDQUFDLEdBQUcsU0FBUztBQUMvRix3QkFBSSwrQ0FBMEMsT0FBTyxLQUFLLE9BQU8sR0FBRztBQUdwRSx1Q0FBbUI7QUFDbkIsaUNBQWE7QUFHYix3QkFBSSxnQkFBZ0IsS0FBSyxpQkFBaUIsS0FBSyxnQkFBZ0IsS0FBSyxpQkFBaUIsR0FBRztBQUN0RixpQ0FBVyxHQUFHLGFBQWEsRUFBRSxtQkFBbUIsR0FBRyxPQUFPO0FBQzFELDZCQUFPO0FBQUEsb0JBQ1Q7QUFHQSwrQkFBVyxZQUFZO0FBQ3JCLDRCQUFNLDJCQUEyQixpQkFBaUIsZ0JBQWdCO0FBQUEsb0JBQ3BFLEdBQUcsR0FBSTtBQUFBLGtCQUNUO0FBQUEsZ0JBQ0Y7QUFBQSxjQUNGO0FBQUEsWUFDRjtBQUVBLG1CQUFPO0FBQUEsVUFDVCxTQUFTLE9BQU87QUFDZCxnQkFBSSxxQ0FBZ0MsS0FBSztBQUN6Qyx5QkFBYTtBQUNiLG1CQUFPLGNBQWMsS0FBSyxPQUFPO0FBQUEsVUFDbkM7QUFBQSxRQUNGO0FBR0EsZUFBTyxjQUFjLEtBQUssT0FBTztBQUFBLE1BQ25DO0FBQUEsSUFDRjtBQUdBLDJCQUF1QjtBQUd2QixlQUFXLEdBQUcsYUFBYSxFQUFFLHVCQUF1QixHQUFHLE1BQU07QUFHN0QsZUFBVyxNQUFNO0FBQ2YsVUFBSSxDQUFDLGtCQUFrQjtBQUNyQixxQkFBYTtBQUNiLG1CQUFXLEdBQUcsYUFBYSxFQUFFLHdCQUF3QixHQUFHLE9BQU87QUFDL0QsWUFBSSwyQ0FBZ0M7QUFBQSxNQUN0QztBQUFBLElBQ0YsR0FBRyxJQUFNO0FBQUEsRUFDWDtBQUVBLGlCQUFlLDJCQUEyQixXQUFXLFlBQVk7QUFDL0QsUUFBSTtBQUNGLFlBQU0sT0FBTztBQUFBLFFBQ1gsSUFBSSxVQUFVO0FBQUEsUUFDZCxJQUFJLFVBQVU7QUFBQSxRQUNkLElBQUksV0FBVztBQUFBLFFBQ2YsSUFBSSxXQUFXO0FBQUEsTUFDakI7QUFFQSxpQkFBVyxHQUFHLGFBQWEsRUFBRSxxQkFBcUIsR0FBRyxNQUFNO0FBRTNELFlBQU0sV0FBVyxNQUFNLGtCQUFrQixJQUFJO0FBRTdDLGlCQUFXLGlCQUFpQjtBQUM1QixpQkFBVyxpQkFBaUI7QUFDNUIsaUJBQVcsUUFBUSxNQUFNO0FBRXpCLGlCQUFXLEdBQUcsZUFBZSxHQUFHLFNBQVMsSUFBSTtBQUM3QyxpQkFBVyxHQUFHLGFBQWEsRUFBRSxzQkFBc0IsRUFBRSxPQUFPLFNBQVMsS0FBSyxDQUFDLEdBQUcsU0FBUztBQUN2RixpQkFBVyxHQUFHLGVBQWU7QUFFN0IsVUFBSSw2QkFBcUIsU0FBUyxJQUFJLHdCQUFxQjtBQUFBLElBRTdELFNBQVMsT0FBTztBQUNkLFVBQUksb0NBQTRCLEtBQUs7QUFDckMsaUJBQVcsR0FBRyxhQUFhLEVBQUUsc0JBQXNCLEVBQUUsT0FBTyxNQUFNLFFBQVEsQ0FBQyxHQUFHLE9BQU87QUFBQSxJQUN2RjtBQUFBLEVBQ0Y7QUFFQSxpQkFBZSxhQUFhO0FBQzFCLFFBQUksQ0FBQyxXQUFXLGtCQUFrQixDQUFDLFdBQVcsZUFBZSxNQUFNO0FBQ2pFLGlCQUFXLEdBQUcsYUFBYSxFQUFFLG9CQUFvQixHQUFHLE9BQU87QUFDM0Q7QUFBQSxJQUNGO0FBRUEsZUFBVyxVQUFVO0FBQ3JCLGVBQVcsR0FBRyxnQkFBZ0IsSUFBSTtBQUNsQyxlQUFXLEdBQUcsYUFBYSxFQUFFLHlCQUF5QixHQUFHLFNBQVM7QUFFbEUsUUFBSSxxREFBbUM7QUFHdkMsZUFBVyxnQkFBZ0IsWUFBWSxpQkFBaUIsZUFBZSxjQUFjO0FBR3JGLFVBQU0sZ0JBQWdCO0FBQUEsRUFDeEI7QUFFQSxXQUFTLFlBQVk7QUFDbkIsZUFBVyxVQUFVO0FBRXJCLFFBQUksV0FBVyxlQUFlO0FBQzVCLG9CQUFjLFdBQVcsYUFBYTtBQUN0QyxpQkFBVyxnQkFBZ0I7QUFBQSxJQUM3QjtBQUVBLFFBQUksV0FBVyxJQUFJO0FBQ2pCLGlCQUFXLEdBQUcsZ0JBQWdCLEtBQUs7QUFDbkMsaUJBQVcsR0FBRyxhQUFhLEVBQUUseUJBQXlCLEdBQUcsU0FBUztBQUFBLElBQ3BFO0FBRUEsUUFBSSxxQ0FBd0I7QUFBQSxFQUM5Qjs7O0FDN2RBLEdBQUMsaUJBQWlCO0FBSmxCO0FBS0UsUUFBSTtBQUNGLGNBQVEsSUFBSSxrRUFBd0Q7QUFDcEUsWUFBTSxxQkFBcUIsR0FBRyxJQUFJO0FBQUEsSUFDcEMsU0FBUyxPQUFPO0FBQ2QsY0FBUSxJQUFJLG9FQUF1RCxLQUFLO0FBQUEsSUFDMUU7QUFHQSxTQUFJLFlBQU8sZ0JBQVAsbUJBQW9CLGNBQWM7QUFDcEMsWUFBTSxrQ0FBK0I7QUFBQSxJQUN2QyxPQUFPO0FBRUwsZUFBUyxFQUFFLE1BQU0sV0FBUztBQUN4QixnQkFBUSxNQUFNLG9DQUFvQyxLQUFLO0FBQ3ZELFlBQUksT0FBTyxhQUFhO0FBQ3RCLGlCQUFPLFlBQVksZUFBZTtBQUFBLFFBQ3BDO0FBQ0EsY0FBTSwrQ0FBK0M7QUFBQSxNQUN2RCxDQUFDO0FBQUEsSUFDSDtBQUFBLEVBQ0YsR0FBRzsiLAogICJuYW1lcyI6IFsidCJdCn0K

--- a/Auto-Image.js
+++ b/Auto-Image.js
@@ -1,11 +1,2870 @@
-/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-20T07:18:37.796Z */
-(()=>{var d=(...l)=>console.log("[WPA-UI]",...l);var Z={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selecci\xF3n",user:"Usuario",charges:"Cargas",backend:"Backend",database:"Database",uptime:"Uptime",close:"Cerrar",launch:"Lanzar",loading:"Cargando\u2026",executing:"Ejecutando\u2026",downloading:"Descargando script\u2026",chooseBot:"Elige un bot y presiona Lanzar",readyToLaunch:"Listo para lanzar",loadError:"Error al cargar",loadErrorMsg:"No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",checking:"\u{1F504} Verificando...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Iniciar Auto-BOT",uploadImage:"Subir Imagen",resizeImage:"Redimensionar Imagen",selectPosition:"Seleccionar Posici\xF3n",startPainting:"Iniciar Pintura",stopPainting:"Detener Pintura",saveProgress:"Guardar Progreso",loadProgress:"Cargar Progreso",checkingColors:"\u{1F50D} Verificando colores disponibles...",noColorsFound:"\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",colorsFound:"\u2705 {count} colores disponibles encontrados",loadingImage:"\u{1F5BC}\uFE0F Cargando imagen...",imageLoaded:"\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",imageError:"\u274C Error al cargar la imagen",selectPositionAlert:"\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Posici\xF3n establecida con \xE9xito!",positionTimeout:"\u274C Tiempo agotado para seleccionar posici\xF3n",positionDetected:"\u{1F3AF} Posici\xF3n detectada, procesando...",positionError:"\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",startPaintingMsg:"\u{1F3A8} Iniciando pintura...",paintingProgress:"\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",noCharges:"\u231B Sin cargas. Esperando {time}...",paintingStopped:"\u23F9\uFE0F Pintura detenida por el usuario",paintingComplete:"\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",paintingError:"\u274C Error durante la pintura",missingRequirements:"\u274C Carga una imagen y selecciona una posici\xF3n primero",progress:"Progreso",userName:"Usuario",pixels:"P\xEDxeles",charges:"Cargas",estimatedTime:"Tiempo estimado",initMessage:"Haz clic en 'Iniciar Auto-BOT' para comenzar",waitingInit:"Esperando inicializaci\xF3n...",resizeSuccess:"\u2705 Imagen redimensionada a {width}x{height}",paintingPaused:"\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",pixelsPerBatch:"P\xEDxeles por lote",batchSize:"Tama\xF1o del lote",nextBatchTime:"Siguiente lote en",useAllCharges:"Usar todas las cargas disponibles",showOverlay:"Mostrar overlay",maxCharges:"Cargas m\xE1ximas por lote",waitingForCharges:"\u23F3 Esperando cargas: {current}/{needed}",timeRemaining:"Tiempo restante",cooldownWaiting:"\u23F3 Esperando {time} para continuar...",progressSaved:"\u2705 Progreso guardado como {filename}",progressLoaded:"\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",progressLoadError:"\u274C Error al cargar progreso: {error}",progressSaveError:"\u274C Error al guardar progreso: {error}",confirmSaveProgress:"\xBFDeseas guardar el progreso actual antes de detener?",saveProgressTitle:"Guardar Progreso",discardProgress:"Descartar",cancel:"Cancelar",minimize:"Minimizar",width:"Ancho",height:"Alto",keepAspect:"Mantener proporci\xF3n",apply:"Aplicar",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",waitingChargesCountdown:"\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Bot iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",manualInitRequired:"\u{1F527} Inicio manual requerido",retryAttempt:"\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",retryError:"\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",retryFailed:"\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",networkError:"\u{1F310} Error de red. Reintentando...",serverError:"\u{1F525} Error del servidor. Reintentando...",timeoutError:"\u23F0 Timeout del servidor. Reintentando..."},farm:{title:"WPlace Farm Bot",start:"Iniciar",stop:"Detener",stopped:"Bot detenido",calibrate:"Calibrar",paintOnce:"Una vez",checkingStatus:"Verificando estado...",configuration:"Configuraci\xF3n",delay:"Delay (ms)",pixelsPerBatch:"P\xEDxeles/lote",minCharges:"Cargas m\xEDn",colorMode:"Modo color",random:"Aleatorio",fixed:"Fijo",range:"Rango",fixedColor:"Color fijo",advanced:"Avanzado",tileX:"Tile X",tileY:"Tile Y",customPalette:"Paleta personalizada",paletteExample:"ej: #FF0000,#00FF00,#0000FF",capture:"Capturar",painted:"Pintados",charges:"Cargas",retries:"Fallos",tile:"Tile",configSaved:"Configuraci\xF3n guardada",configLoaded:"Configuraci\xF3n cargada",configReset:"Configuraci\xF3n reiniciada",captureInstructions:"Pinta un p\xEDxel manualmente para capturar coordenadas...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Iniciando bot...",stoppingBot:"Deteniendo bot...",calibrating:"Calibrando...",alreadyRunning:"Auto-Farm ya est\xE1 corriendo.",imageRunningWarning:"Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",selectPosition:"Seleccionar Zona",selectPositionAlert:"\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Zona establecida! Radio: 500px",positionTimeout:"\u274C Tiempo agotado para seleccionar zona",missingPosition:"\u274C Selecciona una zona primero usando 'Seleccionar Zona'",farmRadius:"Radio farm",positionInfo:"Zona actual",farmingInRadius:"\u{1F33E} Farming en radio {radius}px desde ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",noPosition:"Sin zona",currentZone:"Zona: ({x},{y})",autoSelectPosition:"\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"},common:{yes:"S\xED",no:"No",ok:"Aceptar",cancel:"Cancelar",close:"Cerrar",save:"Guardar",load:"Cargar",delete:"Eliminar",edit:"Editar",start:"Iniciar",stop:"Detener",pause:"Pausar",resume:"Reanudar",reset:"Reiniciar",settings:"Configuraci\xF3n",help:"Ayuda",about:"Acerca de",language:"Idioma",loading:"Cargando...",error:"Error",success:"\xC9xito",warning:"Advertencia",info:"Informaci\xF3n",languageChanged:"Idioma cambiado a {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Inicializar Guard-BOT",selectArea:"Seleccionar \xC1rea",captureArea:"Capturar \xC1rea",startProtection:"Iniciar Protecci\xF3n",stopProtection:"Detener Protecci\xF3n",upperLeft:"Esquina Superior Izquierda",lowerRight:"Esquina Inferior Derecha",protectedPixels:"P\xEDxeles Protegidos",detectedChanges:"Cambios Detectados",repairedPixels:"P\xEDxeles Reparados",charges:"Cargas",waitingInit:"Esperando inicializaci\xF3n...",checkingColors:"\u{1F3A8} Verificando colores disponibles...",noColorsFound:"\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",colorsFound:"\u2705 {count} colores disponibles encontrados",initSuccess:"\u2705 Guard-BOT inicializado correctamente",initError:"\u274C Error inicializando Guard-BOT",invalidCoords:"\u274C Coordenadas inv\xE1lidas",invalidArea:"\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",areaTooLarge:"\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",capturingArea:"\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",areaCaptured:"\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",captureError:"\u274C Error capturando \xE1rea: {error}",captureFirst:"\u274C Primero captura un \xE1rea de protecci\xF3n",protectionStarted:"\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",protectionStopped:"\u23F9\uFE0F Protecci\xF3n detenida",noChanges:"\u2705 \xC1rea protegida - sin cambios detectados",changesDetected:"\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",repairing:"\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",repairedSuccess:"\u2705 Reparados {count} p\xEDxeles correctamente",repairError:"\u274C Error reparando p\xEDxeles: {error}",noCharges:"\u26A0\uFE0F Sin cargas suficientes para reparar cambios",checkingChanges:"\u{1F50D} Verificando cambios en \xE1rea protegida...",errorChecking:"\u274C Error verificando cambios: {error}",guardActive:"\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",lastCheck:"\xDAltima verificaci\xF3n: {time}",nextCheck:"Pr\xF3xima verificaci\xF3n en: {time}s",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Guard-BOT iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",manualInitRequired:"\u{1F527} Inicio manual requerido",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",selectUpperLeft:"\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",selectLowerRight:"\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",waitingUpperLeft:"\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",waitingLowerRight:"\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",upperLeftCaptured:"\u2705 Esquina superior izquierda capturada: ({x}, {y})",lowerRightCaptured:"\u2705 Esquina inferior derecha capturada: ({x}, {y})",selectionTimeout:"\u274C Tiempo agotado para selecci\xF3n",selectionError:"\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"}};var K={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selection",user:"User",charges:"Charges",backend:"Backend",database:"Database",uptime:"Uptime",close:"Close",launch:"Launch",loading:"Loading\u2026",executing:"Executing\u2026",downloading:"Downloading script\u2026",chooseBot:"Choose a bot and press Launch",readyToLaunch:"Ready to launch",loadError:"Load error",loadErrorMsg:"Could not load the selected bot. Check your connection or try again.",checking:"\u{1F504} Checking...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialize Auto-BOT",uploadImage:"Upload Image",resizeImage:"Resize Image",selectPosition:"Select Position",startPainting:"Start Painting",stopPainting:"Stop Painting",saveProgress:"Save Progress",loadProgress:"Load Progress",checkingColors:"\u{1F50D} Checking available colors...",noColorsFound:"\u274C Open the color palette on the site and try again!",colorsFound:"\u2705 Found {count} available colors",loadingImage:"\u{1F5BC}\uFE0F Loading image...",imageLoaded:"\u2705 Image loaded with {count} valid pixels",imageError:"\u274C Error loading image",selectPositionAlert:"Paint the first pixel at the location where you want the art to start!",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Position set successfully!",positionTimeout:"\u274C Timeout for position selection",positionDetected:"\u{1F3AF} Position detected, processing...",positionError:"\u274C Error detecting position, please try again",startPaintingMsg:"\u{1F3A8} Starting painting...",paintingProgress:"\u{1F9F1} Progress: {painted}/{total} pixels...",noCharges:"\u231B No charges. Waiting {time}...",paintingStopped:"\u23F9\uFE0F Painting stopped by user",paintingComplete:"\u2705 Painting completed! {count} pixels painted.",paintingError:"\u274C Error during painting",missingRequirements:"\u274C Load an image and select a position first",progress:"Progress",userName:"User",pixels:"Pixels",charges:"Charges",estimatedTime:"Estimated time",initMessage:"Click 'Initialize Auto-BOT' to begin",waitingInit:"Waiting for initialization...",resizeSuccess:"\u2705 Image resized to {width}x{height}",paintingPaused:"\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",pixelsPerBatch:"Pixels per batch",batchSize:"Batch size",nextBatchTime:"Next batch in",useAllCharges:"Use all available charges",showOverlay:"Show overlay",maxCharges:"Max charges per batch",waitingForCharges:"\u23F3 Waiting for charges: {current}/{needed}",timeRemaining:"Time remaining",cooldownWaiting:"\u23F3 Waiting {time} to continue...",progressSaved:"\u2705 Progress saved as {filename}",progressLoaded:"\u2705 Progress loaded: {painted}/{total} pixels painted",progressLoadError:"\u274C Error loading progress: {error}",progressSaveError:"\u274C Error saving progress: {error}",confirmSaveProgress:"Do you want to save the current progress before stopping?",saveProgressTitle:"Save Progress",discardProgress:"Discard",cancel:"Cancel",minimize:"Minimize",width:"Width",height:"Height",keepAspect:"Keep aspect ratio",apply:"Apply",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",waitingChargesCountdown:"\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Bot auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",manualInitRequired:"\u{1F527} Manual initialization required",retryAttempt:"\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",retryError:"\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",retryFailed:"\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",networkError:"\u{1F310} Network error. Retrying...",serverError:"\u{1F525} Server error. Retrying...",timeoutError:"\u23F0 Server timeout. Retrying..."},farm:{title:"WPlace Farm Bot",start:"Start",stop:"Stop",stopped:"Bot stopped",calibrate:"Calibrate",paintOnce:"Once",checkingStatus:"Checking status...",configuration:"Configuration",delay:"Delay (ms)",pixelsPerBatch:"Pixels/batch",minCharges:"Min charges",colorMode:"Color mode",random:"Random",fixed:"Fixed",range:"Range",fixedColor:"Fixed color",advanced:"Advanced",tileX:"Tile X",tileY:"Tile Y",customPalette:"Custom palette",paletteExample:"e.g: #FF0000,#00FF00,#0000FF",capture:"Capture",painted:"Painted",charges:"Charges",retries:"Retries",tile:"Tile",configSaved:"Configuration saved",configLoaded:"Configuration loaded",configReset:"Configuration reset",captureInstructions:"Paint a pixel manually to capture coordinates...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Starting bot...",stoppingBot:"Stopping bot...",calibrating:"Calibrating...",alreadyRunning:"Auto-Farm is already running.",imageRunningWarning:"Auto-Image is running. Close it before starting Auto-Farm.",selectPosition:"Select Area",selectPositionAlert:"\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Area set! Radius: 500px",positionTimeout:"\u274C Timeout for area selection",missingPosition:"\u274C Select an area first using 'Select Area'",farmRadius:"Farm radius",positionInfo:"Current area",farmingInRadius:"\u{1F33E} Farming in {radius}px radius from ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",noPosition:"No area",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"},common:{yes:"Yes",no:"No",ok:"OK",cancel:"Cancel",close:"Close",save:"Save",load:"Load",delete:"Delete",edit:"Edit",start:"Start",stop:"Stop",pause:"Pause",resume:"Resume",reset:"Reset",settings:"Settings",help:"Help",about:"About",language:"Language",loading:"Loading...",error:"Error",success:"Success",warning:"Warning",info:"Information",languageChanged:"Language changed to {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialize Guard-BOT",selectArea:"Select Area",captureArea:"Capture Area",startProtection:"Start Protection",stopProtection:"Stop Protection",upperLeft:"Upper Left Corner",lowerRight:"Lower Right Corner",protectedPixels:"Protected Pixels",detectedChanges:"Detected Changes",repairedPixels:"Repaired Pixels",charges:"Charges",waitingInit:"Waiting for initialization...",checkingColors:"\u{1F3A8} Checking available colors...",noColorsFound:"\u274C No colors found. Open the color palette on the site.",colorsFound:"\u2705 Found {count} available colors",initSuccess:"\u2705 Guard-BOT initialized successfully",initError:"\u274C Error initializing Guard-BOT",invalidCoords:"\u274C Invalid coordinates",invalidArea:"\u274C Area must have upper left corner less than lower right corner",areaTooLarge:"\u274C Area too large: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capturing protection area...",areaCaptured:"\u2705 Area captured: {count} pixels under protection",captureError:"\u274C Error capturing area: {error}",captureFirst:"\u274C First capture a protection area",protectionStarted:"\u{1F6E1}\uFE0F Protection started - monitoring area",protectionStopped:"\u23F9\uFE0F Protection stopped",noChanges:"\u2705 Protected area - no changes detected",changesDetected:"\u{1F6A8} {count} changes detected in protected area",repairing:"\u{1F6E0}\uFE0F Repairing {count} altered pixels...",repairedSuccess:"\u2705 Successfully repaired {count} pixels",repairError:"\u274C Error repairing pixels: {error}",noCharges:"\u26A0\uFE0F Insufficient charges to repair changes",checkingChanges:"\u{1F50D} Checking changes in protected area...",errorChecking:"\u274C Error checking changes: {error}",guardActive:"\u{1F6E1}\uFE0F Guardian active - area under protection",lastCheck:"Last check: {time}",nextCheck:"Next check in: {time}s",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Guard-BOT auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",manualInitRequired:"\u{1F527} Manual initialization required",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",selectUpperLeft:"\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",selectLowerRight:"\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",waitingUpperLeft:"\u{1F446} Waiting for upper left corner selection...",waitingLowerRight:"\u{1F446} Waiting for lower right corner selection...",upperLeftCaptured:"\u2705 Upper left corner captured: ({x}, {y})",lowerRightCaptured:"\u2705 Lower right corner captured: ({x}, {y})",selectionTimeout:"\u274C Selection timeout",selectionError:"\u274C Selection error, please try again"}};var Q={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"S\xE9lection",user:"Utilisateur",charges:"Charges",backend:"Backend",database:"Base de donn\xE9es",uptime:"Temps actif",close:"Fermer",launch:"Lancer",loading:"Chargement\u2026",executing:"Ex\xE9cution\u2026",downloading:"T\xE9l\xE9chargement du script\u2026",chooseBot:"Choisissez un bot et appuyez sur Lancer",readyToLaunch:"Pr\xEAt \xE0 lancer",loadError:"Erreur de chargement",loadErrorMsg:"Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",checking:"\u{1F504} V\xE9rification...",online:"\u{1F7E2} En ligne",offline:"\u{1F534} Hors ligne",ok:"\u{1F7E2} OK",error:"\u{1F534} Erreur",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialiser Auto-BOT",uploadImage:"T\xE9l\xE9charger Image",resizeImage:"Redimensionner Image",selectPosition:"S\xE9lectionner Position",startPainting:"Commencer Peinture",stopPainting:"Arr\xEAter Peinture",saveProgress:"Sauvegarder Progr\xE8s",loadProgress:"Charger Progr\xE8s",checkingColors:"\u{1F50D} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",loadingImage:"\u{1F5BC}\uFE0F Chargement de l'image...",imageLoaded:"\u2705 Image charg\xE9e avec {count} pixels valides",imageError:"\u274C Erreur lors du chargement de l'image",selectPositionAlert:"Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Position d\xE9finie avec succ\xE8s!",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",positionDetected:"\u{1F3AF} Position d\xE9tect\xE9e, traitement...",positionError:"\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",startPaintingMsg:"\u{1F3A8} D\xE9but de la peinture...",paintingProgress:"\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",noCharges:"\u231B Aucune charge. Attendre {time}...",paintingStopped:"\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",paintingComplete:"\u2705 Peinture termin\xE9e! {count} pixels peints.",paintingError:"\u274C Erreur pendant la peinture",missingRequirements:"\u274C Chargez une image et s\xE9lectionnez une position d'abord",progress:"Progr\xE8s",userName:"Usager",pixels:"Pixels",charges:"Charges",estimatedTime:"Temps estim\xE9",initMessage:"Cliquez sur 'Initialiser Auto-BOT' pour commencer",waitingInit:"En attente d'initialisation...",resizeSuccess:"\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",paintingPaused:"\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",pixelsPerBatch:"Pixels par lot",batchSize:"Taille du lot",nextBatchTime:"Prochain lot dans",useAllCharges:"Utiliser toutes les charges disponibles",showOverlay:"Afficher l'overlay",maxCharges:"Charges max par lot",waitingForCharges:"\u23F3 En attente de charges: {current}/{needed}",timeRemaining:"Temps restant",cooldownWaiting:"\u23F3 Attendre {time} pour continuer...",progressSaved:"\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",progressLoaded:"\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",progressLoadError:"\u274C Erreur lors du chargement du progr\xE8s: {error}",progressSaveError:"\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",confirmSaveProgress:"Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",saveProgressTitle:"Sauvegarder Progr\xE8s",discardProgress:"Abandonner",cancel:"Annuler",minimize:"Minimiser",width:"Largeur",height:"Hauteur",keepAspect:"Garder les proportions",apply:"Appliquer",overlayOn:"Overlay : ON",overlayOff:"Overlay : OFF",passCompleted:"\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",waitingChargesCountdown:"\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Bot d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",manualInitRequired:"\u{1F527} Initialisation manuelle requise",retryAttempt:"\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",retryError:"\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",retryFailed:"\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",networkError:"\u{1F310} Erreur r\xE9seau. Nouvel essai...",serverError:"\u{1F525} Erreur serveur. Nouvel essai...",timeoutError:"\u23F0 Timeout serveur. Nouvel essai..."},farm:{title:"WPlace Farm Bot",start:"D\xE9marrer",stop:"Arr\xEAter",stopped:"Bot arr\xEAt\xE9",calibrate:"Calibrer",paintOnce:"Une fois",checkingStatus:"V\xE9rification du statut...",configuration:"Configuration",delay:"D\xE9lai (ms)",pixelsPerBatch:"Pixels/lot",minCharges:"Charges min",colorMode:"Mode couleur",random:"Al\xE9atoire",fixed:"Fixe",range:"Plage",fixedColor:"Couleur fixe",advanced:"Avanc\xE9",tileX:"Tuile X",tileY:"Tuile Y",customPalette:"Palette personnalis\xE9e",paletteExample:"ex: #FF0000,#00FF00,#0000FF",capture:"Capturer",painted:"Peints",charges:"Charges",retries:"\xC9checs",tile:"Tuile",configSaved:"Configuration sauvegard\xE9e",configLoaded:"Configuration charg\xE9e",configReset:"Configuration r\xE9initialis\xE9e",captureInstructions:"Peindre un pixel manuellement pour capturer les coordonn\xE9es...",backendOnline:"Backend En ligne",backendOffline:"Backend Hors ligne",startingBot:"D\xE9marrage du bot...",stoppingBot:"Arr\xEAt du bot...",calibrating:"Calibrage...",alreadyRunning:"Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",imageRunningWarning:"Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",selectPosition:"S\xE9lectionner Zone",selectPositionAlert:"\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Zone d\xE9finie! Rayon: 500px",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",missingPosition:"\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",farmRadius:"Rayon farm",positionInfo:"Zone actuelle",farmingInRadius:"\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",noPosition:"Aucune zone",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"},common:{yes:"Oui",no:"Non",ok:"OK",cancel:"Annuler",close:"Fermer",save:"Sauvegarder",load:"Charger",delete:"Supprimer",edit:"Modifier",start:"D\xE9marrer",stop:"Arr\xEAter",pause:"Pause",resume:"Reprendre",reset:"R\xE9initialiser",settings:"Param\xE8tres",help:"Aide",about:"\xC0 propos",language:"Langue",loading:"Chargement...",error:"Erreur",success:"Succ\xE8s",warning:"Avertissement",info:"Information",languageChanged:"Langue chang\xE9e en {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialiser Guard-BOT",selectArea:"S\xE9lectionner Zone",captureArea:"Capturer Zone",startProtection:"D\xE9marrer Protection",stopProtection:"Arr\xEAter Protection",upperLeft:"Coin Sup\xE9rieur Gauche",lowerRight:"Coin Inf\xE9rieur Droit",protectedPixels:"Pixels Prot\xE9g\xE9s",detectedChanges:"Changements D\xE9tect\xE9s",repairedPixels:"Pixels R\xE9par\xE9s",charges:"Charges",waitingInit:"En attente d'initialisation...",checkingColors:"\u{1F3A8} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",initSuccess:"\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",initError:"\u274C Erreur lors de l'initialisation de Guard-BOT",invalidCoords:"\u274C Coordonn\xE9es invalides",invalidArea:"\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",areaTooLarge:"\u274C Zone trop grande: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capture de la zone de protection...",areaCaptured:"\u2705 Zone captur\xE9e: {count} pixels sous protection",captureError:"\u274C Erreur lors de la capture de zone: {error}",captureFirst:"\u274C Capturez d'abord une zone de protection",protectionStarted:"\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",protectionStopped:"\u23F9\uFE0F Protection arr\xEAt\xE9e",noChanges:"\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",changesDetected:"\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",repairing:"\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",repairedSuccess:"\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",repairError:"\u274C Erreur lors de la r\xE9paration des pixels: {error}",noCharges:"\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",checkingChanges:"\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",errorChecking:"\u274C Erreur lors de la v\xE9rification des changements: {error}",guardActive:"\u{1F6E1}\uFE0F Gardien actif - zone sous protection",lastCheck:"Derni\xE8re v\xE9rification: {time}",nextCheck:"Prochaine v\xE9rification dans: {time}s",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",manualInitRequired:"\u{1F527} Initialisation manuelle requise",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",selectUpperLeft:"\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",selectLowerRight:"\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",waitingUpperLeft:"\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",waitingLowerRight:"\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",upperLeftCaptured:"\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",lowerRightCaptured:"\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",selectionTimeout:"\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",selectionError:"\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"}};var J={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",autoImage:"\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",autoGuard:"\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",selection:"\u0412\u044B\u0431\u0440\u0430\u043D\u043E",user:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",charges:"\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",backend:"\u0411\u044D\u043A\u0435\u043D\u0434",database:"\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",uptime:"\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",launch:"\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",executing:"\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",downloading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",chooseBot:"\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",readyToLaunch:"\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",loadError:"\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",loadErrorMsg:"\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",checking:"\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",online:"\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",offline:"\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",ok:"\u{1F7E2} \u041E\u041A",error:"\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",unknown:"-"},image:{title:"WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",uploadImage:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",resizeImage:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",startPainting:"\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",stopPainting:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",saveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",loadProgress:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",checkingColors:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",loadingImage:"\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",imageLoaded:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",imageError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPositionAlert:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",positionDetected:"\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",positionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",startPaintingMsg:"\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",paintingProgress:"\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",noCharges:"\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",paintingStopped:"\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",paintingComplete:"\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",paintingError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",missingRequirements:"\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",progress:"\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",userName:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",pixels:"\u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",estimatedTime:"\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",initMessage:"\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",resizeSuccess:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",paintingPaused:"\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",batchSize:"\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",nextBatchTime:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",useAllCharges:"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",showOverlay:"\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",maxCharges:"\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",waitingForCharges:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",timeRemaining:"\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",cooldownWaiting:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",progressSaved:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",progressLoaded:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",progressLoadError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",progressSaveError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",confirmSaveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",saveProgressTitle:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",discardProgress:"\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",minimize:"\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",width:"\u0428\u0438\u0440\u0438\u043D\u0430",height:"\u0412\u044B\u0441\u043E\u0442\u0430",keepAspect:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",apply:"\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",passCompleted:"\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",waitingChargesRegen:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",waitingChargesCountdown:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",retryAttempt:"\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryError:"\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryFailed:"\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",networkError:"\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",serverError:"\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",timeoutError:"\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."},farm:{title:"WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",stopped:"\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",calibrate:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",paintOnce:"\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",checkingStatus:"\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",configuration:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",delay:"\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",minCharges:"\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",colorMode:"\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",random:"\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",fixed:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",range:"\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",fixedColor:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",advanced:"\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",tileX:"\u041F\u043B\u0438\u0442\u043A\u0430 X",tileY:"\u041F\u043B\u0438\u0442\u043A\u0430 Y",customPalette:"\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",paletteExample:"\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",capture:"\u0417\u0430\u0445\u0432\u0430\u0442",painted:"\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",retries:"\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",tile:"\u041F\u043B\u0438\u0442\u043A\u0430",configSaved:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",configLoaded:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",configReset:"\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",captureInstructions:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",backendOnline:"\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",backendOffline:"\u0411\u044D\u043A\u044D\u043D\u0434",startingBot:"\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",stoppingBot:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",calibrating:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",alreadyRunning:"\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",imageRunningWarning:"\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C",selectPositionAlert:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",missingPosition:"\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",farmRadius:"\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",positionInfo:"\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",farmingInRadius:"\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",selectEmptyArea:"\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",noPosition:"\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",currentZone:"\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",autoSelectPosition:"\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."},common:{yes:"\u0414\u0430",no:"\u041D\u0435\u0442",ok:"\u041E\u041A",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",save:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",load:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",delete:"\u0423\u0434\u0430\u043B\u0438\u0442\u044C",edit:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",pause:"\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",resume:"\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",reset:"\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",settings:"\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",help:"\u041F\u043E\u043C\u043E\u0449\u044C",about:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",language:"\u042F\u0437\u044B\u043A",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",error:"\u041E\u0448\u0438\u0431\u043A\u0430",success:"\u0423\u0441\u043F\u0435\u0445",warning:"\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",info:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",languageChanged:"\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"},guard:{title:"WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",selectArea:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",captureArea:"\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",startProtection:"\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",stopProtection:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",upperLeft:"\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",lowerRight:"\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",protectedPixels:"\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",detectedChanges:"\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",repairedPixels:"\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",checkingColors:"\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",initSuccess:"\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",initError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",invalidCoords:"\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",invalidArea:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",areaTooLarge:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",capturingArea:"\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",areaCaptured:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",captureError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",captureFirst:"\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",protectionStarted:"\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",protectionStopped:"\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",noChanges:"\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",changesDetected:"\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",repairing:"\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",repairedSuccess:"\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",repairError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",noCharges:"\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",checkingChanges:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",errorChecking:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",guardActive:"\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",lastCheck:"\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",nextCheck:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",selectUpperLeft:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",selectLowerRight:"\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",waitingUpperLeft:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",waitingLowerRight:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",upperLeftCaptured:"\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",lowerRightCaptured:"\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",selectionTimeout:"\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",selectionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"}};var $={es:Z,en:K,fr:Q,ru:J},N="es",M=$[N];function Pe(){let t=(window.navigator.language||window.navigator.userLanguage||"es").split("-")[0].toLowerCase();return $[t]?t:"es"}function we(){return null}function X(){let l=we(),t=Pe(),s="es";return l&&$[l]?s=l:t&&$[t]&&(s=t),be(s),s}function be(l){if(!$[l]){console.warn(`Idioma '${l}' no disponible. Usando '${N}'`);return}N=l,M=$[l],typeof window!="undefined"&&window.CustomEvent&&window.dispatchEvent(new window.CustomEvent("languageChanged",{detail:{language:l,translations:M}}))}function ee(){return N}function w(l,t={}){let s=l.split("."),a=M;for(let i of s)if(a&&typeof a=="object"&&i in a)a=a[i];else return console.warn(`Clave de traducci\xF3n no encontrada: '${l}'`),l;return typeof a!="string"?(console.warn(`Clave de traducci\xF3n no es string: '${l}'`),l):ye(a,t)}function ye(l,t){return!t||Object.keys(t).length===0?l:l.replace(/\{(\w+)\}/g,(s,a)=>t[a]!==void 0?t[a]:s)}function V(l){return M[l]?M[l]:(console.warn(`Secci\xF3n de traducci\xF3n no encontrada: '${l}'`),{})}X();var T={SITEKEY:"0x4AAAAAABpqJe8FO0N84q0F",COOLDOWN_DEFAULT:31e3,TRANSPARENCY_THRESHOLD:100,WHITE_THRESHOLD:250,LOG_INTERVAL:10,TILE_SIZE:3e3,PIXELS_PER_BATCH:20,CHARGE_REGEN_MS:3e4,THEME:{primary:"#000000",secondary:"#111111",accent:"#222222",text:"#ffffff",highlight:"#775ce3",success:"#00ff00",error:"#ff0000",warning:"#ffaa00"}};var e={running:!1,imageLoaded:!1,processing:!1,totalPixels:0,paintedPixels:0,availableColors:[],currentCharges:0,cooldown:T.COOLDOWN_DEFAULT,imageData:null,stopFlag:!1,colorsChecked:!1,startPosition:null,selectingPosition:!1,positionTimeoutId:null,cleanupObserver:null,region:null,minimized:!1,lastPosition:{x:0,y:0},estimatedTime:0,language:"es",tileX:null,tileY:null,pixelsPerBatch:T.PIXELS_PER_BATCH,useAllChargesFirst:!0,isFirstBatch:!0,maxCharges:50,nextBatchCooldown:0,inCooldown:!1,cooldownEndTime:0,remainingPixels:[],lastChargeUpdate:0,chargeDecimalPart:0,originalImageName:null,retryCount:0};function H(){d("\u{1F3A8} Detectando colores disponibles...");let l=document.querySelectorAll('[id^="color-"]'),t=[];for(let s of l){if(s.querySelector("svg"))continue;let a=s.id.replace("color-",""),i=parseInt(a);if(i===0||i===5)continue;let c=s.style.backgroundColor;if(c){let g=c.match(/\d+/g);if(g&&g.length>=3){let o={r:parseInt(g[0]),g:parseInt(g[1]),b:parseInt(g[2])};t.push({id:i,element:s,...o}),d(`Color detectado: id=${i}, rgb(${o.r},${o.g},${o.b})`)}}}return d(`\u2705 ${t.length} colores disponibles detectados`),t}var q=class{constructor(t){this.imageSrc=t,this.img=new window.Image,this.originalName=null,this.tileSize=1e3,this.drawMult=3,this.shreadSize=3,this.bitmap=null,this.imageWidth=0,this.imageHeight=0,this.totalPixels=0,this.requiredPixelCount=0,this.defacePixelCount=0,this.colorPalette={},this.allowedColorsSet=new Set,this.rgbToMeta=new Map,this.coords=[0,0,0,0],this.templateTiles={},this.templateTilesBuffers={},this.tilePrefixes=new Set}async load(){return new Promise((t,s)=>{this.img.onload=async()=>{try{this.bitmap=await createImageBitmap(this.img),this.imageWidth=this.bitmap.width,this.imageHeight=this.bitmap.height,this.totalPixels=this.imageWidth*this.imageHeight,d(`[BLUE MARBLE] Imagen cargada: ${this.imageWidth}\xD7${this.imageHeight} = ${this.totalPixels.toLocaleString()} p\xEDxeles`),t()}catch(a){s(a)}},this.img.onerror=s,this.img.src=this.imageSrc})}initializeColorPalette(){d("[BLUE MARBLE] Inicializando paleta de colores...");let t=this.detectSiteColors();this.allowedColorsSet=new Set(t.filter(a=>a.name&&a.name.toLowerCase()!=="transparent"&&Array.isArray(a.rgb)).map(a=>`${a.rgb[0]},${a.rgb[1]},${a.rgb[2]}`));let s="222,250,206";this.allowedColorsSet.add(s),this.rgbToMeta=new Map(t.filter(a=>Array.isArray(a.rgb)).map(a=>[`${a.rgb[0]},${a.rgb[1]},${a.rgb[2]}`,{id:a.id,premium:!!a.premium,name:a.name||`Color ${a.id}`}]));try{let a=t.find(i=>i.name&&i.name.toLowerCase()==="transparent");a&&Array.isArray(a.rgb)&&this.rgbToMeta.set(s,{id:a.id,premium:!!a.premium,name:a.name})}catch{}return d(`[BLUE MARBLE] Paleta inicializada: ${this.allowedColorsSet.size} colores permitidos`),Array.from(t)}detectSiteColors(){let t=document.querySelectorAll('[id^="color-"]'),s=[];for(let a of t){if(a.querySelector("svg"))continue;let i=a.id.replace("color-",""),c=parseInt(i),g=a.style.backgroundColor;if(g){let o=g.match(/\d+/g);if(o&&o.length>=3){let p=[parseInt(o[0]),parseInt(o[1]),parseInt(o[2])];s.push({id:c,element:a,rgb:p,name:a.title||a.getAttribute("aria-label")||`Color ${c}`,premium:a.classList.contains("premium")||a.querySelector(".premium")})}}}return d(`[BLUE MARBLE] ${s.length} colores detectados del sitio`),s}setCoords(t,s,a,i){this.coords=[t,s,a,i],d(`[BLUE MARBLE] Coordenadas establecidas: tile(${t},${s}) pixel(${a},${i})`)}async analyzePixels(){if(!this.bitmap)throw new Error("Imagen no cargada. Llama a load() primero.");d("[BLUE MARBLE] Analizando p\xEDxeles de la imagen...");try{let s=new OffscreenCanvas(this.imageWidth,this.imageHeight).getContext("2d",{willReadFrequently:!0});s.imageSmoothingEnabled=!1,s.clearRect(0,0,this.imageWidth,this.imageHeight),s.drawImage(this.bitmap,0,0);let a=s.getImageData(0,0,this.imageWidth,this.imageHeight).data,i=0,c=0,g=new Map;for(let p=0;p<this.imageHeight;p++)for(let r=0;r<this.imageWidth;r++){let n=(p*this.imageWidth+r)*4,u=a[n],m=a[n+1],y=a[n+2];if(a[n+3]===0)continue;let h=`${u},${m},${y}`;u===222&&m===250&&y===206&&c++,this.allowedColorsSet.has(h)&&(i++,g.set(h,(g.get(h)||0)+1))}this.requiredPixelCount=i,this.defacePixelCount=c;let o={};for(let[p,r]of g.entries())o[p]={count:r,enabled:!0};return this.colorPalette=o,d("[BLUE MARBLE] An\xE1lisis completado:"),d(`  - P\xEDxeles requeridos: ${i.toLocaleString()}`),d(`  - P\xEDxeles #deface: ${c.toLocaleString()}`),d(`  - Colores \xFAnicos: ${g.size}`),{totalPixels:this.totalPixels,requiredPixels:i,defacePixels:c,uniqueColors:g.size,colorPalette:o}}catch{return this.requiredPixelCount=Math.max(0,this.totalPixels),this.defacePixelCount=0,d("[BLUE MARBLE] Fallback: usando total de p\xEDxeles como requeridos"),{totalPixels:this.totalPixels,requiredPixels:this.totalPixels,defacePixels:0,uniqueColors:0,colorPalette:{}}}}async createTemplateTiles(){if(!this.bitmap)throw new Error("Imagen no cargada. Llama a load() primero.");d("[BLUE MARBLE] Creando tiles de template...");let t={},s={},a=new OffscreenCanvas(this.tileSize,this.tileSize),i=a.getContext("2d",{willReadFrequently:!0});for(let c=this.coords[3];c<this.imageHeight+this.coords[3];){let g=Math.min(this.tileSize-c%this.tileSize,this.imageHeight-(c-this.coords[3]));for(let o=this.coords[2];o<this.imageWidth+this.coords[2];){let p=Math.min(this.tileSize-o%this.tileSize,this.imageWidth-(o-this.coords[2])),r=p*this.shreadSize,n=g*this.shreadSize;a.width=r,a.height=n,i.imageSmoothingEnabled=!1,i.clearRect(0,0,r,n),i.drawImage(this.bitmap,o-this.coords[2],c-this.coords[3],p,g,0,0,p*this.shreadSize,g*this.shreadSize);let u=i.getImageData(0,0,r,n);for(let h=0;h<n;h++)for(let f=0;f<r;f++){let P=(h*r+f)*4;if(u.data[P]===222&&u.data[P+1]===250&&u.data[P+2]===206)(f+h)%2===0?(u.data[P]=0,u.data[P+1]=0,u.data[P+2]=0):(u.data[P]=255,u.data[P+1]=255,u.data[P+2]=255),u.data[P+3]=32;else if(f%this.shreadSize!==1||h%this.shreadSize!==1)u.data[P+3]=0;else{let C=u.data[P],E=u.data[P+1],L=u.data[P+2];this.allowedColorsSet.has(`${C},${E},${L}`)||(u.data[P+3]=0)}}i.putImageData(u,0,0);let m=`${(this.coords[0]+Math.floor(o/1e3)).toString().padStart(4,"0")},${(this.coords[1]+Math.floor(c/1e3)).toString().padStart(4,"0")},${(o%1e3).toString().padStart(3,"0")},${(c%1e3).toString().padStart(3,"0")}`;t[m]=await createImageBitmap(a),this.tilePrefixes.add(m.split(",").slice(0,2).join(","));let v=await(await a.convertToBlob()).arrayBuffer();s[m]=v,o+=p}c+=g}return this.templateTiles=t,this.templateTilesBuffers=s,d(`[BLUE MARBLE] Tiles creados: ${Object.keys(t).length} tiles`),d(`[BLUE MARBLE] Prefijos registrados: ${this.tilePrefixes.size} tiles \xFAnicos`),{templateTiles:t,templateTilesBuffers:s}}generatePixelQueue(){if(!this.bitmap)throw new Error("Imagen no cargada. Llama a load() primero.");d("[BLUE MARBLE] Generando cola de p\xEDxeles...");let t=[],s=this.coords[0]*1e3+(this.coords[2]||0),a=this.coords[1]*1e3+(this.coords[3]||0),c=new OffscreenCanvas(this.imageWidth,this.imageHeight).getContext("2d",{willReadFrequently:!0});c.imageSmoothingEnabled=!1,c.drawImage(this.bitmap,0,0);let g=c.getImageData(0,0,this.imageWidth,this.imageHeight).data;for(let o=0;o<this.imageHeight;o++)for(let p=0;p<this.imageWidth;p++){let r=(o*this.imageWidth+p)*4,n=g[r],u=g[r+1],m=g[r+2],y=g[r+3];if(y===0||n===222&&u===250&&m===206)continue;let v=`${n},${u},${m}`;if(!this.allowedColorsSet.has(v))continue;let h=s+p,f=a+o,P=Math.floor(h/1e3),C=Math.floor(f/1e3),E=h%1e3,L=f%1e3,b=this.rgbToMeta.get(v)||{id:0,name:"Unknown"};t.push({imageX:p,imageY:o,globalX:h,globalY:f,tileX:P,tileY:C,localX:E,localY:L,color:{r:n,g:u,b:m,id:b.id,name:b.name},originalColor:{r:n,g:u,b:m,alpha:y}})}return d(`[BLUE MARBLE] Cola generada: ${t.length} p\xEDxeles v\xE1lidos`),t}async resize(t,s,a=!0){if(!this.img)throw new Error("Imagen no cargada. Llama a load() primero.");let i=this.img.width,c=this.img.height;if(a){let r=i/c;t/s>r?t=s*r:s=t/r}let g=document.createElement("canvas");g.width=t,g.height=s;let o=g.getContext("2d");o.imageSmoothingEnabled=!1,o.drawImage(this.img,0,0,t,s);let p=g.toDataURL();return this.img.src=p,this.imageSrc=p,await new Promise(r=>{this.img.onload=async()=>{this.bitmap=await createImageBitmap(this.img),this.imageWidth=this.bitmap.width,this.imageHeight=this.bitmap.height,this.totalPixels=this.imageWidth*this.imageHeight,r()}}),d(`[BLUE MARBLE] Imagen redimensionada: ${i}\xD7${c} \u2192 ${this.imageWidth}\xD7${this.imageHeight}`),{width:this.imageWidth,height:this.imageHeight}}getImageData(){return{width:this.imageWidth,height:this.imageHeight,totalPixels:this.totalPixels,requiredPixels:this.requiredPixelCount,defacePixels:this.defacePixelCount,colorPalette:this.colorPalette,coords:[...this.coords],originalName:this.originalName||"image.png",pixels:this.generatePixelQueue()}}generatePreview(t=200,s=200){if(!this.img)return null;let a=document.createElement("canvas"),i=a.getContext("2d"),{width:c,height:g}=this.img,o=c/g,p,r;return t/s>o?(r=s,p=s*o):(p=t,r=t/o),a.width=p,a.height=r,i.imageSmoothingEnabled=!1,i.drawImage(this.img,0,0,p,r),a.toDataURL()}getDimensions(){return{width:this.imageWidth,height:this.imageHeight}}};var k=l=>new Promise(t=>setTimeout(t,l));var te="https://backend.wplace.live";async function ie(){var l,t,s;try{let a=await fetch(`${te}/me`,{credentials:"include"}).then(o=>o.json()),i=a||null,c=(a==null?void 0:a.charges)||{},g={count:(l=c.count)!=null?l:0,max:(t=c.max)!=null?t:0,cooldownMs:(s=c.cooldownMs)!=null?s:3e4};return{success:!0,data:{user:i,charges:g.count,maxCharges:g.max,chargeRegen:g.cooldownMs}}}catch(a){return{success:!1,error:a.message,data:{user:null,charges:0,maxCharges:0,chargeRegen:3e4}}}}async function ae(l,t,s,a,i){try{let c=JSON.stringify({colors:a,coords:s,t:i}),g=await fetch(`${te}/s0/pixel/${l}/${t}`,{method:"POST",credentials:"include",headers:{"Content-Type":"text/plain;charset=UTF-8"},body:c}),o=null;try{o=await g.json()}catch{o={}}return{status:g.status,json:o,success:g.ok,painted:(o==null?void 0:o.painted)||0}}catch(c){return{status:0,json:{error:c.message},success:!1,painted:0}}}var ne=!1;async function Ce(){if(!(ne||window.turnstile))return new Promise((l,t)=>{let s=document.createElement("script");s.src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit",s.async=!0,s.defer=!0,s.onload=()=>{ne=!0,l()},s.onerror=()=>t(new Error("No se pudo cargar Turnstile")),document.head.appendChild(s)})}async function ve(l,t="paint"){var s;if(await Ce(),typeof((s=window.turnstile)==null?void 0:s.execute)=="function")try{let a=await window.turnstile.execute(l,{action:t});if(a&&a.length>20)return a}catch{}return await new Promise(a=>{let i=document.createElement("div");i.style.position="fixed",i.style.left="-9999px",document.body.appendChild(i),window.turnstile.render(i,{sitekey:l,callback:c=>{document.body.removeChild(i),a(c)}})})}async function oe(l){return ve(l,"paint")}function re(l=""){var t;try{let s=document.querySelector("[data-sitekey]");if(s){let i=s.getAttribute("data-sitekey");if(i&&i.length>10)return i}let a=document.querySelector(".cf-turnstile");if(a&&((t=a.dataset)!=null&&t.sitekey)&&a.dataset.sitekey.length>10)return a.dataset.sitekey;if(typeof window!="undefined"&&window.__TURNSTILE_SITEKEY&&window.__TURNSTILE_SITEKEY.length>10)return window.__TURNSTILE_SITEKEY}catch{}return l}async function se(l,t,s,a,i){let{width:c,height:g}=l,{x:o,y:p}=t;if(d(`Iniciando pintado: imagen(${c}x${g}) inicio LOCAL(${o},${p}) tile(${e.tileX},${e.tileY})`),!e.remainingPixels||e.remainingPixels.length===0||e.lastPosition.x===0&&e.lastPosition.y===0){d("Generando cola de p\xEDxeles..."),e.remainingPixels=Le(l,t,e.tileX,e.tileY),(e.lastPosition.x>0||e.lastPosition.y>0)&&(e.remainingPixels=e.remainingPixels.filter(r=>{let n=r.imageY*c+r.imageX,u=e.lastPosition.y*c+e.lastPosition.x;return n>=u})),d(`Cola generada: ${e.remainingPixels.length} p\xEDxeles pendientes`);try{window.__WPA_PLAN_OVERLAY__&&(window.__WPA_PLAN_OVERLAY__.injectStyles(),window.__WPA_PLAN_OVERLAY__.setEnabled(!0),e.startPosition&&e.tileX!==void 0&&e.tileY!==void 0&&window.__WPA_PLAN_OVERLAY__.setAnchor({tileX:e.tileX,tileY:e.tileY,pxX:e.startPosition.x,pxY:e.startPosition.y}),window.__WPA_PLAN_OVERLAY__.setPlan(e.remainingPixels,{enabled:!0,nextBatchCount:e.pixelsPerBatch}),d(`\u2705 Plan overlay actualizado con ${e.remainingPixels.length} p\xEDxeles en cola`))}catch(r){d("\u26A0\uFE0F Error actualizando plan overlay:",r)}}try{for(;e.remainingPixels.length>0&&!e.stopFlag;){let r=Math.floor(e.currentCharges),n;if(e.isFirstBatch&&e.useAllChargesFirst&&r>0?(n=Math.min(r,e.remainingPixels.length),e.isFirstBatch=!1,d(`Primera pasada: usando ${n} cargas de ${r} disponibles`)):n=Math.min(e.pixelsPerBatch,e.remainingPixels.length),r<n){d(`Cargas insuficientes: ${r}/${n} necesarias`),await Ae(n-r,s),r=Math.floor(e.currentCharges),e.isFirstBatch||(n=Math.min(e.pixelsPerBatch,e.remainingPixels.length,r));continue}let u=e.remainingPixels.splice(0,n);d(`Pintando lote de ${u.length} p\xEDxeles...`);try{window.__WPA_PLAN_OVERLAY__&&window.__WPA_PLAN_OVERLAY__.setPlan(e.remainingPixels,{enabled:!0,nextBatchCount:e.pixelsPerBatch})}catch(y){d("\u26A0\uFE0F Error actualizando plan overlay durante pintado:",y)}let m=await Se(u,s);if(m.success&&m.painted>0){if(e.paintedPixels+=m.painted,e.currentCharges=Math.max(0,e.currentCharges-m.painted),d(`Cargas despu\xE9s del lote: ${e.currentCharges.toFixed(1)} (consumidas: ${m.painted})`),u.length>0){let f=u[u.length-1];e.lastPosition={x:f.imageX,y:f.imageY}}d(`Lote exitoso: ${m.painted}/${u.length} p\xEDxeles pintados. Total: ${e.paintedPixels}/${e.totalPixels}`);let y=Ie(),v=(e.paintedPixels/e.totalPixels*100).toFixed(1),h=w("image.passCompleted",{painted:m.painted,percent:v,current:e.paintedPixels,total:e.totalPixels});s&&s(e.paintedPixels,e.totalPixels,h,y),await k(2e3)}else m.shouldContinue?d("Lote fall\xF3 despu\xE9s de todos los reintentos, continuando con siguiente lote..."):(e.remainingPixels.unshift(...u),d("Lote fall\xF3: reintentando en 5 segundos..."),await k(5e3));await k(500)}if(e.stopFlag)d(`Pintado pausado en p\xEDxel imagen(${e.lastPosition.x},${e.lastPosition.y})`),a&&a(!1,e.paintedPixels);else{d(`Pintado completado: ${e.paintedPixels} p\xEDxeles pintados`),e.lastPosition={x:0,y:0},e.remainingPixels=[];try{window.__WPA_PLAN_OVERLAY__&&(window.__WPA_PLAN_OVERLAY__.setPlan([],{enabled:!0,nextBatchCount:0}),d("\u2705 Plan overlay limpiado al completar pintado"))}catch(r){d("\u26A0\uFE0F Error limpiando plan overlay:",r)}a&&a(!0,e.paintedPixels)}}catch(r){d("Error en proceso de pintado:",r),i&&i(r)}}async function Ee(l){var t;try{if(!l||l.length===0)return{success:!1,painted:0,error:"Lote vac\xEDo"};let s=new Map;for(let g of l){let o=`${g.tileX},${g.tileY}`;s.has(o)||s.set(o,{coords:[],colors:[],tx:g.tileX,ty:g.tileY});let p=s.get(o);p.coords.push(g.localX,g.localY),p.colors.push(g.color.id||g.color.value||1)}let a=re(T.SITEKEY),i=await oe(a),c=0;for(let{coords:g,colors:o,tx:p,ty:r}of s.values()){if(o.length===0)continue;let n=[];for(let m=0;m<g.length;m+=2){let y=(Number(g[m])%1e3+1e3)%1e3,v=(Number(g[m+1])%1e3+1e3)%1e3;Number.isFinite(y)&&Number.isFinite(v)&&n.push(y,v)}try{let m=999,y=0,v=999,h=0;for(let f=0;f<n.length;f+=2){let P=n[f],C=n[f+1];P<m&&(m=P),P>y&&(y=P),C<v&&(v=C),C>h&&(h=C)}d(`[IMG] Enviando tile ${p},${r}: ${o.length} px | x:[${m},${y}] y:[${v},${h}]`)}catch{}let u=await ae(p,r,n,o,i);if(u.status!==200)return{success:!1,painted:c,error:((t=u.json)==null?void 0:t.message)||`HTTP ${u.status}`,status:u.status};c+=u.painted||0}return{success:!0,painted:c}}catch(s){return d("Error en paintPixelBatch:",s),{success:!1,painted:0,error:s.message}}}async function Se(l,t){for(let c=1;c<=5;c++)try{let g=await Ee(l);if(g.success)return e.retryCount=0,g;if(e.retryCount=c,c<5){let o=3e3*Math.pow(2,c-1),p=Math.round(o/1e3),r;g.status===0||g.status==="NetworkError"?r=w("image.networkError"):g.status>=500?r=w("image.serverError"):g.status===408?r=w("image.timeoutError"):r=w("image.retryAttempt",{attempt:c,maxAttempts:5,delay:p}),t&&t(e.paintedPixels,e.totalPixels,r),d(`Reintento ${c}/5 despu\xE9s de ${p}s. Error: ${g.error}`),await k(o)}}catch(g){if(d(`Error en intento ${c}:`,g),e.retryCount=c,c<5){let o=3e3*Math.pow(2,c-1),p=Math.round(o/1e3),r=w("image.retryError",{attempt:c,maxAttempts:5,delay:p});t&&t(e.paintedPixels,e.totalPixels,r),await k(o)}}e.retryCount=5;let i=w("image.retryFailed",{maxAttempts:5});return t&&t(e.paintedPixels,e.totalPixels,i),d("Fall\xF3 despu\xE9s de 5 intentos, continuando con siguiente lote"),{success:!1,painted:0,error:"Fall\xF3 despu\xE9s de 5 intentos",shouldContinue:!0}}async function Ae(l,t){let a=T.CHARGE_REGEN_MS*l+5e3;if(d(`Esperando ${Math.round(a/1e3)}s para obtener ${l} cargas`),e.inCooldown=!0,e.cooldownEndTime=Date.now()+a,e.nextBatchCooldown=Math.round(a/1e3),t){let i=Math.floor(a/6e4),c=Math.floor(a%6e4/1e3),g=i>0?`${i}m ${c}s`:`${c}s`,o=w("image.waitingChargesRegen",{current:Math.floor(e.currentCharges),needed:l,time:g});t(e.paintedPixels,e.totalPixels,o)}for(let i=Math.round(a/1e3);i>0&&!e.stopFlag;i--){if(e.nextBatchCooldown=i,t&&(i%5===0||i<=10||i===Math.round(a/1e3))){let c=Math.floor(i/60),g=i%60,o=c>0?`${c}m ${g}s`:`${g}s`,p=w("image.waitingChargesCountdown",{current:Math.floor(e.currentCharges),needed:l,time:o});t(e.paintedPixels,e.totalPixels,p)}await k(1e3)}e.inCooldown=!1,e.nextBatchCooldown=0,e.currentCharges=Math.min(e.maxCharges||50,e.currentCharges+a/T.CHARGE_REGEN_MS)}function Le(l,t,s,a){let{pixels:i}=l,{x:c,y:g}=t,o=[];if(!Array.isArray(i))return d(`\u274C Error: pixels no es un array iterable. Tipo: ${typeof i}`,i),[];for(let p of i){if(!p)continue;let r=p.imageX!==void 0?p.imageX:p.x,n=p.imageY!==void 0?p.imageY:p.y,u=p.color!==void 0?p.color:p.targetColor;if(r===void 0||n===void 0){d("\u26A0\uFE0F P\xEDxel con coordenadas inv\xE1lidas:",p);continue}let m=c+r,y=g+n,v=Math.floor(m/1e3),h=Math.floor(y/1e3),f=s+v,P=a+h,C=(m%1e3+1e3)%1e3,E=(y%1e3+1e3)%1e3;o.push({imageX:r,imageY:n,localX:C,localY:E,tileX:f,tileY:P,color:u,originalColor:p.originalColor})}return d(`Cola de p\xEDxeles generada: ${o.length} p\xEDxeles para pintar`),o}function Ie(){if(!e.remainingPixels||e.remainingPixels.length===0)return 0;let l=e.remainingPixels.length,t=e.pixelsPerBatch,s=T.CHARGE_REGEN_MS/1e3,a=Math.ceil(l/t),i=t*s,c=(a-1)*i,g=a*2;return Math.ceil(c+g)}function j(){e.stopFlag=!0,e.running=!1,d("\u{1F6D1} Deteniendo proceso de pintado...")}function G(l=null){try{if(!e.imageData||e.paintedPixels===0)throw new Error("No hay progreso para guardar");let t={version:"1.0",timestamp:Date.now(),imageData:{width:e.imageData.width,height:e.imageData.height,originalName:e.originalImageName},progress:{paintedPixels:e.paintedPixels,totalPixels:e.totalPixels,lastPosition:{...e.lastPosition}},position:{startPosition:{...e.startPosition},tileX:e.tileX,tileY:e.tileY},config:{pixelsPerBatch:e.pixelsPerBatch,useAllChargesFirst:e.useAllChargesFirst,isFirstBatch:e.isFirstBatch,maxCharges:e.maxCharges},colors:e.availableColors.map(o=>({id:o.id,r:o.r,g:o.g,b:o.b})),remainingPixels:e.remainingPixels||[]},s=JSON.stringify(t,null,2),a=new window.Blob([s],{type:"application/json"}),i=l||`wplace_progress_${e.originalImageName||"image"}_${new Date().toISOString().slice(0,19).replace(/:/g,"-")}.json`,c=window.URL.createObjectURL(a),g=document.createElement("a");return g.href=c,g.download=i,document.body.appendChild(g),g.click(),document.body.removeChild(g),window.URL.revokeObjectURL(c),d(`\u2705 Progreso guardado: ${i}`),{success:!0,filename:i}}catch(t){return d("\u274C Error guardando progreso:",t),{success:!1,error:t.message}}}async function ce(l){return new Promise(t=>{try{let s=new window.FileReader;s.onload=a=>{try{let i=JSON.parse(a.target.result),g=["imageData","progress","position","colors"].filter(o=>!(o in i));if(g.length>0)throw new Error(`Campos requeridos faltantes: ${g.join(", ")}`);if(e.availableColors.length>0){let o=i.colors.map(n=>n.id),p=e.availableColors.map(n=>n.id);o.filter(n=>p.includes(n)).length<o.length*.8&&d("\u26A0\uFE0F Los colores guardados no coinciden completamente con los actuales")}e.imageData={...i.imageData,pixels:[]},e.paintedPixels=i.progress.paintedPixels,e.totalPixels=i.progress.totalPixels,i.progress.lastPosition?e.lastPosition=i.progress.lastPosition:i.position.lastX!==void 0&&i.position.lastY!==void 0&&(e.lastPosition={x:i.position.lastX,y:i.position.lastY}),i.position.startPosition?e.startPosition=i.position.startPosition:i.position.startX!==void 0&&i.position.startY!==void 0&&(e.startPosition={x:i.position.startX,y:i.position.startY}),e.tileX=i.position.tileX,e.tileY=i.position.tileY,e.originalImageName=i.imageData.originalName,e.remainingPixels=i.remainingPixels||i.progress.remainingPixels||[];try{window.__WPA_PLAN_OVERLAY__&&(window.__WPA_PLAN_OVERLAY__.injectStyles(),window.__WPA_PLAN_OVERLAY__.setEnabled(!0),e.startPosition&&e.tileX!==void 0&&e.tileY!==void 0&&(window.__WPA_PLAN_OVERLAY__.setAnchor({tileX:e.tileX,tileY:e.tileY,pxX:e.startPosition.x,pxY:e.startPosition.y}),d(`\u2705 Plan overlay anclado con posici\xF3n cargada: tile(${e.tileX},${e.tileY}) local(${e.startPosition.x},${e.startPosition.y})`)),window.__WPA_PLAN_OVERLAY__.setPlan(e.remainingPixels,{enabled:!0,nextBatchCount:e.pixelsPerBatch}),d(`\u2705 Plan overlay activado con ${e.remainingPixels.length} p\xEDxeles restantes`))}catch(o){d("\u26A0\uFE0F Error activando plan overlay al cargar progreso:",o)}i.config&&(e.pixelsPerBatch=i.config.pixelsPerBatch||e.pixelsPerBatch,e.useAllChargesFirst=i.config.useAllChargesFirst!==void 0?i.config.useAllChargesFirst:e.useAllChargesFirst,e.isFirstBatch=i.config.isFirstBatch!==void 0?i.config.isFirstBatch:!0,e.maxCharges=i.config.maxCharges||e.maxCharges),e.imageLoaded=!0,e.colorsChecked=!0,d(`\u2705 Progreso cargado: ${e.paintedPixels}/${e.totalPixels} p\xEDxeles`),t({success:!0,data:i,painted:e.paintedPixels,total:e.totalPixels,canContinue:e.remainingPixels.length>0})}catch(i){d("\u274C Error parseando archivo de progreso:",i),t({success:!1,error:i.message})}},s.onerror=()=>{let a="Error leyendo archivo";d("\u274C",a),t({success:!1,error:a})},s.readAsText(l)}catch(s){d("\u274C Error cargando progreso:",s),t({success:!1,error:s.message})}})}function de(){e.paintedPixels=0,e.totalPixels=0,e.lastPosition={x:0,y:0},e.remainingPixels=[],e.imageData=null,e.startPosition=null,e.imageLoaded=!1,e.originalImageName=null,e.isFirstBatch=!0,e.nextBatchCooldown=0,d("\u{1F9F9} Progreso limpiado")}function le(){return e.imageLoaded&&e.paintedPixels>0&&e.remainingPixels&&e.remainingPixels.length>0}function ue(){return{hasProgress:le(),painted:e.paintedPixels,total:e.totalPixels,remaining:e.remainingPixels?e.remainingPixels.length:0,percentage:e.totalPixels>0?e.paintedPixels/e.totalPixels*100:0,lastPosition:{...e.lastPosition},canContinue:le()}}function ge(l=null){let t=document.createElement("div");l&&(t.id=l),t.style.cssText=`
+/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-21T06:28:30.591Z */
+(() => {
+  // src/core/logger.js
+  var log = (...a) => console.log("[WPA-UI]", ...a);
+
+  // src/locales/es.js
+  var es = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selecci\xF3n",
+      user: "Usuario",
+      charges: "Cargas",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Cerrar",
+      launch: "Lanzar",
+      loading: "Cargando\u2026",
+      executing: "Ejecutando\u2026",
+      downloading: "Descargando script\u2026",
+      chooseBot: "Elige un bot y presiona Lanzar",
+      readyToLaunch: "Listo para lanzar",
+      loadError: "Error al cargar",
+      loadErrorMsg: "No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",
+      checking: "\u{1F504} Verificando...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Iniciar Auto-BOT",
+      uploadImage: "Subir Imagen",
+      resizeImage: "Redimensionar Imagen",
+      selectPosition: "Seleccionar Posici\xF3n",
+      startPainting: "Iniciar Pintura",
+      stopPainting: "Detener Pintura",
+      saveProgress: "Guardar Progreso",
+      loadProgress: "Cargar Progreso",
+      checkingColors: "\u{1F50D} Verificando colores disponibles...",
+      noColorsFound: "\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      loadingImage: "\u{1F5BC}\uFE0F Cargando imagen...",
+      imageLoaded: "\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",
+      imageError: "\u274C Error al cargar la imagen",
+      selectPositionAlert: "\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Posici\xF3n establecida con \xE9xito!",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar posici\xF3n",
+      positionDetected: "\u{1F3AF} Posici\xF3n detectada, procesando...",
+      positionError: "\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",
+      startPaintingMsg: "\u{1F3A8} Iniciando pintura...",
+      paintingProgress: "\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",
+      noCharges: "\u231B Sin cargas. Esperando {time}...",
+      paintingStopped: "\u23F9\uFE0F Pintura detenida por el usuario",
+      paintingComplete: "\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",
+      paintingError: "\u274C Error durante la pintura",
+      missingRequirements: "\u274C Carga una imagen y selecciona una posici\xF3n primero",
+      progress: "Progreso",
+      userName: "Usuario",
+      pixels: "P\xEDxeles",
+      charges: "Cargas",
+      estimatedTime: "Tiempo estimado",
+      initMessage: "Haz clic en 'Iniciar Auto-BOT' para comenzar",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      resizeSuccess: "\u2705 Imagen redimensionada a {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",
+      pixelsPerBatch: "P\xEDxeles por lote",
+      batchSize: "Tama\xF1o del lote",
+      nextBatchTime: "Siguiente lote en",
+      useAllCharges: "Usar todas las cargas disponibles",
+      showOverlay: "Mostrar overlay",
+      maxCharges: "Cargas m\xE1ximas por lote",
+      waitingForCharges: "\u23F3 Esperando cargas: {current}/{needed}",
+      timeRemaining: "Tiempo restante",
+      cooldownWaiting: "\u23F3 Esperando {time} para continuar...",
+      progressSaved: "\u2705 Progreso guardado como {filename}",
+      progressLoaded: "\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",
+      progressLoadError: "\u274C Error al cargar progreso: {error}",
+      progressSaveError: "\u274C Error al guardar progreso: {error}",
+      confirmSaveProgress: "\xBFDeseas guardar el progreso actual antes de detener?",
+      saveProgressTitle: "Guardar Progreso",
+      discardProgress: "Descartar",
+      cancel: "Cancelar",
+      minimize: "Minimizar",
+      width: "Ancho",
+      height: "Alto",
+      keepAspect: "Mantener proporci\xF3n",
+      apply: "Aplicar",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",
+      waitingChargesCountdown: "\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Bot iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      retryAttempt: "\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",
+      retryError: "\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",
+      retryFailed: "\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",
+      networkError: "\u{1F310} Error de red. Reintentando...",
+      serverError: "\u{1F525} Error del servidor. Reintentando...",
+      timeoutError: "\u23F0 Timeout del servidor. Reintentando..."
+    },
+    // Farm Module (por implementar)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Iniciar",
+      stop: "Detener",
+      stopped: "Bot detenido",
+      calibrate: "Calibrar",
+      paintOnce: "Una vez",
+      checkingStatus: "Verificando estado...",
+      configuration: "Configuraci\xF3n",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "P\xEDxeles/lote",
+      minCharges: "Cargas m\xEDn",
+      colorMode: "Modo color",
+      random: "Aleatorio",
+      fixed: "Fijo",
+      range: "Rango",
+      fixedColor: "Color fijo",
+      advanced: "Avanzado",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Paleta personalizada",
+      paletteExample: "ej: #FF0000,#00FF00,#0000FF",
+      capture: "Capturar",
+      painted: "Pintados",
+      charges: "Cargas",
+      retries: "Fallos",
+      tile: "Tile",
+      configSaved: "Configuraci\xF3n guardada",
+      configLoaded: "Configuraci\xF3n cargada",
+      configReset: "Configuraci\xF3n reiniciada",
+      captureInstructions: "Pinta un p\xEDxel manualmente para capturar coordenadas...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Iniciando bot...",
+      stoppingBot: "Deteniendo bot...",
+      calibrating: "Calibrando...",
+      alreadyRunning: "Auto-Farm ya est\xE1 corriendo.",
+      imageRunningWarning: "Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",
+      selectPosition: "Seleccionar Zona",
+      selectPositionAlert: "\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Zona establecida! Radio: 500px",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar zona",
+      missingPosition: "\u274C Selecciona una zona primero usando 'Seleccionar Zona'",
+      farmRadius: "Radio farm",
+      positionInfo: "Zona actual",
+      farmingInRadius: "\u{1F33E} Farming en radio {radius}px desde ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",
+      noPosition: "Sin zona",
+      currentZone: "Zona: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "S\xED",
+      no: "No",
+      ok: "Aceptar",
+      cancel: "Cancelar",
+      close: "Cerrar",
+      save: "Guardar",
+      load: "Cargar",
+      delete: "Eliminar",
+      edit: "Editar",
+      start: "Iniciar",
+      stop: "Detener",
+      pause: "Pausar",
+      resume: "Reanudar",
+      reset: "Reiniciar",
+      settings: "Configuraci\xF3n",
+      help: "Ayuda",
+      about: "Acerca de",
+      language: "Idioma",
+      loading: "Cargando...",
+      error: "Error",
+      success: "\xC9xito",
+      warning: "Advertencia",
+      info: "Informaci\xF3n",
+      languageChanged: "Idioma cambiado a {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Inicializar Guard-BOT",
+      selectArea: "Seleccionar \xC1rea",
+      captureArea: "Capturar \xC1rea",
+      startProtection: "Iniciar Protecci\xF3n",
+      stopProtection: "Detener Protecci\xF3n",
+      upperLeft: "Esquina Superior Izquierda",
+      lowerRight: "Esquina Inferior Derecha",
+      protectedPixels: "P\xEDxeles Protegidos",
+      detectedChanges: "Cambios Detectados",
+      repairedPixels: "P\xEDxeles Reparados",
+      charges: "Cargas",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      checkingColors: "\u{1F3A8} Verificando colores disponibles...",
+      noColorsFound: "\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      initSuccess: "\u2705 Guard-BOT inicializado correctamente",
+      initError: "\u274C Error inicializando Guard-BOT",
+      invalidCoords: "\u274C Coordenadas inv\xE1lidas",
+      invalidArea: "\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",
+      areaTooLarge: "\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",
+      capturingArea: "\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",
+      areaCaptured: "\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",
+      captureError: "\u274C Error capturando \xE1rea: {error}",
+      captureFirst: "\u274C Primero captura un \xE1rea de protecci\xF3n",
+      protectionStarted: "\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",
+      protectionStopped: "\u23F9\uFE0F Protecci\xF3n detenida",
+      noChanges: "\u2705 \xC1rea protegida - sin cambios detectados",
+      changesDetected: "\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",
+      repairing: "\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",
+      repairedSuccess: "\u2705 Reparados {count} p\xEDxeles correctamente",
+      repairError: "\u274C Error reparando p\xEDxeles: {error}",
+      noCharges: "\u26A0\uFE0F Sin cargas suficientes para reparar cambios",
+      checkingChanges: "\u{1F50D} Verificando cambios en \xE1rea protegida...",
+      errorChecking: "\u274C Error verificando cambios: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",
+      lastCheck: "\xDAltima verificaci\xF3n: {time}",
+      nextCheck: "Pr\xF3xima verificaci\xF3n en: {time}s",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Guard-BOT iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      selectUpperLeft: "\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",
+      selectLowerRight: "\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",
+      waitingUpperLeft: "\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",
+      waitingLowerRight: "\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",
+      upperLeftCaptured: "\u2705 Esquina superior izquierda capturada: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Esquina inferior derecha capturada: ({x}, {y})",
+      selectionTimeout: "\u274C Tiempo agotado para selecci\xF3n",
+      selectionError: "\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"
+    }
+  };
+
+  // src/locales/en.js
+  var en = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selection",
+      user: "User",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Close",
+      launch: "Launch",
+      loading: "Loading\u2026",
+      executing: "Executing\u2026",
+      downloading: "Downloading script\u2026",
+      chooseBot: "Choose a bot and press Launch",
+      readyToLaunch: "Ready to launch",
+      loadError: "Load error",
+      loadErrorMsg: "Could not load the selected bot. Check your connection or try again.",
+      checking: "\u{1F504} Checking...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialize Auto-BOT",
+      uploadImage: "Upload Image",
+      resizeImage: "Resize Image",
+      selectPosition: "Select Position",
+      startPainting: "Start Painting",
+      stopPainting: "Stop Painting",
+      saveProgress: "Save Progress",
+      loadProgress: "Load Progress",
+      checkingColors: "\u{1F50D} Checking available colors...",
+      noColorsFound: "\u274C Open the color palette on the site and try again!",
+      colorsFound: "\u2705 Found {count} available colors",
+      loadingImage: "\u{1F5BC}\uFE0F Loading image...",
+      imageLoaded: "\u2705 Image loaded with {count} valid pixels",
+      imageError: "\u274C Error loading image",
+      selectPositionAlert: "Paint the first pixel at the location where you want the art to start!",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Position set successfully!",
+      positionTimeout: "\u274C Timeout for position selection",
+      positionDetected: "\u{1F3AF} Position detected, processing...",
+      positionError: "\u274C Error detecting position, please try again",
+      startPaintingMsg: "\u{1F3A8} Starting painting...",
+      paintingProgress: "\u{1F9F1} Progress: {painted}/{total} pixels...",
+      noCharges: "\u231B No charges. Waiting {time}...",
+      paintingStopped: "\u23F9\uFE0F Painting stopped by user",
+      paintingComplete: "\u2705 Painting completed! {count} pixels painted.",
+      paintingError: "\u274C Error during painting",
+      missingRequirements: "\u274C Load an image and select a position first",
+      progress: "Progress",
+      userName: "User",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Estimated time",
+      initMessage: "Click 'Initialize Auto-BOT' to begin",
+      waitingInit: "Waiting for initialization...",
+      resizeSuccess: "\u2705 Image resized to {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels per batch",
+      batchSize: "Batch size",
+      nextBatchTime: "Next batch in",
+      useAllCharges: "Use all available charges",
+      showOverlay: "Show overlay",
+      maxCharges: "Max charges per batch",
+      waitingForCharges: "\u23F3 Waiting for charges: {current}/{needed}",
+      timeRemaining: "Time remaining",
+      cooldownWaiting: "\u23F3 Waiting {time} to continue...",
+      progressSaved: "\u2705 Progress saved as {filename}",
+      progressLoaded: "\u2705 Progress loaded: {painted}/{total} pixels painted",
+      progressLoadError: "\u274C Error loading progress: {error}",
+      progressSaveError: "\u274C Error saving progress: {error}",
+      confirmSaveProgress: "Do you want to save the current progress before stopping?",
+      saveProgressTitle: "Save Progress",
+      discardProgress: "Discard",
+      cancel: "Cancel",
+      minimize: "Minimize",
+      width: "Width",
+      height: "Height",
+      keepAspect: "Keep aspect ratio",
+      apply: "Apply",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",
+      waitingChargesCountdown: "\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Bot auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      retryAttempt: "\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",
+      retryError: "\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",
+      retryFailed: "\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",
+      networkError: "\u{1F310} Network error. Retrying...",
+      serverError: "\u{1F525} Server error. Retrying...",
+      timeoutError: "\u23F0 Server timeout. Retrying..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Start",
+      stop: "Stop",
+      stopped: "Bot stopped",
+      calibrate: "Calibrate",
+      paintOnce: "Once",
+      checkingStatus: "Checking status...",
+      configuration: "Configuration",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "Pixels/batch",
+      minCharges: "Min charges",
+      colorMode: "Color mode",
+      random: "Random",
+      fixed: "Fixed",
+      range: "Range",
+      fixedColor: "Fixed color",
+      advanced: "Advanced",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Custom palette",
+      paletteExample: "e.g: #FF0000,#00FF00,#0000FF",
+      capture: "Capture",
+      painted: "Painted",
+      charges: "Charges",
+      retries: "Retries",
+      tile: "Tile",
+      configSaved: "Configuration saved",
+      configLoaded: "Configuration loaded",
+      configReset: "Configuration reset",
+      captureInstructions: "Paint a pixel manually to capture coordinates...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Starting bot...",
+      stoppingBot: "Stopping bot...",
+      calibrating: "Calibrating...",
+      alreadyRunning: "Auto-Farm is already running.",
+      imageRunningWarning: "Auto-Image is running. Close it before starting Auto-Farm.",
+      selectPosition: "Select Area",
+      selectPositionAlert: "\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Area set! Radius: 500px",
+      positionTimeout: "\u274C Timeout for area selection",
+      missingPosition: "\u274C Select an area first using 'Select Area'",
+      farmRadius: "Farm radius",
+      positionInfo: "Current area",
+      farmingInRadius: "\u{1F33E} Farming in {radius}px radius from ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",
+      noPosition: "No area",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"
+    },
+    // Common/Shared
+    common: {
+      yes: "Yes",
+      no: "No",
+      ok: "OK",
+      cancel: "Cancel",
+      close: "Close",
+      save: "Save",
+      load: "Load",
+      delete: "Delete",
+      edit: "Edit",
+      start: "Start",
+      stop: "Stop",
+      pause: "Pause",
+      resume: "Resume",
+      reset: "Reset",
+      settings: "Settings",
+      help: "Help",
+      about: "About",
+      language: "Language",
+      loading: "Loading...",
+      error: "Error",
+      success: "Success",
+      warning: "Warning",
+      info: "Information",
+      languageChanged: "Language changed to {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialize Guard-BOT",
+      selectArea: "Select Area",
+      captureArea: "Capture Area",
+      startProtection: "Start Protection",
+      stopProtection: "Stop Protection",
+      upperLeft: "Upper Left Corner",
+      lowerRight: "Lower Right Corner",
+      protectedPixels: "Protected Pixels",
+      detectedChanges: "Detected Changes",
+      repairedPixels: "Repaired Pixels",
+      charges: "Charges",
+      waitingInit: "Waiting for initialization...",
+      checkingColors: "\u{1F3A8} Checking available colors...",
+      noColorsFound: "\u274C No colors found. Open the color palette on the site.",
+      colorsFound: "\u2705 Found {count} available colors",
+      initSuccess: "\u2705 Guard-BOT initialized successfully",
+      initError: "\u274C Error initializing Guard-BOT",
+      invalidCoords: "\u274C Invalid coordinates",
+      invalidArea: "\u274C Area must have upper left corner less than lower right corner",
+      areaTooLarge: "\u274C Area too large: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capturing protection area...",
+      areaCaptured: "\u2705 Area captured: {count} pixels under protection",
+      captureError: "\u274C Error capturing area: {error}",
+      captureFirst: "\u274C First capture a protection area",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection started - monitoring area",
+      protectionStopped: "\u23F9\uFE0F Protection stopped",
+      noChanges: "\u2705 Protected area - no changes detected",
+      changesDetected: "\u{1F6A8} {count} changes detected in protected area",
+      repairing: "\u{1F6E0}\uFE0F Repairing {count} altered pixels...",
+      repairedSuccess: "\u2705 Successfully repaired {count} pixels",
+      repairError: "\u274C Error repairing pixels: {error}",
+      noCharges: "\u26A0\uFE0F Insufficient charges to repair changes",
+      checkingChanges: "\u{1F50D} Checking changes in protected area...",
+      errorChecking: "\u274C Error checking changes: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardian active - area under protection",
+      lastCheck: "Last check: {time}",
+      nextCheck: "Next check in: {time}s",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Guard-BOT auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      selectUpperLeft: "\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",
+      selectLowerRight: "\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",
+      waitingUpperLeft: "\u{1F446} Waiting for upper left corner selection...",
+      waitingLowerRight: "\u{1F446} Waiting for lower right corner selection...",
+      upperLeftCaptured: "\u2705 Upper left corner captured: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Lower right corner captured: ({x}, {y})",
+      selectionTimeout: "\u274C Selection timeout",
+      selectionError: "\u274C Selection error, please try again"
+    }
+  };
+
+  // src/locales/fr.js
+  var fr = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "S\xE9lection",
+      user: "Utilisateur",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Base de donn\xE9es",
+      uptime: "Temps actif",
+      close: "Fermer",
+      launch: "Lancer",
+      loading: "Chargement\u2026",
+      executing: "Ex\xE9cution\u2026",
+      downloading: "T\xE9l\xE9chargement du script\u2026",
+      chooseBot: "Choisissez un bot et appuyez sur Lancer",
+      readyToLaunch: "Pr\xEAt \xE0 lancer",
+      loadError: "Erreur de chargement",
+      loadErrorMsg: "Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",
+      checking: "\u{1F504} V\xE9rification...",
+      online: "\u{1F7E2} En ligne",
+      offline: "\u{1F534} Hors ligne",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Erreur",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialiser Auto-BOT",
+      uploadImage: "T\xE9l\xE9charger Image",
+      resizeImage: "Redimensionner Image",
+      selectPosition: "S\xE9lectionner Position",
+      startPainting: "Commencer Peinture",
+      stopPainting: "Arr\xEAter Peinture",
+      saveProgress: "Sauvegarder Progr\xE8s",
+      loadProgress: "Charger Progr\xE8s",
+      checkingColors: "\u{1F50D} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      loadingImage: "\u{1F5BC}\uFE0F Chargement de l'image...",
+      imageLoaded: "\u2705 Image charg\xE9e avec {count} pixels valides",
+      imageError: "\u274C Erreur lors du chargement de l'image",
+      selectPositionAlert: "Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Position d\xE9finie avec succ\xE8s!",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",
+      positionDetected: "\u{1F3AF} Position d\xE9tect\xE9e, traitement...",
+      positionError: "\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",
+      startPaintingMsg: "\u{1F3A8} D\xE9but de la peinture...",
+      paintingProgress: "\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",
+      noCharges: "\u231B Aucune charge. Attendre {time}...",
+      paintingStopped: "\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",
+      paintingComplete: "\u2705 Peinture termin\xE9e! {count} pixels peints.",
+      paintingError: "\u274C Erreur pendant la peinture",
+      missingRequirements: "\u274C Chargez une image et s\xE9lectionnez une position d'abord",
+      progress: "Progr\xE8s",
+      userName: "Usager",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Temps estim\xE9",
+      initMessage: "Cliquez sur 'Initialiser Auto-BOT' pour commencer",
+      waitingInit: "En attente d'initialisation...",
+      resizeSuccess: "\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels par lot",
+      batchSize: "Taille du lot",
+      nextBatchTime: "Prochain lot dans",
+      useAllCharges: "Utiliser toutes les charges disponibles",
+      showOverlay: "Afficher l'overlay",
+      maxCharges: "Charges max par lot",
+      waitingForCharges: "\u23F3 En attente de charges: {current}/{needed}",
+      timeRemaining: "Temps restant",
+      cooldownWaiting: "\u23F3 Attendre {time} pour continuer...",
+      progressSaved: "\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",
+      progressLoaded: "\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",
+      progressLoadError: "\u274C Erreur lors du chargement du progr\xE8s: {error}",
+      progressSaveError: "\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",
+      confirmSaveProgress: "Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",
+      saveProgressTitle: "Sauvegarder Progr\xE8s",
+      discardProgress: "Abandonner",
+      cancel: "Annuler",
+      minimize: "Minimiser",
+      width: "Largeur",
+      height: "Hauteur",
+      keepAspect: "Garder les proportions",
+      apply: "Appliquer",
+      overlayOn: "Overlay : ON",
+      overlayOff: "Overlay : OFF",
+      passCompleted: "\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",
+      waitingChargesCountdown: "\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Bot d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      retryAttempt: "\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",
+      retryError: "\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",
+      retryFailed: "\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",
+      networkError: "\u{1F310} Erreur r\xE9seau. Nouvel essai...",
+      serverError: "\u{1F525} Erreur serveur. Nouvel essai...",
+      timeoutError: "\u23F0 Timeout serveur. Nouvel essai..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      stopped: "Bot arr\xEAt\xE9",
+      calibrate: "Calibrer",
+      paintOnce: "Une fois",
+      checkingStatus: "V\xE9rification du statut...",
+      configuration: "Configuration",
+      delay: "D\xE9lai (ms)",
+      pixelsPerBatch: "Pixels/lot",
+      minCharges: "Charges min",
+      colorMode: "Mode couleur",
+      random: "Al\xE9atoire",
+      fixed: "Fixe",
+      range: "Plage",
+      fixedColor: "Couleur fixe",
+      advanced: "Avanc\xE9",
+      tileX: "Tuile X",
+      tileY: "Tuile Y",
+      customPalette: "Palette personnalis\xE9e",
+      paletteExample: "ex: #FF0000,#00FF00,#0000FF",
+      capture: "Capturer",
+      painted: "Peints",
+      charges: "Charges",
+      retries: "\xC9checs",
+      tile: "Tuile",
+      configSaved: "Configuration sauvegard\xE9e",
+      configLoaded: "Configuration charg\xE9e",
+      configReset: "Configuration r\xE9initialis\xE9e",
+      captureInstructions: "Peindre un pixel manuellement pour capturer les coordonn\xE9es...",
+      backendOnline: "Backend En ligne",
+      backendOffline: "Backend Hors ligne",
+      startingBot: "D\xE9marrage du bot...",
+      stoppingBot: "Arr\xEAt du bot...",
+      calibrating: "Calibrage...",
+      alreadyRunning: "Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",
+      imageRunningWarning: "Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",
+      selectPosition: "S\xE9lectionner Zone",
+      selectPositionAlert: "\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Zone d\xE9finie! Rayon: 500px",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",
+      missingPosition: "\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",
+      farmRadius: "Rayon farm",
+      positionInfo: "Zone actuelle",
+      farmingInRadius: "\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",
+      noPosition: "Aucune zone",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "Oui",
+      no: "Non",
+      ok: "OK",
+      cancel: "Annuler",
+      close: "Fermer",
+      save: "Sauvegarder",
+      load: "Charger",
+      delete: "Supprimer",
+      edit: "Modifier",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      pause: "Pause",
+      resume: "Reprendre",
+      reset: "R\xE9initialiser",
+      settings: "Param\xE8tres",
+      help: "Aide",
+      about: "\xC0 propos",
+      language: "Langue",
+      loading: "Chargement...",
+      error: "Erreur",
+      success: "Succ\xE8s",
+      warning: "Avertissement",
+      info: "Information",
+      languageChanged: "Langue chang\xE9e en {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialiser Guard-BOT",
+      selectArea: "S\xE9lectionner Zone",
+      captureArea: "Capturer Zone",
+      startProtection: "D\xE9marrer Protection",
+      stopProtection: "Arr\xEAter Protection",
+      upperLeft: "Coin Sup\xE9rieur Gauche",
+      lowerRight: "Coin Inf\xE9rieur Droit",
+      protectedPixels: "Pixels Prot\xE9g\xE9s",
+      detectedChanges: "Changements D\xE9tect\xE9s",
+      repairedPixels: "Pixels R\xE9par\xE9s",
+      charges: "Charges",
+      waitingInit: "En attente d'initialisation...",
+      checkingColors: "\u{1F3A8} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      initSuccess: "\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",
+      initError: "\u274C Erreur lors de l'initialisation de Guard-BOT",
+      invalidCoords: "\u274C Coordonn\xE9es invalides",
+      invalidArea: "\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",
+      areaTooLarge: "\u274C Zone trop grande: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capture de la zone de protection...",
+      areaCaptured: "\u2705 Zone captur\xE9e: {count} pixels sous protection",
+      captureError: "\u274C Erreur lors de la capture de zone: {error}",
+      captureFirst: "\u274C Capturez d'abord une zone de protection",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",
+      protectionStopped: "\u23F9\uFE0F Protection arr\xEAt\xE9e",
+      noChanges: "\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",
+      changesDetected: "\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",
+      repairing: "\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",
+      repairedSuccess: "\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",
+      repairError: "\u274C Erreur lors de la r\xE9paration des pixels: {error}",
+      noCharges: "\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",
+      checkingChanges: "\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",
+      errorChecking: "\u274C Erreur lors de la v\xE9rification des changements: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Gardien actif - zone sous protection",
+      lastCheck: "Derni\xE8re v\xE9rification: {time}",
+      nextCheck: "Prochaine v\xE9rification dans: {time}s",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      selectUpperLeft: "\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",
+      selectLowerRight: "\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",
+      waitingUpperLeft: "\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",
+      waitingLowerRight: "\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",
+      upperLeftCaptured: "\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",
+      selectionTimeout: "\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",
+      selectionError: "\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"
+    }
+  };
+
+  // src/locales/ru.js
+  var ru = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      autoImage: "\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      autoGuard: "\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      selection: "\u0412\u044B\u0431\u0440\u0430\u043D\u043E",
+      user: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      charges: "\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      backend: "\u0411\u044D\u043A\u0435\u043D\u0434",
+      database: "\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",
+      uptime: "\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      launch: "\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",
+      executing: "\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",
+      downloading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",
+      chooseBot: "\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      readyToLaunch: "\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",
+      loadError: "\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",
+      loadErrorMsg: "\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",
+      checking: "\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",
+      online: "\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",
+      offline: "\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",
+      ok: "\u{1F7E2} \u041E\u041A",
+      error: "\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",
+      uploadImage: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      resizeImage: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      startPainting: "\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",
+      stopPainting: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",
+      saveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      loadProgress: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      checkingColors: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      loadingImage: "\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",
+      imageLoaded: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",
+      imageError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPositionAlert: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",
+      positionDetected: "\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",
+      positionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",
+      startPaintingMsg: "\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",
+      paintingProgress: "\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      noCharges: "\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",
+      paintingComplete: "\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",
+      paintingError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",
+      missingRequirements: "\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      progress: "\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      userName: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      pixels: "\u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      estimatedTime: "\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",
+      initMessage: "\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      resizeSuccess: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",
+      batchSize: "\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",
+      nextBatchTime: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",
+      useAllCharges: "\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",
+      showOverlay: "\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",
+      maxCharges: "\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      waitingForCharges: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",
+      timeRemaining: "\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",
+      cooldownWaiting: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",
+      progressSaved: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",
+      progressLoaded: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",
+      progressLoadError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      progressSaveError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      confirmSaveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",
+      saveProgressTitle: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      discardProgress: "\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      minimize: "\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",
+      width: "\u0428\u0438\u0440\u0438\u043D\u0430",
+      height: "\u0412\u044B\u0441\u043E\u0442\u0430",
+      keepAspect: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",
+      apply: "\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",
+      passCompleted: "\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",
+      waitingChargesRegen: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",
+      waitingChargesCountdown: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      retryAttempt: "\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryError: "\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryFailed: "\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",
+      networkError: "\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      serverError: "\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      timeoutError: "\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      stopped: "\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",
+      calibrate: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",
+      paintOnce: "\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",
+      checkingStatus: "\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",
+      configuration: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",
+      delay: "\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      minCharges: "\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",
+      colorMode: "\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",
+      random: "\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",
+      fixed: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",
+      range: "\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",
+      fixedColor: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",
+      advanced: "\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",
+      tileX: "\u041F\u043B\u0438\u0442\u043A\u0430 X",
+      tileY: "\u041F\u043B\u0438\u0442\u043A\u0430 Y",
+      customPalette: "\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",
+      paletteExample: "\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",
+      capture: "\u0417\u0430\u0445\u0432\u0430\u0442",
+      painted: "\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      retries: "\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",
+      tile: "\u041F\u043B\u0438\u0442\u043A\u0430",
+      configSaved: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",
+      configLoaded: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",
+      configReset: "\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",
+      captureInstructions: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",
+      backendOnline: "\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",
+      backendOffline: "\u0411\u044D\u043A\u044D\u043D\u0434",
+      startingBot: "\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",
+      stoppingBot: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",
+      calibrating: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",
+      alreadyRunning: "\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",
+      imageRunningWarning: "\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C",
+      selectPositionAlert: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      missingPosition: "\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",
+      farmRadius: "\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",
+      positionInfo: "\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",
+      farmingInRadius: "\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",
+      noPosition: "\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      currentZone: "\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."
+    },
+    // Common/Shared
+    common: {
+      yes: "\u0414\u0430",
+      no: "\u041D\u0435\u0442",
+      ok: "\u041E\u041A",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      save: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",
+      load: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",
+      delete: "\u0423\u0434\u0430\u043B\u0438\u0442\u044C",
+      edit: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",
+      pause: "\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      resume: "\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",
+      reset: "\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",
+      settings: "\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",
+      help: "\u041F\u043E\u043C\u043E\u0449\u044C",
+      about: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      language: "\u042F\u0437\u044B\u043A",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",
+      error: "\u041E\u0448\u0438\u0431\u043A\u0430",
+      success: "\u0423\u0441\u043F\u0435\u0445",
+      warning: "\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",
+      info: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      languageChanged: "\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",
+      selectArea: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      captureArea: "\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      startProtection: "\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      stopProtection: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      upperLeft: "\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      lowerRight: "\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      protectedPixels: "\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      detectedChanges: "\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      repairedPixels: "\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      checkingColors: "\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      initSuccess: "\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",
+      initError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",
+      invalidCoords: "\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",
+      invalidArea: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",
+      areaTooLarge: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",
+      capturingArea: "\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",
+      areaCaptured: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      captureError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",
+      captureFirst: "\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",
+      protectionStarted: "\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      protectionStopped: "\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",
+      noChanges: "\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",
+      changesDetected: "\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      repairing: "\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      repairedSuccess: "\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",
+      repairError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",
+      noCharges: "\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",
+      checkingChanges: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",
+      errorChecking: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      lastCheck: "\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",
+      nextCheck: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      selectUpperLeft: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",
+      selectLowerRight: "\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      waitingUpperLeft: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      waitingLowerRight: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      upperLeftCaptured: "\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      selectionTimeout: "\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",
+      selectionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"
+    }
+  };
+
+  // src/locales/zh-Hans.js
+  var zhHans = {
+    // 启动器
+    launcher: {
+      title: "WPlace \u81EA\u52A8\u673A\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52A8\u519C\u573A",
+      autoImage: "\u{1F3A8} \u81EA\u52A8\u7ED8\u56FE",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52A8\u5B88\u62A4",
+      selection: "\u9009\u62E9",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6570",
+      backend: "\u540E\u7AEF",
+      database: "\u6570\u636E\u5E93",
+      uptime: "\u8FD0\u884C\u65F6\u95F4",
+      close: "\u5173\u95ED",
+      launch: "\u542F\u52A8",
+      loading: "\u52A0\u8F7D\u4E2D\u2026",
+      executing: "\u6267\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F7D\u811A\u672C\u2026",
+      chooseBot: "\u9009\u62E9\u4E00\u4E2A\u673A\u5668\u4EBA\u5E76\u70B9\u51FB\u542F\u52A8",
+      readyToLaunch: "\u51C6\u5907\u542F\u52A8",
+      loadError: "\u52A0\u8F7D\u9519\u8BEF",
+      loadErrorMsg: "\u65E0\u6CD5\u52A0\u8F7D\u6240\u9009\u673A\u5668\u4EBA\u3002\u8BF7\u68C0\u67E5\u7F51\u7EDC\u8FDE\u63A5\u6216\u91CD\u8BD5\u3002",
+      checking: "\u{1F504} \u68C0\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7EBF",
+      offline: "\u{1F534} \u79BB\u7EBF",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u9519\u8BEF",
+      unknown: "-"
+    },
+    // 绘图模块
+    image: {
+      title: "WPlace \u81EA\u52A8\u7ED8\u56FE",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA",
+      uploadImage: "\u4E0A\u4F20\u56FE\u7247",
+      resizeImage: "\u8C03\u6574\u56FE\u7247\u5927\u5C0F",
+      selectPosition: "\u9009\u62E9\u4F4D\u7F6E",
+      startPainting: "\u5F00\u59CB\u7ED8\u5236",
+      stopPainting: "\u505C\u6B62\u7ED8\u5236",
+      saveProgress: "\u4FDD\u5B58\u8FDB\u5EA6",
+      loadProgress: "\u52A0\u8F7D\u8FDB\u5EA6",
+      checkingColors: "\u{1F50D} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u540E\u91CD\u8BD5\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F7D\u56FE\u7247...",
+      imageLoaded: "\u2705 \u56FE\u7247\u5DF2\u52A0\u8F7D\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u4E2A",
+      imageError: "\u274C \u56FE\u7247\u52A0\u8F7D\u5931\u8D25",
+      selectPositionAlert: "\u8BF7\u5728\u4F60\u60F3\u5F00\u59CB\u7ED8\u5236\u7684\u5730\u65B9\u6D82\u7B2C\u4E00\u4E2A\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8BBE\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9009\u62E9\u8D85\u65F6",
+      positionDetected: "\u{1F3AF} \u5DF2\u68C0\u6D4B\u5230\u4F4D\u7F6E\uFF0C\u5904\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u68C0\u6D4B\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5",
+      startPaintingMsg: "\u{1F3A8} \u5F00\u59CB\u7ED8\u5236...",
+      paintingProgress: "\u{1F9F1} \u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6CA1\u6709\u6B21\u6570\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7ED8\u5236",
+      paintingComplete: "\u2705 \u7ED8\u5236\u5B8C\u6210\uFF01\u5171\u7ED8\u5236 {count} \u4E2A\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7ED8\u5236\u8FC7\u7A0B\u4E2D\u51FA\u9519",
+      missingRequirements: "\u274C \u8BF7\u5148\u52A0\u8F7D\u56FE\u7247\u5E76\u9009\u62E9\u4F4D\u7F6E",
+      progress: "\u8FDB\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      estimatedTime: "\u9884\u8BA1\u65F6\u95F4",
+      initMessage: "\u70B9\u51FB\u201C\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA\u201D\u5F00\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u56FE\u7247\u5DF2\u8C03\u6574\u4E3A {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7ED8\u5236\u6682\u505C\u4E8E\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6570",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u65F6\u95F4",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6570",
+      showOverlay: "\u663E\u793A\u8986\u76D6\u5C42",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6570",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed}",
+      timeRemaining: "\u5269\u4F59\u65F6\u95F4",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u540E\u7EE7\u7EED...",
+      progressSaved: "\u2705 \u8FDB\u5EA6\u5DF2\u4FDD\u5B58\u4E3A {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F7D\u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7ED8\u5236",
+      progressLoadError: "\u274C \u52A0\u8F7D\u8FDB\u5EA6\u5931\u8D25: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u8FDB\u5EA6\u5931\u8D25: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u5F53\u524D\u8FDB\u5EA6\u5417\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u8FDB\u5EA6",
+      discardProgress: "\u653E\u5F03",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BBD\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7EB5\u6A2A\u6BD4",
+      apply: "\u5E94\u7528",
+      overlayOn: "\u8986\u76D6\u5C42: \u5F00\u542F",
+      overlayOff: "\u8986\u76D6\u5C42: \u5173\u95ED",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7ED8\u5236 {painted} \u50CF\u7D20 | \u8FDB\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6570\u6062\u590D: {current}/{needed} - \u65F6\u95F4: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed} - \u5269\u4F59: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8BD5 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5C1D\u8BD5\u51FA\u9519\uFF0C\u5C06\u5728 {delay} \u79D2\u540E\u91CD\u8BD5...",
+      retryFailed: "\u274C \u8D85\u8FC7 {maxAttempts} \u6B21\u5C1D\u8BD5\u5931\u8D25\u3002\u7EE7\u7EED\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7F51\u7EDC\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      serverError: "\u{1F525} \u670D\u52A1\u5668\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      timeoutError: "\u23F0 \u670D\u52A1\u5668\u8D85\u65F6\uFF0C\u6B63\u5728\u91CD\u8BD5..."
+    },
+    // 农场模块（待实现）
+    farm: {
+      title: "WPlace \u519C\u573A\u673A\u5668\u4EBA",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u673A\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u51C6",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u68C0\u67E5\u72B6\u6001\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u8FDF (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6570",
+      colorMode: "\u989C\u8272\u6A21\u5F0F",
+      random: "\u968F\u673A",
+      fixed: "\u56FA\u5B9A",
+      range: "\u8303\u56F4",
+      fixedColor: "\u56FA\u5B9A\u989C\u8272",
+      advanced: "\u9AD8\u7EA7",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u4E49\u8C03\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u83B7",
+      painted: "\u5DF2\u7ED8\u5236",
+      charges: "\u6B21\u6570",
+      retries: "\u91CD\u8BD5",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F7D",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8BF7\u624B\u52A8\u7ED8\u5236\u4E00\u4E2A\u50CF\u7D20\u4EE5\u6355\u83B7\u5750\u6807...",
+      backendOnline: "\u540E\u7AEF\u5728\u7EBF",
+      backendOffline: "\u540E\u7AEF\u79BB\u7EBF",
+      startingBot: "\u6B63\u5728\u542F\u52A8\u673A\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u673A\u5668\u4EBA...",
+      calibrating: "\u6821\u51C6\u4E2D...",
+      alreadyRunning: "\u81EA\u52A8\u519C\u573A\u5DF2\u5728\u8FD0\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52A8\u7ED8\u56FE\u6B63\u5728\u8FD0\u884C\uFF0C\u8BF7\u5148\u5173\u95ED\u518D\u542F\u52A8\u81EA\u52A8\u519C\u573A\u3002",
+      selectPosition: "\u9009\u62E9\u533A\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u56FE\u7684\u7A7A\u767D\u533A\u57DF\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u533A\u57DF\u8BBE\u7F6E\u6210\u529F\uFF01\u534A\u5F84: 500px",
+      positionTimeout: "\u274C \u533A\u57DF\u9009\u62E9\u8D85\u65F6",
+      missingPosition: "\u274C \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF08\u4F7F\u7528\u201C\u9009\u62E9\u533A\u57DF\u201D\u6309\u94AE\uFF09",
+      farmRadius: "\u519C\u573A\u534A\u5F84",
+      positionInfo: "\u5F53\u524D\u533A\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F84 {radius}px \u5728 ({x},{y}) \u519C\u573A",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8BF7\u9009\u62E9\u7A7A\u767D\u533A\u57DF\u4EE5\u907F\u514D\u51B2\u7A81",
+      noPosition: "\u672A\u9009\u62E9\u533A\u57DF",
+      currentZone: "\u533A\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF0C\u5728\u5730\u56FE\u4E0A\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u786E\u8BA4",
+      cancel: "\u53D6\u6D88",
+      close: "\u5173\u95ED",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F7D",
+      delete: "\u5220\u9664",
+      edit: "\u7F16\u8F91",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u6682\u505C",
+      resume: "\u7EE7\u7EED",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8BBE\u7F6E",
+      help: "\u5E2E\u52A9",
+      about: "\u5173\u4E8E",
+      language: "\u8BED\u8A00",
+      loading: "\u52A0\u8F7D\u4E2D...",
+      error: "\u9519\u8BEF",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8BED\u8A00\u5DF2\u5207\u6362\u4E3A {language}"
+    },
+    // 守护模块
+    guard: {
+      title: "WPlace \u81EA\u52A8\u5B88\u62A4",
+      initBot: "\u521D\u59CB\u5316\u5B88\u62A4\u673A\u5668\u4EBA",
+      selectArea: "\u9009\u62E9\u533A\u57DF",
+      captureArea: "\u6355\u83B7\u533A\u57DF",
+      startProtection: "\u5F00\u59CB\u5B88\u62A4",
+      stopProtection: "\u505C\u6B62\u5B88\u62A4",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u62A4\u50CF\u7D20",
+      detectedChanges: "\u68C0\u6D4B\u5230\u7684\u53D8\u5316",
+      repairedPixels: "\u4FEE\u590D\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u989C\u8272\uFF0C\u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      initSuccess: "\u2705 \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u5931\u8D25",
+      invalidCoords: "\u274C \u5750\u6807\u65E0\u6548",
+      invalidArea: "\u274C \u533A\u57DF\u65E0\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u987B\u5C0F\u4E8E\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u533A\u57DF\u8FC7\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u83B7\u5B88\u62A4\u533A\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u533A\u57DF\u6355\u83B7\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u62A4",
+      captureError: "\u274C \u6355\u83B7\u533A\u57DF\u51FA\u9519: {error}",
+      captureFirst: "\u274C \u8BF7\u5148\u6355\u83B7\u4E00\u4E2A\u5B88\u62A4\u533A\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u62A4\u5DF2\u542F\u52A8 - \u533A\u57DF\u76D1\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u62A4\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u533A\u57DF\u5B89\u5168 - \u672A\u68C0\u6D4B\u5230\u53D8\u5316",
+      changesDetected: "\u{1F6A8} \u68C0\u6D4B\u5230 {count} \u4E2A\u53D8\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u590D {count} \u4E2A\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u590D {count} \u4E2A\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u590D\u51FA\u9519: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6570\u4E0D\u8DB3\uFF0C\u65E0\u6CD5\u4FEE\u590D",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u68C0\u67E5\u533A\u57DF\u53D8\u5316...",
+      errorChecking: "\u274C \u68C0\u67E5\u51FA\u9519: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u62A4\u4E2D - \u533A\u57DF\u53D7\u4FDD\u62A4",
+      lastCheck: "\u4E0A\u6B21\u68C0\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u68C0\u67E5: {time} \u79D2\u540E",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u62A4\u533A\u57DF\u7684\u5DE6\u4E0A\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73B0\u5728\u5728\u53F3\u4E0B\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u83B7\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u83B7\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9009\u62E9\u8D85\u65F6",
+      selectionError: "\u274C \u9009\u62E9\u51FA\u9519\uFF0C\u8BF7\u91CD\u8BD5"
+    }
+  };
+
+  // src/locales/zh-Hant.js
+  var zhHant = {
+    // 啓動器
+    launcher: {
+      title: "WPlace \u81EA\u52D5\u6A5F\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52D5\u8FB2\u5834",
+      autoImage: "\u{1F3A8} \u81EA\u52D5\u7E6A\u5716",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52D5\u5B88\u8B77",
+      selection: "\u9078\u64C7",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6578",
+      backend: "\u5F8C\u7AEF",
+      database: "\u6578\u64DA\u5EAB",
+      uptime: "\u904B\u884C\u6642\u9593",
+      close: "\u95DC\u9589",
+      launch: "\u5553\u52D5",
+      loading: "\u52A0\u8F09\u4E2D\u2026",
+      executing: "\u57F7\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F09\u8173\u672C\u2026",
+      chooseBot: "\u9078\u64C7\u4E00\u500B\u6A5F\u5668\u4EBA\u4E26\u9EDE\u64CA\u5553\u52D5",
+      readyToLaunch: "\u6E96\u5099\u5553\u52D5",
+      loadError: "\u52A0\u8F09\u932F\u8AA4",
+      loadErrorMsg: "\u7121\u6CD5\u52A0\u8F09\u6240\u9078\u6A5F\u5668\u4EBA\u3002\u8ACB\u6AA2\u67E5\u7DB2\u7D61\u9023\u63A5\u6216\u91CD\u8A66\u3002",
+      checking: "\u{1F504} \u6AA2\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7DDA",
+      offline: "\u{1F534} \u96E2\u7DDA",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u932F\u8AA4",
+      unknown: "-"
+    },
+    // 繪圖模塊
+    image: {
+      title: "WPlace \u81EA\u52D5\u7E6A\u5716",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA",
+      uploadImage: "\u4E0A\u50B3\u5716\u7247",
+      resizeImage: "\u8ABF\u6574\u5716\u7247\u5927\u5C0F",
+      selectPosition: "\u9078\u64C7\u4F4D\u7F6E",
+      startPainting: "\u958B\u59CB\u7E6A\u88FD",
+      stopPainting: "\u505C\u6B62\u7E6A\u88FD",
+      saveProgress: "\u4FDD\u5B58\u9032\u5EA6",
+      loadProgress: "\u52A0\u8F09\u9032\u5EA6",
+      checkingColors: "\u{1F50D} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u5F8C\u91CD\u8A66\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F09\u5716\u7247...",
+      imageLoaded: "\u2705 \u5716\u7247\u5DF2\u52A0\u8F09\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u500B",
+      imageError: "\u274C \u5716\u7247\u52A0\u8F09\u5931\u6557",
+      selectPositionAlert: "\u8ACB\u5728\u4F60\u60F3\u958B\u59CB\u7E6A\u88FD\u7684\u5730\u65B9\u5857\u7B2C\u4E00\u500B\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8A2D\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9078\u64C7\u8D85\u6642",
+      positionDetected: "\u{1F3AF} \u5DF2\u6AA2\u6E2C\u5230\u4F4D\u7F6E\uFF0C\u8655\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u6AA2\u6E2C\u5931\u6557\uFF0C\u8ACB\u91CD\u8A66",
+      startPaintingMsg: "\u{1F3A8} \u958B\u59CB\u7E6A\u88FD...",
+      paintingProgress: "\u{1F9F1} \u9032\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6C92\u6709\u6B21\u6578\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7E6A\u88FD",
+      paintingComplete: "\u2705 \u7E6A\u88FD\u5B8C\u6210\uFF01\u5171\u7E6A\u88FD {count} \u500B\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7E6A\u88FD\u904E\u7A0B\u4E2D\u51FA\u932F",
+      missingRequirements: "\u274C \u8ACB\u5148\u52A0\u8F09\u5716\u7247\u4E26\u9078\u64C7\u4F4D\u7F6E",
+      progress: "\u9032\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      estimatedTime: "\u9810\u8A08\u6642\u9593",
+      initMessage: "\u9EDE\u64CA\u201C\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA\u201D\u958B\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u5716\u7247\u5DF2\u8ABF\u6574\u70BA {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7E6A\u88FD\u66AB\u505C\u65BC\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6578",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u6642\u9593",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6578",
+      showOverlay: "\u986F\u793A\u8986\u84CB\u5C64",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6578",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed}",
+      timeRemaining: "\u5269\u9918\u6642\u9593",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u5F8C\u7E7C\u7E8C...",
+      progressSaved: "\u2705 \u9032\u5EA6\u5DF2\u4FDD\u5B58\u70BA {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F09\u9032\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7E6A\u88FD",
+      progressLoadError: "\u274C \u52A0\u8F09\u9032\u5EA6\u5931\u6557: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u9032\u5EA6\u5931\u6557: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u7576\u524D\u9032\u5EA6\u55CE\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u9032\u5EA6",
+      discardProgress: "\u653E\u68C4",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BEC\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7E31\u6A6B\u6BD4",
+      apply: "\u61C9\u7528",
+      overlayOn: "\u8986\u84CB\u5C64: \u958B\u5553",
+      overlayOff: "\u8986\u84CB\u5C64: \u95DC\u9589",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7E6A\u88FD {painted} \u50CF\u7D20 | \u9032\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6578\u6062\u5FA9: {current}/{needed} - \u6642\u9593: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed} - \u5269\u9918: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8A66 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5617\u8A66\u51FA\u932F\uFF0C\u5C07\u5728 {delay} \u79D2\u5F8C\u91CD\u8A66...",
+      retryFailed: "\u274C \u8D85\u904E {maxAttempts} \u6B21\u5617\u8A66\u5931\u6557\u3002\u7E7C\u7E8C\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7DB2\u7D61\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      serverError: "\u{1F525} \u670D\u52D9\u5668\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      timeoutError: "\u23F0 \u670D\u52D9\u5668\u8D85\u6642\uFF0C\u6B63\u5728\u91CD\u8A66..."
+    },
+    // 農場模塊（待實現）
+    farm: {
+      title: "WPlace \u8FB2\u5834\u6A5F\u5668\u4EBA",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u6A5F\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u6E96",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u6AA2\u67E5\u72C0\u614B\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u9072 (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6578",
+      colorMode: "\u984F\u8272\u6A21\u5F0F",
+      random: "\u96A8\u6A5F",
+      fixed: "\u56FA\u5B9A",
+      range: "\u7BC4\u570D",
+      fixedColor: "\u56FA\u5B9A\u984F\u8272",
+      advanced: "\u9AD8\u7D1A",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u7FA9\u8ABF\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u7372",
+      painted: "\u5DF2\u7E6A\u88FD",
+      charges: "\u6B21\u6578",
+      retries: "\u91CD\u8A66",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F09",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8ACB\u624B\u52D5\u7E6A\u88FD\u4E00\u500B\u50CF\u7D20\u4EE5\u6355\u7372\u5EA7\u6A19...",
+      backendOnline: "\u5F8C\u7AEF\u5728\u7DDA",
+      backendOffline: "\u5F8C\u7AEF\u96E2\u7DDA",
+      startingBot: "\u6B63\u5728\u5553\u52D5\u6A5F\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u6A5F\u5668\u4EBA...",
+      calibrating: "\u6821\u6E96\u4E2D...",
+      alreadyRunning: "\u81EA\u52D5\u8FB2\u5834\u5DF2\u5728\u904B\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52D5\u7E6A\u5716\u6B63\u5728\u904B\u884C\uFF0C\u8ACB\u5148\u95DC\u9589\u518D\u5553\u52D5\u81EA\u52D5\u8FB2\u5834\u3002",
+      selectPosition: "\u9078\u64C7\u5340\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u5716\u7684\u7A7A\u767D\u5340\u57DF\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u5340\u57DF\u8A2D\u7F6E\u6210\u529F\uFF01\u534A\u5F91: 500px",
+      positionTimeout: "\u274C \u5340\u57DF\u9078\u64C7\u8D85\u6642",
+      missingPosition: "\u274C \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF08\u4F7F\u7528\u201C\u9078\u64C7\u5340\u57DF\u201D\u6309\u9215\uFF09",
+      farmRadius: "\u8FB2\u5834\u534A\u5F91",
+      positionInfo: "\u7576\u524D\u5340\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F91 {radius}px \u5728 ({x},{y}) \u8FB2\u5834",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8ACB\u9078\u64C7\u7A7A\u767D\u5340\u57DF\u4EE5\u907F\u514D\u885D\u7A81",
+      noPosition: "\u672A\u9078\u64C7\u5340\u57DF",
+      currentZone: "\u5340\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF0C\u5728\u5730\u5716\u4E0A\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u78BA\u8A8D",
+      cancel: "\u53D6\u6D88",
+      close: "\u95DC\u9589",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F09",
+      delete: "\u522A\u9664",
+      edit: "\u7DE8\u8F2F",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u66AB\u505C",
+      resume: "\u7E7C\u7E8C",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8A2D\u7F6E",
+      help: "\u5E6B\u52A9",
+      about: "\u95DC\u65BC",
+      language: "\u8A9E\u8A00",
+      loading: "\u52A0\u8F09\u4E2D...",
+      error: "\u932F\u8AA4",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8A9E\u8A00\u5DF2\u5207\u63DB\u70BA {language}"
+    },
+    // 守護模塊
+    guard: {
+      title: "WPlace \u81EA\u52D5\u5B88\u8B77",
+      initBot: "\u521D\u59CB\u5316\u5B88\u8B77\u6A5F\u5668\u4EBA",
+      selectArea: "\u9078\u64C7\u5340\u57DF",
+      captureArea: "\u6355\u7372\u5340\u57DF",
+      startProtection: "\u958B\u59CB\u5B88\u8B77",
+      stopProtection: "\u505C\u6B62\u5B88\u8B77",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u8B77\u50CF\u7D20",
+      detectedChanges: "\u6AA2\u6E2C\u5230\u7684\u8B8A\u5316",
+      repairedPixels: "\u4FEE\u5FA9\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u984F\u8272\uFF0C\u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      initSuccess: "\u2705 \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u5931\u6557",
+      invalidCoords: "\u274C \u5EA7\u6A19\u7121\u6548",
+      invalidArea: "\u274C \u5340\u57DF\u7121\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u9808\u5C0F\u65BC\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u5340\u57DF\u904E\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u7372\u5B88\u8B77\u5340\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u5340\u57DF\u6355\u7372\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u8B77",
+      captureError: "\u274C \u6355\u7372\u5340\u57DF\u51FA\u932F: {error}",
+      captureFirst: "\u274C \u8ACB\u5148\u6355\u7372\u4E00\u500B\u5B88\u8B77\u5340\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u8B77\u5DF2\u5553\u52D5 - \u5340\u57DF\u76E3\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u8B77\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u5340\u57DF\u5B89\u5168 - \u672A\u6AA2\u6E2C\u5230\u8B8A\u5316",
+      changesDetected: "\u{1F6A8} \u6AA2\u6E2C\u5230 {count} \u500B\u8B8A\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u5FA9\u51FA\u932F: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6578\u4E0D\u8DB3\uFF0C\u7121\u6CD5\u4FEE\u5FA9",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u6AA2\u67E5\u5340\u57DF\u8B8A\u5316...",
+      errorChecking: "\u274C \u6AA2\u67E5\u51FA\u932F: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u8B77\u4E2D - \u5340\u57DF\u53D7\u4FDD\u8B77",
+      lastCheck: "\u4E0A\u6B21\u6AA2\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u6AA2\u67E5: {time} \u79D2\u5F8C",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u8B77\u5340\u57DF\u7684\u5DE6\u4E0A\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73FE\u5728\u5728\u53F3\u4E0B\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u7372\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u7372\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9078\u64C7\u8D85\u6642",
+      selectionError: "\u274C \u9078\u64C7\u51FA\u932F\uFF0C\u8ACB\u91CD\u8A66"
+    }
+  };
+
+  // src/locales/index.js
+  var translations = {
+    es,
+    en,
+    fr,
+    ru,
+    zhHans,
+    zhHant
+  };
+  var currentLanguage = "es";
+  var currentTranslations = translations[currentLanguage];
+  function detectBrowserLanguage() {
+    const browserLang = window.navigator.language || window.navigator.userLanguage || "es";
+    const langCode = browserLang.split("-")[0].toLowerCase();
+    if (translations[langCode]) {
+      return langCode;
+    }
+    return "es";
+  }
+  function getSavedLanguage() {
+    return null;
+  }
+  function saveLanguage(langCode) {
+    return;
+  }
+  function initializeLanguage() {
+    const savedLang = getSavedLanguage();
+    const browserLang = detectBrowserLanguage();
+    let selectedLang = "es";
+    if (savedLang && translations[savedLang]) {
+      selectedLang = savedLang;
+    } else if (browserLang && translations[browserLang]) {
+      selectedLang = browserLang;
+    }
+    setLanguage(selectedLang);
+    return selectedLang;
+  }
+  function setLanguage(langCode) {
+    if (!translations[langCode]) {
+      console.warn(`Idioma '${langCode}' no disponible. Usando '${currentLanguage}'`);
+      return;
+    }
+    currentLanguage = langCode;
+    currentTranslations = translations[langCode];
+    saveLanguage(langCode);
+    if (typeof window !== "undefined" && window.CustomEvent) {
+      window.dispatchEvent(new window.CustomEvent("languageChanged", {
+        detail: { language: langCode, translations: currentTranslations }
+      }));
+    }
+  }
+  function getCurrentLanguage() {
+    return currentLanguage;
+  }
+  function t(key, params = {}) {
+    const keys = key.split(".");
+    let value = currentTranslations;
+    for (const k of keys) {
+      if (value && typeof value === "object" && k in value) {
+        value = value[k];
+      } else {
+        console.warn(`Clave de traducci\xF3n no encontrada: '${key}'`);
+        return key;
+      }
+    }
+    if (typeof value !== "string") {
+      console.warn(`Clave de traducci\xF3n no es string: '${key}'`);
+      return key;
+    }
+    return interpolate(value, params);
+  }
+  function interpolate(text, params) {
+    if (!params || Object.keys(params).length === 0) {
+      return text;
+    }
+    return text.replace(/\{(\w+)\}/g, (match, key) => {
+      return params[key] !== void 0 ? params[key] : match;
+    });
+  }
+  function getSection(section) {
+    if (currentTranslations[section]) {
+      return currentTranslations[section];
+    }
+    console.warn(`Secci\xF3n de traducci\xF3n no encontrada: '${section}'`);
+    return {};
+  }
+  initializeLanguage();
+
+  // src/image/config.js
+  var IMAGE_DEFAULTS = {
+    SITEKEY: "0x4AAAAAABpqJe8FO0N84q0F",
+    COOLDOWN_DEFAULT: 31e3,
+    TRANSPARENCY_THRESHOLD: 100,
+    WHITE_THRESHOLD: 250,
+    LOG_INTERVAL: 10,
+    TILE_SIZE: 3e3,
+    PIXELS_PER_BATCH: 20,
+    CHARGE_REGEN_MS: 3e4,
+    THEME: {
+      primary: "#000000",
+      secondary: "#111111",
+      accent: "#222222",
+      text: "#ffffff",
+      highlight: "#775ce3",
+      success: "#00ff00",
+      error: "#ff0000",
+      warning: "#ffaa00"
+    }
+  };
+  var imageState = {
+    running: false,
+    imageLoaded: false,
+    processing: false,
+    totalPixels: 0,
+    paintedPixels: 0,
+    availableColors: [],
+    currentCharges: 0,
+    cooldown: IMAGE_DEFAULTS.COOLDOWN_DEFAULT,
+    imageData: null,
+    stopFlag: false,
+    colorsChecked: false,
+    startPosition: null,
+    selectingPosition: false,
+    positionTimeoutId: null,
+    // Para manejar timeout de selección
+    cleanupObserver: null,
+    // Para limpiar observers
+    region: null,
+    minimized: false,
+    lastPosition: { x: 0, y: 0 },
+    estimatedTime: 0,
+    language: "es",
+    tileX: null,
+    tileY: null,
+    pixelsPerBatch: IMAGE_DEFAULTS.PIXELS_PER_BATCH,
+    useAllChargesFirst: true,
+    // Usar todas las cargas en la primera pasada
+    isFirstBatch: true,
+    // Controlar si es la primera pasada
+    maxCharges: 50,
+    // Cargas máximas del usuario
+    nextBatchCooldown: 0,
+    // Tiempo para el siguiente lote
+    inCooldown: false,
+    cooldownEndTime: 0,
+    remainingPixels: [],
+    lastChargeUpdate: 0,
+    chargeDecimalPart: 0,
+    originalImageName: null,
+    retryCount: 0
+    // Contador de reintentos para estadísticas
+  };
+
+  // src/image/processor.js
+  function detectAvailableColors() {
+    log("\u{1F3A8} Detectando colores disponibles...");
+    const colorElements = document.querySelectorAll('[id^="color-"]');
+    const colors = [];
+    for (const element of colorElements) {
+      if (element.querySelector("svg")) {
+        continue;
+      }
+      const idStr = element.id.replace("color-", "");
+      const id = parseInt(idStr);
+      if (id === 0) {
+        continue;
+      }
+      const backgroundStyle = element.style.backgroundColor;
+      if (backgroundStyle) {
+        const rgbMatch = backgroundStyle.match(/\d+/g);
+        if (rgbMatch && rgbMatch.length >= 3) {
+          const rgb = {
+            r: parseInt(rgbMatch[0]),
+            g: parseInt(rgbMatch[1]),
+            b: parseInt(rgbMatch[2])
+          };
+          colors.push({
+            id,
+            element,
+            ...rgb
+          });
+          log(`Color detectado: id=${id}, rgb(${rgb.r},${rgb.g},${rgb.b})`);
+        }
+      }
+    }
+    log(`\u2705 ${colors.length} colores disponibles detectados`);
+    return colors;
+  }
+
+  // src/image/blue-marble-processor.js
+  var BlueMarblelImageProcessor = class {
+    constructor(imageSrc) {
+      this.imageSrc = imageSrc;
+      this.img = new window.Image();
+      this.originalName = null;
+      this.tileSize = 1e3;
+      this.drawMult = 3;
+      this.shreadSize = 3;
+      this.bitmap = null;
+      this.imageWidth = 0;
+      this.imageHeight = 0;
+      this.totalPixels = 0;
+      this.requiredPixelCount = 0;
+      this.defacePixelCount = 0;
+      this.colorPalette = {};
+      this.allowedColorsSet = /* @__PURE__ */ new Set();
+      this.rgbToMeta = /* @__PURE__ */ new Map();
+      this.coords = [0, 0, 0, 0];
+      this.templateTiles = {};
+      this.templateTilesBuffers = {};
+      this.tilePrefixes = /* @__PURE__ */ new Set();
+    }
+    async load() {
+      return new Promise((resolve, reject) => {
+        this.img.onload = async () => {
+          try {
+            this.bitmap = await createImageBitmap(this.img);
+            this.imageWidth = this.bitmap.width;
+            this.imageHeight = this.bitmap.height;
+            this.totalPixels = this.imageWidth * this.imageHeight;
+            log(`[BLUE MARBLE] Imagen cargada: ${this.imageWidth}\xD7${this.imageHeight} = ${this.totalPixels.toLocaleString()} p\xEDxeles`);
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        };
+        this.img.onerror = reject;
+        this.img.src = this.imageSrc;
+      });
+    }
+    /**
+     * Inicializa la paleta de colores desde WPlace (como Blue Marble)
+     */
+    initializeColorPalette() {
+      log("[BLUE MARBLE] Inicializando paleta de colores...");
+      const availableColors = this.detectSiteColors();
+      const filteredColors = availableColors.filter((c) => c.name && c.name.toLowerCase() !== "transparent" && Array.isArray(c.rgb));
+      this.allowedColorsSet = new Set(
+        filteredColors.map((c) => `${c.rgb[0]},${c.rgb[1]},${c.rgb[2]}`)
+      );
+      const defaceKey = "222,250,206";
+      this.allowedColorsSet.add(defaceKey);
+      this.rgbToMeta = new Map(
+        availableColors.filter((c) => Array.isArray(c.rgb)).map((c) => [
+          `${c.rgb[0]},${c.rgb[1]},${c.rgb[2]}`,
+          {
+            id: c.id,
+            premium: !!c.premium,
+            name: c.name || `Color ${c.id}`
+          }
+        ])
+      );
+      try {
+        const transparent = availableColors.find((c) => c.name && c.name.toLowerCase() === "transparent");
+        if (transparent && Array.isArray(transparent.rgb)) {
+          this.rgbToMeta.set(defaceKey, {
+            id: transparent.id,
+            premium: !!transparent.premium,
+            name: transparent.name
+          });
+        }
+      } catch (_error) {
+      }
+      log(`[BLUE MARBLE] Paleta inicializada: ${this.allowedColorsSet.size} colores permitidos`);
+      return Array.from(availableColors);
+    }
+    /**
+     * Detecta colores disponibles del sitio (versión mejorada de Blue Marble)
+     */
+    detectSiteColors() {
+      const colorElements = document.querySelectorAll('[id^="color-"]');
+      const colors = [];
+      for (const element of colorElements) {
+        const idStr = element.id.replace("color-", "");
+        const id = parseInt(idStr);
+        if (element.querySelector("svg")) {
+          continue;
+        }
+        if (id === 0) {
+          continue;
+        }
+        const backgroundStyle = element.style.backgroundColor;
+        if (backgroundStyle) {
+          const rgbMatch = backgroundStyle.match(/\d+/g);
+          if (rgbMatch && rgbMatch.length >= 3) {
+            const rgb = [
+              parseInt(rgbMatch[0]),
+              parseInt(rgbMatch[1]),
+              parseInt(rgbMatch[2])
+            ];
+            const colorInfo = {
+              id,
+              element,
+              rgb,
+              name: element.title || element.getAttribute("aria-label") || `Color ${id}`,
+              premium: element.classList.contains("premium") || element.querySelector(".premium")
+            };
+            colors.push(colorInfo);
+          }
+        }
+      }
+      log(`[BLUE MARBLE] ${colors.length} colores detectados del sitio`);
+      return colors;
+    }
+    /**
+     * Establece las coordenadas de posición (como Blue Marble)
+     */
+    setCoords(tileX, tileY, pixelX, pixelY) {
+      this.coords = [tileX, tileY, pixelX, pixelY];
+      log(`[BLUE MARBLE] Coordenadas establecidas: tile(${tileX},${tileY}) pixel(${pixelX},${pixelY})`);
+    }
+    /**
+     * Analiza píxeles de la imagen y cuenta requeridos vs #deface (como Blue Marble)
+     */
+    async analyzePixels() {
+      if (!this.bitmap) {
+        throw new Error("Imagen no cargada. Llama a load() primero.");
+      }
+      log("[BLUE MARBLE] Analizando p\xEDxeles de la imagen...");
+      try {
+        const inspectCanvas = new OffscreenCanvas(this.imageWidth, this.imageHeight);
+        const inspectCtx = inspectCanvas.getContext("2d", { willReadFrequently: true });
+        inspectCtx.imageSmoothingEnabled = false;
+        inspectCtx.clearRect(0, 0, this.imageWidth, this.imageHeight);
+        inspectCtx.drawImage(this.bitmap, 0, 0);
+        const inspectData = inspectCtx.getImageData(0, 0, this.imageWidth, this.imageHeight).data;
+        let required = 0;
+        let deface = 0;
+        const paletteMap = /* @__PURE__ */ new Map();
+        for (let y = 0; y < this.imageHeight; y++) {
+          for (let x = 0; x < this.imageWidth; x++) {
+            const idx = (y * this.imageWidth + x) * 4;
+            const r = inspectData[idx];
+            const g = inspectData[idx + 1];
+            const b = inspectData[idx + 2];
+            const a = inspectData[idx + 3];
+            if (a === 0) continue;
+            const key = `${r},${g},${b}`;
+            if (r === 222 && g === 250 && b === 206) {
+              deface++;
+            }
+            let matchedKey = key;
+            let isValidPixel = this.allowedColorsSet.has(key);
+            if (!isValidPixel && this.allowedColorsSet.has("255,255,255")) {
+              if (r >= 245 && g >= 245 && b >= 245) {
+                matchedKey = "255,255,255";
+                isValidPixel = true;
+              }
+            }
+            if (!isValidPixel) continue;
+            required++;
+            paletteMap.set(matchedKey, (paletteMap.get(matchedKey) || 0) + 1);
+          }
+        }
+        this.requiredPixelCount = required;
+        this.defacePixelCount = deface;
+        const paletteObj = {};
+        for (const [key, count] of paletteMap.entries()) {
+          paletteObj[key] = { count, enabled: true };
+        }
+        this.colorPalette = paletteObj;
+        log(`[BLUE MARBLE] An\xE1lisis completado:`);
+        log(`  - P\xEDxeles requeridos: ${required.toLocaleString()}`);
+        log(`  - P\xEDxeles #deface: ${deface.toLocaleString()}`);
+        log(`  - Colores \xFAnicos: ${paletteMap.size}`);
+        return {
+          totalPixels: this.totalPixels,
+          requiredPixels: required,
+          defacePixels: deface,
+          uniqueColors: paletteMap.size,
+          colorPalette: paletteObj
+        };
+      } catch (_err) {
+        this.requiredPixelCount = Math.max(0, this.totalPixels);
+        this.defacePixelCount = 0;
+        log("[BLUE MARBLE] Fallback: usando total de p\xEDxeles como requeridos");
+        return {
+          totalPixels: this.totalPixels,
+          requiredPixels: this.totalPixels,
+          defacePixels: 0,
+          uniqueColors: 0,
+          colorPalette: {}
+        };
+      }
+    }
+    /**
+     * Crea tiles de template (proceso principal de Blue Marble)
+     */
+    async createTemplateTiles() {
+      if (!this.bitmap) {
+        throw new Error("Imagen no cargada. Llama a load() primero.");
+      }
+      log("[BLUE MARBLE] Creando tiles de template...");
+      const templateTiles = {};
+      const templateTilesBuffers = {};
+      const canvas = new OffscreenCanvas(this.tileSize, this.tileSize);
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      for (let pixelY = this.coords[3]; pixelY < this.imageHeight + this.coords[3]; ) {
+        const drawSizeY = Math.min(
+          this.tileSize - pixelY % this.tileSize,
+          this.imageHeight - (pixelY - this.coords[3])
+        );
+        for (let pixelX = this.coords[2]; pixelX < this.imageWidth + this.coords[2]; ) {
+          const drawSizeX = Math.min(
+            this.tileSize - pixelX % this.tileSize,
+            this.imageWidth - (pixelX - this.coords[2])
+          );
+          const canvasWidth = drawSizeX * this.shreadSize;
+          const canvasHeight = drawSizeY * this.shreadSize;
+          canvas.width = canvasWidth;
+          canvas.height = canvasHeight;
+          context.imageSmoothingEnabled = false;
+          context.clearRect(0, 0, canvasWidth, canvasHeight);
+          context.drawImage(
+            this.bitmap,
+            // Bitmap de imagen a dibujar
+            pixelX - this.coords[2],
+            // Coordenada X desde donde dibujar
+            pixelY - this.coords[3],
+            // Coordenada Y desde donde dibujar
+            drawSizeX,
+            // Ancho X a dibujar desde
+            drawSizeY,
+            // Alto Y a dibujar desde
+            0,
+            // Coordenada X donde dibujar
+            0,
+            // Coordenada Y donde dibujar
+            drawSizeX * this.shreadSize,
+            // Ancho X donde dibujar
+            drawSizeY * this.shreadSize
+            // Alto Y donde dibujar
+          );
+          const imageData = context.getImageData(0, 0, canvasWidth, canvasHeight);
+          for (let y = 0; y < canvasHeight; y++) {
+            for (let x = 0; x < canvasWidth; x++) {
+              const pixelIndex = (y * canvasWidth + x) * 4;
+              if (imageData.data[pixelIndex] === 222 && imageData.data[pixelIndex + 1] === 250 && imageData.data[pixelIndex + 2] === 206) {
+                if ((x + y) % 2 === 0) {
+                  imageData.data[pixelIndex] = 0;
+                  imageData.data[pixelIndex + 1] = 0;
+                  imageData.data[pixelIndex + 2] = 0;
+                } else {
+                  imageData.data[pixelIndex] = 255;
+                  imageData.data[pixelIndex + 1] = 255;
+                  imageData.data[pixelIndex + 2] = 255;
+                }
+                imageData.data[pixelIndex + 3] = 32;
+              } else if (x % this.shreadSize !== 1 || y % this.shreadSize !== 1) {
+                imageData.data[pixelIndex + 3] = 0;
+              } else {
+                const r = imageData.data[pixelIndex];
+                const g = imageData.data[pixelIndex + 1];
+                const b = imageData.data[pixelIndex + 2];
+                if (!this.allowedColorsSet.has(`${r},${g},${b}`)) {
+                  imageData.data[pixelIndex + 3] = 0;
+                }
+              }
+            }
+          }
+          context.putImageData(imageData, 0, 0);
+          const templateTileName = `${(this.coords[0] + Math.floor(pixelX / 1e3)).toString().padStart(4, "0")},${(this.coords[1] + Math.floor(pixelY / 1e3)).toString().padStart(4, "0")},${(pixelX % 1e3).toString().padStart(3, "0")},${(pixelY % 1e3).toString().padStart(3, "0")}`;
+          templateTiles[templateTileName] = await createImageBitmap(canvas);
+          this.tilePrefixes.add(templateTileName.split(",").slice(0, 2).join(","));
+          const canvasBlob = await canvas.convertToBlob();
+          const canvasBuffer = await canvasBlob.arrayBuffer();
+          templateTilesBuffers[templateTileName] = canvasBuffer;
+          pixelX += drawSizeX;
+        }
+        pixelY += drawSizeY;
+      }
+      this.templateTiles = templateTiles;
+      this.templateTilesBuffers = templateTilesBuffers;
+      log(`[BLUE MARBLE] Tiles creados: ${Object.keys(templateTiles).length} tiles`);
+      log(`[BLUE MARBLE] Prefijos registrados: ${this.tilePrefixes.size} tiles \xFAnicos`);
+      return { templateTiles, templateTilesBuffers };
+    }
+    /**
+     * Genera cola de píxeles para pintar (compatible con Auto-Image)
+     */
+    generatePixelQueue() {
+      if (!this.bitmap) {
+        throw new Error("Imagen no cargada. Llama a load() primero.");
+      }
+      log("[BLUE MARBLE] Generando cola de p\xEDxeles...");
+      const queue = [];
+      const baseX = this.coords[0] * 1e3 + (this.coords[2] || 0);
+      const baseY = this.coords[1] * 1e3 + (this.coords[3] || 0);
+      const readCanvas = new OffscreenCanvas(this.imageWidth, this.imageHeight);
+      const readCtx = readCanvas.getContext("2d", { willReadFrequently: true });
+      readCtx.imageSmoothingEnabled = false;
+      readCtx.drawImage(this.bitmap, 0, 0);
+      const pixelData = readCtx.getImageData(0, 0, this.imageWidth, this.imageHeight).data;
+      for (let y = 0; y < this.imageHeight; y++) {
+        for (let x = 0; x < this.imageWidth; x++) {
+          const idx = (y * this.imageWidth + x) * 4;
+          const r = pixelData[idx];
+          const g = pixelData[idx + 1];
+          const b = pixelData[idx + 2];
+          const alpha = pixelData[idx + 3];
+          if (alpha === 0) continue;
+          if (r === 222 && g === 250 && b === 206) continue;
+          const colorKey = `${r},${g},${b}`;
+          if (!this.allowedColorsSet.has(colorKey)) continue;
+          const globalX = baseX + x;
+          const globalY = baseY + y;
+          const tileX = Math.floor(globalX / 1e3);
+          const tileY = Math.floor(globalY / 1e3);
+          const localX = globalX % 1e3;
+          const localY = globalY % 1e3;
+          const colorMeta = this.rgbToMeta.get(colorKey) || { id: 0, name: "Unknown" };
+          queue.push({
+            // Coordenadas de imagen (relativas)
+            imageX: x,
+            imageY: y,
+            // Coordenadas globales
+            globalX,
+            globalY,
+            // Coordenadas de tile/local
+            tileX,
+            tileY,
+            localX,
+            localY,
+            // Información de color
+            color: {
+              r,
+              g,
+              b,
+              id: colorMeta.id,
+              name: colorMeta.name
+            },
+            originalColor: { r, g, b, alpha }
+          });
+        }
+      }
+      log(`[BLUE MARBLE] Cola generada: ${queue.length} p\xEDxeles v\xE1lidos`);
+      return queue;
+    }
+    /**
+     * Redimensiona la imagen (preserva proporciones por defecto)
+     */
+    async resize(newWidth, newHeight, keepAspectRatio = true) {
+      if (!this.img) {
+        throw new Error("Imagen no cargada. Llama a load() primero.");
+      }
+      const originalWidth = this.img.width;
+      const originalHeight = this.img.height;
+      if (keepAspectRatio) {
+        const aspectRatio = originalWidth / originalHeight;
+        if (newWidth / newHeight > aspectRatio) {
+          newWidth = newHeight * aspectRatio;
+        } else {
+          newHeight = newWidth / aspectRatio;
+        }
+      }
+      const tempCanvas = document.createElement("canvas");
+      tempCanvas.width = newWidth;
+      tempCanvas.height = newHeight;
+      const tempCtx = tempCanvas.getContext("2d");
+      tempCtx.imageSmoothingEnabled = false;
+      tempCtx.drawImage(this.img, 0, 0, newWidth, newHeight);
+      const newDataUrl = tempCanvas.toDataURL();
+      this.img.src = newDataUrl;
+      this.imageSrc = newDataUrl;
+      await new Promise((resolve) => {
+        this.img.onload = async () => {
+          this.bitmap = await createImageBitmap(this.img);
+          this.imageWidth = this.bitmap.width;
+          this.imageHeight = this.bitmap.height;
+          this.totalPixels = this.imageWidth * this.imageHeight;
+          resolve();
+        };
+      });
+      log(`[BLUE MARBLE] Imagen redimensionada: ${originalWidth}\xD7${originalHeight} \u2192 ${this.imageWidth}\xD7${this.imageHeight}`);
+      return {
+        width: this.imageWidth,
+        height: this.imageHeight
+      };
+    }
+    /**
+     * Obtiene información completa de la imagen procesada
+     */
+    getImageData() {
+      return {
+        width: this.imageWidth,
+        height: this.imageHeight,
+        totalPixels: this.totalPixels,
+        requiredPixels: this.requiredPixelCount,
+        defacePixels: this.defacePixelCount,
+        colorPalette: this.colorPalette,
+        coords: [...this.coords],
+        originalName: this.originalName || "image.png",
+        // Para compatibilidad con Auto-Image actual
+        pixels: this.generatePixelQueue()
+      };
+    }
+    /**
+     * Genera preview de la imagen
+     */
+    generatePreview(maxWidth = 200, maxHeight = 200) {
+      if (!this.img) return null;
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      const { width: origWidth, height: origHeight } = this.img;
+      const aspectRatio = origWidth / origHeight;
+      let newWidth, newHeight;
+      if (maxWidth / maxHeight > aspectRatio) {
+        newHeight = maxHeight;
+        newWidth = maxHeight * aspectRatio;
+      } else {
+        newWidth = maxWidth;
+        newHeight = maxWidth / aspectRatio;
+      }
+      canvas.width = newWidth;
+      canvas.height = newHeight;
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(this.img, 0, 0, newWidth, newHeight);
+      return canvas.toDataURL();
+    }
+    getDimensions() {
+      return {
+        width: this.imageWidth,
+        height: this.imageHeight
+      };
+    }
+  };
+
+  // src/core/timing.js
+  var sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  // src/core/wplace-api.js
+  var BASE = "https://backend.wplace.live";
+  async function getSession() {
+    var _a, _b, _c;
+    try {
+      const me = await fetch(`${BASE}/me`, { credentials: "include" }).then((r) => r.json());
+      const user = me || null;
+      const c = (me == null ? void 0 : me.charges) || {};
+      const charges = {
+        count: (_a = c.count) != null ? _a : 0,
+        // Mantener valor decimal original
+        max: (_b = c.max) != null ? _b : 0,
+        // Mantener valor original (puede variar por usuario)
+        cooldownMs: (_c = c.cooldownMs) != null ? _c : 3e4
+      };
+      return {
+        success: true,
+        data: {
+          user,
+          charges: charges.count,
+          maxCharges: charges.max,
+          chargeRegen: charges.cooldownMs
+        }
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message,
+        data: {
+          user: null,
+          charges: 0,
+          maxCharges: 0,
+          chargeRegen: 3e4
+        }
+      };
+    }
+  }
+  async function postPixelBatchImage(tileX, tileY, coords, colors, turnstileToken) {
+    try {
+      const body = JSON.stringify({
+        colors,
+        coords,
+        t: turnstileToken
+      });
+      const response = await fetch(`${BASE}/s0/pixel/${tileX}/${tileY}`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        body
+      });
+      let responseData = null;
+      try {
+        responseData = await response.json();
+      } catch {
+        responseData = {};
+      }
+      return {
+        status: response.status,
+        json: responseData,
+        success: response.ok,
+        painted: (responseData == null ? void 0 : responseData.painted) || 0
+      };
+    } catch (error) {
+      return {
+        status: 0,
+        json: { error: error.message },
+        success: false,
+        painted: 0
+      };
+    }
+  }
+
+  // src/core/turnstile.js
+  var loaded = false;
+  async function loadTurnstile() {
+    if (loaded || window.turnstile) return;
+    return new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+      s.async = true;
+      s.defer = true;
+      s.onload = () => {
+        loaded = true;
+        resolve();
+      };
+      s.onerror = () => reject(new Error("No se pudo cargar Turnstile"));
+      document.head.appendChild(s);
+    });
+  }
+  async function executeTurnstile(siteKey, action = "paint") {
+    var _a;
+    await loadTurnstile();
+    if (typeof ((_a = window.turnstile) == null ? void 0 : _a.execute) === "function") {
+      try {
+        const token = await window.turnstile.execute(siteKey, { action });
+        if (token && token.length > 20) return token;
+      } catch {
+      }
+    }
+    return await new Promise((resolve) => {
+      const host = document.createElement("div");
+      host.style.position = "fixed";
+      host.style.left = "-9999px";
+      document.body.appendChild(host);
+      window.turnstile.render(host, {
+        sitekey: siteKey,
+        callback: (t2) => {
+          document.body.removeChild(host);
+          resolve(t2);
+        }
+      });
+    });
+  }
+  async function getTurnstileToken(siteKey) {
+    return executeTurnstile(siteKey, "paint");
+  }
+  function detectSiteKey(fallback = "") {
+    var _a;
+    try {
+      const el = document.querySelector("[data-sitekey]");
+      if (el) {
+        const key = el.getAttribute("data-sitekey");
+        if (key && key.length > 10) return key;
+      }
+      const cf = document.querySelector(".cf-turnstile");
+      if (cf && ((_a = cf.dataset) == null ? void 0 : _a.sitekey) && cf.dataset.sitekey.length > 10) {
+        return cf.dataset.sitekey;
+      }
+      if (typeof window !== "undefined" && window.__TURNSTILE_SITEKEY && window.__TURNSTILE_SITEKEY.length > 10) {
+        return window.__TURNSTILE_SITEKEY;
+      }
+    } catch {
+    }
+    return fallback;
+  }
+
+  // src/image/painter.js
+  async function processImage(imageData, startPosition, onProgress, onComplete, onError) {
+    const { width, height } = imageData;
+    const { x: localStartX, y: localStartY } = startPosition;
+    log(`Iniciando pintado: imagen(${width}x${height}) inicio LOCAL(${localStartX},${localStartY}) tile(${imageState.tileX},${imageState.tileY})`);
+    if (!imageState.remainingPixels || imageState.remainingPixels.length === 0 || imageState.lastPosition.x === 0 && imageState.lastPosition.y === 0) {
+      log("Generando cola de p\xEDxeles...");
+      imageState.remainingPixels = generatePixelQueue(imageData, startPosition, imageState.tileX, imageState.tileY);
+      if (imageState.lastPosition.x > 0 || imageState.lastPosition.y > 0) {
+        imageState.remainingPixels = imageState.remainingPixels.filter((pixel) => {
+          const pixelIndex = pixel.imageY * width + pixel.imageX;
+          const lastIndex = imageState.lastPosition.y * width + imageState.lastPosition.x;
+          return pixelIndex >= lastIndex;
+        });
+      }
+      log(`Cola generada: ${imageState.remainingPixels.length} p\xEDxeles pendientes`);
+      try {
+        if (window.__WPA_PLAN_OVERLAY__) {
+          window.__WPA_PLAN_OVERLAY__.injectStyles();
+          window.__WPA_PLAN_OVERLAY__.setEnabled(true);
+          if (imageState.startPosition && imageState.tileX !== void 0 && imageState.tileY !== void 0) {
+            window.__WPA_PLAN_OVERLAY__.setAnchor({
+              tileX: imageState.tileX,
+              tileY: imageState.tileY,
+              pxX: imageState.startPosition.x,
+              pxY: imageState.startPosition.y
+            });
+          }
+          window.__WPA_PLAN_OVERLAY__.setPlan(imageState.remainingPixels, {
+            enabled: true,
+            nextBatchCount: imageState.pixelsPerBatch
+          });
+          log(`\u2705 Plan overlay actualizado con ${imageState.remainingPixels.length} p\xEDxeles en cola`);
+        }
+      } catch (e) {
+        log("\u26A0\uFE0F Error actualizando plan overlay:", e);
+      }
+    }
+    try {
+      while (imageState.remainingPixels.length > 0 && !imageState.stopFlag) {
+        let availableCharges = Math.floor(imageState.currentCharges);
+        let pixelsPerBatch;
+        if (imageState.isFirstBatch && imageState.useAllChargesFirst && availableCharges > 0) {
+          pixelsPerBatch = Math.min(availableCharges, imageState.remainingPixels.length);
+          imageState.isFirstBatch = false;
+          log(`Primera pasada: usando ${pixelsPerBatch} cargas de ${availableCharges} disponibles`);
+        } else {
+          pixelsPerBatch = Math.min(imageState.pixelsPerBatch, imageState.remainingPixels.length);
+        }
+        if (availableCharges < pixelsPerBatch) {
+          log(`Cargas insuficientes: ${availableCharges}/${pixelsPerBatch} necesarias`);
+          await waitForCooldown(pixelsPerBatch - availableCharges, onProgress);
+          availableCharges = Math.floor(imageState.currentCharges);
+          if (!imageState.isFirstBatch) {
+            pixelsPerBatch = Math.min(imageState.pixelsPerBatch, imageState.remainingPixels.length, availableCharges);
+          }
+          continue;
+        }
+        const batch = imageState.remainingPixels.splice(0, pixelsPerBatch);
+        log(`Pintando lote de ${batch.length} p\xEDxeles...`);
+        try {
+          if (window.__WPA_PLAN_OVERLAY__) {
+            window.__WPA_PLAN_OVERLAY__.setPlan(imageState.remainingPixels, {
+              enabled: true,
+              // Mantener habilitado
+              nextBatchCount: imageState.pixelsPerBatch
+            });
+          }
+        } catch (e) {
+          log("\u26A0\uFE0F Error actualizando plan overlay durante pintado:", e);
+        }
+        const result = await paintPixelBatchWithRetry(batch, onProgress);
+        if (result.success && result.painted > 0) {
+          imageState.paintedPixels += result.painted;
+          imageState.currentCharges = Math.max(0, imageState.currentCharges - result.painted);
+          log(`Cargas despu\xE9s del lote: ${imageState.currentCharges.toFixed(1)} (consumidas: ${result.painted})`);
+          if (batch.length > 0) {
+            const lastPixel = batch[batch.length - 1];
+            imageState.lastPosition = { x: lastPixel.imageX, y: lastPixel.imageY };
+          }
+          log(`Lote exitoso: ${result.painted}/${batch.length} p\xEDxeles pintados. Total: ${imageState.paintedPixels}/${imageState.totalPixels}`);
+          const estimatedTime = calculateEstimatedTime();
+          const progressPercent = (imageState.paintedPixels / imageState.totalPixels * 100).toFixed(1);
+          const successMessage = t("image.passCompleted", {
+            painted: result.painted,
+            percent: progressPercent,
+            current: imageState.paintedPixels,
+            total: imageState.totalPixels
+          });
+          if (onProgress) {
+            onProgress(imageState.paintedPixels, imageState.totalPixels, successMessage, estimatedTime);
+          }
+          await sleep(2e3);
+        } else if (result.shouldContinue) {
+          log(`Lote fall\xF3 despu\xE9s de todos los reintentos, continuando con siguiente lote...`);
+        } else {
+          imageState.remainingPixels.unshift(...batch);
+          log(`Lote fall\xF3: reintentando en 5 segundos...`);
+          await sleep(5e3);
+        }
+        await sleep(500);
+      }
+      if (imageState.stopFlag) {
+        log(`Pintado pausado en p\xEDxel imagen(${imageState.lastPosition.x},${imageState.lastPosition.y})`);
+        if (onComplete) {
+          onComplete(false, imageState.paintedPixels);
+        }
+      } else {
+        log(`Pintado completado: ${imageState.paintedPixels} p\xEDxeles pintados`);
+        imageState.lastPosition = { x: 0, y: 0 };
+        imageState.remainingPixels = [];
+        try {
+          if (window.__WPA_PLAN_OVERLAY__) {
+            window.__WPA_PLAN_OVERLAY__.setPlan([], {
+              enabled: true,
+              // Mantener habilitado pero sin píxeles
+              nextBatchCount: 0
+            });
+            log("\u2705 Plan overlay limpiado al completar pintado");
+          }
+        } catch (e) {
+          log("\u26A0\uFE0F Error limpiando plan overlay:", e);
+        }
+        if (onComplete) {
+          onComplete(true, imageState.paintedPixels);
+        }
+      }
+    } catch (error) {
+      log("Error en proceso de pintado:", error);
+      if (onError) {
+        onError(error);
+      }
+    }
+  }
+  async function paintPixelBatch(batch) {
+    var _a;
+    try {
+      if (!batch || batch.length === 0) {
+        return { success: false, painted: 0, error: "Lote vac\xEDo" };
+      }
+      const byTile = /* @__PURE__ */ new Map();
+      for (const p of batch) {
+        const key = `${p.tileX},${p.tileY}`;
+        if (!byTile.has(key)) byTile.set(key, { coords: [], colors: [], tx: p.tileX, ty: p.tileY });
+        const bucket = byTile.get(key);
+        bucket.coords.push(p.localX, p.localY);
+        bucket.colors.push(p.color.id || p.color.value || 1);
+      }
+      const siteKey = detectSiteKey(IMAGE_DEFAULTS.SITEKEY);
+      const token = await getTurnstileToken(siteKey);
+      let totalPainted = 0;
+      for (const { coords, colors, tx, ty } of byTile.values()) {
+        if (colors.length === 0) continue;
+        const sanitized = [];
+        for (let i = 0; i < coords.length; i += 2) {
+          const x = (Number(coords[i]) % 1e3 + 1e3) % 1e3;
+          const y = (Number(coords[i + 1]) % 1e3 + 1e3) % 1e3;
+          if (Number.isFinite(x) && Number.isFinite(y)) {
+            sanitized.push(x, y);
+          }
+        }
+        try {
+          let minX = 999, maxX = 0, minY = 999, maxY = 0;
+          for (let i = 0; i < sanitized.length; i += 2) {
+            const x = sanitized[i], y = sanitized[i + 1];
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+          }
+          log(`[IMG] Enviando tile ${tx},${ty}: ${colors.length} px | x:[${minX},${maxX}] y:[${minY},${maxY}]`);
+        } catch (e) {
+        }
+        const resp = await postPixelBatchImage(tx, ty, sanitized, colors, token);
+        if (resp.status !== 200) {
+          return {
+            success: false,
+            painted: totalPainted,
+            error: ((_a = resp.json) == null ? void 0 : _a.message) || `HTTP ${resp.status}`,
+            status: resp.status
+          };
+        }
+        totalPainted += resp.painted || 0;
+      }
+      return { success: true, painted: totalPainted };
+    } catch (error) {
+      log("Error en paintPixelBatch:", error);
+      return {
+        success: false,
+        painted: 0,
+        error: error.message
+      };
+    }
+  }
+  async function paintPixelBatchWithRetry(batch, onProgress) {
+    const maxAttempts = 5;
+    const baseDelay = 3e3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const result = await paintPixelBatch(batch);
+        if (result.success) {
+          imageState.retryCount = 0;
+          return result;
+        }
+        imageState.retryCount = attempt;
+        if (attempt < maxAttempts) {
+          const delay = baseDelay * Math.pow(2, attempt - 1);
+          const delaySeconds = Math.round(delay / 1e3);
+          let errorMessage;
+          if (result.status === 0 || result.status === "NetworkError") {
+            errorMessage = t("image.networkError");
+          } else if (result.status >= 500) {
+            errorMessage = t("image.serverError");
+          } else if (result.status === 408) {
+            errorMessage = t("image.timeoutError");
+          } else {
+            errorMessage = t("image.retryAttempt", {
+              attempt,
+              maxAttempts,
+              delay: delaySeconds
+            });
+          }
+          if (onProgress) {
+            onProgress(imageState.paintedPixels, imageState.totalPixels, errorMessage);
+          }
+          log(`Reintento ${attempt}/${maxAttempts} despu\xE9s de ${delaySeconds}s. Error: ${result.error}`);
+          await sleep(delay);
+        }
+      } catch (error) {
+        log(`Error en intento ${attempt}:`, error);
+        imageState.retryCount = attempt;
+        if (attempt < maxAttempts) {
+          const delay = baseDelay * Math.pow(2, attempt - 1);
+          const delaySeconds = Math.round(delay / 1e3);
+          const errorMessage = t("image.retryError", {
+            attempt,
+            maxAttempts,
+            delay: delaySeconds
+          });
+          if (onProgress) {
+            onProgress(imageState.paintedPixels, imageState.totalPixels, errorMessage);
+          }
+          await sleep(delay);
+        }
+      }
+    }
+    imageState.retryCount = maxAttempts;
+    const failMessage = t("image.retryFailed", { maxAttempts });
+    if (onProgress) {
+      onProgress(imageState.paintedPixels, imageState.totalPixels, failMessage);
+    }
+    log(`Fall\xF3 despu\xE9s de ${maxAttempts} intentos, continuando con siguiente lote`);
+    return {
+      success: false,
+      painted: 0,
+      error: `Fall\xF3 despu\xE9s de ${maxAttempts} intentos`,
+      shouldContinue: true
+      // Indica que debe continuar con el siguiente lote
+    };
+  }
+  async function waitForCooldown(chargesNeeded, onProgress) {
+    const chargeTime = IMAGE_DEFAULTS.CHARGE_REGEN_MS * chargesNeeded;
+    const waitTime = chargeTime + 5e3;
+    log(`Esperando ${Math.round(waitTime / 1e3)}s para obtener ${chargesNeeded} cargas`);
+    imageState.inCooldown = true;
+    imageState.cooldownEndTime = Date.now() + waitTime;
+    imageState.nextBatchCooldown = Math.round(waitTime / 1e3);
+    if (onProgress) {
+      const minutes = Math.floor(waitTime / 6e4);
+      const seconds = Math.floor(waitTime % 6e4 / 1e3);
+      const timeText = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+      const message = t("image.waitingChargesRegen", {
+        current: Math.floor(imageState.currentCharges),
+        needed: chargesNeeded,
+        time: timeText
+      });
+      onProgress(imageState.paintedPixels, imageState.totalPixels, message);
+    }
+    for (let i = Math.round(waitTime / 1e3); i > 0; i--) {
+      if (imageState.stopFlag) break;
+      imageState.nextBatchCooldown = i;
+      if (onProgress && (i % 5 === 0 || i <= 10 || i === Math.round(waitTime / 1e3))) {
+        const minutes = Math.floor(i / 60);
+        const seconds = i % 60;
+        const timeText = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+        const message = t("image.waitingChargesCountdown", {
+          current: Math.floor(imageState.currentCharges),
+          needed: chargesNeeded,
+          time: timeText
+        });
+        onProgress(imageState.paintedPixels, imageState.totalPixels, message);
+      }
+      await sleep(1e3);
+    }
+    imageState.inCooldown = false;
+    imageState.nextBatchCooldown = 0;
+    imageState.currentCharges = Math.min(
+      imageState.maxCharges || 50,
+      // usar maxCharges del estado
+      imageState.currentCharges + waitTime / IMAGE_DEFAULTS.CHARGE_REGEN_MS
+    );
+  }
+  function generatePixelQueue(imageData, startPosition, baseTileX, baseTileY) {
+    const { pixels } = imageData;
+    const { x: localStartX, y: localStartY } = startPosition;
+    const queue = [];
+    if (!Array.isArray(pixels)) {
+      log(`\u274C Error: pixels no es un array iterable. Tipo: ${typeof pixels}`, pixels);
+      return [];
+    }
+    for (const pixelData of pixels) {
+      if (!pixelData) continue;
+      const pixelX = pixelData.imageX !== void 0 ? pixelData.imageX : pixelData.x;
+      const pixelY = pixelData.imageY !== void 0 ? pixelData.imageY : pixelData.y;
+      const pixelColor = pixelData.color !== void 0 ? pixelData.color : pixelData.targetColor;
+      if (pixelX === void 0 || pixelY === void 0) {
+        log(`\u26A0\uFE0F P\xEDxel con coordenadas inv\xE1lidas:`, pixelData);
+        continue;
+      }
+      const globalX = localStartX + pixelX;
+      const globalY = localStartY + pixelY;
+      const tileOffsetX = Math.floor(globalX / 1e3);
+      const tileOffsetY = Math.floor(globalY / 1e3);
+      const tx = baseTileX + tileOffsetX;
+      const ty = baseTileY + tileOffsetY;
+      const localX = (globalX % 1e3 + 1e3) % 1e3;
+      const localY = (globalY % 1e3 + 1e3) % 1e3;
+      queue.push({
+        imageX: pixelX,
+        imageY: pixelY,
+        localX,
+        localY,
+        tileX: tx,
+        tileY: ty,
+        color: pixelColor,
+        originalColor: pixelData.originalColor
+      });
+    }
+    log(`Cola de p\xEDxeles generada: ${queue.length} p\xEDxeles para pintar`);
+    return queue;
+  }
+  function calculateEstimatedTime() {
+    if (!imageState.remainingPixels || imageState.remainingPixels.length === 0) {
+      return 0;
+    }
+    const remainingPixels = imageState.remainingPixels.length;
+    const batchSize = imageState.pixelsPerBatch;
+    const chargeRegenTime = IMAGE_DEFAULTS.CHARGE_REGEN_MS / 1e3;
+    const batchesNeeded = Math.ceil(remainingPixels / batchSize);
+    const waitTimeBetweenBatches = batchSize * chargeRegenTime;
+    const totalWaitTime = (batchesNeeded - 1) * waitTimeBetweenBatches;
+    const executionTime = batchesNeeded * 2;
+    return Math.ceil(totalWaitTime + executionTime);
+  }
+  function stopPainting() {
+    imageState.stopFlag = true;
+    imageState.running = false;
+    log("\u{1F6D1} Deteniendo proceso de pintado...");
+  }
+
+  // src/image/save-load.js
+  function saveProgress(filename = null) {
+    try {
+      if (!imageState.imageData || imageState.paintedPixels === 0) {
+        throw new Error("No hay progreso para guardar");
+      }
+      const progressData = {
+        version: "1.0",
+        timestamp: Date.now(),
+        imageData: {
+          width: imageState.imageData.width,
+          height: imageState.imageData.height,
+          originalName: imageState.originalImageName
+        },
+        progress: {
+          paintedPixels: imageState.paintedPixels,
+          totalPixels: imageState.totalPixels,
+          lastPosition: { ...imageState.lastPosition }
+        },
+        position: {
+          startPosition: { ...imageState.startPosition },
+          tileX: imageState.tileX,
+          tileY: imageState.tileY
+        },
+        config: {
+          pixelsPerBatch: imageState.pixelsPerBatch,
+          useAllChargesFirst: imageState.useAllChargesFirst,
+          isFirstBatch: imageState.isFirstBatch,
+          maxCharges: imageState.maxCharges
+        },
+        // Filtrar solo los datos serializables de los colores (sin elementos DOM)
+        colors: imageState.availableColors.map((color) => ({
+          id: color.id,
+          r: color.r,
+          g: color.g,
+          b: color.b
+        })),
+        remainingPixels: imageState.remainingPixels || []
+      };
+      const dataStr = JSON.stringify(progressData, null, 2);
+      const blob = new window.Blob([dataStr], { type: "application/json" });
+      const finalFilename = filename || `wplace_progress_${imageState.originalImageName || "image"}_${(/* @__PURE__ */ new Date()).toISOString().slice(0, 19).replace(/:/g, "-")}.json`;
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = finalFilename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+      log(`\u2705 Progreso guardado: ${finalFilename}`);
+      return { success: true, filename: finalFilename };
+    } catch (error) {
+      log("\u274C Error guardando progreso:", error);
+      return { success: false, error: error.message };
+    }
+  }
+  async function loadProgress(file) {
+    return new Promise((resolve) => {
+      try {
+        const reader = new window.FileReader();
+        reader.onload = (e) => {
+          try {
+            const progressData = JSON.parse(e.target.result);
+            const requiredFields = ["imageData", "progress", "position", "colors"];
+            const missingFields = requiredFields.filter((field) => !(field in progressData));
+            if (missingFields.length > 0) {
+              throw new Error(`Campos requeridos faltantes: ${missingFields.join(", ")}`);
+            }
+            if (imageState.availableColors.length > 0) {
+              const savedColorIds = progressData.colors.map((c) => c.id);
+              const currentColorIds = imageState.availableColors.map((c) => c.id);
+              const commonColors = savedColorIds.filter((id) => currentColorIds.includes(id));
+              if (commonColors.length < savedColorIds.length * 0.8) {
+                log("\u26A0\uFE0F Los colores guardados no coinciden completamente con los actuales");
+              }
+            }
+            imageState.imageData = {
+              ...progressData.imageData,
+              pixels: []
+              // Los píxeles se regenerarán si es necesario
+            };
+            imageState.paintedPixels = progressData.progress.paintedPixels;
+            imageState.totalPixels = progressData.progress.totalPixels;
+            if (progressData.progress.lastPosition) {
+              imageState.lastPosition = progressData.progress.lastPosition;
+            } else if (progressData.position.lastX !== void 0 && progressData.position.lastY !== void 0) {
+              imageState.lastPosition = { x: progressData.position.lastX, y: progressData.position.lastY };
+            }
+            if (progressData.position.startPosition) {
+              imageState.startPosition = progressData.position.startPosition;
+            } else if (progressData.position.startX !== void 0 && progressData.position.startY !== void 0) {
+              imageState.startPosition = { x: progressData.position.startX, y: progressData.position.startY };
+            }
+            imageState.tileX = progressData.position.tileX;
+            imageState.tileY = progressData.position.tileY;
+            imageState.originalImageName = progressData.imageData.originalName;
+            imageState.remainingPixels = progressData.remainingPixels || progressData.progress.remainingPixels || [];
+            try {
+              if (window.__WPA_PLAN_OVERLAY__) {
+                window.__WPA_PLAN_OVERLAY__.injectStyles();
+                window.__WPA_PLAN_OVERLAY__.setEnabled(true);
+                if (imageState.startPosition && imageState.tileX !== void 0 && imageState.tileY !== void 0) {
+                  window.__WPA_PLAN_OVERLAY__.setAnchor({
+                    tileX: imageState.tileX,
+                    tileY: imageState.tileY,
+                    pxX: imageState.startPosition.x,
+                    pxY: imageState.startPosition.y
+                  });
+                  log(`\u2705 Plan overlay anclado con posici\xF3n cargada: tile(${imageState.tileX},${imageState.tileY}) local(${imageState.startPosition.x},${imageState.startPosition.y})`);
+                }
+                window.__WPA_PLAN_OVERLAY__.setPlan(imageState.remainingPixels, {
+                  enabled: true,
+                  nextBatchCount: imageState.pixelsPerBatch
+                });
+                log(`\u2705 Plan overlay activado con ${imageState.remainingPixels.length} p\xEDxeles restantes`);
+              }
+            } catch (e2) {
+              log("\u26A0\uFE0F Error activando plan overlay al cargar progreso:", e2);
+            }
+            if (progressData.config) {
+              imageState.pixelsPerBatch = progressData.config.pixelsPerBatch || imageState.pixelsPerBatch;
+              imageState.useAllChargesFirst = progressData.config.useAllChargesFirst !== void 0 ? progressData.config.useAllChargesFirst : imageState.useAllChargesFirst;
+              imageState.isFirstBatch = progressData.config.isFirstBatch !== void 0 ? progressData.config.isFirstBatch : true;
+              imageState.maxCharges = progressData.config.maxCharges || imageState.maxCharges;
+            }
+            imageState.imageLoaded = true;
+            imageState.colorsChecked = true;
+            log(`\u2705 Progreso cargado: ${imageState.paintedPixels}/${imageState.totalPixels} p\xEDxeles`);
+            resolve({
+              success: true,
+              data: progressData,
+              painted: imageState.paintedPixels,
+              total: imageState.totalPixels,
+              canContinue: imageState.remainingPixels.length > 0
+            });
+          } catch (parseError) {
+            log("\u274C Error parseando archivo de progreso:", parseError);
+            resolve({ success: false, error: parseError.message });
+          }
+        };
+        reader.onerror = () => {
+          const error = "Error leyendo archivo";
+          log("\u274C", error);
+          resolve({ success: false, error });
+        };
+        reader.readAsText(file);
+      } catch (error) {
+        log("\u274C Error cargando progreso:", error);
+        resolve({ success: false, error: error.message });
+      }
+    });
+  }
+  function clearProgress() {
+    imageState.paintedPixels = 0;
+    imageState.totalPixels = 0;
+    imageState.lastPosition = { x: 0, y: 0 };
+    imageState.remainingPixels = [];
+    imageState.imageData = null;
+    imageState.startPosition = null;
+    imageState.imageLoaded = false;
+    imageState.originalImageName = null;
+    imageState.isFirstBatch = true;
+    imageState.nextBatchCooldown = 0;
+    log("\u{1F9F9} Progreso limpiado");
+  }
+  function hasProgress() {
+    return imageState.imageLoaded && imageState.paintedPixels > 0 && imageState.remainingPixels && imageState.remainingPixels.length > 0;
+  }
+  function getProgressInfo() {
+    return {
+      hasProgress: hasProgress(),
+      painted: imageState.paintedPixels,
+      total: imageState.totalPixels,
+      remaining: imageState.remainingPixels ? imageState.remainingPixels.length : 0,
+      percentage: imageState.totalPixels > 0 ? imageState.paintedPixels / imageState.totalPixels * 100 : 0,
+      lastPosition: { ...imageState.lastPosition },
+      canContinue: hasProgress()
+    };
+  }
+
+  // src/core/ui-utils.js
+  function createShadowRoot(hostId = null) {
+    const host = document.createElement("div");
+    if (hostId) {
+      host.id = hostId;
+    }
+    host.style.cssText = `
     position: fixed;
     top: 10px;
     right: 10px;
     z-index: 2147483647;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  `;let s=t.attachShadow({mode:"open"});return document.body.appendChild(t),{host:t,root:s}}function pe(l,t){let s=0,a=0,i=0,c=0;l.style.cursor="move",l.addEventListener("mousedown",g);function g(r){r.target.closest(".header-btn, .wplace-header-btn")||(r.preventDefault(),i=r.clientX,c=r.clientY,document.addEventListener("mouseup",p),document.addEventListener("mousemove",o))}function o(r){r.preventDefault(),s=i-r.clientX,a=c-r.clientY,i=r.clientX,c=r.clientY,t.style.top=t.offsetTop-a+"px",t.style.left=t.offsetLeft-s+"px"}function p(){document.removeEventListener("mouseup",p),document.removeEventListener("mousemove",o)}}async function me({texts:l,...t}){if(d("\u{1F3A8} Creando interfaz de Auto-Image"),!document.querySelector('link[href*="font-awesome"]')){let x=document.createElement("link");x.rel="stylesheet",x.href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css",document.head.appendChild(x),d("\u{1F4E6} FontAwesome a\xF1adido al document.head")}let{host:s,root:a}=ge(),i=document.createElement("style");i.textContent=`
+  `;
+    const root = host.attachShadow({ mode: "open" });
+    document.body.appendChild(host);
+    return { host, root };
+  }
+  function makeDraggable(dragHandle, element) {
+    let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    dragHandle.style.cursor = "move";
+    dragHandle.addEventListener("mousedown", dragMouseDown);
+    function dragMouseDown(e) {
+      if (e.target.closest(".header-btn, .wplace-header-btn")) return;
+      e.preventDefault();
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      document.addEventListener("mouseup", closeDragElement);
+      document.addEventListener("mousemove", elementDrag);
+    }
+    function elementDrag(e) {
+      e.preventDefault();
+      pos1 = pos3 - e.clientX;
+      pos2 = pos4 - e.clientY;
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      element.style.top = element.offsetTop - pos2 + "px";
+      element.style.left = element.offsetLeft - pos1 + "px";
+    }
+    function closeDragElement() {
+      document.removeEventListener("mouseup", closeDragElement);
+      document.removeEventListener("mousemove", elementDrag);
+    }
+  }
+
+  // src/image/ui.js
+  async function createImageUI({ texts, ...handlers }) {
+    log("\u{1F3A8} Creando interfaz de Auto-Image");
+    if (!document.querySelector('link[href*="font-awesome"]')) {
+      const fontAwesome = document.createElement("link");
+      fontAwesome.rel = "stylesheet";
+      fontAwesome.href = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css";
+      document.head.appendChild(fontAwesome);
+      log("\u{1F4E6} FontAwesome a\xF1adido al document.head");
+    }
+    const { host, root } = createShadowRoot();
+    const style = document.createElement("style");
+    style.textContent = `
     @keyframes slideIn {
       from { transform: translateY(20px); opacity: 0; }
       to { transform: translateY(0); opacity: 1; }
@@ -408,17 +3267,21 @@
       gap: 10px;
       margin-top: 15px;
     }
-  `,a.appendChild(i);let c=document.createElement("div");c.className="container",c.innerHTML=`
+  `;
+    root.appendChild(style);
+    const container = document.createElement("div");
+    container.className = "container";
+    container.innerHTML = `
     <div class="header">
       <div class="header-title">
         \u{1F5BC}\uFE0F
-        <span>${l.title}</span>
+        <span>${texts.title}</span>
       </div>
       <div class="header-controls">
         <button class="header-btn config-btn" title="Configuraci\xF3n">
           \u2699\uFE0F
         </button>
-        <button class="header-btn minimize-btn" title="${l.minimize}">
+        <button class="header-btn minimize-btn" title="${texts.minimize}">
           \u2796
         </button>
       </div>
@@ -426,19 +3289,19 @@
     <div class="content">
       <div class="config-panel">
         <div class="config-item">
-          <label>${l.batchSize}:</label>
+          <label>${texts.batchSize}:</label>
           <input class="config-input pixels-per-batch" type="number" min="1" max="50" value="20">
         </div>
         <div class="config-item">
           <label>
             <input class="config-checkbox use-all-charges" type="checkbox" checked>
-            ${l.useAllCharges}
+            ${texts.useAllCharges}
           </label>
         </div>
         <div class="config-item">
           <label>
             <input class="config-checkbox show-overlay" type="checkbox" checked>
-            ${l.showOverlay||"Mostrar overlay"}
+            ${texts.showOverlay || "Mostrar overlay"}
           </label>
         </div>
       </div>
@@ -447,11 +3310,11 @@
       <div class="main-config">
         <div class="config-row">
           <div class="config-label">
-            \u{1F3AF} ${l.batchSize}:
+            \u{1F3AF} ${texts.batchSize}:
             <span class="batch-value">20</span>
           </div>
           <div class="config-label">
-            \u23F1\uFE0F ${l.nextBatchTime}:
+            \u23F1\uFE0F ${texts.nextBatchTime}:
             <span class="cooldown-value">--</span>
           </div>
         </div>
@@ -460,31 +3323,31 @@
       <div class="controls">
         <button class="btn btn-primary init-btn">
           \u{1F916}
-          <span>${l.initBot}</span>
+          <span>${texts.initBot}</span>
         </button>
         <button class="btn btn-upload upload-btn" disabled>
           \u{1F4E4}
-          <span>${l.uploadImage}</span>
+          <span>${texts.uploadImage}</span>
         </button>
         <button class="btn btn-load load-progress-btn" disabled>
           \u{1F4C1}
-          <span>${l.loadProgress}</span>
+          <span>${texts.loadProgress}</span>
         </button>
         <button class="btn btn-primary resize-btn" disabled>
           \u{1F504}
-          <span>${l.resizeImage}</span>
+          <span>${texts.resizeImage}</span>
         </button>
         <button class="btn btn-select select-pos-btn" disabled>
           \u{1F3AF}
-          <span>${l.selectPosition}</span>
+          <span>${texts.selectPosition}</span>
         </button>
         <button class="btn btn-start start-btn" disabled>
           \u25B6\uFE0F
-          <span>${l.startPainting}</span>
+          <span>${texts.startPainting}</span>
         </button>
         <button class="btn btn-stop stop-btn" disabled>
           \u23F9\uFE0F
-          <span>${l.stopPainting}</span>
+          <span>${texts.stopPainting}</span>
         </button>
       </div>
       
@@ -495,73 +3358,1301 @@
       <div class="stats">
         <div class="stats-area">
           <div class="stat-item">
-            <div class="stat-label">\u2139\uFE0F ${l.initMessage}</div>
+            <div class="stat-label">\u2139\uFE0F ${texts.initMessage}</div>
           </div>
         </div>
       </div>
       
       <div class="status status-default">
-        ${l.waitingInit}
+        ${texts.waitingInit}
       </div>
     </div>
-  `,a.appendChild(c);let g=document.createElement("input");g.type="file",g.accept="image/png,image/jpeg",g.style.display="none",a.appendChild(g);let o=document.createElement("input");o.type="file",o.accept=".json",o.style.display="none",a.appendChild(o);let p=document.createElement("div");p.className="resize-overlay",a.appendChild(p);let r=document.createElement("div");r.className="resize-container",r.innerHTML=`
-    <h3>${l.resizeImage}</h3>
+  `;
+    root.appendChild(container);
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.accept = "image/png,image/jpeg";
+    fileInput.style.display = "none";
+    root.appendChild(fileInput);
+    const progressFileInput = document.createElement("input");
+    progressFileInput.type = "file";
+    progressFileInput.accept = ".json";
+    progressFileInput.style.display = "none";
+    root.appendChild(progressFileInput);
+    const resizeOverlay = document.createElement("div");
+    resizeOverlay.className = "resize-overlay";
+    root.appendChild(resizeOverlay);
+    const resizeContainer = document.createElement("div");
+    resizeContainer.className = "resize-container";
+    resizeContainer.innerHTML = `
+    <h3>${texts.resizeImage}</h3>
     <div class="resize-controls">
       <label>
-        ${l.width}: <span class="width-value">0</span>px
+        ${texts.width}: <span class="width-value">0</span>px
         <input type="range" class="resize-slider width-slider" min="10" max="500" value="100">
       </label>
       <label>
-        ${l.height}: <span class="height-value">0</span>px
+        ${texts.height}: <span class="height-value">0</span>px
         <input type="range" class="resize-slider height-slider" min="10" max="500" value="100">
       </label>
       <label>
         <input type="checkbox" class="keep-aspect" checked>
-        ${l.keepAspect}
+        ${texts.keepAspect}
       </label>
       <img class="resize-preview" src="" alt="Preview">
       <div class="resize-buttons">
         <button class="btn btn-primary confirm-resize">
           \u2705
-          <span>${l.apply}</span>
+          <span>${texts.apply}</span>
         </button>
         <button class="btn btn-stop cancel-resize">
           \u274C
-          <span>${l.cancel}</span>
+          <span>${texts.cancel}</span>
         </button>
       </div>
     </div>
-  `,a.appendChild(r);let n={header:c.querySelector(".header"),configBtn:c.querySelector(".config-btn"),minimizeBtn:c.querySelector(".minimize-btn"),configPanel:c.querySelector(".config-panel"),pixelsPerBatch:c.querySelector(".pixels-per-batch"),useAllCharges:c.querySelector(".use-all-charges"),showOverlay:c.querySelector(".show-overlay"),batchValue:c.querySelector(".batch-value"),cooldownValue:c.querySelector(".cooldown-value"),initBtn:c.querySelector(".init-btn"),uploadBtn:c.querySelector(".upload-btn"),loadProgressBtn:c.querySelector(".load-progress-btn"),resizeBtn:c.querySelector(".resize-btn"),selectPosBtn:c.querySelector(".select-pos-btn"),startBtn:c.querySelector(".start-btn"),stopBtn:c.querySelector(".stop-btn"),progressBar:c.querySelector(".progress-bar"),statsArea:c.querySelector(".stats-area"),status:c.querySelector(".status"),content:c.querySelector(".content")},u={overlay:p,container:r,widthSlider:r.querySelector(".width-slider"),heightSlider:r.querySelector(".height-slider"),widthValue:r.querySelector(".width-value"),heightValue:r.querySelector(".height-value"),keepAspect:r.querySelector(".keep-aspect"),preview:r.querySelector(".resize-preview"),confirmBtn:r.querySelector(".confirm-resize"),cancelBtn:r.querySelector(".cancel-resize")},m={minimized:!1,configVisible:!1};pe(n.header,c),n.minimizeBtn.addEventListener("click",()=>{m.minimized=!m.minimized,m.minimized?(c.classList.add("minimized"),n.minimizeBtn.innerHTML="\u{1F53C}"):(c.classList.remove("minimized"),n.minimizeBtn.innerHTML="\u{1F53D}")}),n.configBtn.addEventListener("click",()=>{m.configVisible=!m.configVisible,m.configVisible?(n.configPanel.classList.add("visible"),n.configBtn.innerHTML="\u274C"):(n.configPanel.classList.remove("visible"),n.configBtn.innerHTML="\u2699\uFE0F")}),n.pixelsPerBatch.addEventListener("change",()=>{let x=parseInt(n.pixelsPerBatch.value)||20;n.batchValue.textContent=x,t.onConfigChange&&t.onConfigChange({pixelsPerBatch:x})}),n.useAllCharges.addEventListener("change",()=>{t.onConfigChange&&t.onConfigChange({useAllCharges:n.useAllCharges.checked})});function y(){n.uploadBtn.disabled=!1,n.loadProgressBtn.disabled=!1}n.initBtn.addEventListener("click",async()=>{n.initBtn.disabled=!0,t.onInitBot&&await t.onInitBot()&&y(),n.initBtn.disabled=!1}),n.uploadBtn.addEventListener("click",()=>{g.click()}),g.addEventListener("change",async()=>{g.files.length>0&&t.onUploadImage&&await t.onUploadImage(g.files[0])&&(n.selectPosBtn.disabled=!1,n.resizeBtn.disabled=!1)}),n.loadProgressBtn.addEventListener("click",()=>{o.click()}),o.addEventListener("change",async()=>{o.files.length>0&&t.onLoadProgress&&await t.onLoadProgress(o.files[0])&&(n.selectPosBtn.disabled=!1,n.startBtn.disabled=!1,n.resizeBtn.disabled=!1)}),n.resizeBtn.addEventListener("click",()=>{t.onResizeImage&&t.onResizeImage()}),n.selectPosBtn.addEventListener("click",async()=>{t.onSelectPosition&&(n.selectPosBtn.disabled=!0,await t.onSelectPosition()&&(n.startBtn.disabled=!1),n.selectPosBtn.disabled=!1)}),n.showOverlay.addEventListener("change",()=>{if(!window.__WPA_PLAN_OVERLAY__)return;window.__WPA_PLAN_OVERLAY__.injectStyles();let x=n.showOverlay.checked;window.__WPA_PLAN_OVERLAY__.setEnabled(x)}),n.startBtn.addEventListener("click",async()=>{t.onStartPainting&&(n.startBtn.disabled=!0,n.stopBtn.disabled=!1,await t.onStartPainting()||(n.startBtn.disabled=!1,n.stopBtn.disabled=!0))}),n.stopBtn.addEventListener("click",async()=>{t.onStopPainting&&await t.onStopPainting()&&(n.startBtn.disabled=!1,n.stopBtn.disabled=!0)});function v(x,A="default"){n.status.textContent=x,n.status.className=`status status-${A}`,n.status.style.animation="none",n.status.offsetWidth,n.status.style.animation="slideIn 0.3s ease-out"}function h(x){let{width:A,height:I}=x.getDimensions(),_=A/I;u.widthSlider.value=A,u.heightSlider.value=I,u.widthValue.textContent=A,u.heightValue.textContent=I,u.preview.src=x.img.src,u.overlay.style.display="block",u.container.style.display="block";let B=()=>{let R=parseInt(u.widthSlider.value),z=parseInt(u.heightSlider.value);u.widthValue.textContent=R,u.heightValue.textContent=z,u.preview.src=x.generatePreview(R,z)},O=()=>{if(u.keepAspect.checked){let R=parseInt(u.widthSlider.value),z=Math.round(R/_);u.heightSlider.value=z}B()},F=()=>{if(u.keepAspect.checked){let R=parseInt(u.heightSlider.value),z=Math.round(R*_);u.widthSlider.value=z}B()};u.widthSlider.addEventListener("input",O),u.heightSlider.addEventListener("input",F);let Y=()=>{let R=parseInt(u.widthSlider.value),z=parseInt(u.heightSlider.value);t.onConfirmResize&&t.onConfirmResize(x,R,z),f()},D=()=>{f()};u.confirmBtn.addEventListener("click",Y),u.cancelBtn.addEventListener("click",D),u.overlay.addEventListener("click",D),window.cleanupResizeDialog=()=>{u.widthSlider.removeEventListener("input",O),u.heightSlider.removeEventListener("input",F),u.confirmBtn.removeEventListener("click",Y),u.cancelBtn.removeEventListener("click",D),u.overlay.removeEventListener("click",D)},B()}function f(){u.overlay.style.display="none",u.container.style.display="none",window.cleanupResizeDialog&&(window.cleanupResizeDialog(),delete window.cleanupResizeDialog)}function P(x,A,I=null){let _=A>0?x/A*100:0;n.progressBar.style.width=`${_}%`;let B=`
+  `;
+    root.appendChild(resizeContainer);
+    const elements = {
+      header: container.querySelector(".header"),
+      configBtn: container.querySelector(".config-btn"),
+      minimizeBtn: container.querySelector(".minimize-btn"),
+      configPanel: container.querySelector(".config-panel"),
+      pixelsPerBatch: container.querySelector(".pixels-per-batch"),
+      useAllCharges: container.querySelector(".use-all-charges"),
+      showOverlay: container.querySelector(".show-overlay"),
+      batchValue: container.querySelector(".batch-value"),
+      cooldownValue: container.querySelector(".cooldown-value"),
+      initBtn: container.querySelector(".init-btn"),
+      uploadBtn: container.querySelector(".upload-btn"),
+      loadProgressBtn: container.querySelector(".load-progress-btn"),
+      resizeBtn: container.querySelector(".resize-btn"),
+      selectPosBtn: container.querySelector(".select-pos-btn"),
+      startBtn: container.querySelector(".start-btn"),
+      stopBtn: container.querySelector(".stop-btn"),
+      progressBar: container.querySelector(".progress-bar"),
+      statsArea: container.querySelector(".stats-area"),
+      status: container.querySelector(".status"),
+      content: container.querySelector(".content")
+    };
+    const resizeElements = {
+      overlay: resizeOverlay,
+      container: resizeContainer,
+      widthSlider: resizeContainer.querySelector(".width-slider"),
+      heightSlider: resizeContainer.querySelector(".height-slider"),
+      widthValue: resizeContainer.querySelector(".width-value"),
+      heightValue: resizeContainer.querySelector(".height-value"),
+      keepAspect: resizeContainer.querySelector(".keep-aspect"),
+      preview: resizeContainer.querySelector(".resize-preview"),
+      confirmBtn: resizeContainer.querySelector(".confirm-resize"),
+      cancelBtn: resizeContainer.querySelector(".cancel-resize")
+    };
+    let state = {
+      minimized: false,
+      configVisible: false
+    };
+    makeDraggable(elements.header, container);
+    elements.minimizeBtn.addEventListener("click", () => {
+      state.minimized = !state.minimized;
+      if (state.minimized) {
+        container.classList.add("minimized");
+        elements.minimizeBtn.innerHTML = "\u{1F53C}";
+      } else {
+        container.classList.remove("minimized");
+        elements.minimizeBtn.innerHTML = "\u{1F53D}";
+      }
+    });
+    elements.configBtn.addEventListener("click", () => {
+      state.configVisible = !state.configVisible;
+      if (state.configVisible) {
+        elements.configPanel.classList.add("visible");
+        elements.configBtn.innerHTML = "\u274C";
+      } else {
+        elements.configPanel.classList.remove("visible");
+        elements.configBtn.innerHTML = "\u2699\uFE0F";
+      }
+    });
+    elements.pixelsPerBatch.addEventListener("change", () => {
+      const value = parseInt(elements.pixelsPerBatch.value) || 20;
+      elements.batchValue.textContent = value;
+      if (handlers.onConfigChange) {
+        handlers.onConfigChange({ pixelsPerBatch: value });
+      }
+    });
+    elements.useAllCharges.addEventListener("change", () => {
+      if (handlers.onConfigChange) {
+        handlers.onConfigChange({ useAllCharges: elements.useAllCharges.checked });
+      }
+    });
+    function enableButtonsAfterInit() {
+      elements.uploadBtn.disabled = false;
+      elements.loadProgressBtn.disabled = false;
+    }
+    elements.initBtn.addEventListener("click", async () => {
+      elements.initBtn.disabled = true;
+      if (handlers.onInitBot) {
+        const success = await handlers.onInitBot();
+        if (success) {
+          enableButtonsAfterInit();
+        }
+      }
+      elements.initBtn.disabled = false;
+    });
+    elements.uploadBtn.addEventListener("click", () => {
+      fileInput.click();
+    });
+    fileInput.addEventListener("change", async () => {
+      if (fileInput.files.length > 0 && handlers.onUploadImage) {
+        const success = await handlers.onUploadImage(fileInput.files[0]);
+        if (success) {
+          elements.selectPosBtn.disabled = false;
+          elements.resizeBtn.disabled = false;
+        }
+      }
+    });
+    elements.loadProgressBtn.addEventListener("click", () => {
+      progressFileInput.click();
+    });
+    progressFileInput.addEventListener("change", async () => {
+      if (progressFileInput.files.length > 0 && handlers.onLoadProgress) {
+        const success = await handlers.onLoadProgress(progressFileInput.files[0]);
+        if (success) {
+          elements.selectPosBtn.disabled = false;
+          elements.startBtn.disabled = false;
+          elements.resizeBtn.disabled = false;
+        }
+      }
+    });
+    elements.resizeBtn.addEventListener("click", () => {
+      if (handlers.onResizeImage) {
+        handlers.onResizeImage();
+      }
+    });
+    elements.selectPosBtn.addEventListener("click", async () => {
+      if (handlers.onSelectPosition) {
+        elements.selectPosBtn.disabled = true;
+        const success = await handlers.onSelectPosition();
+        if (success) {
+          elements.startBtn.disabled = false;
+        }
+        elements.selectPosBtn.disabled = false;
+      }
+    });
+    elements.showOverlay.addEventListener("change", () => {
+      if (!window.__WPA_PLAN_OVERLAY__) return;
+      window.__WPA_PLAN_OVERLAY__.injectStyles();
+      const isEnabled = elements.showOverlay.checked;
+      window.__WPA_PLAN_OVERLAY__.setEnabled(isEnabled);
+    });
+    elements.startBtn.addEventListener("click", async () => {
+      if (handlers.onStartPainting) {
+        elements.startBtn.disabled = true;
+        elements.stopBtn.disabled = false;
+        const success = await handlers.onStartPainting();
+        if (!success) {
+          elements.startBtn.disabled = false;
+          elements.stopBtn.disabled = true;
+        }
+      }
+    });
+    elements.stopBtn.addEventListener("click", async () => {
+      if (handlers.onStopPainting) {
+        const shouldStop = await handlers.onStopPainting();
+        if (shouldStop) {
+          elements.startBtn.disabled = false;
+          elements.stopBtn.disabled = true;
+        }
+      }
+    });
+    function setStatus(message, type = "default") {
+      elements.status.textContent = message;
+      elements.status.className = `status status-${type}`;
+      elements.status.style.animation = "none";
+      void elements.status.offsetWidth;
+      elements.status.style.animation = "slideIn 0.3s ease-out";
+    }
+    function showResizeDialog(processor) {
+      const { width, height } = processor.getDimensions();
+      const aspectRatio = width / height;
+      resizeElements.widthSlider.value = width;
+      resizeElements.heightSlider.value = height;
+      resizeElements.widthValue.textContent = width;
+      resizeElements.heightValue.textContent = height;
+      resizeElements.preview.src = processor.img.src;
+      resizeElements.overlay.style.display = "block";
+      resizeElements.container.style.display = "block";
+      const updatePreview = () => {
+        const newWidth = parseInt(resizeElements.widthSlider.value);
+        const newHeight = parseInt(resizeElements.heightSlider.value);
+        resizeElements.widthValue.textContent = newWidth;
+        resizeElements.heightValue.textContent = newHeight;
+        resizeElements.preview.src = processor.generatePreview(newWidth, newHeight);
+      };
+      const onWidthChange = () => {
+        if (resizeElements.keepAspect.checked) {
+          const newWidth = parseInt(resizeElements.widthSlider.value);
+          const newHeight = Math.round(newWidth / aspectRatio);
+          resizeElements.heightSlider.value = newHeight;
+        }
+        updatePreview();
+      };
+      const onHeightChange = () => {
+        if (resizeElements.keepAspect.checked) {
+          const newHeight = parseInt(resizeElements.heightSlider.value);
+          const newWidth = Math.round(newHeight * aspectRatio);
+          resizeElements.widthSlider.value = newWidth;
+        }
+        updatePreview();
+      };
+      resizeElements.widthSlider.addEventListener("input", onWidthChange);
+      resizeElements.heightSlider.addEventListener("input", onHeightChange);
+      const onConfirm = () => {
+        const newWidth = parseInt(resizeElements.widthSlider.value);
+        const newHeight = parseInt(resizeElements.heightSlider.value);
+        if (handlers.onConfirmResize) {
+          handlers.onConfirmResize(processor, newWidth, newHeight);
+        }
+        closeResizeDialog();
+      };
+      const onCancel = () => {
+        closeResizeDialog();
+      };
+      resizeElements.confirmBtn.addEventListener("click", onConfirm);
+      resizeElements.cancelBtn.addEventListener("click", onCancel);
+      resizeElements.overlay.addEventListener("click", onCancel);
+      window.cleanupResizeDialog = () => {
+        resizeElements.widthSlider.removeEventListener("input", onWidthChange);
+        resizeElements.heightSlider.removeEventListener("input", onHeightChange);
+        resizeElements.confirmBtn.removeEventListener("click", onConfirm);
+        resizeElements.cancelBtn.removeEventListener("click", onCancel);
+        resizeElements.overlay.removeEventListener("click", onCancel);
+      };
+      updatePreview();
+    }
+    function closeResizeDialog() {
+      resizeElements.overlay.style.display = "none";
+      resizeElements.container.style.display = "none";
+      if (window.cleanupResizeDialog) {
+        window.cleanupResizeDialog();
+        delete window.cleanupResizeDialog;
+      }
+    }
+    function updateProgress(current, total, userInfo = null) {
+      const percentage = total > 0 ? current / total * 100 : 0;
+      elements.progressBar.style.width = `${percentage}%`;
+      let statsHTML = `
       <div class="stat-item">
-        <div class="stat-label">\u{1F3A8} ${l.progress}</div>
-        <div>${x}/${A} (${_.toFixed(1)}%)</div>
+        <div class="stat-label">\u{1F3A8} ${texts.progress}</div>
+        <div>${current}/${total} (${percentage.toFixed(1)}%)</div>
       </div>
-    `;if(I&&(I.username&&(B+=`
+    `;
+      if (userInfo) {
+        if (userInfo.username) {
+          statsHTML += `
           <div class="stat-item">
-            <div class="stat-label">\u{1F464} ${l.userName}</div>
-            <div>${I.username}</div>
+            <div class="stat-label">\u{1F464} ${texts.userName}</div>
+            <div>${userInfo.username}</div>
           </div>
-        `),I.charges!==void 0&&(B+=`
+        `;
+        }
+        if (userInfo.charges !== void 0) {
+          statsHTML += `
           <div class="stat-item">
-            <div class="stat-label">\u26A1 ${l.charges}</div>
-            <div>${Math.floor(I.charges)}</div>
+            <div class="stat-label">\u26A1 ${texts.charges}</div>
+            <div>${Math.floor(userInfo.charges)}</div>
           </div>
-        `),I.pixels!==void 0&&(B+=`
+        `;
+        }
+        if (userInfo.pixels !== void 0) {
+          statsHTML += `
           <div class="stat-item">
-            <div class="stat-label">\u{1F533} ${l.pixels}</div>
-            <div>${I.pixels.toLocaleString()}</div>
+            <div class="stat-label">\u{1F533} ${texts.pixels}</div>
+            <div>${userInfo.pixels.toLocaleString()}</div>
           </div>
-        `),I.estimatedTime!==void 0&&I.estimatedTime>0)){let O=Math.floor(I.estimatedTime/3600),F=Math.floor(I.estimatedTime%3600/60),Y=O>0?`${O}h ${F}m`:`${F}m`;B+=`
+        `;
+        }
+        if (userInfo.estimatedTime !== void 0 && userInfo.estimatedTime > 0) {
+          const hours = Math.floor(userInfo.estimatedTime / 3600);
+          const minutes = Math.floor(userInfo.estimatedTime % 3600 / 60);
+          const timeStr = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+          statsHTML += `
           <div class="stat-item">
-            <div class="stat-label">\u23F0 ${l.timeRemaining}</div>
-            <div>${Y}</div>
+            <div class="stat-label">\u23F0 ${texts.timeRemaining}</div>
+            <div>${timeStr}</div>
           </div>
-        `}n.statsArea.innerHTML=B}function C(x){if(x>0){let A=Math.floor(x/60),I=x%60,_=A>0?`${A}m ${I}s`:`${I}s`;n.cooldownValue.textContent=_}else n.cooldownValue.textContent="--"}function E(x){x&&x.includes("\u23F3")?(n.status.textContent=x,n.status.className="status status-info"):x&&v(x,"info")}function L(x){x?(n.initBtn.disabled=!0,n.initBtn.style.opacity="0.6",n.initBtn.innerHTML=`\u2705 <span>${l.initBot} - Completado</span>`):(n.initBtn.disabled=!1,n.initBtn.style.opacity="1",n.initBtn.innerHTML=`\u{1F916} <span>${l.initBot}</span>`)}function b(x){n.initBtn.style.display=x?"flex":"none"}function S(){s.remove()}return d("\u2705 Interfaz de Auto-Image creada"),{setStatus:v,updateProgress:P,updateCooldownDisplay:C,updateCooldownMessage:E,setInitialized:L,setInitButtonVisible:b,enableButtonsAfterInit:y,showResizeDialog:h,closeResizeDialog:f,destroy:S}}function he(l,t,s={}){return new Promise(a=>{let i=document.createElement("div");i.className="modal-overlay",i.style.position="fixed",i.style.top="0",i.style.left="0",i.style.width="100%",i.style.height="100%",i.style.background="rgba(0,0,0,0.7)",i.style.zIndex="10001",i.style.display="flex",i.style.alignItems="center",i.style.justifyContent="center";let c=document.createElement("div");c.style.background="#1a1a1a",c.style.border="2px solid #333",c.style.borderRadius="15px",c.style.padding="25px",c.style.color="#eee",c.style.minWidth="350px",c.style.maxWidth="400px",c.style.boxShadow="0 10px 30px rgba(0,0,0,0.5)",c.style.fontFamily="'Segoe UI', Roboto, sans-serif",c.innerHTML=`
-      <h3 style="margin: 0 0 15px 0; text-align: center; font-size: 18px;">${t}</h3>
-      <p style="margin: 0 0 20px 0; text-align: center; line-height: 1.4;">${l}</p>
+        `;
+        }
+      }
+      elements.statsArea.innerHTML = statsHTML;
+    }
+    function updateCooldownDisplay(seconds) {
+      if (seconds > 0) {
+        const minutes = Math.floor(seconds / 60);
+        const secs = seconds % 60;
+        const timeStr = minutes > 0 ? `${minutes}m ${secs}s` : `${secs}s`;
+        elements.cooldownValue.textContent = timeStr;
+      } else {
+        elements.cooldownValue.textContent = "--";
+      }
+    }
+    function updateCooldownMessage(message) {
+      if (message && message.includes("\u23F3")) {
+        elements.status.textContent = message;
+        elements.status.className = "status status-info";
+      } else if (message) {
+        setStatus(message, "info");
+      }
+    }
+    function setInitialized(isInitialized) {
+      if (isInitialized) {
+        elements.initBtn.disabled = true;
+        elements.initBtn.style.opacity = "0.6";
+        elements.initBtn.innerHTML = `\u2705 <span>${texts.initBot} - Completado</span>`;
+      } else {
+        elements.initBtn.disabled = false;
+        elements.initBtn.style.opacity = "1";
+        elements.initBtn.innerHTML = `\u{1F916} <span>${texts.initBot}</span>`;
+      }
+    }
+    function setInitButtonVisible(visible) {
+      elements.initBtn.style.display = visible ? "flex" : "none";
+    }
+    function destroy() {
+      host.remove();
+    }
+    log("\u2705 Interfaz de Auto-Image creada");
+    return {
+      setStatus,
+      updateProgress,
+      updateCooldownDisplay,
+      updateCooldownMessage,
+      setInitialized,
+      setInitButtonVisible,
+      enableButtonsAfterInit,
+      showResizeDialog,
+      closeResizeDialog,
+      destroy
+    };
+  }
+  function showConfirmDialog(message, title, buttons = {}) {
+    return new Promise((resolve) => {
+      const overlay = document.createElement("div");
+      overlay.className = "modal-overlay";
+      overlay.style.position = "fixed";
+      overlay.style.top = "0";
+      overlay.style.left = "0";
+      overlay.style.width = "100%";
+      overlay.style.height = "100%";
+      overlay.style.background = "rgba(0,0,0,0.7)";
+      overlay.style.zIndex = "10001";
+      overlay.style.display = "flex";
+      overlay.style.alignItems = "center";
+      overlay.style.justifyContent = "center";
+      const modal = document.createElement("div");
+      modal.style.background = "#1a1a1a";
+      modal.style.border = "2px solid #333";
+      modal.style.borderRadius = "15px";
+      modal.style.padding = "25px";
+      modal.style.color = "#eee";
+      modal.style.minWidth = "350px";
+      modal.style.maxWidth = "400px";
+      modal.style.boxShadow = "0 10px 30px rgba(0,0,0,0.5)";
+      modal.style.fontFamily = "'Segoe UI', Roboto, sans-serif";
+      modal.innerHTML = `
+      <h3 style="margin: 0 0 15px 0; text-align: center; font-size: 18px;">${title}</h3>
+      <p style="margin: 0 0 20px 0; text-align: center; line-height: 1.4;">${message}</p>
       <div style="display: flex; gap: 10px; justify-content: center;">
-        ${s.save?`<button class="save-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #10b981; color: white;">${s.save}</button>`:""}
-        ${s.discard?`<button class="discard-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #ef4444; color: white;">${s.discard}</button>`:""}
-        ${s.cancel?`<button class="cancel-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #2d3748; color: white;">${s.cancel}</button>`:""}
+        ${buttons.save ? `<button class="save-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #10b981; color: white;">${buttons.save}</button>` : ""}
+        ${buttons.discard ? `<button class="discard-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #ef4444; color: white;">${buttons.discard}</button>` : ""}
+        ${buttons.cancel ? `<button class="cancel-btn" style="padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: bold; cursor: pointer; min-width: 100px; background: #2d3748; color: white;">${buttons.cancel}</button>` : ""}
       </div>
-    `,i.appendChild(c),document.body.appendChild(i);let g=c.querySelector(".save-btn"),o=c.querySelector(".discard-btn"),p=c.querySelector(".cancel-btn"),r=()=>{document.body.removeChild(i)};g&&g.addEventListener("click",()=>{r(),a("save")}),o&&o.addEventListener("click",()=>{r(),a("discard")}),p&&p.addEventListener("click",()=>{r(),a("cancel")}),i.addEventListener("click",n=>{n.target===i&&(r(),a("cancel"))})})}function W(l=!1){let t=['[data-testid="color-picker"]',".color-picker",".palette",'[class*="color"][class*="picker"]','[class*="palette"]'];for(let i of t){let c=document.querySelector(i);if(c&&c.offsetParent!==null)return l&&console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por selector: ${i}`),!0}let s=document.querySelectorAll('[style*="background-color"], [style*="background:"], .color, [class*="color"]'),a=0;for(let i of s)if(i.offsetParent!==null&&i.offsetWidth>10&&i.offsetHeight>10&&(a++,a>=5))return l&&console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por colores visibles: ${a}`),!0;return l&&console.log(`[WPA-UI] \u{1F50D} Paleta no detectada. Colores visibles: ${a}`),!1}function fe(l=!1,t=!1){let s=document.querySelector("button.btn.btn-primary.btn-lg, button.btn.btn-primary.sm\\:btn-xl");if(s){let i=s.textContent.toLowerCase(),c=i.includes("paint")||i.includes("pintar"),g=s.querySelector('svg path[d*="240-120"]')||s.querySelector('svg path[d*="M15"]');if(c||g)return l&&console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por selector espec\xEDfico: "${i}"`),s.click(),t&&setTimeout(()=>{l&&console.log("[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint"),s.click()},500),!0}let a=document.querySelectorAll("button");for(let i of a){let c=i.textContent.toLowerCase();if((c.includes("paint")||c.includes("pintar"))&&i.offsetParent!==null&&!i.disabled)return l&&console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por texto: "${i.textContent.trim()}"`),i.click(),t&&setTimeout(()=>{l&&console.log("[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint"),i.click()},500),!0}return l&&console.log("[WPA-UI] \u274C Bot\xF3n Paint no encontrado"),!1}async function U(l=3,t=!0){t&&console.log(`[WPA-UI] \u{1F916} Iniciando auto-click del bot\xF3n Paint (m\xE1ximo ${l} intentos)`);for(let s=1;s<=l;s++){if(t&&console.log(`[WPA-UI] \u{1F3AF} Intento ${s}/${l} - Buscando bot\xF3n Paint...`),W())return t&&console.log("[WPA-UI] \u2705 Paleta ya est\xE1 abierta, auto-click completado"),!0;if(fe(t,!1))if(t&&console.log("[WPA-UI] \u{1F446} Primer clic en bot\xF3n Paint realizado"),await new Promise(a=>setTimeout(a,1500)),t&&console.log("[WPA-UI] \u{1F50D} Buscando bot\xF3n Paint otra vez para segundo clic..."),fe(t,!1)){if(t&&console.log("[WPA-UI] \u{1F446} Segundo clic en bot\xF3n Paint realizado"),await new Promise(a=>setTimeout(a,2e3)),W())return t&&console.log(`[WPA-UI] \u2705 Paleta abierta exitosamente despu\xE9s del intento ${s}`),!0;t&&console.log(`[WPA-UI] \u26A0\uFE0F Paleta no se abri\xF3 despu\xE9s del segundo clic en intento ${s}`)}else t&&console.log(`[WPA-UI] \u274C No se pudo hacer segundo clic en bot\xF3n Paint en intento ${s}`);else t&&console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado para primer clic en intento ${s}`);s<l&&await new Promise(a=>setTimeout(a,1e3))}return t&&console.log(`[WPA-UI] \u274C Auto-click fall\xF3 despu\xE9s de ${l} intentos`),!1}(()=>{let t={enabled:!1,templates:[],templatesShouldBeDrawn:!0,tileSize:1e3,drawMult:3,pixelPlan:null,nextBatchCount:0,anchor:null,imageWidth:null,imageHeight:null,originalFetch:null,fetchedBlobQueue:new Map,isIntercepting:!1};function s(){console.log("[PLAN OVERLAY] Blue Marble tile system initialized")}function a(){t.isIntercepting||(t.originalFetch=window.fetch,t.isIntercepting=!0,window.fetch=async function(...h){var L;let f=await t.originalFetch.apply(this,h),P=f.clone(),C=(h[0]instanceof Request?(L=h[0])==null?void 0:L.url:h[0])||"ignore";if((P.headers.get("content-type")||"").includes("image/")&&C.includes("/tiles/")&&!C.includes("openfreemap")&&!C.includes("maps")){console.log("[PLAN OVERLAY] Intercepting tile request:",C);try{let b=await P.blob(),S=await c(b,C);return new Response(S,{headers:P.headers,status:P.status,statusText:P.statusText})}catch(b){return console.error("[PLAN OVERLAY] Error processing tile:",b),f}}return f},console.log("[PLAN OVERLAY] Fetch interception started"))}function i(){!t.isIntercepting||!t.originalFetch||(window.fetch=t.originalFetch,t.isIntercepting=!1,console.log("[PLAN OVERLAY] Fetch interception stopped"))}async function c(h,f){if(!t.enabled||!t.templatesShouldBeDrawn||!t.pixelPlan)return h;let P=f.split("/"),C=parseInt(P[P.length-1].replace(".png","")),E=parseInt(P[P.length-2]);if(isNaN(E)||isNaN(C))return console.warn("[PLAN OVERLAY] Could not extract tile coordinates from URL:",f),h;console.log(`[PLAN OVERLAY] Processing tile: ${E},${C}`);let L=g(E,C);if(L.length===0)return h;console.log(`[PLAN OVERLAY] Found ${L.length} pixels for tile ${E},${C}`);let b=t.tileSize*t.drawMult,S=await createImageBitmap(h),x=new OffscreenCanvas(b,b),A=x.getContext("2d");return A.imageSmoothingEnabled=!1,A.clearRect(0,0,b,b),A.drawImage(S,0,0,b,b),o(A,L,E,C),await x.convertToBlob({type:"image/png"})}function g(h,f){return!t.pixelPlan||!t.pixelPlan.pixels?[]:t.pixelPlan.pixels.filter(P=>{let C=Math.floor(P.globalX/3e3),E=Math.floor(P.globalY/3e3);return C===h&&E===f})}function o(h,f,P,C){let E=P*3e3,L=C*3e3;h.globalAlpha=.7;for(let b of f){let S=(b.globalX-E)*t.drawMult+1,x=(b.globalY-L)*t.drawMult+1;S>=0&&S<t.tileSize*t.drawMult&&x>=0&&x<t.tileSize*t.drawMult&&(h.fillStyle=`rgb(${b.r},${b.g},${b.b})`,h.fillRect(S,x,1,1))}if(t.nextBatchCount>0){h.globalAlpha=1;let b=f.slice(0,t.nextBatchCount);for(let S of b){let x=(S.globalX-E)*t.drawMult+1,A=(S.globalY-L)*t.drawMult+1;x>=0&&x<t.tileSize*t.drawMult&&A>=0&&A<t.tileSize*t.drawMult&&(h.fillStyle=`rgb(${S.r},${S.g},${S.b})`,h.fillRect(x,A,1,1))}}}function p(h){t.enabled=!!h,t.enabled?a():i(),console.log(`[PLAN OVERLAY] setEnabled: ${t.enabled}`)}function r(h,f={}){var C,E,L;if(!h||h.length===0){t.pixelPlan=null,console.log("[PLAN OVERLAY] Plan cleared");return}let P=[];for(let b of h){let S,x;if(typeof b.tileX=="number"&&typeof b.localX=="number")S=b.tileX*3e3+b.localX,x=b.tileY*3e3+b.localY;else if(f.anchor&&typeof b.imageX=="number"){let A=f.anchor.tileX*3e3+(f.anchor.pxX||0),I=f.anchor.tileY*3e3+(f.anchor.pxY||0);S=A+b.imageX,x=I+b.imageY}else continue;P.push({globalX:S,globalY:x,r:((C=b.color)==null?void 0:C.r)||0,g:((E=b.color)==null?void 0:E.g)||0,b:((L=b.color)==null?void 0:L.b)||0})}t.pixelPlan={pixels:P},t.nextBatchCount=f.nextBatchCount||0,t.anchor=f.anchor||null,t.imageWidth=f.imageWidth||null,t.imageHeight=f.imageHeight||null,console.log(`[PLAN OVERLAY] Plan set: ${P.length} pixels`),typeof f.enabled=="boolean"&&p(f.enabled)}function n(h){t.nextBatchCount=Math.max(0,Number(h||0)),console.log(`[PLAN OVERLAY] Next batch count: ${t.nextBatchCount}`)}function u(h){t.anchor=h,console.log("[PLAN OVERLAY] Anchor set:",h)}function m(h,f){console.log("[PLAN OVERLAY] CSS anchor set (ignored in tile system):",{x:h,y:f})}function y(){console.log("[PLAN OVERLAY] Selection mode ended (ignored in tile system)")}function v(){i(),t.pixelPlan=null,t.fetchedBlobQueue.clear(),console.log("[PLAN OVERLAY] Cleanup completed")}window.__WPA_PLAN_OVERLAY__={injectStyles:s,setEnabled:p,setPlan:r,setPlanItemsFromTileList:r,setNextBatchCount:n,setAnchor:u,setAnchorCss:m,endSelectionMode:y,render:()=>{},cleanup:v,get state(){return t}},console.log("[PLAN OVERLAY] Blue Marble tile system ready")})();async function xe(){d("\u{1F680} Iniciando WPlace Auto-Image (versi\xF3n modular)"),X(),window.__wplaceBot={...window.__wplaceBot,imageRunning:!0};let l=null,t=window.fetch,s=()=>{window.fetch!==t&&(window.fetch=t,d("\u{1F504} Fetch original restaurado")),e.positionTimeoutId&&(clearTimeout(e.positionTimeoutId),e.positionTimeoutId=null),e.cleanupObserver&&(e.cleanupObserver(),e.cleanupObserver=null),e.selectingPosition=!1};try{let a={...T},i=V("image");if(e.language=ee(),!a.SITEKEY){let r=document.querySelector("*[data-sitekey]");r?(a.SITEKEY=r.getAttribute("data-sitekey"),d(`\u{1F4DD} Sitekey encontrada autom\xE1ticamente: ${a.SITEKEY.substring(0,20)}...`)):d("\u26A0\uFE0F No se pudo encontrar la sitekey autom\xE1ticamente")}async function c(){return d("\u{1F916} Intentando auto-inicio..."),W()?(d("\u{1F3A8} Paleta de colores ya est\xE1 abierta"),!0):(d("\u{1F50D} Paleta no encontrada, iniciando auto-click del bot\xF3n Paint..."),await U(3,!0)?(d("\u2705 Auto-click exitoso, paleta abierta"),!0):(d("\u274C Auto-click fall\xF3, requerir\xE1 inicio manual"),!1))}async function g(r=!1){d("\u{1F916} Inicializando Auto-Image..."),o.setStatus(w("image.checkingColors"),"info");let n=H();if(n.length===0)return o.setStatus(w("image.noColorsFound"),"error"),!1;let u=await ie(),m=null;u.success&&u.data.user?(m={username:u.data.user.name||"An\xF3nimo",charges:u.data.charges,maxCharges:u.data.maxCharges,pixels:u.data.user.pixelsPainted||0},l=m,e.currentCharges=u.data.charges,e.maxCharges=u.data.maxCharges||50,d(`\u{1F464} Usuario conectado: ${u.data.user.name||"An\xF3nimo"} - Cargas: ${m.charges}/${m.maxCharges} - P\xEDxeles: ${m.pixels}`)):d("\u26A0\uFE0F No se pudo obtener informaci\xF3n del usuario"),e.availableColors=n,e.colorsChecked=!0,o.setStatus(w("image.colorsFound",{count:n.length}),"success"),o.updateProgress(0,0,m),r||d(`\u2705 ${n.length} colores disponibles detectados`),o.setInitialized(!0),o.enableButtonsAfterInit();try{}catch{}return!0}let o=await me({texts:i,onConfigChange:r=>{r.pixelsPerBatch!==void 0&&(e.pixelsPerBatch=r.pixelsPerBatch),r.useAllCharges!==void 0&&(e.useAllChargesFirst=r.useAllCharges),d("Configuraci\xF3n actualizada:",r)},onInitBot:g,onUploadImage:async r=>{try{o.setStatus(w("image.loadingImage"),"info");let n=window.URL.createObjectURL(r),u=new q(n);u.originalName=r.name,await u.load();let m=u.initializeColorPalette();e.availableColors=m;let y=await u.analyzePixels();u.setCoords(0,0,0,0);let v=u.getImageData();e.imageData=v,e.imageData.processor=u,e.totalPixels=y.requiredPixels,e.paintedPixels=0,e.originalImageName=r.name,e.imageLoaded=!0,o.setStatus(w("image.imageLoaded",{count:y.requiredPixels}),"success"),o.updateProgress(0,y.requiredPixels,l),d(`\u2705 [BLUE MARBLE] Imagen cargada: ${v.width}x${v.height}, ${y.requiredPixels} p\xEDxeles v\xE1lidos`),d(`\u2705 [BLUE MARBLE] An\xE1lisis: ${y.uniqueColors} colores \xFAnicos, ${y.defacePixels} p\xEDxeles #deface`),window.URL.revokeObjectURL(n);try{window.__WPA_PLAN_OVERLAY__&&(window.__WPA_PLAN_OVERLAY__.injectStyles(),window.__WPA_PLAN_OVERLAY__.setEnabled(!0),window.__WPA_PLAN_OVERLAY__.setPlan([],{enabled:!0,nextBatchCount:0}),d("\u2705 Plan overlay activado autom\xE1ticamente al cargar imagen"))}catch(h){d("\u26A0\uFE0F Error activando plan overlay:",h)}return!0}catch(n){return o.setStatus(w("image.imageError"),"error"),d("\u274C Error cargando imagen:",n),!1}},onSelectPosition:async()=>new Promise(r=>{o.setStatus(w("image.selectPositionAlert"),"info"),o.setStatus(w("image.waitingPosition"),"info"),e.selectingPosition=!0;let n=!1,u=()=>{window.fetch=async(v,h)=>{if(e.selectingPosition&&!n&&typeof v=="string"&&v.includes("/s0/pixel/")&&h&&h.method==="POST")try{d(`\u{1F3AF} Interceptando request de pintado: ${v}`);let f=await t(v,h);if(f.ok&&h.body){let P;try{P=JSON.parse(h.body)}catch(C){return d("Error parseando body del request:",C),f}if(P.coords&&Array.isArray(P.coords)&&P.coords.length>=2){let C=P.coords[0],E=P.coords[1],L=v.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);if(L&&!n){n=!0;let b=parseInt(L[1]),S=parseInt(L[2]);if(e.tileX=b,e.tileY=S,e.startPosition={x:C,y:E},e.selectingPosition=!1,e.imageData&&e.imageData.processor){let x=e.imageData.processor;x.setCoords(b,S,C,E);try{await x.createTemplateTiles(),d(`\u2705 [BLUE MARBLE] Template tiles creados para posici\xF3n tile(${b},${S}) pixel(${C},${E})`)}catch(I){d(`\u274C [BLUE MARBLE] Error creando template tiles: ${I.message}`)}let A=x.generatePixelQueue();e.remainingPixels=A,e.totalPixels=A.length,d(`\u2705 Cola de p\xEDxeles generada: ${A.length} p\xEDxeles para overlay`)}try{window.__WPA_PLAN_OVERLAY__&&(window.__WPA_PLAN_OVERLAY__.injectStyles(),window.__WPA_PLAN_OVERLAY__.setEnabled(!0),window.__WPA_PLAN_OVERLAY__.setAnchor({tileX:b,tileY:S,pxX:C,pxY:E}),e.remainingPixels&&e.remainingPixels.length>0?(window.__WPA_PLAN_OVERLAY__.setPlan(e.remainingPixels,{anchor:{tileX:b,tileY:S,pxX:C,pxY:E},imageWidth:e.imageData.width,imageHeight:e.imageData.height,enabled:!0}),d(`\u2705 Plan overlay anclado en tile(${b},${S}) local(${C},${E})`)):d("\u26A0\uFE0F No hay p\xEDxeles para mostrar en overlay"))}catch(x){d(`\u274C Error configurando overlay: ${x.message}`)}s(),o.setStatus(w("image.positionSet"),"success"),d(`\u2705 Posici\xF3n establecida: tile(${e.tileX},${e.tileY}) local(${C},${E})`),r(!0)}else d("\u26A0\uFE0F No se pudo extraer tile de la URL:",v)}}return f}catch(f){if(d("\u274C Error interceptando pixel:",f),!n)return s(),t(v,h)}return t(v,h)}},m=()=>{let v=document.querySelectorAll("canvas");if(v.length===0){d("\u26A0\uFE0F No se encontraron elementos canvas");return}d(`\u{1F4CA} Configurando observer para ${v.length} canvas`);let h=f=>{var C;if(!e.selectingPosition||n)return;let P=f.target;if(P&&P.tagName==="CANVAS"){d("\u{1F5B1}\uFE0F Click detectado en canvas durante selecci\xF3n");try{let L=(((C=document.querySelector("canvas"))==null?void 0:C.parentElement)||document.body).getBoundingClientRect(),b=f.clientX-L.left,S=f.clientY-L.top;window.__WPA_PLAN_OVERLAY__&&(window.__WPA_PLAN_OVERLAY__.setAnchorCss(b,S),d(`Plan overlay: ancla CSS establecida en (${b}, ${S})`))}catch(E){d("Plan Overlay: error calculando ancla CSS",E)}setTimeout(()=>{!n&&e.selectingPosition&&d("\u{1F50D} Buscando requests recientes de pintado...")},500)}};document.addEventListener("click",h),e.cleanupObserver=()=>{document.removeEventListener("click",h)}};u(),m();let y=setTimeout(()=>{e.selectingPosition&&!n&&(s(),e.cleanupObserver&&e.cleanupObserver(),o.setStatus(w("image.positionTimeout"),"error"),d("\u23F0 Timeout en selecci\xF3n de posici\xF3n"),r(!1))},12e4);e.positionTimeoutId=y}),onStartPainting:async()=>{var r;if(d("\u{1F50D} Estado para iniciar pintura:",{imageLoaded:e.imageLoaded,startPosition:e.startPosition,tileX:e.tileX,tileY:e.tileY,totalPixels:e.totalPixels,remainingPixels:((r=e.remainingPixels)==null?void 0:r.length)||0}),!e.imageLoaded||!e.startPosition)return o.setStatus(w("image.missingRequirements"),"error"),d(`\u274C Validaci\xF3n fallida: imageLoaded=${e.imageLoaded}, startPosition=${!!e.startPosition}`),!1;e.running=!0,e.stopFlag=!1,e.isFirstBatch=!0,o.setStatus(w("image.startPaintingMsg"),"success");try{return await se(e.imageData,e.startPosition,(n,u,m,y)=>{l&&(l.charges=Math.floor(e.currentCharges),y!==void 0&&(l.estimatedTime=y)),o.updateProgress(n,u,l),e.inCooldown&&e.nextBatchCooldown>0?o.updateCooldownDisplay(e.nextBatchCooldown):o.updateCooldownDisplay(0),m?m.includes("\u23F3")&&e.inCooldown?o.updateCooldownMessage(m):o.setStatus(m,"info"):o.setStatus(w("image.paintingProgress",{painted:n,total:u}),"info")},(n,u)=>{n?(o.setStatus(w("image.paintingComplete",{count:u}),"success"),de()):o.setStatus(w("image.paintingStopped"),"warning"),e.running=!1},n=>{o.setStatus(w("image.paintingError"),"error"),d("\u274C Error en proceso de pintado:",n),e.running=!1}),!0}catch(n){return o.setStatus(w("image.paintingError"),"error"),d("\u274C Error iniciando pintado:",n),e.running=!1,!1}},onStopPainting:async()=>{if(ue().hasProgress){let n=await he(w("image.confirmSaveProgress"),w("image.saveProgressTitle"),{save:w("image.saveProgress"),discard:w("image.discardProgress"),cancel:w("image.cancel")});if(n==="save"){let u=G();u.success?o.setStatus(w("image.progressSaved",{filename:u.filename}),"success"):o.setStatus(w("image.progressSaveError",{error:u.error}),"error")}else if(n==="cancel")return!1}return j(),o.setStatus(w("image.paintingStopped"),"warning"),!0},onSaveProgress:async()=>{let r=G();return r.success?o.setStatus(w("image.progressSaved",{filename:r.filename}),"success"):o.setStatus(w("image.progressSaveError",{error:r.error}),"error"),r.success},onLoadProgress:async r=>{try{let n=await ce(r);return n.success?(o.setStatus(w("image.progressLoaded",{painted:n.painted,total:n.total}),"success"),o.updateProgress(n.painted,n.total,l),d("\u2705 Progreso cargado - habilitando botones de inicio"),!0):(o.setStatus(w("image.progressLoadError",{error:n.error}),"error"),!1)}catch(n){return o.setStatus(w("image.progressLoadError",{error:n.message}),"error"),!1}},onResizeImage:()=>{e.imageLoaded&&e.imageData&&e.imageData.processor&&o.showResizeDialog(e.imageData.processor)},onConfirmResize:async(r,n,u)=>{d(`\u{1F504} Redimensionando imagen de ${r.getDimensions().width}x${r.getDimensions().height} a ${n}x${u}`);try{await r.resize(n,u);let m=await r.analyzePixels();e.imageData={processor:r,width:n,height:u,validPixelCount:m.validPixelCount,totalPixels:m.totalPixels,unknownPixels:m.unknownPixels},e.totalPixels=m.validPixelCount,e.paintedPixels=0,e.remainingPixels=[],e.lastPosition={x:0,y:0},o.updateProgress(0,m.validPixelCount,l),o.setStatus(w("image.resizeSuccess",{width:n,height:u}),"success"),d(`\u2705 Imagen redimensionada: ${m.validPixelCount} p\xEDxeles v\xE1lidos de ${m.totalPixels} totales`);try{if(window.__WPA_PLAN_OVERLAY__&&e.startPosition&&e.tileX!=null&&e.tileY!=null){await r.createTemplateTiles();let y=r.generatePixelQueue();e.remainingPixels=y,e.totalPixels=y.length,window.__WPA_PLAN_OVERLAY__.setPlan(y,{anchor:{tileX:e.tileX,tileY:e.tileY,pxX:e.startPosition.x,pxY:e.startPosition.y},imageWidth:n,imageHeight:u,enabled:!0}),d(`\u2705 Overlay actualizado con ${y.length} p\xEDxeles despu\xE9s del resize`)}}catch(y){d(`\u26A0\uFE0F Error actualizando overlay despu\xE9s del resize: ${y.message}`)}}catch(m){d(`\u274C Error redimensionando imagen: ${m.message}`),o.setStatus(w("image.imageError"),"error")}}}),p=r=>{let{language:n}=r.detail;d(`\u{1F30D} Imagen: Detectado cambio de idioma desde launcher: ${n}`),e.language=n};window.addEventListener("launcherLanguageChanged",p),window.addEventListener("languageChanged",p),window.addEventListener("beforeunload",()=>{s(),j(),o.destroy(),window.removeEventListener("launcherLanguageChanged",p),window.removeEventListener("languageChanged",p),window.__wplaceBot&&(window.__wplaceBot.imageRunning=!1)}),d("\u2705 Auto-Image inicializado correctamente"),setTimeout(async()=>{try{o.setStatus(w("image.autoInitializing"),"info"),d("\u{1F916} Intentando auto-inicio..."),await c()?(o.setStatus(w("image.autoInitSuccess"),"success"),d("\u2705 Auto-inicio exitoso"),o.setInitButtonVisible(!1),await g(!0)&&d("\u{1F680} Bot auto-iniciado completamente")):(o.setStatus(w("image.autoInitFailed"),"warning"),d("\u26A0\uFE0F Auto-inicio fall\xF3, se requiere inicio manual"))}catch(r){d("\u274C Error en auto-inicio:",r),o.setStatus(w("image.manualInitRequired"),"warning")}},1e3)}catch(a){throw d("\u274C Error inicializando Auto-Image:",a),window.__wplaceBot&&(window.__wplaceBot.imageRunning=!1),a}}(async()=>{"use strict";var l,t;try{console.log("[WPA-Image] \u{1F916} Iniciando auto-click del bot\xF3n Paint..."),await U(3,!0)}catch(s){console.log("[WPA-Image] \u26A0\uFE0F Error en auto-click del bot\xF3n Paint:",s)}if((l=window.__wplaceBot)!=null&&l.imageRunning){alert("Auto-Image ya est\xE1 corriendo.");return}if((t=window.__wplaceBot)!=null&&t.farmRunning){alert("Auto-Farm est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Image.");return}window.__wplaceBot||(window.__wplaceBot={}),window.__wplaceBot.imageRunning=!0,xe().catch(s=>{console.error("[BOT] Error en Auto-Image:",s),window.__wplaceBot&&(window.__wplaceBot.imageRunning=!1),alert("Auto-Image: error inesperado. Revisa consola.")})})();})();
+    `;
+      overlay.appendChild(modal);
+      document.body.appendChild(overlay);
+      const saveBtn = modal.querySelector(".save-btn");
+      const discardBtn = modal.querySelector(".discard-btn");
+      const cancelBtn = modal.querySelector(".cancel-btn");
+      const cleanup = () => {
+        document.body.removeChild(overlay);
+      };
+      if (saveBtn) {
+        saveBtn.addEventListener("click", () => {
+          cleanup();
+          resolve("save");
+        });
+      }
+      if (discardBtn) {
+        discardBtn.addEventListener("click", () => {
+          cleanup();
+          resolve("discard");
+        });
+      }
+      if (cancelBtn) {
+        cancelBtn.addEventListener("click", () => {
+          cleanup();
+          resolve("cancel");
+        });
+      }
+      overlay.addEventListener("click", (e) => {
+        if (e.target === overlay) {
+          cleanup();
+          resolve("cancel");
+        }
+      });
+    });
+  }
+
+  // src/core/dom.js
+  function isPaletteOpen(debug = false) {
+    const paletteSelectors = [
+      '[data-testid="color-picker"]',
+      ".color-picker",
+      ".palette",
+      '[class*="color"][class*="picker"]',
+      '[class*="palette"]'
+    ];
+    for (const selector of paletteSelectors) {
+      const element = document.querySelector(selector);
+      if (element && element.offsetParent !== null) {
+        if (debug) console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por selector: ${selector}`);
+        return true;
+      }
+    }
+    const colorElements = document.querySelectorAll('[style*="background-color"], [style*="background:"], .color, [class*="color"]');
+    let visibleColors = 0;
+    for (const el of colorElements) {
+      if (el.offsetParent !== null && el.offsetWidth > 10 && el.offsetHeight > 10) {
+        visibleColors++;
+        if (visibleColors >= 5) {
+          if (debug) console.log(`[WPA-UI] \u{1F3A8} Paleta detectada por colores visibles: ${visibleColors}`);
+          return true;
+        }
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u{1F50D} Paleta no detectada. Colores visibles: ${visibleColors}`);
+    return false;
+  }
+  function findAndClickPaintButton(debug = false, doubleClick = false) {
+    const specificButton = document.querySelector("button.btn.btn-primary.btn-lg, button.btn.btn-primary.sm\\:btn-xl");
+    if (specificButton) {
+      const buttonText = specificButton.textContent.toLowerCase();
+      const hasPaintText = buttonText.includes("paint") || buttonText.includes("pintar");
+      const hasPaintIcon = specificButton.querySelector('svg path[d*="240-120"]') || specificButton.querySelector('svg path[d*="M15"]');
+      if (hasPaintText || hasPaintIcon) {
+        if (debug) console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por selector espec\xEDfico: "${buttonText}"`);
+        specificButton.click();
+        if (doubleClick) {
+          setTimeout(() => {
+            if (debug) console.log(`[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint`);
+            specificButton.click();
+          }, 500);
+        }
+        return true;
+      }
+    }
+    const buttons = document.querySelectorAll("button");
+    for (const button of buttons) {
+      const buttonText = button.textContent.toLowerCase();
+      if ((buttonText.includes("paint") || buttonText.includes("pintar")) && button.offsetParent !== null && !button.disabled) {
+        if (debug) console.log(`[WPA-UI] \u{1F3AF} Bot\xF3n Paint encontrado por texto: "${button.textContent.trim()}"`);
+        button.click();
+        if (doubleClick) {
+          setTimeout(() => {
+            if (debug) console.log(`[WPA-UI] \u{1F3AF} Segundo clic en bot\xF3n Paint`);
+            button.click();
+          }, 500);
+        }
+        return true;
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado`);
+    return false;
+  }
+  async function autoClickPaintButton(maxAttempts = 3, debug = true) {
+    if (debug) console.log(`[WPA-UI] \u{1F916} Iniciando auto-click del bot\xF3n Paint (m\xE1ximo ${maxAttempts} intentos)`);
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (debug) console.log(`[WPA-UI] \u{1F3AF} Intento ${attempt}/${maxAttempts} - Buscando bot\xF3n Paint...`);
+      if (isPaletteOpen()) {
+        if (debug) console.log(`[WPA-UI] \u2705 Paleta ya est\xE1 abierta, auto-click completado`);
+        return true;
+      }
+      if (findAndClickPaintButton(debug, false)) {
+        if (debug) console.log(`[WPA-UI] \u{1F446} Clic en bot\xF3n Paint realizado (sin segundo clic)`);
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        if (isPaletteOpen()) {
+          if (debug) console.log(`[WPA-UI] \u2705 Paleta abierta exitosamente despu\xE9s del intento ${attempt}`);
+          return true;
+        } else {
+          if (debug) console.log(`[WPA-UI] \u26A0\uFE0F Paleta no detectada tras el clic en intento ${attempt}. Reintentar\xE1.`);
+        }
+      } else {
+        if (debug) console.log(`[WPA-UI] \u274C Bot\xF3n Paint no encontrado para clic en intento ${attempt}`);
+      }
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 1e3));
+      }
+    }
+    if (debug) console.log(`[WPA-UI] \u274C Auto-click fall\xF3 despu\xE9s de ${maxAttempts} intentos`);
+    return false;
+  }
+
+  // src/image/plan-overlay-blue-marble.js
+  (() => {
+    const TILE_SIZE = 3e3;
+    const state = {
+      enabled: false,
+      templates: [],
+      // Plantillas estilo Blue Marble
+      templatesShouldBeDrawn: true,
+      tileSize: 1e3,
+      // Tamaño de tile (como Blue Marble)
+      drawMult: 3,
+      // Multiplicador de dibujo
+      // Plan de píxeles actual
+      pixelPlan: null,
+      nextBatchCount: 0,
+      anchor: null,
+      // { tileX, tileY, pxX, pxY }
+      imageWidth: null,
+      imageHeight: null,
+      // Sistema de intercepción
+      originalFetch: null,
+      fetchedBlobQueue: /* @__PURE__ */ new Map(),
+      isIntercepting: false
+    };
+    function injectStyles() {
+      console.log("[PLAN OVERLAY] Blue Marble tile system initialized");
+    }
+    function startFetchInterception() {
+      if (state.isIntercepting) return;
+      state.originalFetch = window.fetch;
+      state.isIntercepting = true;
+      window.fetch = async function(...args) {
+        var _a;
+        const response = await state.originalFetch.apply(this, args);
+        const cloned = response.clone();
+        const endpointName = (args[0] instanceof Request ? (_a = args[0]) == null ? void 0 : _a.url : args[0]) || "ignore";
+        const contentType = cloned.headers.get("content-type") || "";
+        if (contentType.includes("image/") && endpointName.includes("/tiles/") && !endpointName.includes("openfreemap") && !endpointName.includes("maps")) {
+          console.log("[PLAN OVERLAY] Intercepting tile request:", endpointName);
+          try {
+            const blob = await cloned.blob();
+            const processedBlob = await drawPlanOnTile(blob, endpointName);
+            return new Response(processedBlob, {
+              headers: cloned.headers,
+              status: cloned.status,
+              statusText: cloned.statusText
+            });
+          } catch (error) {
+            console.error("[PLAN OVERLAY] Error processing tile:", error);
+            return response;
+          }
+        }
+        return response;
+      };
+      console.log("[PLAN OVERLAY] Fetch interception started");
+    }
+    function stopFetchInterception() {
+      if (!state.isIntercepting || !state.originalFetch) return;
+      window.fetch = state.originalFetch;
+      state.isIntercepting = false;
+      console.log("[PLAN OVERLAY] Fetch interception stopped");
+    }
+    async function drawPlanOnTile(tileBlob, endpointUrl) {
+      if (!state.enabled || !state.templatesShouldBeDrawn || !state.pixelPlan) {
+        return tileBlob;
+      }
+      const urlParts = endpointUrl.split("/");
+      const tileY = parseInt(urlParts[urlParts.length - 1].replace(".png", ""));
+      const tileX = parseInt(urlParts[urlParts.length - 2]);
+      if (isNaN(tileX) || isNaN(tileY)) {
+        console.warn("[PLAN OVERLAY] Could not extract tile coordinates from URL:", endpointUrl);
+        return tileBlob;
+      }
+      console.log(`[PLAN OVERLAY] Processing tile: ${tileX},${tileY}`);
+      const tilePixels = getPixelsForTile(tileX, tileY);
+      if (tilePixels.length === 0) {
+        return tileBlob;
+      }
+      console.log(`[PLAN OVERLAY] Found ${tilePixels.length} pixels for tile ${tileX},${tileY}`);
+      const drawSize = state.tileSize * state.drawMult;
+      const tileBitmap = await createImageBitmap(tileBlob);
+      const canvas = new OffscreenCanvas(drawSize, drawSize);
+      const context = canvas.getContext("2d");
+      context.imageSmoothingEnabled = false;
+      context.clearRect(0, 0, drawSize, drawSize);
+      context.drawImage(tileBitmap, 0, 0, drawSize, drawSize);
+      drawPixelsOnTile(context, tilePixels, tileX, tileY);
+      return await canvas.convertToBlob({ type: "image/png" });
+    }
+    function getPixelsForTile(tileX, tileY) {
+      if (!state.pixelPlan || !state.pixelPlan.pixels) return [];
+      return state.pixelPlan.pixels.filter((pixel) => {
+        const pixelTileX = Math.floor(pixel.globalX / TILE_SIZE);
+        const pixelTileY = Math.floor(pixel.globalY / TILE_SIZE);
+        return pixelTileX === tileX && pixelTileY === tileY;
+      });
+    }
+    function drawPixelsOnTile(context, pixels, tileX, tileY) {
+      const tileStartX = tileX * TILE_SIZE;
+      const tileStartY = tileY * TILE_SIZE;
+      context.globalAlpha = 0.7;
+      for (const pixel of pixels) {
+        const localX = (pixel.globalX - tileStartX) * state.drawMult + 1;
+        const localY = (pixel.globalY - tileStartY) * state.drawMult + 1;
+        if (localX >= 0 && localX < state.tileSize * state.drawMult && localY >= 0 && localY < state.tileSize * state.drawMult) {
+          context.fillStyle = `rgb(${pixel.r},${pixel.g},${pixel.b})`;
+          context.fillRect(localX, localY, 1, 1);
+        }
+      }
+      if (state.nextBatchCount > 0) {
+        context.globalAlpha = 1;
+        const batchPixels = pixels.slice(0, state.nextBatchCount);
+        for (const pixel of batchPixels) {
+          const localX = (pixel.globalX - tileStartX) * state.drawMult + 1;
+          const localY = (pixel.globalY - tileStartY) * state.drawMult + 1;
+          if (localX >= 0 && localX < state.tileSize * state.drawMult && localY >= 0 && localY < state.tileSize * state.drawMult) {
+            context.fillStyle = `rgb(${pixel.r},${pixel.g},${pixel.b})`;
+            context.fillRect(localX, localY, 1, 1);
+          }
+        }
+      }
+    }
+    function setEnabled(enabled) {
+      state.enabled = !!enabled;
+      if (state.enabled) {
+        startFetchInterception();
+      } else {
+        stopFetchInterception();
+      }
+      console.log(`[PLAN OVERLAY] setEnabled: ${state.enabled}`);
+    }
+    function setPlan(planItems, opts = {}) {
+      var _a, _b, _c;
+      if (!planItems || planItems.length === 0) {
+        state.pixelPlan = null;
+        console.log("[PLAN OVERLAY] Plan cleared");
+        return;
+      }
+      const pixels = [];
+      for (const item of planItems) {
+        let globalX, globalY;
+        if (typeof item.tileX === "number" && typeof item.localX === "number") {
+          globalX = item.tileX * TILE_SIZE + item.localX;
+          globalY = item.tileY * TILE_SIZE + item.localY;
+        } else if (opts.anchor && typeof item.imageX === "number") {
+          const baseX = opts.anchor.tileX * TILE_SIZE + (opts.anchor.pxX || 0);
+          const baseY = opts.anchor.tileY * TILE_SIZE + (opts.anchor.pxY || 0);
+          globalX = baseX + item.imageX;
+          globalY = baseY + item.imageY;
+        } else {
+          continue;
+        }
+        pixels.push({
+          globalX,
+          globalY,
+          r: ((_a = item.color) == null ? void 0 : _a.r) || 0,
+          g: ((_b = item.color) == null ? void 0 : _b.g) || 0,
+          b: ((_c = item.color) == null ? void 0 : _c.b) || 0
+        });
+      }
+      state.pixelPlan = { pixels };
+      state.nextBatchCount = opts.nextBatchCount || 0;
+      state.anchor = opts.anchor || null;
+      state.imageWidth = opts.imageWidth || null;
+      state.imageHeight = opts.imageHeight || null;
+      console.log(`[PLAN OVERLAY] Plan set: ${pixels.length} pixels`);
+      if (typeof opts.enabled === "boolean") {
+        setEnabled(opts.enabled);
+      }
+    }
+    function setNextBatchCount(count) {
+      state.nextBatchCount = Math.max(0, Number(count || 0));
+      console.log(`[PLAN OVERLAY] Next batch count: ${state.nextBatchCount}`);
+    }
+    function setAnchor(anchor) {
+      state.anchor = anchor;
+      console.log("[PLAN OVERLAY] Anchor set:", anchor);
+    }
+    function setAnchorCss(x, y) {
+      console.log("[PLAN OVERLAY] CSS anchor set (ignored in tile system):", { x, y });
+    }
+    function endSelectionMode() {
+      console.log("[PLAN OVERLAY] Selection mode ended (ignored in tile system)");
+    }
+    function cleanup() {
+      stopFetchInterception();
+      state.pixelPlan = null;
+      state.fetchedBlobQueue.clear();
+      console.log("[PLAN OVERLAY] Cleanup completed");
+    }
+    window.__WPA_PLAN_OVERLAY__ = {
+      injectStyles,
+      setEnabled,
+      setPlan,
+      setPlanItemsFromTileList: setPlan,
+      // Alias
+      setNextBatchCount,
+      setAnchor,
+      setAnchorCss,
+      endSelectionMode,
+      render: () => {
+      },
+      // No-op en sistema de tiles
+      cleanup,
+      get state() {
+        return state;
+      }
+    };
+    console.log("[PLAN OVERLAY] Blue Marble tile system ready");
+  })();
+
+  // src/image/index.js
+  async function runImage() {
+    log("\u{1F680} Iniciando WPlace Auto-Image (versi\xF3n modular)");
+    initializeLanguage();
+    window.__wplaceBot = { ...window.__wplaceBot, imageRunning: true };
+    let currentUserInfo = null;
+    let originalFetch = window.fetch;
+    const restoreFetch = () => {
+      if (window.fetch !== originalFetch) {
+        window.fetch = originalFetch;
+        log("\u{1F504} Fetch original restaurado");
+      }
+      if (imageState.positionTimeoutId) {
+        clearTimeout(imageState.positionTimeoutId);
+        imageState.positionTimeoutId = null;
+      }
+      if (imageState.cleanupObserver) {
+        imageState.cleanupObserver();
+        imageState.cleanupObserver = null;
+      }
+      imageState.selectingPosition = false;
+    };
+    try {
+      const config = { ...IMAGE_DEFAULTS };
+      const texts = getSection("image");
+      imageState.language = getCurrentLanguage();
+      if (!config.SITEKEY) {
+        const siteKeyElement = document.querySelector("*[data-sitekey]");
+        if (siteKeyElement) {
+          config.SITEKEY = siteKeyElement.getAttribute("data-sitekey");
+          log(`\u{1F4DD} Sitekey encontrada autom\xE1ticamente: ${config.SITEKEY.substring(0, 20)}...`);
+        } else {
+          log("\u26A0\uFE0F No se pudo encontrar la sitekey autom\xE1ticamente");
+        }
+      }
+      async function tryAutoInit() {
+        log("\u{1F916} Intentando auto-inicio...");
+        if (isPaletteOpen()) {
+          log("\u{1F3A8} Paleta de colores ya est\xE1 abierta");
+          return true;
+        }
+        log("\u{1F50D} Paleta no encontrada, iniciando auto-click del bot\xF3n Paint...");
+        const success = await autoClickPaintButton(3, true);
+        if (success) {
+          log("\u2705 Auto-click exitoso, paleta abierta");
+          return true;
+        } else {
+          log("\u274C Auto-click fall\xF3, requerir\xE1 inicio manual");
+          return false;
+        }
+      }
+      async function initializeBot(isAutoInit = false) {
+        log("\u{1F916} Inicializando Auto-Image...");
+        ui.setStatus(t("image.checkingColors"), "info");
+        const colors = detectAvailableColors();
+        if (colors.length === 0) {
+          ui.setStatus(t("image.noColorsFound"), "error");
+          return false;
+        }
+        const sessionInfo = await getSession();
+        let userInfo = null;
+        if (sessionInfo.success && sessionInfo.data.user) {
+          userInfo = {
+            username: sessionInfo.data.user.name || "An\xF3nimo",
+            charges: sessionInfo.data.charges,
+            maxCharges: sessionInfo.data.maxCharges,
+            pixels: sessionInfo.data.user.pixelsPainted || 0
+            // Usar pixelsPainted en lugar de pixels
+          };
+          currentUserInfo = userInfo;
+          imageState.currentCharges = sessionInfo.data.charges;
+          imageState.maxCharges = sessionInfo.data.maxCharges || 50;
+          log(`\u{1F464} Usuario conectado: ${sessionInfo.data.user.name || "An\xF3nimo"} - Cargas: ${userInfo.charges}/${userInfo.maxCharges} - P\xEDxeles: ${userInfo.pixels}`);
+        } else {
+          log("\u26A0\uFE0F No se pudo obtener informaci\xF3n del usuario");
+        }
+        imageState.availableColors = colors;
+        imageState.colorsChecked = true;
+        ui.setStatus(t("image.colorsFound", { count: colors.length }), "success");
+        ui.updateProgress(0, 0, userInfo);
+        if (!isAutoInit) {
+          log(`\u2705 ${colors.length} colores disponibles detectados`);
+        }
+        ui.setInitialized(true);
+        ui.enableButtonsAfterInit();
+        try {
+        } catch {
+        }
+        return true;
+      }
+      const ui = await createImageUI({
+        texts,
+        onConfigChange: (config2) => {
+          if (config2.pixelsPerBatch !== void 0) {
+            imageState.pixelsPerBatch = config2.pixelsPerBatch;
+          }
+          if (config2.useAllCharges !== void 0) {
+            imageState.useAllChargesFirst = config2.useAllCharges;
+          }
+          log(`Configuraci\xF3n actualizada:`, config2);
+        },
+        onInitBot: initializeBot,
+        onUploadImage: async (file) => {
+          try {
+            ui.setStatus(t("image.loadingImage"), "info");
+            const imageUrl = window.URL.createObjectURL(file);
+            const processor = new BlueMarblelImageProcessor(imageUrl);
+            processor.originalName = file.name;
+            await processor.load();
+            const availableColors = processor.initializeColorPalette();
+            imageState.availableColors = availableColors;
+            const analysisResult = await processor.analyzePixels();
+            processor.setCoords(0, 0, 0, 0);
+            const processedData = processor.getImageData();
+            imageState.imageData = processedData;
+            imageState.imageData.processor = processor;
+            imageState.totalPixels = analysisResult.requiredPixels;
+            imageState.paintedPixels = 0;
+            imageState.originalImageName = file.name;
+            imageState.imageLoaded = true;
+            ui.setStatus(t("image.imageLoaded", { count: analysisResult.requiredPixels }), "success");
+            ui.updateProgress(0, analysisResult.requiredPixels, currentUserInfo);
+            log(`\u2705 [BLUE MARBLE] Imagen cargada: ${processedData.width}x${processedData.height}, ${analysisResult.requiredPixels} p\xEDxeles v\xE1lidos`);
+            log(`\u2705 [BLUE MARBLE] An\xE1lisis: ${analysisResult.uniqueColors} colores \xFAnicos, ${analysisResult.defacePixels} p\xEDxeles #deface`);
+            window.URL.revokeObjectURL(imageUrl);
+            try {
+              if (window.__WPA_PLAN_OVERLAY__) {
+                window.__WPA_PLAN_OVERLAY__.injectStyles();
+                window.__WPA_PLAN_OVERLAY__.setEnabled(true);
+                window.__WPA_PLAN_OVERLAY__.setPlan([], {
+                  enabled: true,
+                  nextBatchCount: 0
+                });
+                log("\u2705 Plan overlay activado autom\xE1ticamente al cargar imagen");
+              }
+            } catch (e) {
+              log("\u26A0\uFE0F Error activando plan overlay:", e);
+            }
+            return true;
+          } catch (error) {
+            ui.setStatus(t("image.imageError"), "error");
+            log("\u274C Error cargando imagen:", error);
+            return false;
+          }
+        },
+        onSelectPosition: async () => {
+          return new Promise((resolve) => {
+            ui.setStatus(t("image.selectPositionAlert"), "info");
+            ui.setStatus(t("image.waitingPosition"), "info");
+            imageState.selectingPosition = true;
+            let positionCaptured = false;
+            const setupFetchInterception = () => {
+              window.fetch = async (url, options) => {
+                if (imageState.selectingPosition && !positionCaptured && typeof url === "string" && url.includes("/s0/pixel/") && options && options.method === "POST") {
+                  try {
+                    log(`\u{1F3AF} Interceptando request de pintado: ${url}`);
+                    const response = await originalFetch(url, options);
+                    if (response.ok && options.body) {
+                      let bodyData;
+                      try {
+                        bodyData = JSON.parse(options.body);
+                      } catch (parseError) {
+                        log("Error parseando body del request:", parseError);
+                        return response;
+                      }
+                      if (bodyData.coords && Array.isArray(bodyData.coords) && bodyData.coords.length >= 2) {
+                        const localX = bodyData.coords[0];
+                        const localY = bodyData.coords[1];
+                        const tileMatch = url.match(/\/s0\/pixel\/(-?\d+)\/(-?\d+)/);
+                        if (tileMatch && !positionCaptured) {
+                          positionCaptured = true;
+                          const tileX = parseInt(tileMatch[1]);
+                          const tileY = parseInt(tileMatch[2]);
+                          imageState.tileX = tileX;
+                          imageState.tileY = tileY;
+                          imageState.startPosition = { x: localX, y: localY };
+                          imageState.selectingPosition = false;
+                          if (imageState.imageData && imageState.imageData.processor) {
+                            const processor = imageState.imageData.processor;
+                            processor.setCoords(tileX, tileY, localX, localY);
+                            try {
+                              await processor.createTemplateTiles();
+                              log(`\u2705 [BLUE MARBLE] Template tiles creados para posici\xF3n tile(${tileX},${tileY}) pixel(${localX},${localY})`);
+                            } catch (error) {
+                              log(`\u274C [BLUE MARBLE] Error creando template tiles: ${error.message}`);
+                            }
+                            const pixelQueue = processor.generatePixelQueue();
+                            imageState.remainingPixels = pixelQueue;
+                            imageState.totalPixels = pixelQueue.length;
+                            log(`\u2705 Cola de p\xEDxeles generada: ${pixelQueue.length} p\xEDxeles para overlay`);
+                          }
+                          try {
+                            if (window.__WPA_PLAN_OVERLAY__) {
+                              window.__WPA_PLAN_OVERLAY__.injectStyles();
+                              window.__WPA_PLAN_OVERLAY__.setEnabled(true);
+                              window.__WPA_PLAN_OVERLAY__.setAnchor({
+                                tileX,
+                                tileY,
+                                pxX: localX,
+                                pxY: localY
+                              });
+                              if (imageState.remainingPixels && imageState.remainingPixels.length > 0) {
+                                window.__WPA_PLAN_OVERLAY__.setPlan(imageState.remainingPixels, {
+                                  anchor: { tileX, tileY, pxX: localX, pxY: localY },
+                                  imageWidth: imageState.imageData.width,
+                                  imageHeight: imageState.imageData.height,
+                                  enabled: true
+                                });
+                                log(`\u2705 Plan overlay anclado en tile(${tileX},${tileY}) local(${localX},${localY})`);
+                              } else {
+                                log(`\u26A0\uFE0F No hay p\xEDxeles para mostrar en overlay`);
+                              }
+                            }
+                          } catch (error) {
+                            log(`\u274C Error configurando overlay: ${error.message}`);
+                          }
+                          restoreFetch();
+                          ui.setStatus(t("image.positionSet"), "success");
+                          log(`\u2705 Posici\xF3n establecida: tile(${imageState.tileX},${imageState.tileY}) local(${localX},${localY})`);
+                          resolve(true);
+                        } else {
+                          log("\u26A0\uFE0F No se pudo extraer tile de la URL:", url);
+                        }
+                      }
+                    }
+                    return response;
+                  } catch (error) {
+                    log("\u274C Error interceptando pixel:", error);
+                    if (!positionCaptured) {
+                      restoreFetch();
+                      return originalFetch(url, options);
+                    }
+                  }
+                }
+                return originalFetch(url, options);
+              };
+            };
+            const setupCanvasObserver = () => {
+              const canvasElements = document.querySelectorAll("canvas");
+              if (canvasElements.length === 0) {
+                log("\u26A0\uFE0F No se encontraron elementos canvas");
+                return;
+              }
+              log(`\u{1F4CA} Configurando observer para ${canvasElements.length} canvas`);
+              const clickHandler = (event) => {
+                var _a;
+                if (!imageState.selectingPosition || positionCaptured) return;
+                const target = event.target;
+                if (target && target.tagName === "CANVAS") {
+                  log("\u{1F5B1}\uFE0F Click detectado en canvas durante selecci\xF3n");
+                  try {
+                    const board = ((_a = document.querySelector("canvas")) == null ? void 0 : _a.parentElement) || document.body;
+                    const rect = board.getBoundingClientRect();
+                    const cssX = event.clientX - rect.left;
+                    const cssY = event.clientY - rect.top;
+                    if (window.__WPA_PLAN_OVERLAY__) {
+                      window.__WPA_PLAN_OVERLAY__.setAnchorCss(cssX, cssY);
+                      log(`Plan overlay: ancla CSS establecida en (${cssX}, ${cssY})`);
+                    }
+                  } catch (e) {
+                    log("Plan Overlay: error calculando ancla CSS", e);
+                  }
+                  setTimeout(() => {
+                    if (!positionCaptured && imageState.selectingPosition) {
+                      log("\u{1F50D} Buscando requests recientes de pintado...");
+                    }
+                  }, 500);
+                }
+              };
+              document.addEventListener("click", clickHandler);
+              imageState.cleanupObserver = () => {
+                document.removeEventListener("click", clickHandler);
+              };
+            };
+            setupFetchInterception();
+            setupCanvasObserver();
+            const timeoutId = setTimeout(() => {
+              if (imageState.selectingPosition && !positionCaptured) {
+                restoreFetch();
+                if (imageState.cleanupObserver) {
+                  imageState.cleanupObserver();
+                }
+                ui.setStatus(t("image.positionTimeout"), "error");
+                log("\u23F0 Timeout en selecci\xF3n de posici\xF3n");
+                resolve(false);
+              }
+            }, 12e4);
+            imageState.positionTimeoutId = timeoutId;
+          });
+        },
+        onStartPainting: async () => {
+          var _a;
+          log(`\u{1F50D} Estado para iniciar pintura:`, {
+            imageLoaded: imageState.imageLoaded,
+            startPosition: imageState.startPosition,
+            tileX: imageState.tileX,
+            tileY: imageState.tileY,
+            totalPixels: imageState.totalPixels,
+            remainingPixels: ((_a = imageState.remainingPixels) == null ? void 0 : _a.length) || 0
+          });
+          if (!imageState.imageLoaded || !imageState.startPosition) {
+            ui.setStatus(t("image.missingRequirements"), "error");
+            log(`\u274C Validaci\xF3n fallida: imageLoaded=${imageState.imageLoaded}, startPosition=${!!imageState.startPosition}`);
+            return false;
+          }
+          imageState.running = true;
+          imageState.stopFlag = false;
+          imageState.isFirstBatch = true;
+          ui.setStatus(t("image.startPaintingMsg"), "success");
+          try {
+            await processImage(
+              imageState.imageData,
+              imageState.startPosition,
+              // onProgress - ahora incluye tiempo estimado
+              (painted, total, message, estimatedTime) => {
+                if (currentUserInfo) {
+                  currentUserInfo.charges = Math.floor(imageState.currentCharges);
+                  if (estimatedTime !== void 0) {
+                    currentUserInfo.estimatedTime = estimatedTime;
+                  }
+                }
+                ui.updateProgress(painted, total, currentUserInfo);
+                if (imageState.inCooldown && imageState.nextBatchCooldown > 0) {
+                  ui.updateCooldownDisplay(imageState.nextBatchCooldown);
+                } else {
+                  ui.updateCooldownDisplay(0);
+                }
+                if (message) {
+                  if (message.includes("\u23F3") && imageState.inCooldown) {
+                    ui.updateCooldownMessage(message);
+                  } else {
+                    ui.setStatus(message, "info");
+                  }
+                } else {
+                  ui.setStatus(t("image.paintingProgress", { painted, total }), "info");
+                }
+              },
+              // onComplete
+              (completed, pixelsPainted) => {
+                if (completed) {
+                  ui.setStatus(t("image.paintingComplete", { count: pixelsPainted }), "success");
+                  clearProgress();
+                } else {
+                  ui.setStatus(t("image.paintingStopped"), "warning");
+                }
+                imageState.running = false;
+              },
+              // onError
+              (error) => {
+                ui.setStatus(t("image.paintingError"), "error");
+                log("\u274C Error en proceso de pintado:", error);
+                imageState.running = false;
+              }
+            );
+            return true;
+          } catch (error) {
+            ui.setStatus(t("image.paintingError"), "error");
+            log("\u274C Error iniciando pintado:", error);
+            imageState.running = false;
+            return false;
+          }
+        },
+        onStopPainting: async () => {
+          const progressInfo = getProgressInfo();
+          if (progressInfo.hasProgress) {
+            const shouldSave = await showConfirmDialog(
+              t("image.confirmSaveProgress"),
+              t("image.saveProgressTitle"),
+              {
+                save: t("image.saveProgress"),
+                discard: t("image.discardProgress"),
+                cancel: t("image.cancel")
+              }
+            );
+            if (shouldSave === "save") {
+              const result = saveProgress();
+              if (result.success) {
+                ui.setStatus(t("image.progressSaved", { filename: result.filename }), "success");
+              } else {
+                ui.setStatus(t("image.progressSaveError", { error: result.error }), "error");
+              }
+            } else if (shouldSave === "cancel") {
+              return false;
+            }
+          }
+          stopPainting();
+          ui.setStatus(t("image.paintingStopped"), "warning");
+          return true;
+        },
+        onSaveProgress: async () => {
+          const result = saveProgress();
+          if (result.success) {
+            ui.setStatus(t("image.progressSaved", { filename: result.filename }), "success");
+          } else {
+            ui.setStatus(t("image.progressSaveError", { error: result.error }), "error");
+          }
+          return result.success;
+        },
+        onLoadProgress: async (file) => {
+          try {
+            const result = await loadProgress(file);
+            if (result.success) {
+              ui.setStatus(t("image.progressLoaded", { painted: result.painted, total: result.total }), "success");
+              ui.updateProgress(result.painted, result.total, currentUserInfo);
+              log("\u2705 Progreso cargado - habilitando botones de inicio");
+              return true;
+            } else {
+              ui.setStatus(t("image.progressLoadError", { error: result.error }), "error");
+              return false;
+            }
+          } catch (error) {
+            ui.setStatus(t("image.progressLoadError", { error: error.message }), "error");
+            return false;
+          }
+        },
+        onResizeImage: () => {
+          if (imageState.imageLoaded && imageState.imageData && imageState.imageData.processor) {
+            ui.showResizeDialog(imageState.imageData.processor);
+          }
+        },
+        onConfirmResize: async (processor, newWidth, newHeight) => {
+          log(`\u{1F504} Redimensionando imagen de ${processor.getDimensions().width}x${processor.getDimensions().height} a ${newWidth}x${newHeight}`);
+          try {
+            await processor.resize(newWidth, newHeight);
+            const analysisResult = await processor.analyzePixels();
+            imageState.imageData = {
+              processor,
+              width: newWidth,
+              height: newHeight,
+              validPixelCount: analysisResult.validPixelCount,
+              totalPixels: analysisResult.totalPixels,
+              unknownPixels: analysisResult.unknownPixels
+            };
+            imageState.totalPixels = analysisResult.validPixelCount;
+            imageState.paintedPixels = 0;
+            imageState.remainingPixels = [];
+            imageState.lastPosition = { x: 0, y: 0 };
+            ui.updateProgress(0, analysisResult.validPixelCount, currentUserInfo);
+            ui.setStatus(t("image.resizeSuccess", { width: newWidth, height: newHeight }), "success");
+            log(`\u2705 Imagen redimensionada: ${analysisResult.validPixelCount} p\xEDxeles v\xE1lidos de ${analysisResult.totalPixels} totales`);
+            try {
+              if (window.__WPA_PLAN_OVERLAY__ && imageState.startPosition && imageState.tileX != null && imageState.tileY != null) {
+                await processor.createTemplateTiles();
+                const pixelQueue = processor.generatePixelQueue();
+                imageState.remainingPixels = pixelQueue;
+                imageState.totalPixels = pixelQueue.length;
+                window.__WPA_PLAN_OVERLAY__.setPlan(pixelQueue, {
+                  anchor: {
+                    tileX: imageState.tileX,
+                    tileY: imageState.tileY,
+                    pxX: imageState.startPosition.x,
+                    pxY: imageState.startPosition.y
+                  },
+                  imageWidth: newWidth,
+                  imageHeight: newHeight,
+                  enabled: true
+                });
+                log(`\u2705 Overlay actualizado con ${pixelQueue.length} p\xEDxeles despu\xE9s del resize`);
+              }
+            } catch (overlayError) {
+              log(`\u26A0\uFE0F Error actualizando overlay despu\xE9s del resize: ${overlayError.message}`);
+            }
+          } catch (error) {
+            log(`\u274C Error redimensionando imagen: ${error.message}`);
+            ui.setStatus(t("image.imageError"), "error");
+          }
+        }
+      });
+      const handleLauncherLanguageChange = (event) => {
+        const { language } = event.detail;
+        log(`\u{1F30D} Imagen: Detectado cambio de idioma desde launcher: ${language}`);
+        imageState.language = language;
+      };
+      window.addEventListener("launcherLanguageChanged", handleLauncherLanguageChange);
+      window.addEventListener("languageChanged", handleLauncherLanguageChange);
+      window.addEventListener("beforeunload", () => {
+        restoreFetch();
+        stopPainting();
+        ui.destroy();
+        window.removeEventListener("launcherLanguageChanged", handleLauncherLanguageChange);
+        window.removeEventListener("languageChanged", handleLauncherLanguageChange);
+        if (window.__wplaceBot) {
+          window.__wplaceBot.imageRunning = false;
+        }
+      });
+      log("\u2705 Auto-Image inicializado correctamente");
+      setTimeout(async () => {
+        try {
+          ui.setStatus(t("image.autoInitializing"), "info");
+          log("\u{1F916} Intentando auto-inicio...");
+          const autoInitSuccess = await tryAutoInit();
+          if (autoInitSuccess) {
+            ui.setStatus(t("image.autoInitSuccess"), "success");
+            log("\u2705 Auto-inicio exitoso");
+            ui.setInitButtonVisible(false);
+            const initResult = await initializeBot(true);
+            if (initResult) {
+              log("\u{1F680} Bot auto-iniciado completamente");
+            }
+          } else {
+            ui.setStatus(t("image.autoInitFailed"), "warning");
+            log("\u26A0\uFE0F Auto-inicio fall\xF3, se requiere inicio manual");
+          }
+        } catch (error) {
+          log("\u274C Error en auto-inicio:", error);
+          ui.setStatus(t("image.manualInitRequired"), "warning");
+        }
+      }, 1e3);
+    } catch (error) {
+      log("\u274C Error inicializando Auto-Image:", error);
+      if (window.__wplaceBot) {
+        window.__wplaceBot.imageRunning = false;
+      }
+      throw error;
+    }
+  }
+
+  // src/entries/image.js
+  (async () => {
+    "use strict";
+    var _a, _b;
+    try {
+      console.log("[WPA-Image] \u{1F916} Iniciando auto-click del bot\xF3n Paint...");
+      await autoClickPaintButton(3, true);
+    } catch (error) {
+      console.log("[WPA-Image] \u26A0\uFE0F Error en auto-click del bot\xF3n Paint:", error);
+    }
+    if ((_a = window.__wplaceBot) == null ? void 0 : _a.imageRunning) {
+      alert("Auto-Image ya est\xE1 corriendo.");
+      return;
+    }
+    if ((_b = window.__wplaceBot) == null ? void 0 : _b.farmRunning) {
+      alert("Auto-Farm est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Image.");
+      return;
+    }
+    if (!window.__wplaceBot) {
+      window.__wplaceBot = {};
+    }
+    window.__wplaceBot.imageRunning = true;
+    runImage().catch((e) => {
+      console.error("[BOT] Error en Auto-Image:", e);
+      if (window.__wplaceBot) {
+        window.__wplaceBot.imageRunning = false;
+      }
+      alert("Auto-Image: error inesperado. Revisa consola.");
+    });
+  })();
+})();
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsic3JjL2NvcmUvbG9nZ2VyLmpzIiwgInNyYy9sb2NhbGVzL2VzLmpzIiwgInNyYy9sb2NhbGVzL2VuLmpzIiwgInNyYy9sb2NhbGVzL2ZyLmpzIiwgInNyYy9sb2NhbGVzL3J1LmpzIiwgInNyYy9sb2NhbGVzL3poLUhhbnMuanMiLCAic3JjL2xvY2FsZXMvemgtSGFudC5qcyIsICJzcmMvbG9jYWxlcy9pbmRleC5qcyIsICJzcmMvaW1hZ2UvY29uZmlnLmpzIiwgInNyYy9pbWFnZS9wcm9jZXNzb3IuanMiLCAic3JjL2ltYWdlL2JsdWUtbWFyYmxlLXByb2Nlc3Nvci5qcyIsICJzcmMvY29yZS90aW1pbmcuanMiLCAic3JjL2NvcmUvd3BsYWNlLWFwaS5qcyIsICJzcmMvY29yZS90dXJuc3RpbGUuanMiLCAic3JjL2ltYWdlL3BhaW50ZXIuanMiLCAic3JjL2ltYWdlL3NhdmUtbG9hZC5qcyIsICJzcmMvY29yZS91aS11dGlscy5qcyIsICJzcmMvaW1hZ2UvdWkuanMiLCAic3JjL2NvcmUvZG9tLmpzIiwgInNyYy9pbWFnZS9wbGFuLW92ZXJsYXktYmx1ZS1tYXJibGUuanMiLCAic3JjL2ltYWdlL2luZGV4LmpzIiwgInNyYy9lbnRyaWVzL2ltYWdlLmpzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJleHBvcnQgY29uc3QgbG9nZ2VyID0ge1xuICBkZWJ1Z0VuYWJsZWQ6IGZhbHNlLFxuICBzZXREZWJ1Zyh2KSB7IHRoaXMuZGVidWdFbmFibGVkID0gISF2OyB9LFxuICBkZWJ1ZyguLi5hKSB7IGlmICh0aGlzLmRlYnVnRW5hYmxlZCkgY29uc29sZS5kZWJ1ZyhcIltCT1RdXCIsIC4uLmEpOyB9LFxuICBpbmZvKC4uLmEpICB7IGNvbnNvbGUuaW5mbyhcIltCT1RdXCIsIC4uLmEpOyB9LFxuICB3YXJuKC4uLmEpICB7IGNvbnNvbGUud2FybihcIltCT1RdXCIsIC4uLmEpOyB9LFxuICBlcnJvciguLi5hKSB7IGNvbnNvbGUuZXJyb3IoXCJbQk9UXVwiLCAuLi5hKTsgfVxufTtcblxuLy8gRmFybS1zcGVjaWZpYyBsb2dnZXJcbmV4cG9ydCBjb25zdCBsb2cgPSAoLi4uYSkgPT4gY29uc29sZS5sb2coJ1tXUEEtVUldJywgLi4uYSk7XG5cbi8vIFV0aWxpdHkgZnVuY3Rpb25zXG5leHBvcnQgY29uc3Qgbm9vcCA9ICgpID0+IHt9O1xuZXhwb3J0IGNvbnN0IGNsYW1wID0gKG4sIGEsIGIpID0+IE1hdGgubWF4KGEsIE1hdGgubWluKGIsIG4pKTtcbiIsICJleHBvcnQgY29uc3QgZXMgPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgQXV0by1GYXJtJyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggQXV0by1JbWFnZScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIEF1dG8tR3VhcmQnLFxuICAgIHNlbGVjdGlvbjogJ1NlbGVjY2lcdTAwRjNuJyxcbiAgICB1c2VyOiAnVXN1YXJpbycsXG4gICAgY2hhcmdlczogJ0NhcmdhcycsXG4gICAgYmFja2VuZDogJ0JhY2tlbmQnLFxuICAgIGRhdGFiYXNlOiAnRGF0YWJhc2UnLFxuICAgIHVwdGltZTogJ1VwdGltZScsXG4gICAgY2xvc2U6ICdDZXJyYXInLFxuICAgIGxhdW5jaDogJ0xhbnphcicsXG4gICAgbG9hZGluZzogJ0NhcmdhbmRvXHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdFamVjdXRhbmRvXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ0Rlc2NhcmdhbmRvIHNjcmlwdFx1MjAyNicsXG4gICAgY2hvb3NlQm90OiAnRWxpZ2UgdW4gYm90IHkgcHJlc2lvbmEgTGFuemFyJyxcbiAgICByZWFkeVRvTGF1bmNoOiAnTGlzdG8gcGFyYSBsYW56YXInLFxuICAgIGxvYWRFcnJvcjogJ0Vycm9yIGFsIGNhcmdhcicsXG4gICAgbG9hZEVycm9yTXNnOiAnTm8gc2UgcHVkbyBjYXJnYXIgZWwgYm90IHNlbGVjY2lvbmFkby4gUmV2aXNhIHR1IGNvbmV4aVx1MDBGM24gbyBpbnRcdTAwRTludGFsbyBkZSBudWV2by4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFZlcmlmaWNhbmRvLi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgT25saW5lJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IE9mZmxpbmUnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIE9LJyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBFcnJvcicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tSW1hZ2VcIixcbiAgICBpbml0Qm90OiBcIkluaWNpYXIgQXV0by1CT1RcIixcbiAgICB1cGxvYWRJbWFnZTogXCJTdWJpciBJbWFnZW5cIixcbiAgICByZXNpemVJbWFnZTogXCJSZWRpbWVuc2lvbmFyIEltYWdlblwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNlbGVjY2lvbmFyIFBvc2ljaVx1MDBGM25cIixcbiAgICBzdGFydFBhaW50aW5nOiBcIkluaWNpYXIgUGludHVyYVwiLFxuICAgIHN0b3BQYWludGluZzogXCJEZXRlbmVyIFBpbnR1cmFcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiR3VhcmRhciBQcm9ncmVzb1wiLFxuICAgIGxvYWRQcm9ncmVzczogXCJDYXJnYXIgUHJvZ3Jlc29cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgVmVyaWZpY2FuZG8gY29sb3JlcyBkaXNwb25pYmxlcy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1MDBBMUFicmUgbGEgcGFsZXRhIGRlIGNvbG9yZXMgZW4gZWwgc2l0aW8gZSBpbnRcdTAwRTludGFsbyBkZSBudWV2byFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUge2NvdW50fSBjb2xvcmVzIGRpc3BvbmlibGVzIGVuY29udHJhZG9zXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBDYXJnYW5kbyBpbWFnZW4uLi5cIixcbiAgICBpbWFnZUxvYWRlZDogXCJcdTI3MDUgSW1hZ2VuIGNhcmdhZGEgY29uIHtjb3VudH0gcFx1MDBFRHhlbGVzIHZcdTAwRTFsaWRvc1wiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGFsIGNhcmdhciBsYSBpbWFnZW5cIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1MDBBMVBpbnRhIGVsIHByaW1lciBwXHUwMEVEeGVsIGVuIGxhIHViaWNhY2lcdTAwRjNuIGRvbmRlIHF1aWVyZXMgcXVlIGNvbWllbmNlIGVsIGFydGUhXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBFc3BlcmFuZG8gcXVlIHBpbnRlcyBlbCBwXHUwMEVEeGVsIGRlIHJlZmVyZW5jaWEuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHUwMEExUG9zaWNpXHUwMEYzbiBlc3RhYmxlY2lkYSBjb24gXHUwMEU5eGl0byFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpZW1wbyBhZ290YWRvIHBhcmEgc2VsZWNjaW9uYXIgcG9zaWNpXHUwMEYzblwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFBvc2ljaVx1MDBGM24gZGV0ZWN0YWRhLCBwcm9jZXNhbmRvLi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgRXJyb3IgZGV0ZWN0YW5kbyBwb3NpY2lcdTAwRjNuLCBpbnRcdTAwRTludGFsbyBkZSBudWV2b1wiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IEluaWNpYW5kbyBwaW50dXJhLi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgUHJvZ3Jlc286IHtwYWludGVkfS97dG90YWx9IHBcdTAwRUR4ZWxlcy4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgU2luIGNhcmdhcy4gRXNwZXJhbmRvIHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUGludHVyYSBkZXRlbmlkYSBwb3IgZWwgdXN1YXJpb1wiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1MDBBMVBpbnR1cmEgY29tcGxldGFkYSEge2NvdW50fSBwXHUwMEVEeGVsZXMgcGludGFkb3MuXCIsXG4gICAgcGFpbnRpbmdFcnJvcjogXCJcdTI3NEMgRXJyb3IgZHVyYW50ZSBsYSBwaW50dXJhXCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgQ2FyZ2EgdW5hIGltYWdlbiB5IHNlbGVjY2lvbmEgdW5hIHBvc2ljaVx1MDBGM24gcHJpbWVyb1wiLFxuICAgIHByb2dyZXNzOiBcIlByb2dyZXNvXCIsXG4gICAgdXNlck5hbWU6IFwiVXN1YXJpb1wiLFxuICAgIHBpeGVsczogXCJQXHUwMEVEeGVsZXNcIixcbiAgICBjaGFyZ2VzOiBcIkNhcmdhc1wiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiVGllbXBvIGVzdGltYWRvXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiSGF6IGNsaWMgZW4gJ0luaWNpYXIgQXV0by1CT1QnIHBhcmEgY29tZW56YXJcIixcbiAgICB3YWl0aW5nSW5pdDogXCJFc3BlcmFuZG8gaW5pY2lhbGl6YWNpXHUwMEYzbi4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IEltYWdlbiByZWRpbWVuc2lvbmFkYSBhIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgUGludHVyYSBwYXVzYWRhIGVuIGxhIHBvc2ljaVx1MDBGM24gWDoge3h9LCBZOiB7eX1cIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQXHUwMEVEeGVsZXMgcG9yIGxvdGVcIixcbiAgICBiYXRjaFNpemU6IFwiVGFtYVx1MDBGMW8gZGVsIGxvdGVcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlNpZ3VpZW50ZSBsb3RlIGVuXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJVc2FyIHRvZGFzIGxhcyBjYXJnYXMgZGlzcG9uaWJsZXNcIixcbiAgICBzaG93T3ZlcmxheTogXCJNb3N0cmFyIG92ZXJsYXlcIixcbiAgICBtYXhDaGFyZ2VzOiBcIkNhcmdhcyBtXHUwMEUxeGltYXMgcG9yIGxvdGVcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgRXNwZXJhbmRvIGNhcmdhczoge2N1cnJlbnR9L3tuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJUaWVtcG8gcmVzdGFudGVcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIEVzcGVyYW5kbyB7dGltZX0gcGFyYSBjb250aW51YXIuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBQcm9ncmVzbyBndWFyZGFkbyBjb21vIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgUHJvZ3Jlc28gY2FyZ2Fkbzoge3BhaW50ZWR9L3t0b3RhbH0gcFx1MDBFRHhlbGVzIHBpbnRhZG9zXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIEVycm9yIGFsIGNhcmdhciBwcm9ncmVzbzoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBhbCBndWFyZGFyIHByb2dyZXNvOiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJcdTAwQkZEZXNlYXMgZ3VhcmRhciBlbCBwcm9ncmVzbyBhY3R1YWwgYW50ZXMgZGUgZGV0ZW5lcj9cIixcbiAgICBzYXZlUHJvZ3Jlc3NUaXRsZTogXCJHdWFyZGFyIFByb2dyZXNvXCIsXG4gICAgZGlzY2FyZFByb2dyZXNzOiBcIkRlc2NhcnRhclwiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxhclwiLFxuICAgIG1pbmltaXplOiBcIk1pbmltaXphclwiLFxuICAgIHdpZHRoOiBcIkFuY2hvXCIsXG4gICAgaGVpZ2h0OiBcIkFsdG9cIiwgXG4gICAga2VlcEFzcGVjdDogXCJNYW50ZW5lciBwcm9wb3JjaVx1MDBGM25cIixcbiAgICBhcHBseTogXCJBcGxpY2FyXCIsXG4gIG92ZXJsYXlPbjogXCJPdmVybGF5OiBPTlwiLFxuICBvdmVybGF5T2ZmOiBcIk92ZXJsYXk6IE9GRlwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFBhc2FkYSBjb21wbGV0YWRhOiB7cGFpbnRlZH0gcFx1MDBFRHhlbGVzIHBpbnRhZG9zIHwgUHJvZ3Jlc286IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIEVzcGVyYW5kbyByZWdlbmVyYWNpXHUwMEYzbiBkZSBjYXJnYXM6IHtjdXJyZW50fS97bmVlZGVkfSAtIFRpZW1wbzoge3RpbWV9XCIsXG4gICAgd2FpdGluZ0NoYXJnZXNDb3VudGRvd246IFwiXHUyM0YzIEVzcGVyYW5kbyBjYXJnYXM6IHtjdXJyZW50fS97bmVlZGVkfSAtIFF1ZWRhbjoge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgSW5pY2lhbGl6YW5kbyBhdXRvbVx1MDBFMXRpY2FtZW50ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgQm90IGluaWNpYWRvIGF1dG9tXHUwMEUxdGljYW1lbnRlXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZG8gaW5pY2lhciBhdXRvbVx1MDBFMXRpY2FtZW50ZS4gVXNhIGVsIGJvdFx1MDBGM24gbWFudWFsLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXRhIGRlIGNvbG9yZXMgZGV0ZWN0YWRhXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBCdXNjYW5kbyBwYWxldGEgZGUgY29sb3Jlcy4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IEhhY2llbmRvIGNsaWMgZW4gZWwgYm90XHUwMEYzbiBQYWludC4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkb1wiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pY2lvIG1hbnVhbCByZXF1ZXJpZG9cIixcbiAgICByZXRyeUF0dGVtcHQ6IFwiXHVEODNEXHVERDA0IFJlaW50ZW50byB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSBlbiB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IEVycm9yIGVuIGludGVudG8ge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30sIHJlaW50ZW50YW5kbyBlbiB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RmFpbGVkOiBcIlx1Mjc0QyBGYWxsXHUwMEYzIGRlc3B1XHUwMEU5cyBkZSB7bWF4QXR0ZW1wdHN9IGludGVudG9zLiBDb250aW51YW5kbyBjb24gc2lndWllbnRlIGxvdGUuLi5cIixcbiAgICBuZXR3b3JrRXJyb3I6IFwiXHVEODNDXHVERjEwIEVycm9yIGRlIHJlZC4gUmVpbnRlbnRhbmRvLi4uXCIsXG4gICAgc2VydmVyRXJyb3I6IFwiXHVEODNEXHVERDI1IEVycm9yIGRlbCBzZXJ2aWRvci4gUmVpbnRlbnRhbmRvLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBUaW1lb3V0IGRlbCBzZXJ2aWRvci4gUmVpbnRlbnRhbmRvLi4uXCJcbiAgfSxcblxuICAvLyBGYXJtIE1vZHVsZSAocG9yIGltcGxlbWVudGFyKVxuICBmYXJtOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEZhcm0gQm90XCIsXG4gICAgc3RhcnQ6IFwiSW5pY2lhclwiLFxuICAgIHN0b3A6IFwiRGV0ZW5lclwiLCBcbiAgICBzdG9wcGVkOiBcIkJvdCBkZXRlbmlkb1wiLFxuICAgIGNhbGlicmF0ZTogXCJDYWxpYnJhclwiLFxuICAgIHBhaW50T25jZTogXCJVbmEgdmV6XCIsXG4gICAgY2hlY2tpbmdTdGF0dXM6IFwiVmVyaWZpY2FuZG8gZXN0YWRvLi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJDb25maWd1cmFjaVx1MDBGM25cIixcbiAgICBkZWxheTogXCJEZWxheSAobXMpXCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUFx1MDBFRHhlbGVzL2xvdGVcIixcbiAgICBtaW5DaGFyZ2VzOiBcIkNhcmdhcyBtXHUwMEVEblwiLFxuICAgIGNvbG9yTW9kZTogXCJNb2RvIGNvbG9yXCIsXG4gICAgcmFuZG9tOiBcIkFsZWF0b3Jpb1wiLFxuICAgIGZpeGVkOiBcIkZpam9cIixcbiAgICByYW5nZTogXCJSYW5nb1wiLFxuICAgIGZpeGVkQ29sb3I6IFwiQ29sb3IgZmlqb1wiLFxuICAgIGFkdmFuY2VkOiBcIkF2YW56YWRvXCIsXG4gICAgdGlsZVg6IFwiVGlsZSBYXCIsXG4gICAgdGlsZVk6IFwiVGlsZSBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJQYWxldGEgcGVyc29uYWxpemFkYVwiLFxuICAgIHBhbGV0dGVFeGFtcGxlOiBcImVqOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiQ2FwdHVyYXJcIixcbiAgICBwYWludGVkOiBcIlBpbnRhZG9zXCIsXG4gICAgY2hhcmdlczogXCJDYXJnYXNcIixcbiAgICByZXRyaWVzOiBcIkZhbGxvc1wiLFxuICAgIHRpbGU6IFwiVGlsZVwiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIkNvbmZpZ3VyYWNpXHUwMEYzbiBndWFyZGFkYVwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJDb25maWd1cmFjaVx1MDBGM24gY2FyZ2FkYVwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIkNvbmZpZ3VyYWNpXHUwMEYzbiByZWluaWNpYWRhXCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJQaW50YSB1biBwXHUwMEVEeGVsIG1hbnVhbG1lbnRlIHBhcmEgY2FwdHVyYXIgY29vcmRlbmFkYXMuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIkJhY2tlbmQgT25saW5lXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiQmFja2VuZCBPZmZsaW5lXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiSW5pY2lhbmRvIGJvdC4uLlwiLFxuICAgIHN0b3BwaW5nQm90OiBcIkRldGVuaWVuZG8gYm90Li4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiQ2FsaWJyYW5kby4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIkF1dG8tRmFybSB5YSBlc3RcdTAwRTEgY29ycmllbmRvLlwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiQXV0by1JbWFnZSBlc3RcdTAwRTEgZWplY3V0XHUwMEUxbmRvc2UuIENpXHUwMEU5cnJhbG8gYW50ZXMgZGUgaW5pY2lhciBBdXRvLUZhcm0uXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU2VsZWNjaW9uYXIgWm9uYVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFBpbnRhIHVuIHBcdTAwRUR4ZWwgZW4gdW5hIHpvbmEgREVTUE9CTEFEQSBkZWwgbWFwYSBwYXJhIGVzdGFibGVjZXIgZWwgXHUwMEUxcmVhIGRlIGZhcm1pbmdcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBxdWUgcGludGVzIGVsIHBcdTAwRUR4ZWwgZGUgcmVmZXJlbmNpYS4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTAwQTFab25hIGVzdGFibGVjaWRhISBSYWRpbzogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpZW1wbyBhZ290YWRvIHBhcmEgc2VsZWNjaW9uYXIgem9uYVwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgU2VsZWNjaW9uYSB1bmEgem9uYSBwcmltZXJvIHVzYW5kbyAnU2VsZWNjaW9uYXIgWm9uYSdcIixcbiAgICBmYXJtUmFkaXVzOiBcIlJhZGlvIGZhcm1cIixcbiAgICBwb3NpdGlvbkluZm86IFwiWm9uYSBhY3R1YWxcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIEZhcm1pbmcgZW4gcmFkaW8ge3JhZGl1c31weCBkZXNkZSAoe3h9LHt5fSlcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIElNUE9SVEFOVEU6IFNlbGVjY2lvbmEgdW5hIHpvbmEgREVTUE9CTEFEQSBwYXJhIGV2aXRhciBjb25mbGljdG9zXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJTaW4gem9uYVwiLFxuICAgIGN1cnJlbnRab25lOiBcIlpvbmE6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgU2VsZWNjaW9uYSB1bmEgem9uYSBwcmltZXJvLiBQaW50YSB1biBwXHUwMEVEeGVsIGVuIGVsIG1hcGEgcGFyYSBlc3RhYmxlY2VyIGxhIHpvbmEgZGUgZmFybWluZ1wiXG4gIH0sXG5cbiAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiU1x1MDBFRFwiLFxuICAgIG5vOiBcIk5vXCIsXG4gICAgb2s6IFwiQWNlcHRhclwiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxhclwiLFxuICAgIGNsb3NlOiBcIkNlcnJhclwiLFxuICAgIHNhdmU6IFwiR3VhcmRhclwiLFxuICAgIGxvYWQ6IFwiQ2FyZ2FyXCIsXG4gICAgZGVsZXRlOiBcIkVsaW1pbmFyXCIsXG4gICAgZWRpdDogXCJFZGl0YXJcIixcbiAgICBzdGFydDogXCJJbmljaWFyXCIsXG4gICAgc3RvcDogXCJEZXRlbmVyXCIsXG4gICAgcGF1c2U6IFwiUGF1c2FyXCIsXG4gICAgcmVzdW1lOiBcIlJlYW51ZGFyXCIsXG4gICAgcmVzZXQ6IFwiUmVpbmljaWFyXCIsXG4gICAgc2V0dGluZ3M6IFwiQ29uZmlndXJhY2lcdTAwRjNuXCIsXG4gICAgaGVscDogXCJBeXVkYVwiLFxuICAgIGFib3V0OiBcIkFjZXJjYSBkZVwiLFxuICAgIGxhbmd1YWdlOiBcIklkaW9tYVwiLFxuICAgIGxvYWRpbmc6IFwiQ2FyZ2FuZG8uLi5cIixcbiAgICBlcnJvcjogXCJFcnJvclwiLFxuICAgIHN1Y2Nlc3M6IFwiXHUwMEM5eGl0b1wiLFxuICAgIHdhcm5pbmc6IFwiQWR2ZXJ0ZW5jaWFcIixcbiAgICBpbmZvOiBcIkluZm9ybWFjaVx1MDBGM25cIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiSWRpb21hIGNhbWJpYWRvIGEge2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gR3VhcmQgTW9kdWxlXG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tR3VhcmRcIixcbiAgICBpbml0Qm90OiBcIkluaWNpYWxpemFyIEd1YXJkLUJPVFwiLFxuICAgIHNlbGVjdEFyZWE6IFwiU2VsZWNjaW9uYXIgXHUwMEMxcmVhXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiQ2FwdHVyYXIgXHUwMEMxcmVhXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIkluaWNpYXIgUHJvdGVjY2lcdTAwRjNuXCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiRGV0ZW5lciBQcm90ZWNjaVx1MDBGM25cIixcbiAgICB1cHBlckxlZnQ6IFwiRXNxdWluYSBTdXBlcmlvciBJenF1aWVyZGFcIixcbiAgICBsb3dlclJpZ2h0OiBcIkVzcXVpbmEgSW5mZXJpb3IgRGVyZWNoYVwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJQXHUwMEVEeGVsZXMgUHJvdGVnaWRvc1wiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJDYW1iaW9zIERldGVjdGFkb3NcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJQXHUwMEVEeGVsZXMgUmVwYXJhZG9zXCIsXG4gICAgY2hhcmdlczogXCJDYXJnYXNcIixcbiAgICB3YWl0aW5nSW5pdDogXCJFc3BlcmFuZG8gaW5pY2lhbGl6YWNpXHUwMEYzbi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBWZXJpZmljYW5kbyBjb2xvcmVzIGRpc3BvbmlibGVzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgTm8gc2UgZW5jb250cmFyb24gY29sb3Jlcy4gQWJyZSBsYSBwYWxldGEgZGUgY29sb3JlcyBlbiBlbCBzaXRpby5cIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUge2NvdW50fSBjb2xvcmVzIGRpc3BvbmlibGVzIGVuY29udHJhZG9zXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBpbmljaWFsaXphZG8gY29ycmVjdGFtZW50ZVwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgRXJyb3IgaW5pY2lhbGl6YW5kbyBHdWFyZC1CT1RcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBDb29yZGVuYWRhcyBpbnZcdTAwRTFsaWRhc1wiLFxuICAgIGludmFsaWRBcmVhOiBcIlx1Mjc0QyBFbCBcdTAwRTFyZWEgZGViZSB0ZW5lciBlc3F1aW5hIHN1cGVyaW9yIGl6cXVpZXJkYSBtZW5vciBxdWUgaW5mZXJpb3IgZGVyZWNoYVwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHUwMEMxcmVhIGRlbWFzaWFkbyBncmFuZGU6IHtzaXplfSBwXHUwMEVEeGVsZXMgKG1cdTAwRTF4aW1vOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBDYXB0dXJhbmRvIFx1MDBFMXJlYSBkZSBwcm90ZWNjaVx1MDBGM24uLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDBDMXJlYSBjYXB0dXJhZGE6IHtjb3VudH0gcFx1MDBFRHhlbGVzIGJham8gcHJvdGVjY2lcdTAwRjNuXCIsXG4gICAgY2FwdHVyZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBjYXB0dXJhbmRvIFx1MDBFMXJlYToge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgUHJpbWVybyBjYXB0dXJhIHVuIFx1MDBFMXJlYSBkZSBwcm90ZWNjaVx1MDBGM25cIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgUHJvdGVjY2lcdTAwRjNuIGluaWNpYWRhIC0gbW9uaXRvcmVhbmRvIFx1MDBFMXJlYVwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQcm90ZWNjaVx1MDBGM24gZGV0ZW5pZGFcIixcbiAgICBub0NoYW5nZXM6IFwiXHUyNzA1IFx1MDBDMXJlYSBwcm90ZWdpZGEgLSBzaW4gY2FtYmlvcyBkZXRlY3RhZG9zXCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCB7Y291bnR9IGNhbWJpb3MgZGV0ZWN0YWRvcyBlbiBlbCBcdTAwRTFyZWEgcHJvdGVnaWRhXCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBSZXBhcmFuZG8ge2NvdW50fSBwXHUwMEVEeGVsZXMgYWx0ZXJhZG9zLi4uXCIsXG4gICAgcmVwYWlyZWRTdWNjZXNzOiBcIlx1MjcwNSBSZXBhcmFkb3Mge2NvdW50fSBwXHUwMEVEeGVsZXMgY29ycmVjdGFtZW50ZVwiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBFcnJvciByZXBhcmFuZG8gcFx1MDBFRHhlbGVzOiB7ZXJyb3J9XCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjZBMFx1RkUwRiBTaW4gY2FyZ2FzIHN1ZmljaWVudGVzIHBhcmEgcmVwYXJhciBjYW1iaW9zXCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBWZXJpZmljYW5kbyBjYW1iaW9zIGVuIFx1MDBFMXJlYSBwcm90ZWdpZGEuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBFcnJvciB2ZXJpZmljYW5kbyBjYW1iaW9zOiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIEd1YXJkaVx1MDBFMW4gYWN0aXZvIC0gXHUwMEUxcmVhIGJham8gcHJvdGVjY2lcdTAwRjNuXCIsXG4gICAgbGFzdENoZWNrOiBcIlx1MDBEQWx0aW1hIHZlcmlmaWNhY2lcdTAwRjNuOiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiUHJcdTAwRjN4aW1hIHZlcmlmaWNhY2lcdTAwRjNuIGVuOiB7dGltZX1zXCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgSW5pY2lhbGl6YW5kbyBhdXRvbVx1MDBFMXRpY2FtZW50ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaWNpYWRvIGF1dG9tXHUwMEUxdGljYW1lbnRlXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZG8gaW5pY2lhciBhdXRvbVx1MDBFMXRpY2FtZW50ZS4gVXNhIGVsIGJvdFx1MDBGM24gbWFudWFsLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pY2lvIG1hbnVhbCByZXF1ZXJpZG9cIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFBhbGV0YSBkZSBjb2xvcmVzIGRldGVjdGFkYVwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgQnVzY2FuZG8gcGFsZXRhIGRlIGNvbG9yZXMuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBIYWNpZW5kbyBjbGljIGVuIGVsIGJvdFx1MDBGM24gUGFpbnQuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBCb3RcdTAwRjNuIFBhaW50IG5vIGVuY29udHJhZG9cIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFBpbnRhIHVuIHBcdTAwRUR4ZWwgZW4gbGEgZXNxdWluYSBTVVBFUklPUiBJWlFVSUVSREEgZGVsIFx1MDBFMXJlYSBhIHByb3RlZ2VyXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgQWhvcmEgcGludGEgdW4gcFx1MDBFRHhlbCBlbiBsYSBlc3F1aW5hIElORkVSSU9SIERFUkVDSEEgZGVsIFx1MDBFMXJlYVwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBzZWxlY2NpXHUwMEYzbiBkZSBlc3F1aW5hIHN1cGVyaW9yIGl6cXVpZXJkYS4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBFc3BlcmFuZG8gc2VsZWNjaVx1MDBGM24gZGUgZXNxdWluYSBpbmZlcmlvciBkZXJlY2hhLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IEVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhIGNhcHR1cmFkYTogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgRXNxdWluYSBpbmZlcmlvciBkZXJlY2hhIGNhcHR1cmFkYTogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpZW1wbyBhZ290YWRvIHBhcmEgc2VsZWNjaVx1MDBGM25cIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgRXJyb3IgZW4gc2VsZWNjaVx1MDBGM24sIGludFx1MDBFOW50YWxvIGRlIG51ZXZvXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgZW4gPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgQXV0by1GYXJtJyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggQXV0by1JbWFnZScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIEF1dG8tR3VhcmQnLFxuICAgIHNlbGVjdGlvbjogJ1NlbGVjdGlvbicsXG4gICAgdXNlcjogJ1VzZXInLFxuICAgIGNoYXJnZXM6ICdDaGFyZ2VzJyxcbiAgICBiYWNrZW5kOiAnQmFja2VuZCcsXG4gICAgZGF0YWJhc2U6ICdEYXRhYmFzZScsXG4gICAgdXB0aW1lOiAnVXB0aW1lJyxcbiAgICBjbG9zZTogJ0Nsb3NlJyxcbiAgICBsYXVuY2g6ICdMYXVuY2gnLFxuICAgIGxvYWRpbmc6ICdMb2FkaW5nXHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdFeGVjdXRpbmdcdTIwMjYnLFxuICAgIGRvd25sb2FkaW5nOiAnRG93bmxvYWRpbmcgc2NyaXB0XHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdDaG9vc2UgYSBib3QgYW5kIHByZXNzIExhdW5jaCcsXG4gICAgcmVhZHlUb0xhdW5jaDogJ1JlYWR5IHRvIGxhdW5jaCcsXG4gICAgbG9hZEVycm9yOiAnTG9hZCBlcnJvcicsXG4gICAgbG9hZEVycm9yTXNnOiAnQ291bGQgbm90IGxvYWQgdGhlIHNlbGVjdGVkIGJvdC4gQ2hlY2sgeW91ciBjb25uZWN0aW9uIG9yIHRyeSBhZ2Fpbi4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IENoZWNraW5nLi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgT25saW5lJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IE9mZmxpbmUnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIE9LJyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBFcnJvcicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tSW1hZ2VcIixcbiAgICBpbml0Qm90OiBcIkluaXRpYWxpemUgQXV0by1CT1RcIixcbiAgICB1cGxvYWRJbWFnZTogXCJVcGxvYWQgSW1hZ2VcIixcbiAgICByZXNpemVJbWFnZTogXCJSZXNpemUgSW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTZWxlY3QgUG9zaXRpb25cIixcbiAgICBzdGFydFBhaW50aW5nOiBcIlN0YXJ0IFBhaW50aW5nXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlN0b3AgUGFpbnRpbmdcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiU2F2ZSBQcm9ncmVzc1wiLFxuICAgIGxvYWRQcm9ncmVzczogXCJMb2FkIFByb2dyZXNzXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIENoZWNraW5nIGF2YWlsYWJsZSBjb2xvcnMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBPcGVuIHRoZSBjb2xvciBwYWxldHRlIG9uIHRoZSBzaXRlIGFuZCB0cnkgYWdhaW4hXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IEZvdW5kIHtjb3VudH0gYXZhaWxhYmxlIGNvbG9yc1wiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgTG9hZGluZyBpbWFnZS4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBJbWFnZSBsb2FkZWQgd2l0aCB7Y291bnR9IHZhbGlkIHBpeGVsc1wiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGxvYWRpbmcgaW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlBhaW50IHRoZSBmaXJzdCBwaXhlbCBhdCB0aGUgbG9jYXRpb24gd2hlcmUgeW91IHdhbnQgdGhlIGFydCB0byBzdGFydCFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFdhaXRpbmcgZm9yIHlvdSB0byBwYWludCB0aGUgcmVmZXJlbmNlIHBpeGVsLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFBvc2l0aW9uIHNldCBzdWNjZXNzZnVsbHkhXCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBUaW1lb3V0IGZvciBwb3NpdGlvbiBzZWxlY3Rpb25cIixcbiAgICBwb3NpdGlvbkRldGVjdGVkOiBcIlx1RDgzQ1x1REZBRiBQb3NpdGlvbiBkZXRlY3RlZCwgcHJvY2Vzc2luZy4uLlwiLFxuICAgIHBvc2l0aW9uRXJyb3I6IFwiXHUyNzRDIEVycm9yIGRldGVjdGluZyBwb3NpdGlvbiwgcGxlYXNlIHRyeSBhZ2FpblwiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IFN0YXJ0aW5nIHBhaW50aW5nLi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgUHJvZ3Jlc3M6IHtwYWludGVkfS97dG90YWx9IHBpeGVscy4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgTm8gY2hhcmdlcy4gV2FpdGluZyB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFBhaW50aW5nIHN0b3BwZWQgYnkgdXNlclwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFBhaW50aW5nIGNvbXBsZXRlZCEge2NvdW50fSBwaXhlbHMgcGFpbnRlZC5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBFcnJvciBkdXJpbmcgcGFpbnRpbmdcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBMb2FkIGFuIGltYWdlIGFuZCBzZWxlY3QgYSBwb3NpdGlvbiBmaXJzdFwiLFxuICAgIHByb2dyZXNzOiBcIlByb2dyZXNzXCIsXG4gICAgdXNlck5hbWU6IFwiVXNlclwiLFxuICAgIHBpeGVsczogXCJQaXhlbHNcIixcbiAgICBjaGFyZ2VzOiBcIkNoYXJnZXNcIixcbiAgICBlc3RpbWF0ZWRUaW1lOiBcIkVzdGltYXRlZCB0aW1lXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiQ2xpY2sgJ0luaXRpYWxpemUgQXV0by1CT1QnIHRvIGJlZ2luXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiV2FpdGluZyBmb3IgaW5pdGlhbGl6YXRpb24uLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBJbWFnZSByZXNpemVkIHRvIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgUGFpbnRpbmcgcGF1c2VkIGF0IHBvc2l0aW9uIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUGl4ZWxzIHBlciBiYXRjaFwiLFxuICAgIGJhdGNoU2l6ZTogXCJCYXRjaCBzaXplXCIsXG4gICAgbmV4dEJhdGNoVGltZTogXCJOZXh0IGJhdGNoIGluXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJVc2UgYWxsIGF2YWlsYWJsZSBjaGFyZ2VzXCIsXG4gICAgc2hvd092ZXJsYXk6IFwiU2hvdyBvdmVybGF5XCIsXG4gICAgbWF4Q2hhcmdlczogXCJNYXggY2hhcmdlcyBwZXIgYmF0Y2hcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgV2FpdGluZyBmb3IgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJUaW1lIHJlbWFpbmluZ1wiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgV2FpdGluZyB7dGltZX0gdG8gY29udGludWUuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBQcm9ncmVzcyBzYXZlZCBhcyB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFByb2dyZXNzIGxvYWRlZDoge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzIHBhaW50ZWRcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgRXJyb3IgbG9hZGluZyBwcm9ncmVzczoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBzYXZpbmcgcHJvZ3Jlc3M6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIkRvIHlvdSB3YW50IHRvIHNhdmUgdGhlIGN1cnJlbnQgcHJvZ3Jlc3MgYmVmb3JlIHN0b3BwaW5nP1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlNhdmUgUHJvZ3Jlc3NcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiRGlzY2FyZFwiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxcIixcbiAgICBtaW5pbWl6ZTogXCJNaW5pbWl6ZVwiLFxuICAgIHdpZHRoOiBcIldpZHRoXCIsXG4gICAgaGVpZ2h0OiBcIkhlaWdodFwiLCBcbiAgICBrZWVwQXNwZWN0OiBcIktlZXAgYXNwZWN0IHJhdGlvXCIsXG4gICAgYXBwbHk6IFwiQXBwbHlcIixcbiAgb3ZlcmxheU9uOiBcIk92ZXJsYXk6IE9OXCIsXG4gIG92ZXJsYXlPZmY6IFwiT3ZlcmxheTogT0ZGXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgUGFzcyBjb21wbGV0ZWQ6IHtwYWludGVkfSBwaXhlbHMgcGFpbnRlZCB8IFByb2dyZXNzOiB7cGVyY2VudH0lICh7Y3VycmVudH0ve3RvdGFsfSlcIixcbiAgICB3YWl0aW5nQ2hhcmdlc1JlZ2VuOiBcIlx1MjNGMyBXYWl0aW5nIGZvciBjaGFyZ2UgcmVnZW5lcmF0aW9uOiB7Y3VycmVudH0ve25lZWRlZH0gLSBUaW1lOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgV2FpdGluZyBmb3IgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gUmVtYWluaW5nOiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBBdXRvLWluaXRpYWxpemluZy4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgQm90IGF1dG8tc3RhcnRlZCBzdWNjZXNzZnVsbHlcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgQ291bGQgbm90IGF1dG8tc3RhcnQuIFVzZSBtYW51YWwgYnV0dG9uLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggQ29sb3IgcGFsZXR0ZSBkZXRlY3RlZFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgU2VhcmNoaW5nIGZvciBjb2xvciBwYWxldHRlLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpY2tpbmcgUGFpbnQgYnV0dG9uLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgUGFpbnQgYnV0dG9uIG5vdCBmb3VuZFwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgTWFudWFsIGluaXRpYWxpemF0aW9uIHJlcXVpcmVkXCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBSZXRyeSB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSBpbiB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IEVycm9yIGluIGF0dGVtcHQge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30sIHJldHJ5aW5nIGluIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIEZhaWxlZCBhZnRlciB7bWF4QXR0ZW1wdHN9IGF0dGVtcHRzLiBDb250aW51aW5nIHdpdGggbmV4dCBiYXRjaC4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgTmV0d29yayBlcnJvci4gUmV0cnlpbmcuLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgU2VydmVyIGVycm9yLiBSZXRyeWluZy4uLlwiLFxuICAgIHRpbWVvdXRFcnJvcjogXCJcdTIzRjAgU2VydmVyIHRpbWVvdXQuIFJldHJ5aW5nLi4uXCJcbiAgfSxcblxuICAvLyBGYXJtIE1vZHVsZSAodG8gYmUgaW1wbGVtZW50ZWQpXG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgRmFybSBCb3RcIixcbiAgICBzdGFydDogXCJTdGFydFwiLFxuICAgIHN0b3A6IFwiU3RvcFwiLFxuICAgIHN0b3BwZWQ6IFwiQm90IHN0b3BwZWRcIixcbiAgICBjYWxpYnJhdGU6IFwiQ2FsaWJyYXRlXCIsXG4gICAgcGFpbnRPbmNlOiBcIk9uY2VcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJDaGVja2luZyBzdGF0dXMuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIkNvbmZpZ3VyYXRpb25cIixcbiAgICBkZWxheTogXCJEZWxheSAobXMpXCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUGl4ZWxzL2JhdGNoXCIsXG4gICAgbWluQ2hhcmdlczogXCJNaW4gY2hhcmdlc1wiLFxuICAgIGNvbG9yTW9kZTogXCJDb2xvciBtb2RlXCIsXG4gICAgcmFuZG9tOiBcIlJhbmRvbVwiLFxuICAgIGZpeGVkOiBcIkZpeGVkXCIsXG4gICAgcmFuZ2U6IFwiUmFuZ2VcIixcbiAgICBmaXhlZENvbG9yOiBcIkZpeGVkIGNvbG9yXCIsXG4gICAgYWR2YW5jZWQ6IFwiQWR2YW5jZWRcIixcbiAgICB0aWxlWDogXCJUaWxlIFhcIixcbiAgICB0aWxlWTogXCJUaWxlIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIkN1c3RvbSBwYWxldHRlXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiZS5nOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiQ2FwdHVyZVwiLFxuICAgIHBhaW50ZWQ6IFwiUGFpbnRlZFwiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIHJldHJpZXM6IFwiUmV0cmllc1wiLFxuICAgIHRpbGU6IFwiVGlsZVwiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIkNvbmZpZ3VyYXRpb24gc2F2ZWRcIixcbiAgICBjb25maWdMb2FkZWQ6IFwiQ29uZmlndXJhdGlvbiBsb2FkZWRcIixcbiAgICBjb25maWdSZXNldDogXCJDb25maWd1cmF0aW9uIHJlc2V0XCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJQYWludCBhIHBpeGVsIG1hbnVhbGx5IHRvIGNhcHR1cmUgY29vcmRpbmF0ZXMuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIkJhY2tlbmQgT25saW5lXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiQmFja2VuZCBPZmZsaW5lXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiU3RhcnRpbmcgYm90Li4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiU3RvcHBpbmcgYm90Li4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiQ2FsaWJyYXRpbmcuLi5cIixcbiAgICBhbHJlYWR5UnVubmluZzogXCJBdXRvLUZhcm0gaXMgYWxyZWFkeSBydW5uaW5nLlwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiQXV0by1JbWFnZSBpcyBydW5uaW5nLiBDbG9zZSBpdCBiZWZvcmUgc3RhcnRpbmcgQXV0by1GYXJtLlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNlbGVjdCBBcmVhXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgUGFpbnQgYSBwaXhlbCBpbiBhbiBFTVBUWSBhcmVhIG9mIHRoZSBtYXAgdG8gc2V0IHRoZSBmYXJtaW5nIHpvbmVcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFdhaXRpbmcgZm9yIHlvdSB0byBwYWludCB0aGUgcmVmZXJlbmNlIHBpeGVsLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IEFyZWEgc2V0ISBSYWRpdXM6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBUaW1lb3V0IGZvciBhcmVhIHNlbGVjdGlvblwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgU2VsZWN0IGFuIGFyZWEgZmlyc3QgdXNpbmcgJ1NlbGVjdCBBcmVhJ1wiLFxuICAgIGZhcm1SYWRpdXM6IFwiRmFybSByYWRpdXNcIixcbiAgICBwb3NpdGlvbkluZm86IFwiQ3VycmVudCBhcmVhXCIsXG4gICAgZmFybWluZ0luUmFkaXVzOiBcIlx1RDgzQ1x1REYzRSBGYXJtaW5nIGluIHtyYWRpdXN9cHggcmFkaXVzIGZyb20gKHt4fSx7eX0pXCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBJTVBPUlRBTlQ6IFNlbGVjdCBhbiBFTVBUWSBhcmVhIHRvIGF2b2lkIGNvbmZsaWN0c1wiLFxuICAgIG5vUG9zaXRpb246IFwiTm8gYXJlYVwiLFxuICAgIGN1cnJlbnRab25lOiBcIlpvbmU6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgU2VsZWN0IGFuIGFyZWEgZmlyc3QuIFBhaW50IGEgcGl4ZWwgb24gdGhlIG1hcCB0byBzZXQgdGhlIGZhcm1pbmcgem9uZVwiXG4gIH0sXG5cbiAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiWWVzXCIsXG4gICAgbm86IFwiTm9cIixcbiAgICBvazogXCJPS1wiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxcIixcbiAgICBjbG9zZTogXCJDbG9zZVwiLFxuICAgIHNhdmU6IFwiU2F2ZVwiLFxuICAgIGxvYWQ6IFwiTG9hZFwiLFxuICAgIGRlbGV0ZTogXCJEZWxldGVcIixcbiAgICBlZGl0OiBcIkVkaXRcIixcbiAgICBzdGFydDogXCJTdGFydFwiLFxuICAgIHN0b3A6IFwiU3RvcFwiLFxuICAgIHBhdXNlOiBcIlBhdXNlXCIsXG4gICAgcmVzdW1lOiBcIlJlc3VtZVwiLFxuICAgIHJlc2V0OiBcIlJlc2V0XCIsXG4gICAgc2V0dGluZ3M6IFwiU2V0dGluZ3NcIixcbiAgICBoZWxwOiBcIkhlbHBcIixcbiAgICBhYm91dDogXCJBYm91dFwiLFxuICAgIGxhbmd1YWdlOiBcIkxhbmd1YWdlXCIsXG4gICAgbG9hZGluZzogXCJMb2FkaW5nLi4uXCIsXG4gICAgZXJyb3I6IFwiRXJyb3JcIixcbiAgICBzdWNjZXNzOiBcIlN1Y2Nlc3NcIixcbiAgICB3YXJuaW5nOiBcIldhcm5pbmdcIixcbiAgICBpbmZvOiBcIkluZm9ybWF0aW9uXCIsXG4gICAgbGFuZ3VhZ2VDaGFuZ2VkOiBcIkxhbmd1YWdlIGNoYW5nZWQgdG8ge2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gR3VhcmQgTW9kdWxlXG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tR3VhcmRcIixcbiAgICBpbml0Qm90OiBcIkluaXRpYWxpemUgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJTZWxlY3QgQXJlYVwiLFxuICAgIGNhcHR1cmVBcmVhOiBcIkNhcHR1cmUgQXJlYVwiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJTdGFydCBQcm90ZWN0aW9uXCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiU3RvcCBQcm90ZWN0aW9uXCIsXG4gICAgdXBwZXJMZWZ0OiBcIlVwcGVyIExlZnQgQ29ybmVyXCIsXG4gICAgbG93ZXJSaWdodDogXCJMb3dlciBSaWdodCBDb3JuZXJcIixcbiAgICBwcm90ZWN0ZWRQaXhlbHM6IFwiUHJvdGVjdGVkIFBpeGVsc1wiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJEZXRlY3RlZCBDaGFuZ2VzXCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiUmVwYWlyZWQgUGl4ZWxzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiV2FpdGluZyBmb3IgaW5pdGlhbGl6YXRpb24uLi5cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0NcdURGQTggQ2hlY2tpbmcgYXZhaWxhYmxlIGNvbG9ycy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIE5vIGNvbG9ycyBmb3VuZC4gT3BlbiB0aGUgY29sb3IgcGFsZXR0ZSBvbiB0aGUgc2l0ZS5cIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgRm91bmQge2NvdW50fSBhdmFpbGFibGUgY29sb3JzXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBpbml0aWFsaXplZCBzdWNjZXNzZnVsbHlcIixcbiAgICBpbml0RXJyb3I6IFwiXHUyNzRDIEVycm9yIGluaXRpYWxpemluZyBHdWFyZC1CT1RcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBJbnZhbGlkIGNvb3JkaW5hdGVzXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIEFyZWEgbXVzdCBoYXZlIHVwcGVyIGxlZnQgY29ybmVyIGxlc3MgdGhhbiBsb3dlciByaWdodCBjb3JuZXJcIixcbiAgICBhcmVhVG9vTGFyZ2U6IFwiXHUyNzRDIEFyZWEgdG9vIGxhcmdlOiB7c2l6ZX0gcGl4ZWxzIChtYXhpbXVtOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBDYXB0dXJpbmcgcHJvdGVjdGlvbiBhcmVhLi4uXCIsXG4gICAgYXJlYUNhcHR1cmVkOiBcIlx1MjcwNSBBcmVhIGNhcHR1cmVkOiB7Y291bnR9IHBpeGVscyB1bmRlciBwcm90ZWN0aW9uXCIsXG4gICAgY2FwdHVyZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBjYXB0dXJpbmcgYXJlYToge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgRmlyc3QgY2FwdHVyZSBhIHByb3RlY3Rpb24gYXJlYVwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBQcm90ZWN0aW9uIHN0YXJ0ZWQgLSBtb25pdG9yaW5nIGFyZWFcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUHJvdGVjdGlvbiBzdG9wcGVkXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBQcm90ZWN0ZWQgYXJlYSAtIG5vIGNoYW5nZXMgZGV0ZWN0ZWRcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gY2hhbmdlcyBkZXRlY3RlZCBpbiBwcm90ZWN0ZWQgYXJlYVwiLFxuICAgIHJlcGFpcmluZzogXCJcdUQ4M0RcdURFRTBcdUZFMEYgUmVwYWlyaW5nIHtjb3VudH0gYWx0ZXJlZCBwaXhlbHMuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFN1Y2Nlc3NmdWxseSByZXBhaXJlZCB7Y291bnR9IHBpeGVsc1wiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBFcnJvciByZXBhaXJpbmcgcGl4ZWxzOiB7ZXJyb3J9XCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjZBMFx1RkUwRiBJbnN1ZmZpY2llbnQgY2hhcmdlcyB0byByZXBhaXIgY2hhbmdlc1wiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgQ2hlY2tpbmcgY2hhbmdlcyBpbiBwcm90ZWN0ZWQgYXJlYS4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIEVycm9yIGNoZWNraW5nIGNoYW5nZXM6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgR3VhcmRpYW4gYWN0aXZlIC0gYXJlYSB1bmRlciBwcm90ZWN0aW9uXCIsXG4gICAgbGFzdENoZWNrOiBcIkxhc3QgY2hlY2s6IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJOZXh0IGNoZWNrIGluOiB7dGltZX1zXCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgQXV0by1pbml0aWFsaXppbmcuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBhdXRvLXN0YXJ0ZWQgc3VjY2Vzc2Z1bGx5XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIENvdWxkIG5vdCBhdXRvLXN0YXJ0LiBVc2UgbWFudWFsIGJ1dHRvbi5cIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IE1hbnVhbCBpbml0aWFsaXphdGlvbiByZXF1aXJlZFwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggQ29sb3IgcGFsZXR0ZSBkZXRlY3RlZFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgU2VhcmNoaW5nIGZvciBjb2xvciBwYWxldHRlLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpY2tpbmcgUGFpbnQgYnV0dG9uLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgUGFpbnQgYnV0dG9uIG5vdCBmb3VuZFwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgUGFpbnQgYSBwaXhlbCBhdCB0aGUgVVBQRVIgTEVGVCBjb3JuZXIgb2YgdGhlIGFyZWEgdG8gcHJvdGVjdFwiLFxuICAgIHNlbGVjdExvd2VyUmlnaHQ6IFwiXHVEODNDXHVERkFGIE5vdyBwYWludCBhIHBpeGVsIGF0IHRoZSBMT1dFUiBSSUdIVCBjb3JuZXIgb2YgdGhlIGFyZWFcIixcbiAgICB3YWl0aW5nVXBwZXJMZWZ0OiBcIlx1RDgzRFx1REM0NiBXYWl0aW5nIGZvciB1cHBlciBsZWZ0IGNvcm5lciBzZWxlY3Rpb24uLi5cIixcbiAgICB3YWl0aW5nTG93ZXJSaWdodDogXCJcdUQ4M0RcdURDNDYgV2FpdGluZyBmb3IgbG93ZXIgcmlnaHQgY29ybmVyIHNlbGVjdGlvbi4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBVcHBlciBsZWZ0IGNvcm5lciBjYXB0dXJlZDogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgTG93ZXIgcmlnaHQgY29ybmVyIGNhcHR1cmVkOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgU2VsZWN0aW9uIHRpbWVvdXRcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgU2VsZWN0aW9uIGVycm9yLCBwbGVhc2UgdHJ5IGFnYWluXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgZnIgPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgQXV0by1GYXJtJyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggQXV0by1JbWFnZScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIEF1dG8tR3VhcmQnLFxuICAgIHNlbGVjdGlvbjogJ1NcdTAwRTlsZWN0aW9uJyxcbiAgICB1c2VyOiAnVXRpbGlzYXRldXInLFxuICAgIGNoYXJnZXM6ICdDaGFyZ2VzJyxcbiAgICBiYWNrZW5kOiAnQmFja2VuZCcsXG4gICAgZGF0YWJhc2U6ICdCYXNlIGRlIGRvbm5cdTAwRTllcycsXG4gICAgdXB0aW1lOiAnVGVtcHMgYWN0aWYnLFxuICAgIGNsb3NlOiAnRmVybWVyJyxcbiAgICBsYXVuY2g6ICdMYW5jZXInLFxuICAgIGxvYWRpbmc6ICdDaGFyZ2VtZW50XHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdFeFx1MDBFOWN1dGlvblx1MjAyNicsXG4gICAgZG93bmxvYWRpbmc6ICdUXHUwMEU5bFx1MDBFOWNoYXJnZW1lbnQgZHUgc2NyaXB0XHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdDaG9pc2lzc2V6IHVuIGJvdCBldCBhcHB1eWV6IHN1ciBMYW5jZXInLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdQclx1MDBFQXQgXHUwMEUwIGxhbmNlcicsXG4gICAgbG9hZEVycm9yOiAnRXJyZXVyIGRlIGNoYXJnZW1lbnQnLFxuICAgIGxvYWRFcnJvck1zZzogJ0ltcG9zc2libGUgZGUgY2hhcmdlciBsZSBib3Qgc1x1MDBFOWxlY3Rpb25uXHUwMEU5LiBWXHUwMEU5cmlmaWV6IHZvdHJlIGNvbm5leGlvbiBvdSByXHUwMEU5ZXNzYXllei4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFZcdTAwRTlyaWZpY2F0aW9uLi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgRW4gbGlnbmUnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgSG9ycyBsaWduZScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgT0snLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IEVycmV1cicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tSW1hZ2VcIixcbiAgICBpbml0Qm90OiBcIkluaXRpYWxpc2VyIEF1dG8tQk9UXCIsXG4gICAgdXBsb2FkSW1hZ2U6IFwiVFx1MDBFOWxcdTAwRTljaGFyZ2VyIEltYWdlXCIsXG4gICAgcmVzaXplSW1hZ2U6IFwiUmVkaW1lbnNpb25uZXIgSW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTXHUwMEU5bGVjdGlvbm5lciBQb3NpdGlvblwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiQ29tbWVuY2VyIFBlaW50dXJlXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIkFyclx1MDBFQXRlciBQZWludHVyZVwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJTYXV2ZWdhcmRlciBQcm9nclx1MDBFOHNcIixcbiAgICBsb2FkUHJvZ3Jlc3M6IFwiQ2hhcmdlciBQcm9nclx1MDBFOHNcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgVlx1MDBFOXJpZmljYXRpb24gZGVzIGNvdWxldXJzIGRpc3BvbmlibGVzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgT3V2cmV6IGxhIHBhbGV0dGUgZGUgY291bGV1cnMgc3VyIGxlIHNpdGUgZXQgclx1MDBFOWVzc2F5ZXohXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IHtjb3VudH0gY291bGV1cnMgZGlzcG9uaWJsZXMgdHJvdXZcdTAwRTllc1wiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgQ2hhcmdlbWVudCBkZSBsJ2ltYWdlLi4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IEltYWdlIGNoYXJnXHUwMEU5ZSBhdmVjIHtjb3VudH0gcGl4ZWxzIHZhbGlkZXNcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkdSBjaGFyZ2VtZW50IGRlIGwnaW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlBlaWduZXogbGUgcHJlbWllciBwaXhlbCBcdTAwRTAgbCdlbXBsYWNlbWVudCBvXHUwMEY5IHZvdXMgdm91bGV6IHF1ZSBsJ2FydCBjb21tZW5jZSFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IEVuIGF0dGVudGUgcXVlIHZvdXMgcGVpZ25pZXogbGUgcGl4ZWwgZGUgclx1MDBFOWZcdTAwRTlyZW5jZS4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBQb3NpdGlvbiBkXHUwMEU5ZmluaWUgYXZlYyBzdWNjXHUwMEU4cyFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIERcdTAwRTlsYWkgZFx1MDBFOXBhc3NcdTAwRTkgcG91ciBsYSBzXHUwMEU5bGVjdGlvbiBkZSBwb3NpdGlvblwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFBvc2l0aW9uIGRcdTAwRTl0ZWN0XHUwMEU5ZSwgdHJhaXRlbWVudC4uLlwiLFxuICAgIHBvc2l0aW9uRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBkXHUwMEU5dGVjdGFudCBsYSBwb3NpdGlvbiwgZXNzYXlleiBcdTAwRTAgbm91dmVhdVwiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IERcdTAwRTlidXQgZGUgbGEgcGVpbnR1cmUuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBQcm9nclx1MDBFOHM6IHtwYWludGVkfS97dG90YWx9IHBpeGVscy4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgQXVjdW5lIGNoYXJnZS4gQXR0ZW5kcmUge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQZWludHVyZSBhcnJcdTAwRUF0XHUwMEU5ZSBwYXIgbCd1dGlsaXNhdGV1clwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFBlaW50dXJlIHRlcm1pblx1MDBFOWUhIHtjb3VudH0gcGl4ZWxzIHBlaW50cy5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBFcnJldXIgcGVuZGFudCBsYSBwZWludHVyZVwiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIENoYXJnZXogdW5lIGltYWdlIGV0IHNcdTAwRTlsZWN0aW9ubmV6IHVuZSBwb3NpdGlvbiBkJ2Fib3JkXCIsXG4gICAgcHJvZ3Jlc3M6IFwiUHJvZ3JcdTAwRThzXCIsXG4gICAgdXNlck5hbWU6IFwiVXNhZ2VyXCIsXG4gICAgcGl4ZWxzOiBcIlBpeGVsc1wiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiVGVtcHMgZXN0aW1cdTAwRTlcIixcbiAgICBpbml0TWVzc2FnZTogXCJDbGlxdWV6IHN1ciAnSW5pdGlhbGlzZXIgQXV0by1CT1QnIHBvdXIgY29tbWVuY2VyXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiRW4gYXR0ZW50ZSBkJ2luaXRpYWxpc2F0aW9uLi4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgSW1hZ2UgcmVkaW1lbnNpb25uXHUwMEU5ZSBcdTAwRTAge3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBQZWludHVyZSBtaXNlIGVuIHBhdXNlIFx1MDBFMCBsYSBwb3NpdGlvbiBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlBpeGVscyBwYXIgbG90XCIsXG4gICAgYmF0Y2hTaXplOiBcIlRhaWxsZSBkdSBsb3RcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlByb2NoYWluIGxvdCBkYW5zXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJVdGlsaXNlciB0b3V0ZXMgbGVzIGNoYXJnZXMgZGlzcG9uaWJsZXNcIixcbiAgICBzaG93T3ZlcmxheTogXCJBZmZpY2hlciBsJ292ZXJsYXlcIixcbiAgICBtYXhDaGFyZ2VzOiBcIkNoYXJnZXMgbWF4IHBhciBsb3RcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgRW4gYXR0ZW50ZSBkZSBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlRlbXBzIHJlc3RhbnRcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIEF0dGVuZHJlIHt0aW1lfSBwb3VyIGNvbnRpbnVlci4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFByb2dyXHUwMEU4cyBzYXV2ZWdhcmRcdTAwRTkgc291cyB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFByb2dyXHUwMEU4cyBjaGFyZ1x1MDBFOToge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzIHBlaW50c1wiLFxuICAgIHByb2dyZXNzTG9hZEVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkdSBjaGFyZ2VtZW50IGR1IHByb2dyXHUwMEU4czoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsYSBzYXV2ZWdhcmRlIGR1IHByb2dyXHUwMEU4czoge2Vycm9yfVwiLFxuICAgIGNvbmZpcm1TYXZlUHJvZ3Jlc3M6IFwiVm91bGV6LXZvdXMgc2F1dmVnYXJkZXIgbGUgcHJvZ3JcdTAwRThzIGFjdHVlbCBhdmFudCBkJ2Fyclx1MDBFQXRlcj9cIixcbiAgICBzYXZlUHJvZ3Jlc3NUaXRsZTogXCJTYXV2ZWdhcmRlciBQcm9nclx1MDBFOHNcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiQWJhbmRvbm5lclwiLFxuICAgIGNhbmNlbDogXCJBbm51bGVyXCIsXG4gICAgbWluaW1pemU6IFwiTWluaW1pc2VyXCIsXG4gICAgd2lkdGg6IFwiTGFyZ2V1clwiLFxuICAgIGhlaWdodDogXCJIYXV0ZXVyXCIsIFxuICAgIGtlZXBBc3BlY3Q6IFwiR2FyZGVyIGxlcyBwcm9wb3J0aW9uc1wiLFxuICAgIGFwcGx5OiBcIkFwcGxpcXVlclwiLFxuICBvdmVybGF5T246IFwiT3ZlcmxheSA6IE9OXCIsXG4gIG92ZXJsYXlPZmY6IFwiT3ZlcmxheSA6IE9GRlwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFBhc3NhZ2UgdGVybWluXHUwMEU5OiB7cGFpbnRlZH0gcGl4ZWxzIHBlaW50cyB8IFByb2dyXHUwMEU4czoge3BlcmNlbnR9JSAoe2N1cnJlbnR9L3t0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgQXR0ZW50ZSBkZSByXHUwMEU5Z1x1MDBFOW5cdTAwRTlyYXRpb24gZGVzIGNoYXJnZXM6IHtjdXJyZW50fS97bmVlZGVkfSAtIFRlbXBzOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgQXR0ZW50ZSBkZXMgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gUmVzdGFudDoge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgSW5pdGlhbGlzYXRpb24gYXV0b21hdGlxdWUuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEJvdCBkXHUwMEU5bWFyclx1MDBFOSBhdXRvbWF0aXF1ZW1lbnRcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgSW1wb3NzaWJsZSBkZSBkXHUwMEU5bWFycmVyIGF1dG9tYXRpcXVlbWVudC4gVXRpbGlzZXogbGUgYm91dG9uIG1hbnVlbC5cIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFBhbGV0dGUgZGUgY291bGV1cnMgZFx1MDBFOXRlY3RcdTAwRTllXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBSZWNoZXJjaGUgZGUgbGEgcGFsZXR0ZSBkZSBjb3VsZXVycy4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IENsaWMgc3VyIGxlIGJvdXRvbiBQYWludC4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIEJvdXRvbiBQYWludCBpbnRyb3V2YWJsZVwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pdGlhbGlzYXRpb24gbWFudWVsbGUgcmVxdWlzZVwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgVGVudGF0aXZlIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IGRhbnMge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUVycm9yOiBcIlx1RDgzRFx1RENBNSBFcnJldXIgZGFucyB0ZW50YXRpdmUge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30sIG5vdXZlbCBlc3NhaSBkYW5zIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIFx1MDBDOWNoZWMgYXByXHUwMEU4cyB7bWF4QXR0ZW1wdHN9IHRlbnRhdGl2ZXMuIENvbnRpbnVhbnQgYXZlYyBsZSBsb3Qgc3VpdmFudC4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgRXJyZXVyIHJcdTAwRTlzZWF1LiBOb3V2ZWwgZXNzYWkuLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgRXJyZXVyIHNlcnZldXIuIE5vdXZlbCBlc3NhaS4uLlwiLFxuICAgIHRpbWVvdXRFcnJvcjogXCJcdTIzRjAgVGltZW91dCBzZXJ2ZXVyLiBOb3V2ZWwgZXNzYWkuLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlICh0byBiZSBpbXBsZW1lbnRlZClcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBGYXJtIEJvdFwiLFxuICAgIHN0YXJ0OiBcIkRcdTAwRTltYXJyZXJcIixcbiAgICBzdG9wOiBcIkFyclx1MDBFQXRlclwiLFxuICAgIHN0b3BwZWQ6IFwiQm90IGFyclx1MDBFQXRcdTAwRTlcIixcbiAgICBjYWxpYnJhdGU6IFwiQ2FsaWJyZXJcIixcbiAgICBwYWludE9uY2U6IFwiVW5lIGZvaXNcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJWXHUwMEU5cmlmaWNhdGlvbiBkdSBzdGF0dXQuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIkNvbmZpZ3VyYXRpb25cIixcbiAgICBkZWxheTogXCJEXHUwMEU5bGFpIChtcylcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQaXhlbHMvbG90XCIsXG4gICAgbWluQ2hhcmdlczogXCJDaGFyZ2VzIG1pblwiLFxuICAgIGNvbG9yTW9kZTogXCJNb2RlIGNvdWxldXJcIixcbiAgICByYW5kb206IFwiQWxcdTAwRTlhdG9pcmVcIixcbiAgICBmaXhlZDogXCJGaXhlXCIsXG4gICAgcmFuZ2U6IFwiUGxhZ2VcIixcbiAgICBmaXhlZENvbG9yOiBcIkNvdWxldXIgZml4ZVwiLFxuICAgIGFkdmFuY2VkOiBcIkF2YW5jXHUwMEU5XCIsXG4gICAgdGlsZVg6IFwiVHVpbGUgWFwiLFxuICAgIHRpbGVZOiBcIlR1aWxlIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlBhbGV0dGUgcGVyc29ubmFsaXNcdTAwRTllXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiZXg6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJDYXB0dXJlclwiLFxuICAgIHBhaW50ZWQ6IFwiUGVpbnRzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgcmV0cmllczogXCJcdTAwQzljaGVjc1wiLFxuICAgIHRpbGU6IFwiVHVpbGVcIixcbiAgICBjb25maWdTYXZlZDogXCJDb25maWd1cmF0aW9uIHNhdXZlZ2FyZFx1MDBFOWVcIixcbiAgICBjb25maWdMb2FkZWQ6IFwiQ29uZmlndXJhdGlvbiBjaGFyZ1x1MDBFOWVcIixcbiAgICBjb25maWdSZXNldDogXCJDb25maWd1cmF0aW9uIHJcdTAwRTlpbml0aWFsaXNcdTAwRTllXCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJQZWluZHJlIHVuIHBpeGVsIG1hbnVlbGxlbWVudCBwb3VyIGNhcHR1cmVyIGxlcyBjb29yZG9ublx1MDBFOWVzLi4uXCIsXG4gICAgYmFja2VuZE9ubGluZTogXCJCYWNrZW5kIEVuIGxpZ25lXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiQmFja2VuZCBIb3JzIGxpZ25lXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiRFx1MDBFOW1hcnJhZ2UgZHUgYm90Li4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiQXJyXHUwMEVBdCBkdSBib3QuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJDYWxpYnJhZ2UuLi5cIixcbiAgICBhbHJlYWR5UnVubmluZzogXCJBdXRvLUZhcm0gZXN0IGRcdTAwRTlqXHUwMEUwIGVuIGNvdXJzIGQnZXhcdTAwRTljdXRpb24uXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJBdXRvLUltYWdlIGVzdCBlbiBjb3VycyBkJ2V4XHUwMEU5Y3V0aW9uLiBGZXJtZXotbGUgYXZhbnQgZGUgZFx1MDBFOW1hcnJlciBBdXRvLUZhcm0uXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU1x1MDBFOWxlY3Rpb25uZXIgWm9uZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFBlaWduZXogdW4gcGl4ZWwgZGFucyB1bmUgem9uZSBWSURFIGRlIGxhIGNhcnRlIHBvdXIgZFx1MDBFOWZpbmlyIGxhIHpvbmUgZGUgZmFybWluZ1wiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgRW4gYXR0ZW50ZSBxdWUgdm91cyBwZWlnbmlleiBsZSBwaXhlbCBkZSByXHUwMEU5Zlx1MDBFOXJlbmNlLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFpvbmUgZFx1MDBFOWZpbmllISBSYXlvbjogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIERcdTAwRTlsYWkgZFx1MDBFOXBhc3NcdTAwRTkgcG91ciBsYSBzXHUwMEU5bGVjdGlvbiBkZSB6b25lXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBTXHUwMEU5bGVjdGlvbm5leiB1bmUgem9uZSBkJ2Fib3JkIGVuIHV0aWxpc2FudCAnU1x1MDBFOWxlY3Rpb25uZXIgWm9uZSdcIixcbiAgICBmYXJtUmFkaXVzOiBcIlJheW9uIGZhcm1cIixcbiAgICBwb3NpdGlvbkluZm86IFwiWm9uZSBhY3R1ZWxsZVwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgRmFybWluZyBkYW5zIHVuIHJheW9uIGRlIHtyYWRpdXN9cHggZGVwdWlzICh7eH0se3l9KVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgSU1QT1JUQU5UOiBTXHUwMEU5bGVjdGlvbm5leiB1bmUgem9uZSBWSURFIHBvdXIgXHUwMEU5dml0ZXIgbGVzIGNvbmZsaXRzXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJBdWN1bmUgem9uZVwiLFxuICAgIGN1cnJlbnRab25lOiBcIlpvbmU6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgU1x1MDBFOWxlY3Rpb25uZXogdW5lIHpvbmUgZCdhYm9yZC4gUGVpZ25leiB1biBwaXhlbCBzdXIgbGEgY2FydGUgcG91ciBkXHUwMEU5ZmluaXIgbGEgem9uZSBkZSBmYXJtaW5nXCJcbiAgfSxcblxuICAgIC8vIENvbW1vbi9TaGFyZWRcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIk91aVwiLFxuICAgIG5vOiBcIk5vblwiLFxuICAgIG9rOiBcIk9LXCIsXG4gICAgY2FuY2VsOiBcIkFubnVsZXJcIixcbiAgICBjbG9zZTogXCJGZXJtZXJcIixcbiAgICBzYXZlOiBcIlNhdXZlZ2FyZGVyXCIsXG4gICAgbG9hZDogXCJDaGFyZ2VyXCIsXG4gICAgZGVsZXRlOiBcIlN1cHByaW1lclwiLFxuICAgIGVkaXQ6IFwiTW9kaWZpZXJcIixcbiAgICBzdGFydDogXCJEXHUwMEU5bWFycmVyXCIsXG4gICAgc3RvcDogXCJBcnJcdTAwRUF0ZXJcIixcbiAgICBwYXVzZTogXCJQYXVzZVwiLFxuICAgIHJlc3VtZTogXCJSZXByZW5kcmVcIixcbiAgICByZXNldDogXCJSXHUwMEU5aW5pdGlhbGlzZXJcIixcbiAgICBzZXR0aW5nczogXCJQYXJhbVx1MDBFOHRyZXNcIixcbiAgICBoZWxwOiBcIkFpZGVcIixcbiAgICBhYm91dDogXCJcdTAwQzAgcHJvcG9zXCIsXG4gICAgbGFuZ3VhZ2U6IFwiTGFuZ3VlXCIsXG4gICAgbG9hZGluZzogXCJDaGFyZ2VtZW50Li4uXCIsXG4gICAgZXJyb3I6IFwiRXJyZXVyXCIsXG4gICAgc3VjY2VzczogXCJTdWNjXHUwMEU4c1wiLFxuICAgIHdhcm5pbmc6IFwiQXZlcnRpc3NlbWVudFwiLFxuICAgIGluZm86IFwiSW5mb3JtYXRpb25cIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiTGFuZ3VlIGNoYW5nXHUwMEU5ZSBlbiB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1HdWFyZFwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGlzZXIgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJTXHUwMEU5bGVjdGlvbm5lciBab25lXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiQ2FwdHVyZXIgWm9uZVwiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJEXHUwMEU5bWFycmVyIFByb3RlY3Rpb25cIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJBcnJcdTAwRUF0ZXIgUHJvdGVjdGlvblwiLFxuICAgIHVwcGVyTGVmdDogXCJDb2luIFN1cFx1MDBFOXJpZXVyIEdhdWNoZVwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiQ29pbiBJbmZcdTAwRTlyaWV1ciBEcm9pdFwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJQaXhlbHMgUHJvdFx1MDBFOWdcdTAwRTlzXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIkNoYW5nZW1lbnRzIERcdTAwRTl0ZWN0XHUwMEU5c1wiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlBpeGVscyBSXHUwMEU5cGFyXHUwMEU5c1wiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIHdhaXRpbmdJbml0OiBcIkVuIGF0dGVudGUgZCdpbml0aWFsaXNhdGlvbi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBWXHUwMEU5cmlmaWNhdGlvbiBkZXMgY291bGV1cnMgZGlzcG9uaWJsZXMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBBdWN1bmUgY291bGV1ciB0cm91dlx1MDBFOWUuIE91dnJleiBsYSBwYWxldHRlIGRlIGNvdWxldXJzIHN1ciBsZSBzaXRlLlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSB7Y291bnR9IGNvdWxldXJzIGRpc3BvbmlibGVzIHRyb3V2XHUwMEU5ZXNcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaXRpYWxpc1x1MDBFOSBhdmVjIHN1Y2NcdTAwRThzXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsJ2luaXRpYWxpc2F0aW9uIGRlIEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIENvb3Jkb25uXHUwMEU5ZXMgaW52YWxpZGVzXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIExhIHpvbmUgZG9pdCBhdm9pciBsZSBjb2luIHN1cFx1MDBFOXJpZXVyIGdhdWNoZSBpbmZcdTAwRTlyaWV1ciBhdSBjb2luIGluZlx1MDBFOXJpZXVyIGRyb2l0XCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBab25lIHRyb3AgZ3JhbmRlOiB7c2l6ZX0gcGl4ZWxzIChtYXhpbXVtOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBDYXB0dXJlIGRlIGxhIHpvbmUgZGUgcHJvdGVjdGlvbi4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgWm9uZSBjYXB0dXJcdTAwRTllOiB7Y291bnR9IHBpeGVscyBzb3VzIHByb3RlY3Rpb25cIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGRlIGxhIGNhcHR1cmUgZGUgem9uZToge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgQ2FwdHVyZXogZCdhYm9yZCB1bmUgem9uZSBkZSBwcm90ZWN0aW9uXCIsXG4gICAgcHJvdGVjdGlvblN0YXJ0ZWQ6IFwiXHVEODNEXHVERUUxXHVGRTBGIFByb3RlY3Rpb24gZFx1MDBFOW1hcnJcdTAwRTllIC0gc3VydmVpbGxhbmNlIGRlIGxhIHpvbmVcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUHJvdGVjdGlvbiBhcnJcdTAwRUF0XHUwMEU5ZVwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgWm9uZSBwcm90XHUwMEU5Z1x1MDBFOWUgLSBhdWN1biBjaGFuZ2VtZW50IGRcdTAwRTl0ZWN0XHUwMEU5XCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCB7Y291bnR9IGNoYW5nZW1lbnRzIGRcdTAwRTl0ZWN0XHUwMEU5cyBkYW5zIGxhIHpvbmUgcHJvdFx1MDBFOWdcdTAwRTllXCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBSXHUwMEU5cGFyYXRpb24gZGUge2NvdW50fSBwaXhlbHMgYWx0XHUwMEU5clx1MDBFOXMuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IHtjb3VudH0gcGl4ZWxzIHJcdTAwRTlwYXJcdTAwRTlzIGF2ZWMgc3VjY1x1MDBFOHNcIixcbiAgICByZXBhaXJFcnJvcjogXCJcdTI3NEMgRXJyZXVyIGxvcnMgZGUgbGEgclx1MDBFOXBhcmF0aW9uIGRlcyBwaXhlbHM6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIENoYXJnZXMgaW5zdWZmaXNhbnRlcyBwb3VyIHJcdTAwRTlwYXJlciBsZXMgY2hhbmdlbWVudHNcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFZcdTAwRTlyaWZpY2F0aW9uIGRlcyBjaGFuZ2VtZW50cyBkYW5zIGxhIHpvbmUgcHJvdFx1MDBFOWdcdTAwRTllLi4uXCIsXG4gICAgZXJyb3JDaGVja2luZzogXCJcdTI3NEMgRXJyZXVyIGxvcnMgZGUgbGEgdlx1MDBFOXJpZmljYXRpb24gZGVzIGNoYW5nZW1lbnRzOiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIEdhcmRpZW4gYWN0aWYgLSB6b25lIHNvdXMgcHJvdGVjdGlvblwiLFxuICAgIGxhc3RDaGVjazogXCJEZXJuaVx1MDBFOHJlIHZcdTAwRTlyaWZpY2F0aW9uOiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiUHJvY2hhaW5lIHZcdTAwRTlyaWZpY2F0aW9uIGRhbnM6IHt0aW1lfXNcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbml0aWFsaXNhdGlvbiBhdXRvbWF0aXF1ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGRcdTAwRTltYXJyXHUwMEU5IGF1dG9tYXRpcXVlbWVudFwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBJbXBvc3NpYmxlIGRlIGRcdTAwRTltYXJyZXIgYXV0b21hdGlxdWVtZW50LiBVdGlsaXNleiBsZSBib3V0b24gbWFudWVsLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pdGlhbGlzYXRpb24gbWFudWVsbGUgcmVxdWlzZVwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXR0ZSBkZSBjb3VsZXVycyBkXHUwMEU5dGVjdFx1MDBFOWVcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFJlY2hlcmNoZSBkZSBsYSBwYWxldHRlIGRlIGNvdWxldXJzLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpYyBzdXIgbGUgYm91dG9uIFBhaW50Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgQm91dG9uIFBhaW50IGludHJvdXZhYmxlXCIsXG4gICAgc2VsZWN0VXBwZXJMZWZ0OiBcIlx1RDgzQ1x1REZBRiBQZWlnbmV6IHVuIHBpeGVsIGF1IGNvaW4gU1VQXHUwMEM5UklFVVIgR0FVQ0hFIGRlIGxhIHpvbmUgXHUwMEUwIHByb3RcdTAwRTlnZXJcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBNYWludGVuYW50IHBlaWduZXogdW4gcGl4ZWwgYXUgY29pbiBJTkZcdTAwQzlSSUVVUiBEUk9JVCBkZSBsYSB6b25lXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgRW4gYXR0ZW50ZSBkZSBsYSBzXHUwMEU5bGVjdGlvbiBkdSBjb2luIHN1cFx1MDBFOXJpZXVyIGdhdWNoZS4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBFbiBhdHRlbnRlIGRlIGxhIHNcdTAwRTlsZWN0aW9uIGR1IGNvaW4gaW5mXHUwMEU5cmlldXIgZHJvaXQuLi5cIixcbiAgICB1cHBlckxlZnRDYXB0dXJlZDogXCJcdTI3MDUgQ29pbiBzdXBcdTAwRTlyaWV1ciBnYXVjaGUgY2FwdHVyXHUwMEU5OiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBDb2luIGluZlx1MDBFOXJpZXVyIGRyb2l0IGNhcHR1clx1MDBFOTogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIERcdTAwRTlsYWkgZGUgc1x1MDBFOWxlY3Rpb24gZFx1MDBFOXBhc3NcdTAwRTlcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgRXJyZXVyIGRlIHNcdTAwRTlsZWN0aW9uLCB2ZXVpbGxleiByXHUwMEU5ZXNzYXllclwiXG4gIH1cbn07XG4iLCAiZXhwb3J0IGNvbnN0IHJ1ID0ge1xuICAvLyBMYXVuY2hlclxuICBsYXVuY2hlcjoge1xuICAgIHRpdGxlOiAnV1BsYWNlIEF1dG9CT1QnLFxuICAgIGF1dG9GYXJtOiAnXHVEODNDXHVERjNFIFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MjRcdTA0MzBcdTA0NDBcdTA0M0MnLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1JyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzMCcsXG4gICAgc2VsZWN0aW9uOiAnXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDNEXHUwNDNFJyxcbiAgICB1c2VyOiAnXHUwNDFGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM1XHUwNDNCXHUwNDRDJyxcbiAgICBjaGFyZ2VzOiAnXHUwNDE4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGJyxcbiAgICBiYWNrZW5kOiAnXHUwNDExXHUwNDREXHUwNDNBXHUwNDM1XHUwNDNEXHUwNDM0JyxcbiAgICBkYXRhYmFzZTogJ1x1MDQxMVx1MDQzMFx1MDQzN1x1MDQzMCBcdTA0MzRcdTA0MzBcdTA0M0RcdTA0M0RcdTA0NEJcdTA0NDUnLFxuICAgIHVwdGltZTogJ1x1MDQxMlx1MDQ0MFx1MDQzNVx1MDQzQ1x1MDQ0RiBcdTA0NDBcdTA0MzBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0NEInLFxuICAgIGNsb3NlOiAnXHUwNDE3XHUwNDMwXHUwNDNBXHUwNDQwXHUwNDRCXHUwNDQyXHUwNDRDJyxcbiAgICBsYXVuY2g6ICdcdTA0MTdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzhcdTA0NDJcdTA0NEMnLFxuICAgIGxvYWRpbmc6ICdcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzAnLFxuICAgIGV4ZWN1dGluZzogJ1x1MDQxMlx1MDQ0Qlx1MDQzRlx1MDQzRVx1MDQzQlx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNScsXG4gICAgZG93bmxvYWRpbmc6ICdcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDNBXHUwNDQwXHUwNDM4XHUwNDNGXHUwNDQyXHUwNDMwLi4uJyxcbiAgICBjaG9vc2VCb3Q6ICdcdTA0MTJcdTA0NEJcdTA0MzFcdTA0MzVcdTA0NDBcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwIFx1MDQzOCBcdTA0M0RcdTA0MzBcdTA0MzZcdTA0M0NcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDE3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDJyxcbiAgICByZWFkeVRvTGF1bmNoOiAnXHUwNDEzXHUwNDNFXHUwNDQyXHUwNDNFXHUwNDMyXHUwNDNFIFx1MDQzQSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0M0FcdTA0NDMnLFxuICAgIGxvYWRFcnJvcjogJ1x1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzgnLFxuICAgIGxvYWRFcnJvck1zZzogJ1x1MDQxRFx1MDQzNVx1MDQzMlx1MDQzRVx1MDQzN1x1MDQzQ1x1MDQzRVx1MDQzNlx1MDQzRFx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDNEXHUwNDNEXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQzMVx1MDQzRVx1MDQ0Mlx1MDQzMC4gXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDRDXHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzRVx1MDQzNFx1MDQzQVx1MDQzQlx1MDQ0RVx1MDQ0N1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0M0JcdTA0MzggXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzNVx1MDQ0OVx1MDQzNSBcdTA0NDBcdTA0MzBcdTA0MzcuJyxcbiAgICBjaGVja2luZzogJ1x1RDgzRFx1REQwNCBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAuLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBcdTA0MUVcdTA0M0RcdTA0M0JcdTA0MzBcdTA0MzlcdTA0M0QnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgXHUwNDFFXHUwNDQ0XHUwNDNCXHUwNDMwXHUwNDM5XHUwNDNEJyxcbiAgICBvazogJ1x1RDgzRFx1REZFMiBcdTA0MUVcdTA0MUEnLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCcsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBpbml0Qm90OiBcIlx1MDQxOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQ0QyBBdXRvLUJPVFwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlx1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MzhcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICByZXNpemVJbWFnZTogXCJcdTA0MThcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDQwXHUwNDMwXHUwNDM3XHUwNDNDXHUwNDM1XHUwNDQwIFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0NcdTA0MzVcdTA0NDFcdTA0NDJcdTA0M0UgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDMwXCIsXG4gICAgc3RhcnRQYWludGluZzogXCJcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlx1MDQxRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MVwiLFxuICAgIGxvYWRQcm9ncmVzczogXCJcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0MzRcdTA0M0VcdTA0NDFcdTA0NDJcdTA0NDNcdTA0M0ZcdTA0M0RcdTA0NEJcdTA0NDUgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHUwNDFFXHUwNDQyXHUwNDNBXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQ0MyBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIgXHUwNDNEXHUwNDMwIFx1MDQ0MVx1MDQzMFx1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0MzggXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQ0MVx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzMCFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHUwNDFEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDNFIHtjb3VudH0gXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlwiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDNBXHUwNDMwIFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBcdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQ0MSB7Y291bnR9IFx1MDQzNFx1MDQzNVx1MDQzOVx1MDQ0MVx1MDQ0Mlx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQ0Qlx1MDQzQ1x1MDQzOCBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEZcdTA0M0NcdTA0MzhcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDNBXHUwNDM4IFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQ0MFx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQ0Mlx1MDQzRVx1MDQzQyBcdTA0M0NcdTA0MzVcdTA0NDFcdTA0NDJcdTA0MzUsIFx1MDQzM1x1MDQzNFx1MDQzNSBcdTA0MzJcdTA0NEIgXHUwNDQ1XHUwNDNFXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDM1LCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDNEXHUwNDNFXHUwNDNBIFx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzOFx1MDQzRFx1MDQzMFx1MDQzQlx1MDQ0MVx1MDQ0RiFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDFcdTA0NDJcdTA0MzBcdTA0NDBcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRGLi4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTA0MUZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDMwIFx1MDQ0M1x1MDQ0MVx1MDQzRlx1MDQzNVx1MDQ0OFx1MDQzRFx1MDQzRSFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1MDQyMlx1MDQzMFx1MDQzOVx1MDQzQ1x1MDQzMFx1MDQ0M1x1MDQ0MiBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzAgXHUwNDNGXHUwNDNFXHUwNDM3XHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDM4XCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgXHUwNDFGXHUwNDNFXHUwNDM3XHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDRGIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzMCwgXHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0ZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzgsIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzMVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0MzVcdTA0NDlcdTA0MzUgXHUwNDQwXHUwNDMwXHUwNDM3XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDNFIFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIHBhaW50aW5nUHJvZ3Jlc3M6IFwiXHVEODNFXHVEREYxIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MToge3BhaW50ZWR9IFx1MDQzOFx1MDQzNyB7dG90YWx9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOS4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgXHUwNDFEXHUwNDM1XHUwNDQyIFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMi4gXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHUwNDIwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzVcdTA0M0JcdTA0MzVcdTA0M0NcIixcbiAgICBwYWludGluZ0NvbXBsZXRlOiBcIlx1MjcwNSBcdTA0MjBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ4XHUwNDM1XHUwNDNEXHUwNDNFISB7Y291bnR9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0M0RcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0M0UuXCIsXG4gICAgcGFpbnRpbmdFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDZcdTA0MzVcdTA0NDFcdTA0NDFcdTA0MzUgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgXHUwNDIxXHUwNDNGXHUwNDM1XHUwNDQwXHUwNDMyXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MzhcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM4IFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0M0NcdTA0MzVcdTA0NDFcdTA0NDJcdTA0M0UgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDMwXCIsXG4gICAgcHJvZ3Jlc3M6IFwiXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXCIsXG4gICAgdXNlck5hbWU6IFwiXHUwNDFGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM1XHUwNDNCXHUwNDRDXCIsXG4gICAgcGl4ZWxzOiBcIlx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzOFwiLFxuICAgIGNoYXJnZXM6IFwiXHUwNDE3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDRCXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJcdTA0MUZcdTA0NDBcdTA0MzVcdTA0MzRcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0M0VcdTA0MzZcdTA0MzhcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NENcdTA0M0RcdTA0M0VcdTA0MzUgXHUwNDMyXHUwNDQwXHUwNDM1XHUwNDNDXHUwNDRGXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiXHUwNDFEXHUwNDMwXHUwNDM2XHUwNDNDXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDBBQlx1MDQxN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QyBBdXRvLUJPVFx1MDBCQiwgXHUwNDQ3XHUwNDQyXHUwNDNFXHUwNDMxXHUwNDRCIFx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0MzguLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBcdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQzNFx1MDQzRSB7d2lkdGh9eHtoZWlnaHR9XCIsXG4gICAgcGFpbnRpbmdQYXVzZWQ6IFwiXHUyM0Y4XHVGRTBGIFx1MDQyMFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0M0ZcdTA0NDBcdTA0MzhcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDNEXHUwNDMwIFx1MDQzRlx1MDQzRVx1MDQzN1x1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzOCBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0MzIgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XHUwNDM1XCIsXG4gICAgYmF0Y2hTaXplOiBcIlx1MDQyMFx1MDQzMFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQ0MCBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDVcdTA0M0VcdTA0MzRcdTA0MzBcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlx1MDQyMVx1MDQzQlx1MDQzNVx1MDQzNFx1MDQ0M1x1MDQ0RVx1MDQ0OVx1MDQzOFx1MDQzOSBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDVcdTA0M0VcdTA0MzQgXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3XCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJcdTA0MThcdTA0NDFcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDMyXHUwNDQxXHUwNDM1IFx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQ0M1x1MDQzRlx1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0NEJcIixcbiAgICBzaG93T3ZlcmxheTogXCJcdTA0MUZcdTA0M0VcdTA0M0FcdTA0MzBcdTA0MzdcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDNEXHUwNDMwXHUwNDNCXHUwNDNFXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1XCIsXG4gICAgbWF4Q2hhcmdlczogXCJcdTA0MUNcdTA0MzBcdTA0M0FcdTA0NDFcdTA0MzhcdTA0M0NcdTA0MzBcdTA0M0JcdTA0NENcdTA0M0RcdTA0M0VcdTA0MzUgXHUwNDNBXHUwNDNFXHUwNDNCLVx1MDQzMlx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0M0VcdTA0MzIgXHUwNDM3XHUwNDMwIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDNFXHUwNDMyOiB7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHtuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJcdTA0MTJcdTA0NDBcdTA0MzVcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzggXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNCXHUwNDNFXHUwNDQxXHUwNDRDXCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUge3RpbWV9IFx1MDQzNFx1MDQzQlx1MDQ0RiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzRcdTA0M0VcdTA0M0JcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDEgXHUwNDQxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM1XHUwNDNEIFx1MDQzQVx1MDQzMFx1MDQzQSB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0Q6IHtwYWludGVkfSBcdTA0MzhcdTA0Mzcge3RvdGFsfSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDNFXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzggXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXHUwNDMwOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0NDFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXHUwNDMwOiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJcdTA0MjFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDQyXHUwNDM1XHUwNDNBXHUwNDQzXHUwNDQ5XHUwNDM4XHUwNDM5IFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0MzVcdTA0MzQgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNBXHUwNDNFXHUwNDM5P1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlx1MDQyMVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiXHUwNDFEXHUwNDM1IFx1MDQ0MVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQ0Rlx1MDQ0Mlx1MDQ0QyBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICBjYW5jZWw6IFwiXHUwNDFFXHUwNDQyXHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgbWluaW1pemU6IFwiXHUwNDIxXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNEXHUwNDQzXHUwNDQyXHUwNDRDXCIsXG4gICAgd2lkdGg6IFwiXHUwNDI4XHUwNDM4XHUwNDQwXHUwNDM4XHUwNDNEXHUwNDMwXCIsXG4gICAgaGVpZ2h0OiBcIlx1MDQxMlx1MDQ0Qlx1MDQ0MVx1MDQzRVx1MDQ0Mlx1MDQzMFwiLFxuICAgIGtlZXBBc3BlY3Q6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQ0MVx1MDQzRVx1MDQzRVx1MDQ0Mlx1MDQzRFx1MDQzRVx1MDQ0OFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDFcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0VcdTA0M0RcIixcbiAgICBhcHBseTogXCJcdTA0MUZcdTA0NDBcdTA0MzhcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBwYXNzQ29tcGxldGVkOiBcIlx1MjcwNSBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0NDZcdTA0MzVcdTA0NDFcdTA0NDEgXHUwNDM3XHUwNDMwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ4XHUwNDM1XHUwNDNEOiB7cGFpbnRlZH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRSB8IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MToge3BlcmNlbnR9JSAoe2N1cnJlbnR9IFx1MDQzOFx1MDQzNyB7dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzJcdTA0M0VcdTA0NDFcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDMwOiB7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHtuZWVkZWR9IC0gXHUwNDEyXHUwNDQwXHUwNDM1XHUwNDNDXHUwNDRGOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMjoge2N1cnJlbnR9IFx1MDQzOFx1MDQzNyB7bmVlZGVkfSAtIFx1MDQyMlx1MDQ0MFx1MDQzNVx1MDQzMVx1MDQ0M1x1MDQzNVx1MDQ0Mlx1MDQ0MVx1MDQ0Rjoge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDNDXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQ3XHUwNDM1XHUwNDQxXHUwNDNBXHUwNDMwXHUwNDRGIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHUwNDExXHUwNDNFXHUwNDQyIFx1MDQ0M1x1MDQ0MVx1MDQzRlx1MDQzNVx1MDQ0OFx1MDQzRFx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzhcdTA0M0JcdTA0NDFcdTA0NEYgXHUwNDMwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDNDXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQ3XHUwNDM1XHUwNDQxXHUwNDNBXHUwNDM4XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1MDQxRFx1MDQzNSBcdTA0NDNcdTA0MzRcdTA0MzBcdTA0M0JcdTA0M0VcdTA0NDFcdTA0NEMgXHUwNDMyXHUwNDRCXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQS4gXHUwNDE4XHUwNDQxXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQ0MyBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBXHUwNDMwLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHUwNDI2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQzMCBcdTA0M0VcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1MDQxRlx1MDQzRVx1MDQzOFx1MDQ0MVx1MDQzQSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0VcdTA0MzkgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDRCLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgXHUwNDFEXHUwNDMwXHUwNDM2XHUwNDMwXHUwNDQyXHUwNDM4XHUwNDM1IFx1MDQzQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQzOCBcdTAwQUJQYWludFx1MDBCQi4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1MDQxQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQzMCBcdTAwQUJQYWludFx1MDBCQiBcdTA0M0RcdTA0MzUgXHUwNDNEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBcdTA0MjJcdTA0NDBcdTA0MzVcdTA0MzFcdTA0NDNcdTA0MzVcdTA0NDJcdTA0NDFcdTA0NEYgXHUwNDQwXHUwNDQzXHUwNDQ3XHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgXHUwNDFGXHUwNDNFXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDQwXHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzMCB7YXR0ZW1wdH0gXHUwNDM4XHUwNDM3IHttYXhBdHRlbXB0c30gXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3IHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMiBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0FcdTA0MzUge2F0dGVtcHR9IFx1MDQzOFx1MDQzNyB7bWF4QXR0ZW1wdHN9LCBcdTA0M0ZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3IHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0NDFcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0NEYge21heEF0dGVtcHRzfSBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0VcdTA0M0EuIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzNFx1MDQzRVx1MDQzQlx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzIgXHUwNDQxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDQzXHUwNDRFXHUwNDQ5XHUwNDM1XHUwNDNDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFx1MDQzNS4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQ0MVx1MDQzNVx1MDQ0Mlx1MDQzOC4gXHUwNDFGXHUwNDNFXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDQwXHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzMC4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDM1XHUwNDQwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDMwLiBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBcdTA0MjJcdTA0MzBcdTA0MzlcdTA0M0NcdTA0MzBcdTA0NDNcdTA0NDIgXHUwNDQxXHUwNDM1XHUwNDQwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDMwLiBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCJcbiAgfSxcblxuICAvLyBGYXJtIE1vZHVsZSAodG8gYmUgaW1wbGVtZW50ZWQpXG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQ1wiLFxuICAgIHN0YXJ0OiBcIlx1MDQxRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHN0b3A6IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcHBlZDogXCJcdTA0MTFcdTA0M0VcdTA0NDIgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXCIsXG4gICAgY2FsaWJyYXRlOiBcIlx1MDQxQVx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzMVx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHBhaW50T25jZTogXCJcdTA0MTVcdTA0MzRcdTA0MzhcdTA0M0RcdTA0M0VcdTA0NDBcdTA0MzBcdTA0MzdcdTA0M0VcdTA0MzJcdTA0M0VcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQyXHUwNDQzXHUwNDQxXHUwNDMwLi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJcdTA0MUFcdTA0M0VcdTA0M0RcdTA0NDRcdTA0MzhcdTA0MzNcdTA0NDNcdTA0NDBcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEZcIixcbiAgICBkZWxheTogXCJcdTA0MTdcdTA0MzBcdTA0MzRcdTA0MzVcdTA0NDBcdTA0MzZcdTA0M0FcdTA0MzAgKFx1MDQzQ1x1MDQ0MSlcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTA0MUZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDM3XHUwNDMwIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFwiLFxuICAgIG1pbkNoYXJnZXM6IFwiXHUwNDFDXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDNDXHUwNDMwXHUwNDNCXHUwNDRDXHUwNDNEXHUwNDNFXHUwNDM1IFx1MDQzQVx1MDQzRVx1MDQzQi1cdTA0MzJcdTA0M0VcIixcbiAgICBjb2xvck1vZGU6IFwiXHUwNDIwXHUwNDM1XHUwNDM2XHUwNDM4XHUwNDNDIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlwiLFxuICAgIHJhbmRvbTogXCJcdTA0MjFcdTA0M0JcdTA0NDNcdTA0NDdcdTA0MzBcdTA0MzlcdTA0M0RcdTA0NEJcdTA0MzlcIixcbiAgICBmaXhlZDogXCJcdTA0MjRcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzhcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0M0RcdTA0NEJcdTA0MzlcIixcbiAgICByYW5nZTogXCJcdTA0MTRcdTA0MzhcdTA0MzBcdTA0M0ZcdTA0MzBcdTA0MzdcdTA0M0VcdTA0M0RcIixcbiAgICBmaXhlZENvbG9yOiBcIlx1MDQyNFx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzOSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcIixcbiAgICBhZHZhbmNlZDogXCJcdTA0MjBcdTA0MzBcdTA0NDFcdTA0NDhcdTA0MzhcdTA0NDBcdTA0MzVcdTA0M0RcdTA0M0RcdTA0NEJcdTA0MzVcIixcbiAgICB0aWxlWDogXCJcdTA0MUZcdTA0M0JcdTA0MzhcdTA0NDJcdTA0M0FcdTA0MzAgWFwiLFxuICAgIHRpbGVZOiBcIlx1MDQxRlx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQzQVx1MDQzMCBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJcdTA0MjFcdTA0MzJcdTA0M0VcdTA0NEYgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDMwXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiXHUwNDNGXHUwNDQwXHUwNDM4XHUwNDNDXHUwNDM1XHUwNDQwOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiXHUwNDE3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXCIsXG4gICAgcGFpbnRlZDogXCJcdTA0MTdcdTA0MzBcdTA0M0FcdTA0NDBcdTA0MzBcdTA0NDhcdTA0MzVcdTA0M0RcdTA0M0VcIixcbiAgICBjaGFyZ2VzOiBcIlx1MDQxN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQ0QlwiLFxuICAgIHJldHJpZXM6IFwiXHUwNDFGXHUwNDNFXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDQwXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzOFwiLFxuICAgIHRpbGU6IFwiXHUwNDFGXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDNBXHUwNDMwXCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiXHUwNDFBXHUwNDNFXHUwNDNEXHUwNDQ0XHUwNDM4XHUwNDMzXHUwNDQzXHUwNDQwXHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGIFx1MDQ0MVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJcdTA0MUFcdTA0M0VcdTA0M0RcdTA0NDRcdTA0MzhcdTA0MzNcdTA0NDNcdTA0NDBcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgY29uZmlnUmVzZXQ6IFwiXHUwNDIxXHUwNDMxXHUwNDQwXHUwNDNFXHUwNDQxIFx1MDQzQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzOFx1MDQzM1x1MDQ0M1x1MDQ0MFx1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOFwiLFxuICAgIGNhcHR1cmVJbnN0cnVjdGlvbnM6IFwiXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzJcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0NDNcdTA0NEUgXHUwNDM0XHUwNDNCXHUwNDRGIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzMCBcdTA0M0FcdTA0M0VcdTA0M0VcdTA0NDBcdTA0MzRcdTA0MzhcdTA0M0RcdTA0MzBcdTA0NDIuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIlx1MDQxMVx1MDQ0RFx1MDQzQVx1MDQ0RFx1MDQzRFx1MDQzNCBcdTA0MUVcdTA0M0RcdTA0M0JcdTA0MzBcdTA0MzlcdTA0M0RcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJcdTA0MTFcdTA0NERcdTA0M0FcdTA0NERcdTA0M0RcdTA0MzRcIixcbiAgICBzdGFydGluZ0JvdDogXCJcdTA0MTdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0M0EgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwLi4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNBXHUwNDMwIFx1MDQzMVx1MDQzRVx1MDQ0Mlx1MDQzMC4uLlwiLFxuICAgIGNhbGlicmF0aW5nOiBcIlx1MDQxQVx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzMVx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzQVx1MDQzMC4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIlx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MjRcdTA0MzBcdTA0NDBcdTA0M0MgXHUwNDQzXHUwNDM2XHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0OVx1MDQzNVx1MDQzRFwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDlcdTA0MzVcdTA0M0RcdTA0M0UuIFx1MDQxN1x1MDQzMFx1MDQzQVx1MDQ0MFx1MDQzRVx1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM0IFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQVx1MDQzRVx1MDQzQyBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDI0XHUwNDMwXHUwNDQwXHUwNDNDXHUwNDMwLlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFx1MDQxRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQxRlx1MDQyM1x1MDQyMVx1MDQyMlx1MDQxRVx1MDQxOSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzggXHUwNDNBXHUwNDMwXHUwNDQwXHUwNDQyXHUwNDRCLCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDNFXHUwNDMxXHUwNDNFXHUwNDM3XHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0NDRcdTA0MzBcdTA0NDBcdTA0M0NcdTA0MzAuXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQwXHUwNDQyXHUwNDNFXHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0Ri4uLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzMCEgXHUwNDIwXHUwNDMwXHUwNDM0XHUwNDM4XHUwNDQzXHUwNDQxOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHUwNDIyXHUwNDMwXHUwNDM5XHUwNDNDXHUwNDMwXHUwNDQzXHUwNDQyIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQxIFx1MDQzRlx1MDQzRVx1MDQzQ1x1MDQzRVx1MDQ0OVx1MDQ0Q1x1MDQ0RSBcdTAwQUJcdTA0MTJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDXHUwMEJCXCIsXG4gICAgZmFybVJhZGl1czogXCJcdTA0MjBcdTA0MzBcdTA0MzRcdTA0MzhcdTA0NDNcdTA0NDEgXHUwNDQ0XHUwNDMwXHUwNDQwXHUwNDNDXHUwNDMwXCIsXG4gICAgcG9zaXRpb25JbmZvOiBcIlx1MDQyMlx1MDQzNVx1MDQzQVx1MDQ0M1x1MDQ0OVx1MDQzMFx1MDQ0RiBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NENcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIFx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQyBcdTA0MzIgXHUwNDQwXHUwNDMwXHUwNDM0XHUwNDM4XHUwNDQzXHUwNDQxXHUwNDM1IHtyYWRpdXN9cHggXHUwNDNFXHUwNDQyICh7eH0se3l9KVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgXHUwNDEyXHUwNDEwXHUwNDE2XHUwNDFEXHUwNDFFOiBcdTA0MTJcdTA0NEJcdTA0MzFcdTA0MzVcdTA0NDBcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDFGXHUwNDIzXHUwNDIxXHUwNDIyXHUwNDIzXHUwNDJFIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QywgXHUwNDQ3XHUwNDQyXHUwNDNFXHUwNDMxXHUwNDRCIFx1MDQzOFx1MDQzN1x1MDQzMVx1MDQzNVx1MDQzNlx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0FcdTA0M0VcdTA0M0RcdTA0NDRcdTA0M0JcdTA0MzhcdTA0M0FcdTA0NDJcdTA0M0VcdTA0MzIuXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJcdTA0MURcdTA0MzVcdTA0NDIgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4XCIsXG4gICAgY3VycmVudFpvbmU6IFwiXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDOiAoe3h9LHt5fSlcIixcbiAgICBhdXRvU2VsZWN0UG9zaXRpb246IFwiXHVEODNDXHVERkFGIFx1MDQyMVx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQzQlx1MDQzMCBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0MzVcdTA0NDBcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDLiBcdTA0MURcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRDIFx1MDQzRFx1MDQzMCBcdTA0M0FcdTA0MzBcdTA0NDBcdTA0NDJcdTA0MzUsIFx1MDQ0N1x1MDQ0Mlx1MDQzRVx1MDQzMVx1MDQ0QiBcdTA0M0VcdTA0MzFcdTA0M0VcdTA0MzdcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0NFx1MDQzMFx1MDQ0MFx1MDQzQ1x1MDQzMC5cIlxuICB9LFxuXG4gIC8vIENvbW1vbi9TaGFyZWRcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIlx1MDQxNFx1MDQzMFwiLFxuICAgIG5vOiBcIlx1MDQxRFx1MDQzNVx1MDQ0MlwiLFxuICAgIG9rOiBcIlx1MDQxRVx1MDQxQVwiLFxuICAgIGNhbmNlbDogXCJcdTA0MUVcdTA0NDJcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBjbG9zZTogXCJcdTA0MTdcdTA0MzBcdTA0M0FcdTA0NDBcdTA0NEJcdTA0NDJcdTA0NENcIixcbiAgICBzYXZlOiBcIlx1MDQyMVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGxvYWQ6IFwiXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgZGVsZXRlOiBcIlx1MDQyM1x1MDQzNFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGVkaXQ6IFwiXHUwNDE4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgc3RhcnQ6IFwiXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcDogXCJcdTA0MTdcdTA0MzBcdTA0M0FcdTA0M0VcdTA0M0RcdTA0NDdcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBwYXVzZTogXCJcdTA0MUZcdTA0NDBcdTA0MzhcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICByZXN1bWU6IFwiXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDM0XHUwNDNFXHUwNDNCXHUwNDM2XHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgcmVzZXQ6IFwiXHUwNDIxXHUwNDMxXHUwNDQwXHUwNDNFXHUwNDQxXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgc2V0dGluZ3M6IFwiXHUwNDFEXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDNBXHUwNDM4XCIsXG4gICAgaGVscDogXCJcdTA0MUZcdTA0M0VcdTA0M0NcdTA0M0VcdTA0NDlcdTA0NENcIixcbiAgICBhYm91dDogXCJcdTA0MThcdTA0M0RcdTA0NDRcdTA0M0VcdTA0NDBcdTA0M0NcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEZcIixcbiAgICBsYW5ndWFnZTogXCJcdTA0MkZcdTA0MzdcdTA0NEJcdTA0M0FcIixcbiAgICBsb2FkaW5nOiBcIlx1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzMC4uLlwiLFxuICAgIGVycm9yOiBcIlx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMFwiLFxuICAgIHN1Y2Nlc3M6IFwiXHUwNDIzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ1XCIsXG4gICAgd2FybmluZzogXCJcdTA0MUZcdTA0NDBcdTA0MzVcdTA0MzRcdTA0NDNcdTA0M0ZcdTA0NDBcdTA0MzVcdTA0MzZcdTA0MzRcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBpbmZvOiBcIlx1MDQxOFx1MDQzRFx1MDQ0NFx1MDQzRVx1MDQ0MFx1MDQzQ1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJcdTA0MkZcdTA0MzdcdTA0NEJcdTA0M0EgXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEIFx1MDQzRFx1MDQzMCB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzMFwiLFxuICAgIGluaXRCb3Q6IFwiXHUwNDE4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDIEd1YXJkLUJPVFwiLFxuICAgIHNlbGVjdEFyZWE6IFwiXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGNhcHR1cmVBcmVhOiBcIlx1MDQxN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NENcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0M1wiLFxuICAgIHN0b3BQcm90ZWN0aW9uOiBcIlx1MDQxRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NDNcIixcbiAgICB1cHBlckxlZnQ6IFwiXHUwNDEyXHUwNDM1XHUwNDQwXHUwNDQ1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQxQlx1MDQzNVx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0MjNcdTA0MzNcdTA0M0VcdTA0M0JcIixcbiAgICBsb3dlclJpZ2h0OiBcIlx1MDQxRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0MUZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDIzXHUwNDMzXHUwNDNFXHUwNDNCXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0MUZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzhcIixcbiAgICBkZXRlY3RlZENoYW5nZXM6IFwiXHUwNDFFXHUwNDMxXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQxOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RlwiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlx1MDQxMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0MUZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzhcIixcbiAgICBjaGFyZ2VzOiBcIlx1MDQxN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQ0QlwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0MzguLi5cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0NcdURGQTggXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwIFx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQ0M1x1MDQzRlx1MDQzRFx1MDQ0Qlx1MDQ0NSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTA0MjZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0MzAgXHUwNDNEXHUwNDM1IFx1MDQzRFx1MDQzMFx1MDQzOVx1MDQzNFx1MDQzNVx1MDQzRFx1MDQ0Qi4gXHUwNDFFXHUwNDQyXHUwNDNBXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQ0MyBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIgXHUwNDNEXHUwNDMwIFx1MDQ0MVx1MDQzMFx1MDQzOVx1MDQ0Mlx1MDQzNS5cIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHUwNDFEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDNFIHtjb3VudH0gXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlwiLFxuICAgIGluaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgXHUwNDQzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOCBHdWFyZC1CT1RcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBcdTA0MURcdTA0MzVcdTA0MzRcdTA0MzVcdTA0MzlcdTA0NDFcdTA0NDJcdTA0MzJcdTA0MzhcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NENcdTA0M0RcdTA0NEJcdTA0MzUgXHUwNDNBXHUwNDNFXHUwNDNFXHUwNDQwXHUwNDM0XHUwNDM4XHUwNDNEXHUwNDMwXHUwNDQyXHUwNDRCXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0MzRcdTA0M0VcdTA0M0JcdTA0MzZcdTA0M0RcdTA0MzAgXHUwNDM4XHUwNDNDXHUwNDM1XHUwNDQyXHUwNDRDIFx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQ0NVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0JcdTA0MzVcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDQzXHUwNDMzXHUwNDNFXHUwNDNCIFx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQ0Q1x1MDQ0OFx1MDQzNSBcdTA0M0RcdTA0MzhcdTA0MzZcdTA0M0RcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDQwXHUwNDMwXHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQ0M1x1MDQzM1x1MDQzQlx1MDQzMFwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0MVx1MDQzQlx1MDQzOFx1MDQ0OFx1MDQzQVx1MDQzRVx1MDQzQyBcdTA0MzFcdTA0M0VcdTA0M0JcdTA0NENcdTA0NDhcdTA0MzBcdTA0NEY6IHtzaXplfSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgKFx1MDQzQ1x1MDQzMFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQzQ1x1MDQ0M1x1MDQzQzoge21heH0pXCIsXG4gICAgY2FwdHVyaW5nQXJlYTogXCJcdUQ4M0RcdURDRjggXHUwNDE3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOCBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NEIuLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDdcdTA0MzVcdTA0M0RcdTA0MzA6IHtjb3VudH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzRlx1MDQzRVx1MDQzNCBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0M0VcdTA0MzlcIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzAgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4OiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBcdTA0MjFcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NEJcIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzMCAtIFx1MDQzQ1x1MDQzRVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzOFx1MDQzRFx1MDQzMyBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwIFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyAtIFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0RcdTA0MzUgXHUwNDNFXHUwNDMxXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDNFXCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCB7Y291bnR9IFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0VcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDMyIFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRFx1MDQzRVx1MDQzOSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFx1MDQxMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSB7Y291bnR9IFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQ0NSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFx1MDQyM1x1MDQ0MVx1MDQzRlx1MDQzNVx1MDQ0OFx1MDQzRFx1MDQzRSBcdTA0MzJcdTA0M0VcdTA0NDFcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcdTA0M0Uge2NvdW50fSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzlcIixcbiAgICByZXBhaXJFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0Mzk6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIFx1MDQxRFx1MDQzNVx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQ0Mlx1MDQzRVx1MDQ0N1x1MDQzRFx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0M0VcdTA0MzIgXHUwNDM0XHUwNDNCXHUwNDRGIFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzlcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzkgXHUwNDMyIFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRFx1MDQzRVx1MDQzOSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzguLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDM4IFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOToge2Vycm9yfVwiLFxuICAgIGd1YXJkQWN0aXZlOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTA0MjFcdTA0NDJcdTA0NDBcdTA0MzBcdTA0MzYgXHUwNDMwXHUwNDNBXHUwNDQyXHUwNDM4XHUwNDMyXHUwNDM1XHUwNDNEIC0gXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQzRVx1MDQzNCBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0M0VcdTA0MzlcIixcbiAgICBsYXN0Q2hlY2s6IFwiXHUwNDFGXHUwNDNFXHUwNDQxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDNEXHUwNDRGXHUwNDRGIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMDoge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIlx1MDQyMVx1MDQzQlx1MDQzNVx1MDQzNFx1MDQ0M1x1MDQ0RVx1MDQ0OVx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAgXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3OiB7dGltZX1cdTA0NDFcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQ5XHUwNDM1XHUwNDNEIFx1MDQzMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzQ1x1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0N1x1MDQzNVx1MDQ0MVx1MDQzQVx1MDQzOFwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBcdTA0MURcdTA0MzUgXHUwNDQzXHUwNDM0XHUwNDMwXHUwNDNCXHUwNDNFXHUwNDQxXHUwNDRDIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MzBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzguIFx1MDQxOFx1MDQ0MVx1MDQzRlx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQzN1x1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0FcdTA0M0RcdTA0M0VcdTA0M0ZcdTA0M0FcdTA0NDMgXHUwNDQwXHUwNDQzXHUwNDQ3XHUwNDNEXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQVx1MDQzMC5cIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1MDQyMlx1MDQ0MFx1MDQzNVx1MDQzMVx1MDQ0M1x1MDQzNVx1MDQ0Mlx1MDQ0MVx1MDQ0RiBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTA0MjZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDMwIFx1MDQzRVx1MDQzMVx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDNFXHUwNDM4XHUwNDQxXHUwNDNBIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzRVx1MDQzOSBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0NEIuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTA0MURcdTA0MzBcdTA0MzZcdTA0MzBcdTA0NDJcdTA0MzhcdTA0MzUgXHUwNDNBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDM4IFx1MDBBQlBhaW50XHUwMEJCLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHUwNDFBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDMwIFx1MDBBQlBhaW50XHUwMEJCIFx1MDQzRFx1MDQzNSBcdTA0M0RcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFx1MDQxRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQxMlx1MDQxNVx1MDQyMFx1MDQyNVx1MDQxRFx1MDQxNVx1MDQxQyBcdTA0MUJcdTA0MTVcdTA0MTJcdTA0MUVcdTA0MUMgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDQzIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOCBcdTA0MzRcdTA0M0JcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDRCXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgXHUwNDIyXHUwNDM1XHUwNDNGXHUwNDM1XHUwNDQwXHUwNDRDIFx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQxRFx1MDQxOFx1MDQxNlx1MDQxRFx1MDQxNVx1MDQxQyBcdTA0MUZcdTA0MjBcdTA0MTBcdTA0MTJcdTA0MUVcdTA0MUMgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDQzIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzAgXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ1XHUwNDNEXHUwNDM1XHUwNDMzXHUwNDNFIFx1MDQzQlx1MDQzNVx1MDQzMlx1MDQzRVx1MDQzM1x1MDQzRSBcdTA0NDNcdTA0MzNcdTA0M0JcdTA0MzAuLi5cIixcbiAgICB3YWl0aW5nTG93ZXJSaWdodDogXCJcdUQ4M0RcdURDNDYgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0RcdTA0MzhcdTA0MzZcdTA0M0RcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDQwXHUwNDMwXHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQ0M1x1MDQzM1x1MDQzQlx1MDQzMC4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBcdTA0MTJcdTA0MzVcdTA0NDBcdTA0NDVcdTA0M0RcdTA0MzhcdTA0MzkgXHUwNDNCXHUwNDM1XHUwNDMyXHUwNDRCXHUwNDM5IFx1MDQ0M1x1MDQzM1x1MDQzRVx1MDQzQiBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDdcdTA0MzVcdTA0M0Q6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDQxRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0ZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDQzXHUwNDMzXHUwNDNFXHUwNDNCIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0N1x1MDQzNVx1MDQzRDogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1MDQyMlx1MDQzMFx1MDQzOVx1MDQzQy1cdTA0MzBcdTA0NDNcdTA0NDIgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwXCIsXG4gICAgc2VsZWN0aW9uRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzAsIFx1MDQzRlx1MDQzRVx1MDQzNlx1MDQzMFx1MDQzQlx1MDQ0M1x1MDQzOVx1MDQ0MVx1MDQ0Mlx1MDQzMCwgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQ0MVx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzMFwiXG4gIH1cbn07XG4iLCAiZXhwb3J0IGNvbnN0IHpoSGFucyA9IHtcbiAgLy8gXHU1NDJGXHU1MkE4XHU1NjY4XG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgXHU4MUVBXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBcdTgxRUFcdTUyQThcdTUxOUNcdTU3M0EnLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBcdTgxRUFcdTUyQThcdTdFRDhcdTU2RkUnLFxuICAgIGF1dG9HdWFyZDogJ1x1RDgzRFx1REVFMVx1RkUwRiBcdTgxRUFcdTUyQThcdTVCODhcdTYyQTQnLFxuICAgIHNlbGVjdGlvbjogJ1x1OTAwOVx1NjJFOScsXG4gICAgdXNlcjogJ1x1NzUyOFx1NjIzNycsXG4gICAgY2hhcmdlczogJ1x1NkIyMVx1NjU3MCcsXG4gICAgYmFja2VuZDogJ1x1NTQwRVx1N0FFRicsXG4gICAgZGF0YWJhc2U6ICdcdTY1NzBcdTYzNkVcdTVFOTMnLFxuICAgIHVwdGltZTogJ1x1OEZEMFx1ODg0Q1x1NjVGNlx1OTVGNCcsXG4gICAgY2xvc2U6ICdcdTUxNzNcdTk1RUQnLFxuICAgIGxhdW5jaDogJ1x1NTQyRlx1NTJBOCcsXG4gICAgbG9hZGluZzogJ1x1NTJBMFx1OEY3RFx1NEUyRFx1MjAyNicsXG4gICAgZXhlY3V0aW5nOiAnXHU2MjY3XHU4ODRDXHU0RTJEXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ1x1NkI2M1x1NTcyOFx1NEUwQlx1OEY3RFx1ODExQVx1NjcyQ1x1MjAyNicsXG4gICAgY2hvb3NlQm90OiAnXHU5MDA5XHU2MkU5XHU0RTAwXHU0RTJBXHU2NzNBXHU1NjY4XHU0RUJBXHU1RTc2XHU3MEI5XHU1MUZCXHU1NDJGXHU1MkE4JyxcbiAgICByZWFkeVRvTGF1bmNoOiAnXHU1MUM2XHU1OTA3XHU1NDJGXHU1MkE4JyxcbiAgICBsb2FkRXJyb3I6ICdcdTUyQTBcdThGN0RcdTk1MTlcdThCRUYnLFxuICAgIGxvYWRFcnJvck1zZzogJ1x1NjVFMFx1NkNENVx1NTJBMFx1OEY3RFx1NjI0MFx1OTAwOVx1NjczQVx1NTY2OFx1NEVCQVx1MzAwMlx1OEJGN1x1NjhDMFx1NjdFNVx1N0Y1MVx1N0VEQ1x1OEZERVx1NjNBNVx1NjIxNlx1OTFDRFx1OEJENVx1MzAwMicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgXHU2OEMwXHU2N0U1XHU0RTJELi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgXHU1NzI4XHU3RUJGJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IFx1NzlCQlx1N0VCRicsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgXHU2QjYzXHU1RTM4JyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBcdTk1MTlcdThCRUYnLFxuICAgIHVua25vd246ICctJ1xuICB9LFxuXG4gIC8vIFx1N0VEOFx1NTZGRVx1NkEyMVx1NTc1N1xuICBpbWFnZToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTgxRUFcdTUyQThcdTdFRDhcdTU2RkVcIixcbiAgICBpbml0Qm90OiBcIlx1NTIxRFx1NTlDQlx1NTMxNlx1ODFFQVx1NTJBOFx1NjczQVx1NTY2OFx1NEVCQVwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlx1NEUwQVx1NEYyMFx1NTZGRVx1NzI0N1wiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlx1OEMwM1x1NjU3NFx1NTZGRVx1NzI0N1x1NTkyN1x1NUMwRlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1OTAwOVx1NjJFOVx1NEY0RFx1N0Y2RVwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiXHU1RjAwXHU1OUNCXHU3RUQ4XHU1MjM2XCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlx1NTA1Q1x1NkI2Mlx1N0VEOFx1NTIzNlwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJcdTRGRERcdTVCNThcdThGREJcdTVFQTZcIixcbiAgICBsb2FkUHJvZ3Jlc3M6IFwiXHU1MkEwXHU4RjdEXHU4RkRCXHU1RUE2XCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIFx1NjhDMFx1NjdFNVx1NTNFRlx1NzUyOFx1OTg5Q1x1ODI3Mi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1OEJGN1x1NTcyOFx1N0Y1MVx1N0FEOVx1NEUwQVx1NjI1M1x1NUYwMFx1OEMwM1x1ODI3Mlx1Njc3Rlx1NTQwRVx1OTFDRFx1OEJENVx1RkYwMVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTYyN0VcdTUyMzAge2NvdW50fSBcdTc5Q0RcdTUzRUZcdTc1MjhcdTk4OUNcdTgyNzJcIixcbiAgICBsb2FkaW5nSW1hZ2U6IFwiXHVEODNEXHVEREJDXHVGRTBGIFx1NkI2M1x1NTcyOFx1NTJBMFx1OEY3RFx1NTZGRVx1NzI0Ny4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBcdTU2RkVcdTcyNDdcdTVERjJcdTUyQTBcdThGN0RcdUZGMENcdTY3MDlcdTY1NDhcdTUwQ0ZcdTdEMjAge2NvdW50fSBcdTRFMkFcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBcdTU2RkVcdTcyNDdcdTUyQTBcdThGN0RcdTU5MzFcdThEMjVcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1OEJGN1x1NTcyOFx1NEY2MFx1NjBGM1x1NUYwMFx1NTlDQlx1N0VEOFx1NTIzNlx1NzY4NFx1NTczMFx1NjVCOVx1NkQ4Mlx1N0IyQ1x1NEUwMFx1NEUyQVx1NTBDRlx1N0QyMFx1RkYwMVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU0RjYwXHU2RDgyXHU1M0MyXHU4MDAzXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1NEY0RFx1N0Y2RVx1OEJCRVx1N0Y2RVx1NjIxMFx1NTI5Rlx1RkYwMVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU5MDA5XHU2MkU5XHU4RDg1XHU2NUY2XCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgXHU1REYyXHU2OEMwXHU2RDRCXHU1MjMwXHU0RjREXHU3RjZFXHVGRjBDXHU1OTA0XHU3NDA2XHU0RTJELi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU2OEMwXHU2RDRCXHU1OTMxXHU4RDI1XHVGRjBDXHU4QkY3XHU5MUNEXHU4QkQ1XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggXHU1RjAwXHU1OUNCXHU3RUQ4XHU1MjM2Li4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgXHU4RkRCXHU1RUE2OiB7cGFpbnRlZH0ve3RvdGFsfSBcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyMzFCIFx1NkNBMVx1NjcwOVx1NkIyMVx1NjU3MFx1MzAwMlx1N0I0OVx1NUY4NSB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NzUyOFx1NjIzN1x1NURGMlx1NTA1Q1x1NkI2Mlx1N0VEOFx1NTIzNlwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1N0VEOFx1NTIzNlx1NUI4Q1x1NjIxMFx1RkYwMVx1NTE3MVx1N0VEOFx1NTIzNiB7Y291bnR9IFx1NEUyQVx1NTBDRlx1N0QyMFx1MzAwMlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIFx1N0VEOFx1NTIzNlx1OEZDN1x1N0EwQlx1NEUyRFx1NTFGQVx1OTUxOVwiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIFx1OEJGN1x1NTE0OFx1NTJBMFx1OEY3RFx1NTZGRVx1NzI0N1x1NUU3Nlx1OTAwOVx1NjJFOVx1NEY0RFx1N0Y2RVwiLFxuICAgIHByb2dyZXNzOiBcIlx1OEZEQlx1NUVBNlwiLFxuICAgIHVzZXJOYW1lOiBcIlx1NzUyOFx1NjIzN1wiLFxuICAgIHBpeGVsczogXCJcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3MFwiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiXHU5ODg0XHU4QkExXHU2NUY2XHU5NUY0XCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiXHU3MEI5XHU1MUZCXHUyMDFDXHU1MjFEXHU1OUNCXHU1MzE2XHU4MUVBXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBXHUyMDFEXHU1RjAwXHU1OUNCXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHU3QjQ5XHU1Rjg1XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgXHU1NkZFXHU3MjQ3XHU1REYyXHU4QzAzXHU2NTc0XHU0RTNBIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgXHU3RUQ4XHU1MjM2XHU2NjgyXHU1MDVDXHU0RThFXHU0RjREXHU3RjZFIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHU2QkNGXHU2Mjc5XHU1MENGXHU3RDIwXHU2NTcwXCIsXG4gICAgYmF0Y2hTaXplOiBcIlx1NjI3OVx1NkIyMVx1NTkyN1x1NUMwRlwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiXHU0RTBCXHU2QjIxXHU2Mjc5XHU2QjIxXHU2NUY2XHU5NUY0XCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJcdTRGN0ZcdTc1MjhcdTYyNDBcdTY3MDlcdTUzRUZcdTc1MjhcdTZCMjFcdTY1NzBcIixcbiAgICBzaG93T3ZlcmxheTogXCJcdTY2M0VcdTc5M0FcdTg5ODZcdTc2RDZcdTVDNDJcIixcbiAgICBtYXhDaGFyZ2VzOiBcIlx1NkJDRlx1NjI3OVx1NjcwMFx1NTkyN1x1NkIyMVx1NjU3MFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1NzA6IHtjdXJyZW50fS97bmVlZGVkfVwiLFxuICAgIHRpbWVSZW1haW5pbmc6IFwiXHU1MjY5XHU0RjU5XHU2NUY2XHU5NUY0XCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBcdTdCNDlcdTVGODUge3RpbWV9IFx1NTQwRVx1N0VFN1x1N0VFRC4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFx1OEZEQlx1NUVBNlx1NURGMlx1NEZERFx1NUI1OFx1NEUzQSB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFx1NURGMlx1NTJBMFx1OEY3RFx1OEZEQlx1NUVBNjoge3BhaW50ZWR9L3t0b3RhbH0gXHU1MENGXHU3RDIwXHU1REYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIFx1NTJBMFx1OEY3RFx1OEZEQlx1NUVBNlx1NTkzMVx1OEQyNToge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBcdTRGRERcdTVCNThcdThGREJcdTVFQTZcdTU5MzFcdThEMjU6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1NTcyOFx1NTA1Q1x1NkI2Mlx1NEU0Qlx1NTI0RFx1ODk4MVx1NEZERFx1NUI1OFx1NUY1M1x1NTI0RFx1OEZEQlx1NUVBNlx1NTQxN1x1RkYxRlwiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlx1NEZERFx1NUI1OFx1OEZEQlx1NUVBNlwiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJcdTY1M0VcdTVGMDNcIixcbiAgICBjYW5jZWw6IFwiXHU1M0Q2XHU2RDg4XCIsXG4gICAgbWluaW1pemU6IFwiXHU2NzAwXHU1QzBGXHU1MzE2XCIsXG4gICAgd2lkdGg6IFwiXHU1QkJEXHU1RUE2XCIsXG4gICAgaGVpZ2h0OiBcIlx1OUFEOFx1NUVBNlwiLFxuICAgIGtlZXBBc3BlY3Q6IFwiXHU0RkREXHU2MzAxXHU3RUI1XHU2QTJBXHU2QkQ0XCIsXG4gICAgYXBwbHk6IFwiXHU1RTk0XHU3NTI4XCIsXG4gICAgb3ZlcmxheU9uOiBcIlx1ODk4Nlx1NzZENlx1NUM0MjogXHU1RjAwXHU1NDJGXCIsXG4gICAgb3ZlcmxheU9mZjogXCJcdTg5ODZcdTc2RDZcdTVDNDI6IFx1NTE3M1x1OTVFRFwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFx1NjI3OVx1NkIyMVx1NUI4Q1x1NjIxMDogXHU1REYyXHU3RUQ4XHU1MjM2IHtwYWludGVkfSBcdTUwQ0ZcdTdEMjAgfCBcdThGREJcdTVFQTY6IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3MFx1NjA2Mlx1NTkwRDoge2N1cnJlbnR9L3tuZWVkZWR9IC0gXHU2NUY2XHU5NUY0OiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTcwOiB7Y3VycmVudH0ve25lZWRlZH0gLSBcdTUyNjlcdTRGNTk6IHt0aW1lfVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJBOFx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NjVFMFx1NkNENVx1ODFFQVx1NTJBOFx1NTQyRlx1NTJBOFx1RkYwQ1x1OEJGN1x1NjI0Qlx1NTJBOFx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHU1REYyXHU2OEMwXHU2RDRCXHU1MjMwXHU4QzAzXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY0MUNcdTdEMjJcdThDMDNcdTgyNzJcdTY3N0YuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTZCNjNcdTU3MjhcdTcwQjlcdTUxRkJcdTdFRDhcdTUyMzZcdTYzMDlcdTk0QUUuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTdFRDhcdTUyMzZcdTYzMDlcdTk0QUVcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1OTcwMFx1ODk4MVx1NjI0Qlx1NTJBOFx1NTIxRFx1NTlDQlx1NTMxNlwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgXHU5MUNEXHU4QkQ1IHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9XHVGRjBDXHU3QjQ5XHU1Rjg1IHtkZWxheX0gXHU3OUQyLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgXHU3QjJDIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IFx1NkIyMVx1NUMxRFx1OEJENVx1NTFGQVx1OTUxOVx1RkYwQ1x1NUMwNlx1NTcyOCB7ZGVsYXl9IFx1NzlEMlx1NTQwRVx1OTFDRFx1OEJENS4uLlwiLFxuICAgIHJldHJ5RmFpbGVkOiBcIlx1Mjc0QyBcdThEODVcdThGQzcge21heEF0dGVtcHRzfSBcdTZCMjFcdTVDMURcdThCRDVcdTU5MzFcdThEMjVcdTMwMDJcdTdFRTdcdTdFRURcdTRFMEJcdTRFMDBcdTYyNzkuLi5cIixcbiAgICBuZXR3b3JrRXJyb3I6IFwiXHVEODNDXHVERjEwIFx1N0Y1MVx1N0VEQ1x1OTUxOVx1OEJFRlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEJENS4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBcdTY3MERcdTUyQTFcdTU2NjhcdTk1MTlcdThCRUZcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThCRDUuLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFx1NjcwRFx1NTJBMVx1NTY2OFx1OEQ4NVx1NjVGNlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEJENS4uLlwiXG4gIH0sXG5cbiAgLy8gXHU1MTlDXHU1NzNBXHU2QTIxXHU1NzU3XHVGRjA4XHU1Rjg1XHU1QjlFXHU3M0IwXHVGRjA5XG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU1MTlDXHU1NzNBXHU2NzNBXHU1NjY4XHU0RUJBXCIsXG4gICAgc3RhcnQ6IFwiXHU1RjAwXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBzdG9wcGVkOiBcIlx1NjczQVx1NTY2OFx1NEVCQVx1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIGNhbGlicmF0ZTogXCJcdTY4MjFcdTUxQzZcIixcbiAgICBwYWludE9uY2U6IFwiXHU0RTAwXHU2QjIxXCIsXG4gICAgY2hlY2tpbmdTdGF0dXM6IFwiXHU2OEMwXHU2N0U1XHU3MkI2XHU2MDAxXHU0RTJELi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJcdTkxNERcdTdGNkVcIixcbiAgICBkZWxheTogXCJcdTVFRjZcdThGREYgKFx1NkJFQlx1NzlEMilcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTZCQ0ZcdTYyNzlcdTUwQ0ZcdTdEMjBcIixcbiAgICBtaW5DaGFyZ2VzOiBcIlx1NjcwMFx1NUMxMVx1NkIyMVx1NjU3MFwiLFxuICAgIGNvbG9yTW9kZTogXCJcdTk4OUNcdTgyNzJcdTZBMjFcdTVGMEZcIixcbiAgICByYW5kb206IFwiXHU5NjhGXHU2NzNBXCIsXG4gICAgZml4ZWQ6IFwiXHU1NkZBXHU1QjlBXCIsXG4gICAgcmFuZ2U6IFwiXHU4MzAzXHU1NkY0XCIsXG4gICAgZml4ZWRDb2xvcjogXCJcdTU2RkFcdTVCOUFcdTk4OUNcdTgyNzJcIixcbiAgICBhZHZhbmNlZDogXCJcdTlBRDhcdTdFQTdcIixcbiAgICB0aWxlWDogXCJcdTc0RTZcdTcyNDcgWFwiLFxuICAgIHRpbGVZOiBcIlx1NzRFNlx1NzI0NyBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJcdTgxRUFcdTVCOUFcdTRFNDlcdThDMDNcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJcdTRGOEJcdTU5ODI6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJcdTYzNTVcdTgzQjdcIixcbiAgICBwYWludGVkOiBcIlx1NURGMlx1N0VEOFx1NTIzNlwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTcwXCIsXG4gICAgcmV0cmllczogXCJcdTkxQ0RcdThCRDVcIixcbiAgICB0aWxlOiBcIlx1NzRFNlx1NzI0N1wiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1NEZERFx1NUI1OFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTUyQTBcdThGN0RcIixcbiAgICBjb25maWdSZXNldDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTkxQ0RcdTdGNkVcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlx1OEJGN1x1NjI0Qlx1NTJBOFx1N0VEOFx1NTIzNlx1NEUwMFx1NEUyQVx1NTBDRlx1N0QyMFx1NEVFNVx1NjM1NVx1ODNCN1x1NTc1MFx1NjgwNy4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiXHU1NDBFXHU3QUVGXHU1NzI4XHU3RUJGXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiXHU1NDBFXHU3QUVGXHU3OUJCXHU3RUJGXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1NDJGXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1MDVDXHU2QjYyXHU2NzNBXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiXHU2ODIxXHU1MUM2XHU0RTJELi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiXHU4MUVBXHU1MkE4XHU1MTlDXHU1NzNBXHU1REYyXHU1NzI4XHU4RkQwXHU4ODRDXHUzMDAyXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJcdTgxRUFcdTUyQThcdTdFRDhcdTU2RkVcdTZCNjNcdTU3MjhcdThGRDBcdTg4NENcdUZGMENcdThCRjdcdTUxNDhcdTUxNzNcdTk1RURcdTUxOERcdTU0MkZcdTUyQThcdTgxRUFcdTUyQThcdTUxOUNcdTU3M0FcdTMwMDJcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1RDgzQ1x1REZBRiBcdTU3MjhcdTU3MzBcdTU2RkVcdTc2ODRcdTdBN0FcdTc2N0RcdTUzM0FcdTU3REZcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcdTRFRTVcdThCQkVcdTdGNkVcdTUxOUNcdTU3M0FcdTUzM0FcdTU3REZcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1NEY2MFx1NkQ4Mlx1NTNDMlx1ODAwM1x1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTUzM0FcdTU3REZcdThCQkVcdTdGNkVcdTYyMTBcdTUyOUZcdUZGMDFcdTUzNEFcdTVGODQ6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTUzM0FcdTU3REZcdTkwMDlcdTYyRTlcdThEODVcdTY1RjZcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFx1OEJGN1x1NTE0OFx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlx1RkYwOFx1NEY3Rlx1NzUyOFx1MjAxQ1x1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlx1MjAxRFx1NjMwOVx1OTRBRVx1RkYwOVwiLFxuICAgIGZhcm1SYWRpdXM6IFwiXHU1MTlDXHU1NzNBXHU1MzRBXHU1Rjg0XCIsXG4gICAgcG9zaXRpb25JbmZvOiBcIlx1NUY1M1x1NTI0RFx1NTMzQVx1NTdERlwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgXHU2QjYzXHU1NzI4XHU0RUU1XHU1MzRBXHU1Rjg0IHtyYWRpdXN9cHggXHU1NzI4ICh7eH0se3l9KSBcdTUxOUNcdTU3M0FcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIFx1OTFDRFx1ODk4MTogXHU4QkY3XHU5MDA5XHU2MkU5XHU3QTdBXHU3NjdEXHU1MzNBXHU1N0RGXHU0RUU1XHU5MDdGXHU1MTREXHU1MUIyXHU3QTgxXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJcdTY3MkFcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcIixcbiAgICBjdXJyZW50Wm9uZTogXCJcdTUzM0FcdTU3REY6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgXHU4QkY3XHU1MTQ4XHU5MDA5XHU2MkU5XHU1MzNBXHU1N0RGXHVGRjBDXHU1NzI4XHU1NzMwXHU1NkZFXHU0RTBBXHU2RDgyXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXHU0RUU1XHU4QkJFXHU3RjZFXHU1MTlDXHU1NzNBXHU1MzNBXHU1N0RGXCJcbiAgfSxcblxuICAvLyBcdTUxNkNcdTUxNzFcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIlx1NjYyRlwiLFxuICAgIG5vOiBcIlx1NTQyNlwiLFxuICAgIG9rOiBcIlx1Nzg2RVx1OEJBNFwiLFxuICAgIGNhbmNlbDogXCJcdTUzRDZcdTZEODhcIixcbiAgICBjbG9zZTogXCJcdTUxNzNcdTk1RURcIixcbiAgICBzYXZlOiBcIlx1NEZERFx1NUI1OFwiLFxuICAgIGxvYWQ6IFwiXHU1MkEwXHU4RjdEXCIsXG4gICAgZGVsZXRlOiBcIlx1NTIyMFx1OTY2NFwiLFxuICAgIGVkaXQ6IFwiXHU3RjE2XHU4RjkxXCIsXG4gICAgc3RhcnQ6IFwiXHU1RjAwXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBwYXVzZTogXCJcdTY2ODJcdTUwNUNcIixcbiAgICByZXN1bWU6IFwiXHU3RUU3XHU3RUVEXCIsXG4gICAgcmVzZXQ6IFwiXHU5MUNEXHU3RjZFXCIsXG4gICAgc2V0dGluZ3M6IFwiXHU4QkJFXHU3RjZFXCIsXG4gICAgaGVscDogXCJcdTVFMkVcdTUyQTlcIixcbiAgICBhYm91dDogXCJcdTUxNzNcdTRFOEVcIixcbiAgICBsYW5ndWFnZTogXCJcdThCRURcdThBMDBcIixcbiAgICBsb2FkaW5nOiBcIlx1NTJBMFx1OEY3RFx1NEUyRC4uLlwiLFxuICAgIGVycm9yOiBcIlx1OTUxOVx1OEJFRlwiLFxuICAgIHN1Y2Nlc3M6IFwiXHU2MjEwXHU1MjlGXCIsXG4gICAgd2FybmluZzogXCJcdThCNjZcdTU0NEFcIixcbiAgICBpbmZvOiBcIlx1NEZFMVx1NjA2RlwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJcdThCRURcdThBMDBcdTVERjJcdTUyMDdcdTYzNjJcdTRFM0Ege2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gXHU1Qjg4XHU2MkE0XHU2QTIxXHU1NzU3XG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1ODFFQVx1NTJBOFx1NUI4OFx1NjJBNFwiLFxuICAgIGluaXRCb3Q6IFwiXHU1MjFEXHU1OUNCXHU1MzE2XHU1Qjg4XHU2MkE0XHU2NzNBXHU1NjY4XHU0RUJBXCIsXG4gICAgc2VsZWN0QXJlYTogXCJcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcIixcbiAgICBjYXB0dXJlQXJlYTogXCJcdTYzNTVcdTgzQjdcdTUzM0FcdTU3REZcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiXHU1RjAwXHU1OUNCXHU1Qjg4XHU2MkE0XCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiXHU1MDVDXHU2QjYyXHU1Qjg4XHU2MkE0XCIsXG4gICAgdXBwZXJMZWZ0OiBcIlx1NURFNlx1NEUwQVx1ODlEMlwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiXHU1M0YzXHU0RTBCXHU4OUQyXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlx1NTNEN1x1NEZERFx1NjJBNFx1NTBDRlx1N0QyMFwiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJcdTY4QzBcdTZENEJcdTUyMzBcdTc2ODRcdTUzRDhcdTUzMTZcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJcdTRGRUVcdTU5MERcdTc2ODRcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3MFwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1N0I0OVx1NUY4NVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBcdTY4QzBcdTY3RTVcdTUzRUZcdTc1MjhcdTk4OUNcdTgyNzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTk4OUNcdTgyNzJcdUZGMENcdThCRjdcdTU3MjhcdTdGNTFcdTdBRDlcdTRFMEFcdTYyNTNcdTVGMDBcdThDMDNcdTgyNzJcdTY3N0ZcdTMwMDJcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHU2MjdFXHU1MjMwIHtjb3VudH0gXHU3OUNEXHU1M0VGXHU3NTI4XHU5ODlDXHU4MjcyXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1NUI4OFx1NjJBNFx1NjczQVx1NTY2OFx1NEVCQVx1NTIxRFx1NTlDQlx1NTMxNlx1NjIxMFx1NTI5RlwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgXHU1Qjg4XHU2MkE0XHU2NzNBXHU1NjY4XHU0RUJBXHU1MjFEXHU1OUNCXHU1MzE2XHU1OTMxXHU4RDI1XCIsXG4gICAgaW52YWxpZENvb3JkczogXCJcdTI3NEMgXHU1NzUwXHU2ODA3XHU2NUUwXHU2NTQ4XCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIFx1NTMzQVx1NTdERlx1NjVFMFx1NjU0OFx1RkYwQ1x1NURFNlx1NEUwQVx1ODlEMlx1NUZDNVx1OTg3Qlx1NUMwRlx1NEU4RVx1NTNGM1x1NEUwQlx1ODlEMlwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHU1MzNBXHU1N0RGXHU4RkM3XHU1OTI3OiB7c2l6ZX0gXHU1MENGXHU3RDIwIChcdTY3MDBcdTU5Mjc6IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IFx1NjM1NVx1ODNCN1x1NUI4OFx1NjJBNFx1NTMzQVx1NTdERlx1NEUyRC4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHU1MzNBXHU1N0RGXHU2MzU1XHU4M0I3XHU2MjEwXHU1MjlGOiB7Y291bnR9IFx1NTBDRlx1N0QyMFx1NTNEN1x1NEZERFx1NjJBNFwiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgXHU2MzU1XHU4M0I3XHU1MzNBXHU1N0RGXHU1MUZBXHU5NTE5OiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBcdThCRjdcdTUxNDhcdTYzNTVcdTgzQjdcdTRFMDBcdTRFMkFcdTVCODhcdTYyQTRcdTUzM0FcdTU3REZcIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU2MkE0XHU1REYyXHU1NDJGXHU1MkE4IC0gXHU1MzNBXHU1N0RGXHU3NkQxXHU2M0E3XHU0RTJEXCIsXG4gICAgcHJvdGVjdGlvblN0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NUI4OFx1NjJBNFx1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHU1MzNBXHU1N0RGXHU1Qjg5XHU1MTY4IC0gXHU2NzJBXHU2OEMwXHU2RDRCXHU1MjMwXHU1M0Q4XHU1MzE2XCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCBcdTY4QzBcdTZENEJcdTUyMzAge2NvdW50fSBcdTRFMkFcdTUzRDhcdTUzMTZcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFx1NkI2M1x1NTcyOFx1NEZFRVx1NTkwRCB7Y291bnR9IFx1NEUyQVx1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgXHU1REYyXHU2MjEwXHU1MjlGXHU0RkVFXHU1OTBEIHtjb3VudH0gXHU0RTJBXHU1MENGXHU3RDIwXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIFx1NEZFRVx1NTkwRFx1NTFGQVx1OTUxOToge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgXHU2QjIxXHU2NTcwXHU0RTBEXHU4REIzXHVGRjBDXHU2NUUwXHU2Q0Q1XHU0RkVFXHU1OTBEXCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY4QzBcdTY3RTVcdTUzM0FcdTU3REZcdTUzRDhcdTUzMTYuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBcdTY4QzBcdTY3RTVcdTUxRkFcdTk1MTk6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU2MkE0XHU0RTJEIC0gXHU1MzNBXHU1N0RGXHU1M0Q3XHU0RkREXHU2MkE0XCIsXG4gICAgbGFzdENoZWNrOiBcIlx1NEUwQVx1NkIyMVx1NjhDMFx1NjdFNToge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIlx1NEUwQlx1NkIyMVx1NjhDMFx1NjdFNToge3RpbWV9IFx1NzlEMlx1NTQwRVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJBOFx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NjVFMFx1NkNENVx1ODFFQVx1NTJBOFx1NTQyRlx1NTJBOFx1RkYwQ1x1OEJGN1x1NjI0Qlx1NTJBOFx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHU5NzAwXHU4OTgxXHU2MjRCXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2XCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTVERjJcdTY4QzBcdTZENEJcdTUyMzBcdThDMDNcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjQxQ1x1N0QyMlx1OEMwM1x1ODI3Mlx1Njc3Ri4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1NkI2M1x1NTcyOFx1NzBCOVx1NTFGQlx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRS4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRVwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgXHU1NzI4XHU5NzAwXHU4OTgxXHU0RkREXHU2MkE0XHU1MzNBXHU1N0RGXHU3Njg0XHU1REU2XHU0RTBBXHU4OUQyXHU2RDgyXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgXHU3M0IwXHU1NzI4XHU1NzI4XHU1M0YzXHU0RTBCXHU4OUQyXHU2RDgyXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU5MDA5XHU2MkU5XHU1REU2XHU0RTBBXHU4OUQyLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1OTAwOVx1NjJFOVx1NTNGM1x1NEUwQlx1ODlEMi4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBcdTVERjJcdTYzNTVcdTgzQjdcdTVERTZcdTRFMEFcdTg5RDI6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1NURGMlx1NjM1NVx1ODNCN1x1NTNGM1x1NEUwQlx1ODlEMjogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1OTAwOVx1NjJFOVx1OEQ4NVx1NjVGNlwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTkwMDlcdTYyRTlcdTUxRkFcdTk1MTlcdUZGMENcdThCRjdcdTkxQ0RcdThCRDVcIlxuICB9XG59O1xuIiwgImV4cG9ydCBjb25zdCB6aEhhbnQgPSB7XG4gIC8vIFx1NTU1M1x1NTJENVx1NTY2OFxuICBsYXVuY2hlcjoge1xuICAgIHRpdGxlOiAnV1BsYWNlIFx1ODFFQVx1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQScsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgXHU4MUVBXHU1MkQ1XHU4RkIyXHU1ODM0JyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggXHU4MUVBXHU1MkQ1XHU3RTZBXHU1NzE2JyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgXHU4MUVBXHU1MkQ1XHU1Qjg4XHU4Qjc3JyxcbiAgICBzZWxlY3Rpb246ICdcdTkwNzhcdTY0QzcnLFxuICAgIHVzZXI6ICdcdTc1MjhcdTYyMzcnLFxuICAgIGNoYXJnZXM6ICdcdTZCMjFcdTY1NzgnLFxuICAgIGJhY2tlbmQ6ICdcdTVGOENcdTdBRUYnLFxuICAgIGRhdGFiYXNlOiAnXHU2NTc4XHU2NERBXHU1RUFCJyxcbiAgICB1cHRpbWU6ICdcdTkwNEJcdTg4NENcdTY2NDJcdTk1OTMnLFxuICAgIGNsb3NlOiAnXHU5NURDXHU5NTg5JyxcbiAgICBsYXVuY2g6ICdcdTU1NTNcdTUyRDUnLFxuICAgIGxvYWRpbmc6ICdcdTUyQTBcdThGMDlcdTRFMkRcdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ1x1NTdGN1x1ODg0Q1x1NEUyRFx1MjAyNicsXG4gICAgZG93bmxvYWRpbmc6ICdcdTZCNjNcdTU3MjhcdTRFMEJcdThGMDlcdTgxNzNcdTY3MkNcdTIwMjYnLFxuICAgIGNob29zZUJvdDogJ1x1OTA3OFx1NjRDN1x1NEUwMFx1NTAwQlx1NkE1Rlx1NTY2OFx1NEVCQVx1NEUyNlx1OUVERVx1NjRDQVx1NTU1M1x1NTJENScsXG4gICAgcmVhZHlUb0xhdW5jaDogJ1x1NkU5Nlx1NTA5OVx1NTU1M1x1NTJENScsXG4gICAgbG9hZEVycm9yOiAnXHU1MkEwXHU4RjA5XHU5MzJGXHU4QUE0JyxcbiAgICBsb2FkRXJyb3JNc2c6ICdcdTcxMjFcdTZDRDVcdTUyQTBcdThGMDlcdTYyNDBcdTkwNzhcdTZBNUZcdTU2NjhcdTRFQkFcdTMwMDJcdThBQ0JcdTZBQTJcdTY3RTVcdTdEQjJcdTdENjFcdTkwMjNcdTYzQTVcdTYyMTZcdTkxQ0RcdThBNjZcdTMwMDInLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFx1NkFBMlx1NjdFNVx1NEUyRC4uLicsXG4gICAgb25saW5lOiAnXHVEODNEXHVERkUyIFx1NTcyOFx1N0REQScsXG4gICAgb2ZmbGluZTogJ1x1RDgzRFx1REQzNCBcdTk2RTJcdTdEREEnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIFx1NkI2M1x1NUUzOCcsXG4gICAgZXJyb3I6ICdcdUQ4M0RcdUREMzQgXHU5MzJGXHU4QUE0JyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBcdTdFNkFcdTU3MTZcdTZBMjFcdTU4NEFcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU4MUVBXHU1MkQ1XHU3RTZBXHU1NzE2XCIsXG4gICAgaW5pdEJvdDogXCJcdTUyMURcdTU5Q0JcdTUzMTZcdTgxRUFcdTUyRDVcdTZBNUZcdTU2NjhcdTRFQkFcIixcbiAgICB1cGxvYWRJbWFnZTogXCJcdTRFMEFcdTUwQjNcdTU3MTZcdTcyNDdcIixcbiAgICByZXNpemVJbWFnZTogXCJcdThBQkZcdTY1NzRcdTU3MTZcdTcyNDdcdTU5MjdcdTVDMEZcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJcdTkwNzhcdTY0QzdcdTRGNERcdTdGNkVcIixcbiAgICBzdGFydFBhaW50aW5nOiBcIlx1OTU4Qlx1NTlDQlx1N0U2QVx1ODhGRFwiLFxuICAgIHN0b3BQYWludGluZzogXCJcdTUwNUNcdTZCNjJcdTdFNkFcdTg4RkRcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiXHU0RkREXHU1QjU4XHU5MDMyXHU1RUE2XCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIlx1NTJBMFx1OEYwOVx1OTAzMlx1NUVBNlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzRFx1REQwRCBcdTZBQTJcdTY3RTVcdTUzRUZcdTc1MjhcdTk4NEZcdTgyNzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdThBQ0JcdTU3MjhcdTdEQjJcdTdBRDlcdTRFMEFcdTYyNTNcdTk1OEJcdThBQkZcdTgyNzJcdTY3N0ZcdTVGOENcdTkxQ0RcdThBNjZcdUZGMDFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHU2MjdFXHU1MjMwIHtjb3VudH0gXHU3QTJFXHU1M0VGXHU3NTI4XHU5ODRGXHU4MjcyXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBcdTZCNjNcdTU3MjhcdTUyQTBcdThGMDlcdTU3MTZcdTcyNDcuLi5cIixcbiAgICBpbWFnZUxvYWRlZDogXCJcdTI3MDUgXHU1NzE2XHU3MjQ3XHU1REYyXHU1MkEwXHU4RjA5XHVGRjBDXHU2NzA5XHU2NTQ4XHU1MENGXHU3RDIwIHtjb3VudH0gXHU1MDBCXCIsXG4gICAgaW1hZ2VFcnJvcjogXCJcdTI3NEMgXHU1NzE2XHU3MjQ3XHU1MkEwXHU4RjA5XHU1OTMxXHU2NTU3XCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdThBQ0JcdTU3MjhcdTRGNjBcdTYwRjNcdTk1OEJcdTU5Q0JcdTdFNkFcdTg4RkRcdTc2ODRcdTU3MzBcdTY1QjlcdTU4NTdcdTdCMkNcdTRFMDBcdTUwMEJcdTUwQ0ZcdTdEMjBcdUZGMDFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1NEY2MFx1NTg1N1x1NTNDM1x1ODAwM1x1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTRGNERcdTdGNkVcdThBMkRcdTdGNkVcdTYyMTBcdTUyOUZcdUZGMDFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1NEY0RFx1N0Y2RVx1OTA3OFx1NjRDN1x1OEQ4NVx1NjY0MlwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFx1NURGMlx1NkFBMlx1NkUyQ1x1NTIzMFx1NEY0RFx1N0Y2RVx1RkYwQ1x1ODY1NVx1NzQwNlx1NEUyRC4uLlwiLFxuICAgIHBvc2l0aW9uRXJyb3I6IFwiXHUyNzRDIFx1NEY0RFx1N0Y2RVx1NkFBMlx1NkUyQ1x1NTkzMVx1NjU1N1x1RkYwQ1x1OEFDQlx1OTFDRFx1OEE2NlwiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IFx1OTU4Qlx1NTlDQlx1N0U2QVx1ODhGRC4uLlwiLFxuICAgIHBhaW50aW5nUHJvZ3Jlc3M6IFwiXHVEODNFXHVEREYxIFx1OTAzMlx1NUVBNjoge3BhaW50ZWR9L3t0b3RhbH0gXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBcdTZDOTJcdTY3MDlcdTZCMjFcdTY1NzhcdTMwMDJcdTdCNDlcdTVGODUge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTc1MjhcdTYyMzdcdTVERjJcdTUwNUNcdTZCNjJcdTdFNkFcdTg4RkRcIixcbiAgICBwYWludGluZ0NvbXBsZXRlOiBcIlx1MjcwNSBcdTdFNkFcdTg4RkRcdTVCOENcdTYyMTBcdUZGMDFcdTUxNzFcdTdFNkFcdTg4RkQge2NvdW50fSBcdTUwMEJcdTUwQ0ZcdTdEMjBcdTMwMDJcIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBcdTdFNkFcdTg4RkRcdTkwNEVcdTdBMEJcdTRFMkRcdTUxRkFcdTkzMkZcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBcdThBQ0JcdTUxNDhcdTUyQTBcdThGMDlcdTU3MTZcdTcyNDdcdTRFMjZcdTkwNzhcdTY0QzdcdTRGNERcdTdGNkVcIixcbiAgICBwcm9ncmVzczogXCJcdTkwMzJcdTVFQTZcIixcbiAgICB1c2VyTmFtZTogXCJcdTc1MjhcdTYyMzdcIixcbiAgICBwaXhlbHM6IFwiXHU1MENGXHU3RDIwXCIsXG4gICAgY2hhcmdlczogXCJcdTZCMjFcdTY1NzhcIixcbiAgICBlc3RpbWF0ZWRUaW1lOiBcIlx1OTgxMFx1OEEwOFx1NjY0Mlx1OTU5M1wiLFxuICAgIGluaXRNZXNzYWdlOiBcIlx1OUVERVx1NjRDQVx1MjAxQ1x1NTIxRFx1NTlDQlx1NTMxNlx1ODFFQVx1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQVx1MjAxRFx1OTU4Qlx1NTlDQlwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1N0I0OVx1NUY4NVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IFx1NTcxNlx1NzI0N1x1NURGMlx1OEFCRlx1NjU3NFx1NzBCQSB7d2lkdGh9eHtoZWlnaHR9XCIsXG4gICAgcGFpbnRpbmdQYXVzZWQ6IFwiXHUyM0Y4XHVGRTBGIFx1N0U2QVx1ODhGRFx1NjZBQlx1NTA1Q1x1NjVCQ1x1NEY0RFx1N0Y2RSBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1NkJDRlx1NjI3OVx1NTBDRlx1N0QyMFx1NjU3OFwiLFxuICAgIGJhdGNoU2l6ZTogXCJcdTYyNzlcdTZCMjFcdTU5MjdcdTVDMEZcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlx1NEUwQlx1NkIyMVx1NjI3OVx1NkIyMVx1NjY0Mlx1OTU5M1wiLFxuICAgIHVzZUFsbENoYXJnZXM6IFwiXHU0RjdGXHU3NTI4XHU2MjQwXHU2NzA5XHU1M0VGXHU3NTI4XHU2QjIxXHU2NTc4XCIsXG4gICAgc2hvd092ZXJsYXk6IFwiXHU5ODZGXHU3OTNBXHU4OTg2XHU4NENCXHU1QzY0XCIsXG4gICAgbWF4Q2hhcmdlczogXCJcdTZCQ0ZcdTYyNzlcdTY3MDBcdTU5MjdcdTZCMjFcdTY1NzhcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTc4OiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlx1NTI2OVx1OTkxOFx1NjY0Mlx1OTU5M1wiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1IHt0aW1lfSBcdTVGOENcdTdFN0NcdTdFOEMuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBcdTkwMzJcdTVFQTZcdTVERjJcdTRGRERcdTVCNThcdTcwQkEge2ZpbGVuYW1lfVwiLFxuICAgIHByb2dyZXNzTG9hZGVkOiBcIlx1MjcwNSBcdTVERjJcdTUyQTBcdThGMDlcdTkwMzJcdTVFQTY6IHtwYWludGVkfS97dG90YWx9IFx1NTBDRlx1N0QyMFx1NURGMlx1N0U2QVx1ODhGRFwiLFxuICAgIHByb2dyZXNzTG9hZEVycm9yOiBcIlx1Mjc0QyBcdTUyQTBcdThGMDlcdTkwMzJcdTVFQTZcdTU5MzFcdTY1NTc6IHtlcnJvcn1cIixcbiAgICBwcm9ncmVzc1NhdmVFcnJvcjogXCJcdTI3NEMgXHU0RkREXHU1QjU4XHU5MDMyXHU1RUE2XHU1OTMxXHU2NTU3OiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJcdTU3MjhcdTUwNUNcdTZCNjJcdTRFNEJcdTUyNERcdTg5ODFcdTRGRERcdTVCNThcdTc1NzZcdTUyNERcdTkwMzJcdTVFQTZcdTU1Q0VcdUZGMUZcIixcbiAgICBzYXZlUHJvZ3Jlc3NUaXRsZTogXCJcdTRGRERcdTVCNThcdTkwMzJcdTVFQTZcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiXHU2NTNFXHU2OEM0XCIsXG4gICAgY2FuY2VsOiBcIlx1NTNENlx1NkQ4OFwiLFxuICAgIG1pbmltaXplOiBcIlx1NjcwMFx1NUMwRlx1NTMxNlwiLFxuICAgIHdpZHRoOiBcIlx1NUJFQ1x1NUVBNlwiLFxuICAgIGhlaWdodDogXCJcdTlBRDhcdTVFQTZcIixcbiAgICBrZWVwQXNwZWN0OiBcIlx1NEZERFx1NjMwMVx1N0UzMVx1NkE2Qlx1NkJENFwiLFxuICAgIGFwcGx5OiBcIlx1NjFDOVx1NzUyOFwiLFxuICAgIG92ZXJsYXlPbjogXCJcdTg5ODZcdTg0Q0JcdTVDNjQ6IFx1OTU4Qlx1NTU1M1wiLFxuICAgIG92ZXJsYXlPZmY6IFwiXHU4OTg2XHU4NENCXHU1QzY0OiBcdTk1RENcdTk1ODlcIixcbiAgICBwYXNzQ29tcGxldGVkOiBcIlx1MjcwNSBcdTYyNzlcdTZCMjFcdTVCOENcdTYyMTA6IFx1NURGMlx1N0U2QVx1ODhGRCB7cGFpbnRlZH0gXHU1MENGXHU3RDIwIHwgXHU5MDMyXHU1RUE2OiB7cGVyY2VudH0lICh7Y3VycmVudH0ve3RvdGFsfSlcIixcbiAgICB3YWl0aW5nQ2hhcmdlc1JlZ2VuOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1NzhcdTYwNjJcdTVGQTk6IHtjdXJyZW50fS97bmVlZGVkfSAtIFx1NjY0Mlx1OTU5Mzoge3RpbWV9XCIsXG4gICAgd2FpdGluZ0NoYXJnZXNDb3VudGRvd246IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3ODoge2N1cnJlbnR9L3tuZWVkZWR9IC0gXHU1MjY5XHU5OTE4OiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTZCNjNcdTU3MjhcdTgxRUFcdTUyRDVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1NjIxMFx1NTI5RlwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBcdTcxMjFcdTZDRDVcdTgxRUFcdTUyRDVcdTU1NTNcdTUyRDVcdUZGMENcdThBQ0JcdTYyNEJcdTUyRDVcdTY0Q0RcdTRGNUNcdTMwMDJcIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFx1NURGMlx1NkFBMlx1NkUyQ1x1NTIzMFx1OEFCRlx1ODI3Mlx1Njc3RlwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHU2QjYzXHU1NzI4XHU2NDFDXHU3RDIyXHU4QUJGXHU4MjcyXHU2NzdGLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgXHU2QjYzXHU1NzI4XHU5RURFXHU2NENBXHU3RTZBXHU4OEZEXHU2MzA5XHU5MjE1Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHU2NzJBXHU2MjdFXHU1MjMwXHU3RTZBXHU4OEZEXHU2MzA5XHU5MjE1XCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBcdTk3MDBcdTg5ODFcdTYyNEJcdTUyRDVcdTUyMURcdTU5Q0JcdTUzMTZcIixcbiAgICByZXRyeUF0dGVtcHQ6IFwiXHVEODNEXHVERDA0IFx1OTFDRFx1OEE2NiB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfVx1RkYwQ1x1N0I0OVx1NUY4NSB7ZGVsYXl9IFx1NzlEMi4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IFx1N0IyQyB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSBcdTZCMjFcdTU2MTdcdThBNjZcdTUxRkFcdTkzMkZcdUZGMENcdTVDMDdcdTU3Mjgge2RlbGF5fSBcdTc5RDJcdTVGOENcdTkxQ0RcdThBNjYuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgXHU4RDg1XHU5MDRFIHttYXhBdHRlbXB0c30gXHU2QjIxXHU1NjE3XHU4QTY2XHU1OTMxXHU2NTU3XHUzMDAyXHU3RTdDXHU3RThDXHU0RTBCXHU0RTAwXHU2Mjc5Li4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBcdTdEQjJcdTdENjFcdTkzMkZcdThBQTRcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThBNjYuLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgXHU2NzBEXHU1MkQ5XHU1NjY4XHU5MzJGXHU4QUE0XHVGRjBDXHU2QjYzXHU1NzI4XHU5MUNEXHU4QTY2Li4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBcdTY3MERcdTUyRDlcdTU2NjhcdThEODVcdTY2NDJcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThBNjYuLi5cIlxuICB9LFxuXG4gIC8vIFx1OEZCMlx1NTgzNFx1NkEyMVx1NTg0QVx1RkYwOFx1NUY4NVx1NUJFNlx1NzNGRVx1RkYwOVxuICBmYXJtOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1OEZCMlx1NTgzNFx1NkE1Rlx1NTY2OFx1NEVCQVwiLFxuICAgIHN0YXJ0OiBcIlx1OTU4Qlx1NTlDQlwiLFxuICAgIHN0b3A6IFwiXHU1MDVDXHU2QjYyXCIsXG4gICAgc3RvcHBlZDogXCJcdTZBNUZcdTU2NjhcdTRFQkFcdTVERjJcdTUwNUNcdTZCNjJcIixcbiAgICBjYWxpYnJhdGU6IFwiXHU2ODIxXHU2RTk2XCIsXG4gICAgcGFpbnRPbmNlOiBcIlx1NEUwMFx1NkIyMVwiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIlx1NkFBMlx1NjdFNVx1NzJDMFx1NjE0Qlx1NEUyRC4uLlwiLFxuICAgIGNvbmZpZ3VyYXRpb246IFwiXHU5MTREXHU3RjZFXCIsXG4gICAgZGVsYXk6IFwiXHU1RUY2XHU5MDcyIChcdTZCRUJcdTc5RDIpXCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHU2QkNGXHU2Mjc5XHU1MENGXHU3RDIwXCIsXG4gICAgbWluQ2hhcmdlczogXCJcdTY3MDBcdTVDMTFcdTZCMjFcdTY1NzhcIixcbiAgICBjb2xvck1vZGU6IFwiXHU5ODRGXHU4MjcyXHU2QTIxXHU1RjBGXCIsXG4gICAgcmFuZG9tOiBcIlx1OTZBOFx1NkE1RlwiLFxuICAgIGZpeGVkOiBcIlx1NTZGQVx1NUI5QVwiLFxuICAgIHJhbmdlOiBcIlx1N0JDNFx1NTcwRFwiLFxuICAgIGZpeGVkQ29sb3I6IFwiXHU1NkZBXHU1QjlBXHU5ODRGXHU4MjcyXCIsXG4gICAgYWR2YW5jZWQ6IFwiXHU5QUQ4XHU3RDFBXCIsXG4gICAgdGlsZVg6IFwiXHU3NEU2XHU3MjQ3IFhcIixcbiAgICB0aWxlWTogXCJcdTc0RTZcdTcyNDcgWVwiLFxuICAgIGN1c3RvbVBhbGV0dGU6IFwiXHU4MUVBXHU1QjlBXHU3RkE5XHU4QUJGXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiXHU0RjhCXHU1OTgyOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiXHU2MzU1XHU3MzcyXCIsXG4gICAgcGFpbnRlZDogXCJcdTVERjJcdTdFNkFcdTg4RkRcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3OFwiLFxuICAgIHJldHJpZXM6IFwiXHU5MUNEXHU4QTY2XCIsXG4gICAgdGlsZTogXCJcdTc0RTZcdTcyNDdcIixcbiAgICBjb25maWdTYXZlZDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTRGRERcdTVCNThcIixcbiAgICBjb25maWdMb2FkZWQ6IFwiXHU5MTREXHU3RjZFXHU1REYyXHU1MkEwXHU4RjA5XCIsXG4gICAgY29uZmlnUmVzZXQ6IFwiXHU5MTREXHU3RjZFXHU1REYyXHU5MUNEXHU3RjZFXCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJcdThBQ0JcdTYyNEJcdTUyRDVcdTdFNkFcdTg4RkRcdTRFMDBcdTUwMEJcdTUwQ0ZcdTdEMjBcdTRFRTVcdTYzNTVcdTczNzJcdTVFQTdcdTZBMTkuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIlx1NUY4Q1x1N0FFRlx1NTcyOFx1N0REQVwiLFxuICAgIGJhY2tlbmRPZmZsaW5lOiBcIlx1NUY4Q1x1N0FFRlx1OTZFMlx1N0REQVwiLFxuICAgIHN0YXJ0aW5nQm90OiBcIlx1NkI2M1x1NTcyOFx1NTU1M1x1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQS4uLlwiLFxuICAgIHN0b3BwaW5nQm90OiBcIlx1NkI2M1x1NTcyOFx1NTA1Q1x1NkI2Mlx1NkE1Rlx1NTY2OFx1NEVCQS4uLlwiLFxuICAgIGNhbGlicmF0aW5nOiBcIlx1NjgyMVx1NkU5Nlx1NEUyRC4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIlx1ODFFQVx1NTJENVx1OEZCMlx1NTgzNFx1NURGMlx1NTcyOFx1OTA0Qlx1ODg0Q1x1MzAwMlwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiXHU4MUVBXHU1MkQ1XHU3RTZBXHU1NzE2XHU2QjYzXHU1NzI4XHU5MDRCXHU4ODRDXHVGRjBDXHU4QUNCXHU1MTQ4XHU5NURDXHU5NTg5XHU1MThEXHU1NTUzXHU1MkQ1XHU4MUVBXHU1MkQ1XHU4RkIyXHU1ODM0XHUzMDAyXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgXHU1NzI4XHU1NzMwXHU1NzE2XHU3Njg0XHU3QTdBXHU3NjdEXHU1MzQwXHU1N0RGXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXHU0RUU1XHU4QTJEXHU3RjZFXHU4RkIyXHU1ODM0XHU1MzQwXHU1N0RGXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTRGNjBcdTU4NTdcdTUzQzNcdTgwMDNcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHU1MzQwXHU1N0RGXHU4QTJEXHU3RjZFXHU2MjEwXHU1MjlGXHVGRjAxXHU1MzRBXHU1RjkxOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHU1MzQwXHU1N0RGXHU5MDc4XHU2NEM3XHU4RDg1XHU2NjQyXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBcdThBQ0JcdTUxNDhcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcdUZGMDhcdTRGN0ZcdTc1MjhcdTIwMUNcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcdTIwMURcdTYzMDlcdTkyMTVcdUZGMDlcIixcbiAgICBmYXJtUmFkaXVzOiBcIlx1OEZCMlx1NTgzNFx1NTM0QVx1NUY5MVwiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJcdTc1NzZcdTUyNERcdTUzNDBcdTU3REZcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIFx1NkI2M1x1NTcyOFx1NEVFNVx1NTM0QVx1NUY5MSB7cmFkaXVzfXB4IFx1NTcyOCAoe3h9LHt5fSkgXHU4RkIyXHU1ODM0XCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBcdTkxQ0RcdTg5ODE6IFx1OEFDQlx1OTA3OFx1NjRDN1x1N0E3QVx1NzY3RFx1NTM0MFx1NTdERlx1NEVFNVx1OTA3Rlx1NTE0RFx1ODg1RFx1N0E4MVwiLFxuICAgIG5vUG9zaXRpb246IFwiXHU2NzJBXHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXCIsXG4gICAgY3VycmVudFpvbmU6IFwiXHU1MzQwXHU1N0RGOiAoe3h9LHt5fSlcIixcbiAgICBhdXRvU2VsZWN0UG9zaXRpb246IFwiXHVEODNDXHVERkFGIFx1OEFDQlx1NTE0OFx1OTA3OFx1NjRDN1x1NTM0MFx1NTdERlx1RkYwQ1x1NTcyOFx1NTczMFx1NTcxNlx1NEUwQVx1NTg1N1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFx1NEVFNVx1OEEyRFx1N0Y2RVx1OEZCMlx1NTgzNFx1NTM0MFx1NTdERlwiXG4gIH0sXG5cbiAgLy8gXHU1MTZDXHU1MTcxXG4gIGNvbW1vbjoge1xuICAgIHllczogXCJcdTY2MkZcIixcbiAgICBubzogXCJcdTU0MjZcIixcbiAgICBvazogXCJcdTc4QkFcdThBOERcIixcbiAgICBjYW5jZWw6IFwiXHU1M0Q2XHU2RDg4XCIsXG4gICAgY2xvc2U6IFwiXHU5NURDXHU5NTg5XCIsXG4gICAgc2F2ZTogXCJcdTRGRERcdTVCNThcIixcbiAgICBsb2FkOiBcIlx1NTJBMFx1OEYwOVwiLFxuICAgIGRlbGV0ZTogXCJcdTUyMkFcdTk2NjRcIixcbiAgICBlZGl0OiBcIlx1N0RFOFx1OEYyRlwiLFxuICAgIHN0YXJ0OiBcIlx1OTU4Qlx1NTlDQlwiLFxuICAgIHN0b3A6IFwiXHU1MDVDXHU2QjYyXCIsXG4gICAgcGF1c2U6IFwiXHU2NkFCXHU1MDVDXCIsXG4gICAgcmVzdW1lOiBcIlx1N0U3Q1x1N0U4Q1wiLFxuICAgIHJlc2V0OiBcIlx1OTFDRFx1N0Y2RVwiLFxuICAgIHNldHRpbmdzOiBcIlx1OEEyRFx1N0Y2RVwiLFxuICAgIGhlbHA6IFwiXHU1RTZCXHU1MkE5XCIsXG4gICAgYWJvdXQ6IFwiXHU5NURDXHU2NUJDXCIsXG4gICAgbGFuZ3VhZ2U6IFwiXHU4QTlFXHU4QTAwXCIsXG4gICAgbG9hZGluZzogXCJcdTUyQTBcdThGMDlcdTRFMkQuLi5cIixcbiAgICBlcnJvcjogXCJcdTkzMkZcdThBQTRcIixcbiAgICBzdWNjZXNzOiBcIlx1NjIxMFx1NTI5RlwiLFxuICAgIHdhcm5pbmc6IFwiXHU4QjY2XHU1NDRBXCIsXG4gICAgaW5mbzogXCJcdTRGRTFcdTYwNkZcIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiXHU4QTlFXHU4QTAwXHU1REYyXHU1MjA3XHU2M0RCXHU3MEJBIHtsYW5ndWFnZX1cIlxuICB9LFxuXG4gIC8vIFx1NUI4OFx1OEI3N1x1NkEyMVx1NTg0QVxuICBndWFyZDoge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTgxRUFcdTUyRDVcdTVCODhcdThCNzdcIixcbiAgICBpbml0Qm90OiBcIlx1NTIxRFx1NTlDQlx1NTMxNlx1NUI4OFx1OEI3N1x1NkE1Rlx1NTY2OFx1NEVCQVwiLFxuICAgIHNlbGVjdEFyZWE6IFwiXHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiXHU2MzU1XHU3MzcyXHU1MzQwXHU1N0RGXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIlx1OTU4Qlx1NTlDQlx1NUI4OFx1OEI3N1wiLFxuICAgIHN0b3BQcm90ZWN0aW9uOiBcIlx1NTA1Q1x1NkI2Mlx1NUI4OFx1OEI3N1wiLFxuICAgIHVwcGVyTGVmdDogXCJcdTVERTZcdTRFMEFcdTg5RDJcIixcbiAgICBsb3dlclJpZ2h0OiBcIlx1NTNGM1x1NEUwQlx1ODlEMlwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJcdTUzRDdcdTRGRERcdThCNzdcdTUwQ0ZcdTdEMjBcIixcbiAgICBkZXRlY3RlZENoYW5nZXM6IFwiXHU2QUEyXHU2RTJDXHU1MjMwXHU3Njg0XHU4QjhBXHU1MzE2XCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiXHU0RkVFXHU1RkE5XHU3Njg0XHU1MENGXHU3RDIwXCIsXG4gICAgY2hhcmdlczogXCJcdTZCMjFcdTY1NzhcIixcbiAgICB3YWl0aW5nSW5pdDogXCJcdTdCNDlcdTVGODVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0NcdURGQTggXHU2QUEyXHU2N0U1XHU1M0VGXHU3NTI4XHU5ODRGXHU4MjcyLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHU2NzJBXHU2MjdFXHU1MjMwXHU5ODRGXHU4MjcyXHVGRjBDXHU4QUNCXHU1NzI4XHU3REIyXHU3QUQ5XHU0RTBBXHU2MjUzXHU5NThCXHU4QUJGXHU4MjcyXHU2NzdGXHUzMDAyXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IFx1NjI3RVx1NTIzMCB7Y291bnR9IFx1N0EyRVx1NTNFRlx1NzUyOFx1OTg0Rlx1ODI3MlwiLFxuICAgIGluaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTVCODhcdThCNzdcdTZBNUZcdTU2NjhcdTRFQkFcdTUyMURcdTU5Q0JcdTUzMTZcdTYyMTBcdTUyOUZcIixcbiAgICBpbml0RXJyb3I6IFwiXHUyNzRDIFx1NUI4OFx1OEI3N1x1NkE1Rlx1NTY2OFx1NEVCQVx1NTIxRFx1NTlDQlx1NTMxNlx1NTkzMVx1NjU1N1wiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIFx1NUVBN1x1NkExOVx1NzEyMVx1NjU0OFwiLFxuICAgIGludmFsaWRBcmVhOiBcIlx1Mjc0QyBcdTUzNDBcdTU3REZcdTcxMjFcdTY1NDhcdUZGMENcdTVERTZcdTRFMEFcdTg5RDJcdTVGQzVcdTk4MDhcdTVDMEZcdTY1QkNcdTUzRjNcdTRFMEJcdTg5RDJcIixcbiAgICBhcmVhVG9vTGFyZ2U6IFwiXHUyNzRDIFx1NTM0MFx1NTdERlx1OTA0RVx1NTkyNzoge3NpemV9IFx1NTBDRlx1N0QyMCAoXHU2NzAwXHU1OTI3OiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBcdTYzNTVcdTczNzJcdTVCODhcdThCNzdcdTUzNDBcdTU3REZcdTRFMkQuLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IFx1NTM0MFx1NTdERlx1NjM1NVx1NzM3Mlx1NjIxMFx1NTI5Rjoge2NvdW50fSBcdTUwQ0ZcdTdEMjBcdTUzRDdcdTRGRERcdThCNzdcIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIFx1NjM1NVx1NzM3Mlx1NTM0MFx1NTdERlx1NTFGQVx1OTMyRjoge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgXHU4QUNCXHU1MTQ4XHU2MzU1XHU3MzcyXHU0RTAwXHU1MDBCXHU1Qjg4XHU4Qjc3XHU1MzQwXHU1N0RGXCIsXG4gICAgcHJvdGVjdGlvblN0YXJ0ZWQ6IFwiXHVEODNEXHVERUUxXHVGRTBGIFx1NUI4OFx1OEI3N1x1NURGMlx1NTU1M1x1NTJENSAtIFx1NTM0MFx1NTdERlx1NzZFM1x1NjNBN1x1NEUyRFwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTVCODhcdThCNzdcdTVERjJcdTUwNUNcdTZCNjJcIixcbiAgICBub0NoYW5nZXM6IFwiXHUyNzA1IFx1NTM0MFx1NTdERlx1NUI4OVx1NTE2OCAtIFx1NjcyQVx1NkFBMlx1NkUyQ1x1NTIzMFx1OEI4QVx1NTMxNlwiLFxuICAgIGNoYW5nZXNEZXRlY3RlZDogXCJcdUQ4M0RcdURFQTggXHU2QUEyXHU2RTJDXHU1MjMwIHtjb3VudH0gXHU1MDBCXHU4QjhBXHU1MzE2XCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBcdTZCNjNcdTU3MjhcdTRGRUVcdTVGQTkge2NvdW50fSBcdTUwMEJcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFx1NURGMlx1NjIxMFx1NTI5Rlx1NEZFRVx1NUZBOSB7Y291bnR9IFx1NTAwQlx1NTBDRlx1N0QyMFwiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBcdTRGRUVcdTVGQTlcdTUxRkFcdTkzMkY6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIFx1NkIyMVx1NjU3OFx1NEUwRFx1OERCM1x1RkYwQ1x1NzEyMVx1NkNENVx1NEZFRVx1NUZBOVwiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgXHU2QjYzXHU1NzI4XHU2QUEyXHU2N0U1XHU1MzQwXHU1N0RGXHU4QjhBXHU1MzE2Li4uXCIsXG4gICAgZXJyb3JDaGVja2luZzogXCJcdTI3NEMgXHU2QUEyXHU2N0U1XHU1MUZBXHU5MzJGOiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIFx1NUI4OFx1OEI3N1x1NEUyRCAtIFx1NTM0MFx1NTdERlx1NTNEN1x1NEZERFx1OEI3N1wiLFxuICAgIGxhc3RDaGVjazogXCJcdTRFMEFcdTZCMjFcdTZBQTJcdTY3RTU6IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJcdTRFMEJcdTZCMjFcdTZBQTJcdTY3RTU6IHt0aW1lfSBcdTc5RDJcdTVGOENcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTZCNjNcdTU3MjhcdTgxRUFcdTUyRDVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1NjIxMFx1NTI5RlwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBcdTcxMjFcdTZDRDVcdTgxRUFcdTUyRDVcdTU1NTNcdTUyRDVcdUZGMENcdThBQ0JcdTYyNEJcdTUyRDVcdTY0Q0RcdTRGNUNcdTMwMDJcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1OTcwMFx1ODk4MVx1NjI0Qlx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHU1REYyXHU2QUEyXHU2RTJDXHU1MjMwXHU4QUJGXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY0MUNcdTdEMjJcdThBQkZcdTgyNzJcdTY3N0YuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTZCNjNcdTU3MjhcdTlFREVcdTY0Q0FcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTUuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTVcIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFx1NTcyOFx1OTcwMFx1ODk4MVx1NEZERFx1OEI3N1x1NTM0MFx1NTdERlx1NzY4NFx1NURFNlx1NEUwQVx1ODlEMlx1NTg1N1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFwiLFxuICAgIHNlbGVjdExvd2VyUmlnaHQ6IFwiXHVEODNDXHVERkFGIFx1NzNGRVx1NTcyOFx1NTcyOFx1NTNGM1x1NEUwQlx1ODlEMlx1NTg1N1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1OTA3OFx1NjRDN1x1NURFNlx1NEUwQVx1ODlEMi4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTkwNzhcdTY0QzdcdTUzRjNcdTRFMEJcdTg5RDIuLi5cIixcbiAgICB1cHBlckxlZnRDYXB0dXJlZDogXCJcdTI3MDUgXHU1REYyXHU2MzU1XHU3MzcyXHU1REU2XHU0RTBBXHU4OUQyOiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBcdTVERjJcdTYzNTVcdTczNzJcdTUzRjNcdTRFMEJcdTg5RDI6ICh7eH0sIHt5fSlcIixcbiAgICBzZWxlY3Rpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTkwNzhcdTY0QzdcdThEODVcdTY2NDJcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgXHU5MDc4XHU2NEM3XHU1MUZBXHU5MzJGXHVGRjBDXHU4QUNCXHU5MUNEXHU4QTY2XCJcbiAgfVxufTsiLCAiaW1wb3J0IHsgZXMgfSBmcm9tICcuL2VzLmpzJztcbmltcG9ydCB7IGVuIH0gZnJvbSAnLi9lbi5qcyc7XG5pbXBvcnQgeyBmciB9IGZyb20gJy4vZnIuanMnO1xuaW1wb3J0IHsgcnUgfSBmcm9tICcuL3J1LmpzJztcbmltcG9ydCB7IHpoSGFucyB9IGZyb20gJy4vemgtSGFucy5qcyc7XG5pbXBvcnQgeyB6aEhhbnQgfSBmcm9tICcuL3poLUhhbnQuanMnO1xuXG4vLyBJZGlvbWFzIGRpc3BvbmlibGVzXG5leHBvcnQgY29uc3QgQVZBSUxBQkxFX0xBTkdVQUdFUyA9IHtcbiAgZXM6IHsgbmFtZTogJ0VzcGFcdTAwRjFvbCcsIGZsYWc6ICdcdUQ4M0NcdURERUFcdUQ4M0NcdURERjgnLCBjb2RlOiAnZXMnIH0sXG4gIGVuOiB7IG5hbWU6ICdFbmdsaXNoJywgZmxhZzogJ1x1RDgzQ1x1RERGQVx1RDgzQ1x1RERGOCcsIGNvZGU6ICdlbicgfSxcbiAgZnI6IHsgbmFtZTogJ0ZyYW5cdTAwRTdhaXMnLCBmbGFnOiAnXHVEODNDXHVEREVCXHVEODNDXHVEREY3JywgY29kZTogJ2ZyJyB9LFxuICBydTogeyBuYW1lOiAnXHUwNDIwXHUwNDQzXHUwNDQxXHUwNDQxXHUwNDNBXHUwNDM4XHUwNDM5JywgZmxhZzogJ1x1RDgzQ1x1RERGN1x1RDgzQ1x1RERGQScsIGNvZGU6ICdydScgfSxcbiAgemhIYW5zOiB7IG5hbWU6ICdcdTdCODBcdTRGNTNcdTRFMkRcdTY1ODcnLCBmbGFnOiAnXHVEODNDXHVEREU4XHVEODNDXHVEREYzJywgY29kZTogJ3poLUhhbnMnIH0sXG4gIHpoSGFudDogeyBuYW1lOiAnXHU3RTQxXHU5QUQ0XHU0RTJEXHU2NTg3JywgZmxhZzogJ1x1RDgzQ1x1RERFOFx1RDgzQ1x1RERGMycsIGNvZGU6ICd6aC1IYW50JyB9XG59O1xuXG4vLyBUb2RhcyBsYXMgdHJhZHVjY2lvbmVzXG5jb25zdCB0cmFuc2xhdGlvbnMgPSB7XG4gIGVzLFxuICBlbixcbiAgZnIsXG4gIHJ1LFxuICB6aEhhbnMsXG4gIHpoSGFudFxufTtcblxuLy8gRXN0YWRvIGRlbCBpZGlvbWEgYWN0dWFsXG5sZXQgY3VycmVudExhbmd1YWdlID0gJ2VzJztcbmxldCBjdXJyZW50VHJhbnNsYXRpb25zID0gdHJhbnNsYXRpb25zW2N1cnJlbnRMYW5ndWFnZV07XG5cbi8qKlxuICogRGV0ZWN0YSBlbCBpZGlvbWEgZGVsIG5hdmVnYWRvclxuICogQHJldHVybnMge3N0cmluZ30gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYSBkZXRlY3RhZG9cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGRldGVjdEJyb3dzZXJMYW5ndWFnZSgpIHtcbiAgY29uc3QgYnJvd3NlckxhbmcgPSB3aW5kb3cubmF2aWdhdG9yLmxhbmd1YWdlIHx8IHdpbmRvdy5uYXZpZ2F0b3IudXNlckxhbmd1YWdlIHx8ICdlcyc7XG5cbiAgLy8gRXh0cmFlciBzb2xvIGVsIGNcdTAwRjNkaWdvIGRlbCBpZGlvbWEgKGVqOiAnZXMtRVMnIC0+ICdlcycpXG4gIGNvbnN0IGxhbmdDb2RlID0gYnJvd3Nlckxhbmcuc3BsaXQoJy0nKVswXS50b0xvd2VyQ2FzZSgpO1xuXG4gIC8vIFZlcmlmaWNhciBzaSB0ZW5lbW9zIHNvcG9ydGUgcGFyYSBlc3RlIGlkaW9tYVxuICBpZiAodHJhbnNsYXRpb25zW2xhbmdDb2RlXSkge1xuICAgIHJldHVybiBsYW5nQ29kZTtcbiAgfVxuXG4gIC8vIEZhbGxiYWNrIGEgZXNwYVx1MDBGMW9sIHBvciBkZWZlY3RvXG4gIHJldHVybiAnZXMnO1xufVxuXG4vKipcbiAqIE9idGllbmUgZWwgaWRpb21hIGd1YXJkYWRvIChkZXNoYWJpbGl0YWRvIC0gbm8gdXNhciBsb2NhbFN0b3JhZ2UpXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBTaWVtcHJlIHJldG9ybmEgbnVsbFxuICovXG5leHBvcnQgZnVuY3Rpb24gZ2V0U2F2ZWRMYW5ndWFnZSgpIHtcbiAgLy8gTm8gdXNhciBsb2NhbFN0b3JhZ2UgLSBzaWVtcHJlIHJldG9ybmFyIG51bGxcbiAgcmV0dXJuIG51bGw7XG59XG5cbi8qKlxuICogR3VhcmRhIGVsIGlkaW9tYSAoZGVzaGFiaWxpdGFkbyAtIG5vIHVzYXIgbG9jYWxTdG9yYWdlKVxuICogQHBhcmFtIHtzdHJpbmd9IGxhbmdDb2RlIC0gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYVxuICovXG5leHBvcnQgZnVuY3Rpb24gc2F2ZUxhbmd1YWdlKGxhbmdDb2RlKSB7XG4gIC8vIE5vIGd1YXJkYXIgZW4gbG9jYWxTdG9yYWdlIC0gZnVuY2lcdTAwRjNuIGRlc2hhYmlsaXRhZGFcbiAgcmV0dXJuO1xufVxuXG4vKipcbiAqIEluaWNpYWxpemEgZWwgc2lzdGVtYSBkZSBpZGlvbWFzXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hIGluaWNpYWxpemFkb1xuICovXG5leHBvcnQgZnVuY3Rpb24gaW5pdGlhbGl6ZUxhbmd1YWdlKCkge1xuICAvLyBQcmlvcmlkYWQ6IGd1YXJkYWRvID4gbmF2ZWdhZG9yID4gZXNwYVx1MDBGMW9sXG4gIGNvbnN0IHNhdmVkTGFuZyA9IGdldFNhdmVkTGFuZ3VhZ2UoKTtcbiAgY29uc3QgYnJvd3NlckxhbmcgPSBkZXRlY3RCcm93c2VyTGFuZ3VhZ2UoKTtcblxuICBsZXQgc2VsZWN0ZWRMYW5nID0gJ2VzJzsgLy8gZmFsbGJhY2sgcG9yIGRlZmVjdG9cblxuICBpZiAoc2F2ZWRMYW5nICYmIHRyYW5zbGF0aW9uc1tzYXZlZExhbmddKSB7XG4gICAgc2VsZWN0ZWRMYW5nID0gc2F2ZWRMYW5nO1xuICB9IGVsc2UgaWYgKGJyb3dzZXJMYW5nICYmIHRyYW5zbGF0aW9uc1ticm93c2VyTGFuZ10pIHtcbiAgICBzZWxlY3RlZExhbmcgPSBicm93c2VyTGFuZztcbiAgfVxuXG4gIHNldExhbmd1YWdlKHNlbGVjdGVkTGFuZyk7XG4gIHJldHVybiBzZWxlY3RlZExhbmc7XG59XG5cbi8qKlxuICogQ2FtYmlhIGVsIGlkaW9tYSBhY3R1YWxcbiAqIEBwYXJhbSB7c3RyaW5nfSBsYW5nQ29kZSAtIENcdTAwRjNkaWdvIGRlbCBpZGlvbWFcbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIHNldExhbmd1YWdlKGxhbmdDb2RlKSB7XG4gIGlmICghdHJhbnNsYXRpb25zW2xhbmdDb2RlXSkge1xuICAgIGNvbnNvbGUud2FybihgSWRpb21hICcke2xhbmdDb2RlfScgbm8gZGlzcG9uaWJsZS4gVXNhbmRvICcke2N1cnJlbnRMYW5ndWFnZX0nYCk7XG4gICAgcmV0dXJuO1xuICB9XG5cbiAgY3VycmVudExhbmd1YWdlID0gbGFuZ0NvZGU7XG4gIGN1cnJlbnRUcmFuc2xhdGlvbnMgPSB0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdO1xuICBzYXZlTGFuZ3VhZ2UobGFuZ0NvZGUpO1xuXG4gIC8vIEVtaXRpciBldmVudG8gcGVyc29uYWxpemFkbyBwYXJhIHF1ZSBsb3MgbVx1MDBGM2R1bG9zIHB1ZWRhbiByZWFjY2lvbmFyXG4gIGlmICh0eXBlb2Ygd2luZG93ICE9PSAndW5kZWZpbmVkJyAmJiB3aW5kb3cuQ3VzdG9tRXZlbnQpIHtcbiAgICB3aW5kb3cuZGlzcGF0Y2hFdmVudChuZXcgd2luZG93LkN1c3RvbUV2ZW50KCdsYW5ndWFnZUNoYW5nZWQnLCB7XG4gICAgICBkZXRhaWw6IHsgbGFuZ3VhZ2U6IGxhbmdDb2RlLCB0cmFuc2xhdGlvbnM6IGN1cnJlbnRUcmFuc2xhdGlvbnMgfVxuICAgIH0pKTtcbiAgfVxufVxuXG4vKipcbiAqIE9idGllbmUgZWwgaWRpb21hIGFjdHVhbFxuICogQHJldHVybnMge3N0cmluZ30gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYSBhY3R1YWxcbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGdldEN1cnJlbnRMYW5ndWFnZSgpIHtcbiAgcmV0dXJuIGN1cnJlbnRMYW5ndWFnZTtcbn1cblxuLyoqXG4gKiBPYnRpZW5lIGxhcyB0cmFkdWNjaW9uZXMgYWN0dWFsZXNcbiAqIEByZXR1cm5zIHtvYmplY3R9IE9iamV0byBjb24gdG9kYXMgbGFzIHRyYWR1Y2Npb25lcyBkZWwgaWRpb21hIGFjdHVhbFxuICovXG5leHBvcnQgZnVuY3Rpb24gZ2V0Q3VycmVudFRyYW5zbGF0aW9ucygpIHtcbiAgcmV0dXJuIGN1cnJlbnRUcmFuc2xhdGlvbnM7XG59XG5cbi8qKlxuICogT2J0aWVuZSB1biB0ZXh0byB0cmFkdWNpZG8gdXNhbmRvIG5vdGFjaVx1MDBGM24gZGUgcHVudG9cbiAqIEBwYXJhbSB7c3RyaW5nfSBrZXkgLSBDbGF2ZSBkZWwgdGV4dG8gKGVqOiAnaW1hZ2UudGl0bGUnLCAnY29tbW9uLmNhbmNlbCcpXG4gKiBAcGFyYW0ge29iamVjdH0gcGFyYW1zIC0gUGFyXHUwMEUxbWV0cm9zIHBhcmEgaW50ZXJwb2xhY2lcdTAwRjNuIChlajoge2NvdW50OiA1fSlcbiAqIEByZXR1cm5zIHtzdHJpbmd9IFRleHRvIHRyYWR1Y2lkb1xuICovXG5leHBvcnQgZnVuY3Rpb24gdChrZXksIHBhcmFtcyA9IHt9KSB7XG4gIGNvbnN0IGtleXMgPSBrZXkuc3BsaXQoJy4nKTtcbiAgbGV0IHZhbHVlID0gY3VycmVudFRyYW5zbGF0aW9ucztcblxuICAvLyBOYXZlZ2FyIHBvciBsYSBlc3RydWN0dXJhIGRlIG9iamV0b3NcbiAgZm9yIChjb25zdCBrIG9mIGtleXMpIHtcbiAgICBpZiAodmFsdWUgJiYgdHlwZW9mIHZhbHVlID09PSAnb2JqZWN0JyAmJiBrIGluIHZhbHVlKSB7XG4gICAgICB2YWx1ZSA9IHZhbHVlW2tdO1xuICAgIH0gZWxzZSB7XG4gICAgICBjb25zb2xlLndhcm4oYENsYXZlIGRlIHRyYWR1Y2NpXHUwMEYzbiBubyBlbmNvbnRyYWRhOiAnJHtrZXl9J2ApO1xuICAgICAgcmV0dXJuIGtleTsgLy8gUmV0b3JuYXIgbGEgY2xhdmUgY29tbyBmYWxsYmFja1xuICAgIH1cbiAgfVxuXG4gIGlmICh0eXBlb2YgdmFsdWUgIT09ICdzdHJpbmcnKSB7XG4gICAgY29uc29sZS53YXJuKGBDbGF2ZSBkZSB0cmFkdWNjaVx1MDBGM24gbm8gZXMgc3RyaW5nOiAnJHtrZXl9J2ApO1xuICAgIHJldHVybiBrZXk7XG4gIH1cblxuICAvLyBJbnRlcnBvbGFyIHBhclx1MDBFMW1ldHJvc1xuICByZXR1cm4gaW50ZXJwb2xhdGUodmFsdWUsIHBhcmFtcyk7XG59XG5cbi8qKlxuICogSW50ZXJwb2xhIHBhclx1MDBFMW1ldHJvcyBlbiB1biBzdHJpbmdcbiAqIEBwYXJhbSB7c3RyaW5nfSB0ZXh0IC0gVGV4dG8gY29uIG1hcmNhZG9yZXMge2tleX1cbiAqIEBwYXJhbSB7b2JqZWN0fSBwYXJhbXMgLSBQYXJcdTAwRTFtZXRyb3MgYSBpbnRlcnBvbGFyXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBUZXh0byBjb24gcGFyXHUwMEUxbWV0cm9zIGludGVycG9sYWRvc1xuICovXG5mdW5jdGlvbiBpbnRlcnBvbGF0ZSh0ZXh0LCBwYXJhbXMpIHtcbiAgaWYgKCFwYXJhbXMgfHwgT2JqZWN0LmtleXMocGFyYW1zKS5sZW5ndGggPT09IDApIHtcbiAgICByZXR1cm4gdGV4dDtcbiAgfVxuXG4gIHJldHVybiB0ZXh0LnJlcGxhY2UoL1xceyhcXHcrKVxcfS9nLCAobWF0Y2gsIGtleSkgPT4ge1xuICAgIHJldHVybiBwYXJhbXNba2V5XSAhPT0gdW5kZWZpbmVkID8gcGFyYW1zW2tleV0gOiBtYXRjaDtcbiAgfSk7XG59XG5cbi8qKlxuICogT2J0aWVuZSB0cmFkdWNjaW9uZXMgZGUgdW5hIHNlY2NpXHUwMEYzbiBlc3BlY1x1MDBFRGZpY2FcbiAqIEBwYXJhbSB7c3RyaW5nfSBzZWN0aW9uIC0gU2VjY2lcdTAwRjNuIChlajogJ2ltYWdlJywgJ2xhdW5jaGVyJywgJ2NvbW1vbicpXG4gKiBAcmV0dXJucyB7b2JqZWN0fSBPYmpldG8gY29uIGxhcyB0cmFkdWNjaW9uZXMgZGUgbGEgc2VjY2lcdTAwRjNuXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRTZWN0aW9uKHNlY3Rpb24pIHtcbiAgaWYgKGN1cnJlbnRUcmFuc2xhdGlvbnNbc2VjdGlvbl0pIHtcbiAgICByZXR1cm4gY3VycmVudFRyYW5zbGF0aW9uc1tzZWN0aW9uXTtcbiAgfVxuXG4gIGNvbnNvbGUud2FybihgU2VjY2lcdTAwRjNuIGRlIHRyYWR1Y2NpXHUwMEYzbiBubyBlbmNvbnRyYWRhOiAnJHtzZWN0aW9ufSdgKTtcbiAgcmV0dXJuIHt9O1xufVxuXG4vKipcbiAqIFZlcmlmaWNhIHNpIHVuIGlkaW9tYSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICogQHBhcmFtIHtzdHJpbmd9IGxhbmdDb2RlIC0gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYVxuICogQHJldHVybnMge2Jvb2xlYW59IFRydWUgc2kgZXN0XHUwMEUxIGRpc3BvbmlibGVcbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGlzTGFuZ3VhZ2VBdmFpbGFibGUobGFuZ0NvZGUpIHtcbiAgcmV0dXJuICEhdHJhbnNsYXRpb25zW2xhbmdDb2RlXTtcbn1cblxuLy8gSW5pY2lhbGl6YXIgYXV0b21cdTAwRTF0aWNhbWVudGUgYWwgY2FyZ2FyIGVsIG1cdTAwRjNkdWxvXG5pbml0aWFsaXplTGFuZ3VhZ2UoKTtcbiIsICJpbXBvcnQgeyBnZXRTZWN0aW9uIH0gZnJvbSAnLi4vbG9jYWxlcy9pbmRleC5qcyc7XG5cbmV4cG9ydCBjb25zdCBJTUFHRV9ERUZBVUxUUyA9IHtcbiAgU0lURUtFWTogJzB4NEFBQUFBQUJwcUplOEZPME44NHEwRicsXG4gIENPT0xET1dOX0RFRkFVTFQ6IDMxMDAwLFxuICBUUkFOU1BBUkVOQ1lfVEhSRVNIT0xEOiAxMDAsXG4gIFdISVRFX1RIUkVTSE9MRDogMjUwLFxuICBMT0dfSU5URVJWQUw6IDEwLFxuICBUSUxFX1NJWkU6IDMwMDAsXG4gIFBJWEVMU19QRVJfQkFUQ0g6IDIwLFxuICBDSEFSR0VfUkVHRU5fTVM6IDMwMDAwLFxuICBUSEVNRToge1xuICAgIHByaW1hcnk6ICcjMDAwMDAwJyxcbiAgICBzZWNvbmRhcnk6ICcjMTExMTExJyxcbiAgICBhY2NlbnQ6ICcjMjIyMjIyJyxcbiAgICB0ZXh0OiAnI2ZmZmZmZicsXG4gICAgaGlnaGxpZ2h0OiAnIzc3NWNlMycsXG4gICAgc3VjY2VzczogJyMwMGZmMDAnLFxuICAgIGVycm9yOiAnI2ZmMDAwMCcsXG4gICAgd2FybmluZzogJyNmZmFhMDAnXG4gIH1cbn07XG5cbi8vIEVzdGEgZnVuY2lcdTAwRjNuIGFob3JhIHJldG9ybmEgbGFzIHRyYWR1Y2Npb25lcyBkaW5cdTAwRTFtaWNhbWVudGVcbmV4cG9ydCBmdW5jdGlvbiBnZXRJbWFnZVRleHRzKCkge1xuICByZXR1cm4gZ2V0U2VjdGlvbignaW1hZ2UnKTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgb2J0ZW5lciB0ZXh0b3MgY29uIHBhclx1MDBFMW1ldHJvc1xuZXhwb3J0IGZ1bmN0aW9uIGdldEltYWdlVGV4dChrZXksIHBhcmFtcyA9IHt9KSB7XG4gIGNvbnN0IHRleHRzID0gZ2V0SW1hZ2VUZXh0cygpO1xuICBsZXQgdGV4dCA9IHRleHRzW2tleV0gfHwga2V5O1xuICBcbiAgLy8gSW50ZXJwb2xhciBwYXJcdTAwRTFtZXRyb3NcbiAgaWYgKHBhcmFtcyAmJiBPYmplY3Qua2V5cyhwYXJhbXMpLmxlbmd0aCA+IDApIHtcbiAgICB0ZXh0ID0gdGV4dC5yZXBsYWNlKC9cXHsoXFx3KylcXH0vZywgKG1hdGNoLCBwYXJhbUtleSkgPT4ge1xuICAgICAgcmV0dXJuIHBhcmFtc1twYXJhbUtleV0gIT09IHVuZGVmaW5lZCA/IHBhcmFtc1twYXJhbUtleV0gOiBtYXRjaDtcbiAgICB9KTtcbiAgfVxuICBcbiAgcmV0dXJuIHRleHQ7XG59XG5cbi8vIE1hbnRlbmVyIFRFWFRTIHBvciBjb21wYXRpYmlsaWRhZCBwZXJvIG1hcmNhcmxvIGNvbW8gZGVwcmVjYXRlZFxuZXhwb3J0IGNvbnN0IFRFWFRTID0ge1xuICBnZXQgZXMoKSB7XG4gICAgY29uc29sZS53YXJuKCdURVhUUy5lcyBlc3RcdTAwRTEgZGVwcmVjYXRlZC4gVXNhIGdldEltYWdlVGV4dHMoKSBlbiBzdSBsdWdhci4nKTtcbiAgICByZXR1cm4gZ2V0SW1hZ2VUZXh0cygpO1xuICB9XG59O1xuXG5leHBvcnQgY29uc3QgaW1hZ2VTdGF0ZSA9IHtcbiAgcnVubmluZzogZmFsc2UsXG4gIGltYWdlTG9hZGVkOiBmYWxzZSxcbiAgcHJvY2Vzc2luZzogZmFsc2UsXG4gIHRvdGFsUGl4ZWxzOiAwLFxuICBwYWludGVkUGl4ZWxzOiAwLFxuICBhdmFpbGFibGVDb2xvcnM6IFtdLFxuICBjdXJyZW50Q2hhcmdlczogMCxcbiAgY29vbGRvd246IElNQUdFX0RFRkFVTFRTLkNPT0xET1dOX0RFRkFVTFQsXG4gIGltYWdlRGF0YTogbnVsbCxcbiAgc3RvcEZsYWc6IGZhbHNlLFxuICBjb2xvcnNDaGVja2VkOiBmYWxzZSxcbiAgc3RhcnRQb3NpdGlvbjogbnVsbCxcbiAgc2VsZWN0aW5nUG9zaXRpb246IGZhbHNlLFxuICBwb3NpdGlvblRpbWVvdXRJZDogbnVsbCwgLy8gUGFyYSBtYW5lamFyIHRpbWVvdXQgZGUgc2VsZWNjaVx1MDBGM25cbiAgY2xlYW51cE9ic2VydmVyOiBudWxsLCAvLyBQYXJhIGxpbXBpYXIgb2JzZXJ2ZXJzXG4gIHJlZ2lvbjogbnVsbCxcbiAgbWluaW1pemVkOiBmYWxzZSxcbiAgbGFzdFBvc2l0aW9uOiB7IHg6IDAsIHk6IDAgfSxcbiAgZXN0aW1hdGVkVGltZTogMCxcbiAgbGFuZ3VhZ2U6ICdlcycsXG4gIHRpbGVYOiBudWxsLFxuICB0aWxlWTogbnVsbCxcbiAgcGl4ZWxzUGVyQmF0Y2g6IElNQUdFX0RFRkFVTFRTLlBJWEVMU19QRVJfQkFUQ0gsXG4gIHVzZUFsbENoYXJnZXNGaXJzdDogdHJ1ZSwgLy8gVXNhciB0b2RhcyBsYXMgY2FyZ2FzIGVuIGxhIHByaW1lcmEgcGFzYWRhXG4gIGlzRmlyc3RCYXRjaDogdHJ1ZSwgLy8gQ29udHJvbGFyIHNpIGVzIGxhIHByaW1lcmEgcGFzYWRhXG4gIG1heENoYXJnZXM6IDUwLCAvLyBDYXJnYXMgbVx1MDBFMXhpbWFzIGRlbCB1c3VhcmlvXG4gIG5leHRCYXRjaENvb2xkb3duOiAwLCAvLyBUaWVtcG8gcGFyYSBlbCBzaWd1aWVudGUgbG90ZVxuICBpbkNvb2xkb3duOiBmYWxzZSxcbiAgY29vbGRvd25FbmRUaW1lOiAwLFxuICByZW1haW5pbmdQaXhlbHM6IFtdLFxuICBsYXN0Q2hhcmdlVXBkYXRlOiAwLFxuICBjaGFyZ2VEZWNpbWFsUGFydDogMCxcbiAgb3JpZ2luYWxJbWFnZU5hbWU6IG51bGwsXG4gIHJldHJ5Q291bnQ6IDAgLy8gQ29udGFkb3IgZGUgcmVpbnRlbnRvcyBwYXJhIGVzdGFkXHUwMEVEc3RpY2FzXG59O1xuIiwgImltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuXG5leHBvcnQgY2xhc3MgSW1hZ2VQcm9jZXNzb3Ige1xuICBjb25zdHJ1Y3RvcihpbWFnZVNyYykge1xuICAgIHRoaXMuaW1hZ2VTcmMgPSBpbWFnZVNyYztcbiAgICB0aGlzLmltZyA9IG5ldyB3aW5kb3cuSW1hZ2UoKTtcbiAgICB0aGlzLmNhbnZhcyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2NhbnZhcycpO1xuICAgIHRoaXMuY3R4ID0gdGhpcy5jYW52YXMuZ2V0Q29udGV4dCgnMmQnLCB7IHdpbGxSZWFkRnJlcXVlbnRseTogdHJ1ZSB9KTtcbiAgICB0aGlzLnByZXZpZXdDYW52YXMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdjYW52YXMnKTtcbiAgICB0aGlzLnByZXZpZXdDdHggPSB0aGlzLnByZXZpZXdDYW52YXMuZ2V0Q29udGV4dCgnMmQnKTtcbiAgfVxuICBcbiAgYXN5bmMgbG9hZCgpIHtcbiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgdGhpcy5pbWcub25sb2FkID0gKCkgPT4ge1xuICAgICAgICB0aGlzLmNhbnZhcy53aWR0aCA9IHRoaXMuaW1nLndpZHRoO1xuICAgICAgICB0aGlzLmNhbnZhcy5oZWlnaHQgPSB0aGlzLmltZy5oZWlnaHQ7XG4gICAgICAgIHRoaXMuY3R4LmRyYXdJbWFnZSh0aGlzLmltZywgMCwgMCk7XG4gICAgICAgIHJlc29sdmUoKTtcbiAgICAgIH07XG4gICAgICB0aGlzLmltZy5vbmVycm9yID0gcmVqZWN0O1xuICAgICAgdGhpcy5pbWcuc3JjID0gdGhpcy5pbWFnZVNyYztcbiAgICB9KTtcbiAgfVxuICBcbiAgZ2V0UGl4ZWxEYXRhKCkge1xuICAgIHJldHVybiB0aGlzLmN0eC5nZXRJbWFnZURhdGEoMCwgMCwgdGhpcy5jYW52YXMud2lkdGgsIHRoaXMuY2FudmFzLmhlaWdodCkuZGF0YTtcbiAgfVxuICBcbiAgZ2V0RGltZW5zaW9ucygpIHtcbiAgICByZXR1cm4geyB3aWR0aDogdGhpcy5jYW52YXMud2lkdGgsIGhlaWdodDogdGhpcy5jYW52YXMuaGVpZ2h0IH07XG4gIH1cbiAgXG4gIHJlc2l6ZShuZXdXaWR0aCwgbmV3SGVpZ2h0KSB7XG4gICAgY29uc3QgdGVtcENhbnZhcyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2NhbnZhcycpO1xuICAgIHRlbXBDYW52YXMud2lkdGggPSBuZXdXaWR0aDtcbiAgICB0ZW1wQ2FudmFzLmhlaWdodCA9IG5ld0hlaWdodDtcbiAgICBjb25zdCB0ZW1wQ3R4ID0gdGVtcENhbnZhcy5nZXRDb250ZXh0KCcyZCcpO1xuICAgIFxuICAgIHRlbXBDdHguZHJhd0ltYWdlKHRoaXMuaW1nLCAwLCAwLCBuZXdXaWR0aCwgbmV3SGVpZ2h0KTtcbiAgICBcbiAgICB0aGlzLmNhbnZhcy53aWR0aCA9IG5ld1dpZHRoO1xuICAgIHRoaXMuY2FudmFzLmhlaWdodCA9IG5ld0hlaWdodDtcbiAgICB0aGlzLmN0eC5kcmF3SW1hZ2UodGVtcENhbnZhcywgMCwgMCk7XG4gICAgXG4gICAgcmV0dXJuIHRoaXMuZ2V0UGl4ZWxEYXRhKCk7XG4gIH1cbiAgXG4gIGdlbmVyYXRlUHJldmlldyhuZXdXaWR0aCwgbmV3SGVpZ2h0KSB7XG4gICAgdGhpcy5wcmV2aWV3Q2FudmFzLndpZHRoID0gbmV3V2lkdGg7XG4gICAgdGhpcy5wcmV2aWV3Q2FudmFzLmhlaWdodCA9IG5ld0hlaWdodDtcbiAgICB0aGlzLnByZXZpZXdDdHguaW1hZ2VTbW9vdGhpbmdFbmFibGVkID0gZmFsc2U7XG4gICAgdGhpcy5wcmV2aWV3Q3R4LmRyYXdJbWFnZSh0aGlzLmltZywgMCwgMCwgbmV3V2lkdGgsIG5ld0hlaWdodCk7XG4gICAgXG4gICAgcmV0dXJuIHRoaXMucHJldmlld0NhbnZhcy50b0RhdGFVUkwoKTtcbiAgfVxuICBcbiAgZ2V0SW1hZ2VEYXRhKCkge1xuICAgIGNvbnN0IHsgd2lkdGgsIGhlaWdodCB9ID0gdGhpcy5nZXREaW1lbnNpb25zKCk7XG4gICAgY29uc3QgcGl4ZWxzID0gdGhpcy5nZXRQaXhlbERhdGEoKTtcbiAgICBcbiAgICByZXR1cm4ge1xuICAgICAgd2lkdGgsXG4gICAgICBoZWlnaHQsXG4gICAgICBwaXhlbHMsXG4gICAgICBvcmlnaW5hbE5hbWU6IHRoaXMub3JpZ2luYWxOYW1lIHx8ICdpbWFnZS5wbmcnXG4gICAgfTtcbiAgfVxuICBcbiAgcHJvY2Vzc0ltYWdlKGF2YWlsYWJsZUNvbG9ycywgY29uZmlnKSB7XG4gICAgY29uc3QgeyB3aWR0aCwgaGVpZ2h0IH0gPSB0aGlzLmdldERpbWVuc2lvbnMoKTtcbiAgICBjb25zdCBwaXhlbHMgPSB0aGlzLmdldFBpeGVsRGF0YSgpO1xuICAgIGNvbnN0IHByb2Nlc3NlZFBpeGVscyA9IFtdO1xuICAgIGxldCB2YWxpZFBpeGVsQ291bnQgPSAwO1xuICAgIFxuICAgIGZvciAobGV0IHkgPSAwOyB5IDwgaGVpZ2h0OyB5KyspIHtcbiAgICAgIGZvciAobGV0IHggPSAwOyB4IDwgd2lkdGg7IHgrKykge1xuICAgICAgICBjb25zdCBpZHggPSAoeSAqIHdpZHRoICsgeCkgKiA0O1xuICAgICAgICBjb25zdCByID0gcGl4ZWxzW2lkeF07XG4gICAgICAgIGNvbnN0IGcgPSBwaXhlbHNbaWR4ICsgMV07XG4gICAgICAgIGNvbnN0IGIgPSBwaXhlbHNbaWR4ICsgMl07XG4gICAgICAgIGNvbnN0IGFscGhhID0gcGl4ZWxzW2lkeCArIDNdO1xuICAgICAgICBcbiAgICAgICAgLy8gRmlsdHJhciBwXHUwMEVEeGVsZXMgdHJhbnNwYXJlbnRlc1xuICAgICAgICBpZiAoYWxwaGEgPCBjb25maWcuVFJBTlNQQVJFTkNZX1RIUkVTSE9MRCkge1xuICAgICAgICAgIGNvbnRpbnVlO1xuICAgICAgICB9XG4gICAgICAgIFxuICAgICAgICAvLyBOb3RhOiBSZW1vdmlkbyBlbCBmaWx0cm8gYXV0b21cdTAwRTF0aWNvIGRlIHBcdTAwRUR4ZWxlcyBibGFuY29zXG4gICAgICAgIC8vIHBhcmEgcGVybWl0aXIgZWwgdXNvIGRlbCBjb2xvciBibGFuY28gKElEIDUpIGVuIGxhcyBpbVx1MDBFMWdlbmVzXG4gICAgICAgIFxuICAgICAgICAvLyBFbmNvbnRyYXIgZWwgY29sb3IgbVx1MDBFMXMgY2VyY2FubyBlbiBsYSBwYWxldGFcbiAgICAgICAgY29uc3QgY2xvc2VzdENvbG9yID0gdGhpcy5maW5kQ2xvc2VzdENvbG9yKHsgciwgZywgYiB9LCBhdmFpbGFibGVDb2xvcnMpO1xuICAgICAgICBpZiAoY2xvc2VzdENvbG9yKSB7XG4gICAgICAgICAgcHJvY2Vzc2VkUGl4ZWxzLnB1c2goe1xuICAgICAgICAgICAgeCxcbiAgICAgICAgICAgIHksXG4gICAgICAgICAgICBvcmlnaW5hbENvbG9yOiB7IHIsIGcsIGIsIGFscGhhIH0sXG4gICAgICAgICAgICB0YXJnZXRDb2xvcjogY2xvc2VzdENvbG9yXG4gICAgICAgICAgfSk7XG4gICAgICAgICAgdmFsaWRQaXhlbENvdW50Kys7XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gICAgXG4gICAgcmV0dXJuIHtcbiAgICAgIHdpZHRoLFxuICAgICAgaGVpZ2h0LFxuICAgICAgcGl4ZWxzOiBwcm9jZXNzZWRQaXhlbHMsXG4gICAgICB2YWxpZFBpeGVsQ291bnQsXG4gICAgICBvcmlnaW5hbE5hbWU6IHRoaXMub3JpZ2luYWxOYW1lIHx8ICdpbWFnZS5wbmcnXG4gICAgfTtcbiAgfVxuICBcbiAgZmluZENsb3Nlc3RDb2xvcihyZ2IsIHBhbGV0dGUpIHtcbiAgICBpZiAoIXBhbGV0dGUgfHwgcGFsZXR0ZS5sZW5ndGggPT09IDApIHJldHVybiBudWxsO1xuICAgIFxuICAgIGxldCBjbG9zZXN0Q29sb3IgPSBudWxsO1xuICAgIGxldCBtaW5EaXN0YW5jZSA9IEluZmluaXR5O1xuICAgIFxuICAgIGZvciAoY29uc3QgY29sb3Igb2YgcGFsZXR0ZSkge1xuICAgICAgY29uc3QgZGlzdGFuY2UgPSBNYXRoLnNxcnQoXG4gICAgICAgIE1hdGgucG93KHJnYi5yIC0gY29sb3IuciwgMikgK1xuICAgICAgICBNYXRoLnBvdyhyZ2IuZyAtIGNvbG9yLmcsIDIpICtcbiAgICAgICAgTWF0aC5wb3cocmdiLmIgLSBjb2xvci5iLCAyKVxuICAgICAgKTtcbiAgICAgIFxuICAgICAgaWYgKGRpc3RhbmNlIDwgbWluRGlzdGFuY2UpIHtcbiAgICAgICAgbWluRGlzdGFuY2UgPSBkaXN0YW5jZTtcbiAgICAgICAgY2xvc2VzdENvbG9yID0gY29sb3I7XG4gICAgICB9XG4gICAgfVxuICAgIFxuICAgIHJldHVybiBjbG9zZXN0Q29sb3I7XG4gIH1cbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGZpbmRDbG9zZXN0Q29sb3IocmdiLCBwYWxldHRlKSB7XG4gIGlmICghcGFsZXR0ZSB8fCBwYWxldHRlLmxlbmd0aCA9PT0gMCkgcmV0dXJuIG51bGw7XG4gIFxuICBsZXQgY2xvc2VzdENvbG9yID0gbnVsbDtcbiAgbGV0IG1pbkRpc3RhbmNlID0gSW5maW5pdHk7XG4gIFxuICBmb3IgKGNvbnN0IGNvbG9yIG9mIHBhbGV0dGUpIHtcbiAgICBjb25zdCBkaXN0YW5jZSA9IE1hdGguc3FydChcbiAgICAgIE1hdGgucG93KHJnYi5yIC0gY29sb3IuciwgMikgK1xuICAgICAgTWF0aC5wb3cocmdiLmcgLSBjb2xvci5nLCAyKSArXG4gICAgICBNYXRoLnBvdyhyZ2IuYiAtIGNvbG9yLmIsIDIpXG4gICAgKTtcbiAgICBcbiAgICBpZiAoZGlzdGFuY2UgPCBtaW5EaXN0YW5jZSkge1xuICAgICAgbWluRGlzdGFuY2UgPSBkaXN0YW5jZTtcbiAgICAgIGNsb3Nlc3RDb2xvciA9IGNvbG9yO1xuICAgIH1cbiAgfVxuICBcbiAgcmV0dXJuIGNsb3Nlc3RDb2xvcjtcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGdlbmVyYXRlUGl4ZWxRdWV1ZShpbWFnZURhdGEsIHN0YXJ0UG9zaXRpb24sIHRpbGVYLCB0aWxlWSkge1xuICBjb25zdCB7IHdpZHRoLCBoZWlnaHQsIHBpeGVscyB9ID0gaW1hZ2VEYXRhO1xuICBjb25zdCB7IHg6IGxvY2FsU3RhcnRYLCB5OiBsb2NhbFN0YXJ0WSB9ID0gc3RhcnRQb3NpdGlvbjtcbiAgY29uc3QgcXVldWUgPSBbXTtcblxuICBmb3IgKGxldCB5ID0gMDsgeSA8IGhlaWdodDsgeSsrKSB7XG4gICAgZm9yIChsZXQgeCA9IDA7IHggPCB3aWR0aDsgeCsrKSB7XG4gICAgICBjb25zdCBwaXhlbERhdGEgPSBwaXhlbHMuZmluZChwID0+IHAueCA9PT0geCAmJiBwLnkgPT09IHkpO1xuICAgICAgaWYgKCFwaXhlbERhdGEpIGNvbnRpbnVlO1xuICAgICAgXG4gICAgICBjb25zdCBnbG9iYWxYID0gbG9jYWxTdGFydFggKyB4O1xuICAgICAgY29uc3QgZ2xvYmFsWSA9IGxvY2FsU3RhcnRZICsgeTtcbiAgICAgIFxuICAgICAgcXVldWUucHVzaCh7XG4gICAgICAgIGltYWdlWDogeCxcbiAgICAgICAgaW1hZ2VZOiB5LFxuICAgICAgICBsb2NhbFg6IGdsb2JhbFgsXG4gICAgICAgIGxvY2FsWTogZ2xvYmFsWSxcbiAgICAgICAgdGlsZVg6IHRpbGVYLFxuICAgICAgICB0aWxlWTogdGlsZVksXG4gICAgICAgIGNvbG9yOiBwaXhlbERhdGEudGFyZ2V0Q29sb3IsXG4gICAgICAgIG9yaWdpbmFsQ29sb3I6IHBpeGVsRGF0YS5vcmlnaW5hbENvbG9yXG4gICAgICB9KTtcbiAgICB9XG4gIH1cblxuICBsb2coYENvbGEgZGUgcFx1MDBFRHhlbGVzIGdlbmVyYWRhOiAke3F1ZXVlLmxlbmd0aH0gcFx1MDBFRHhlbGVzIHBhcmEgcGludGFyYCk7XG4gIHJldHVybiBxdWV1ZTtcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGRldGVjdEF2YWlsYWJsZUNvbG9ycygpIHtcbiAgbG9nKCdcdUQ4M0NcdURGQTggRGV0ZWN0YW5kbyBjb2xvcmVzIGRpc3BvbmlibGVzLi4uJyk7XG4gIFxuICAvLyBCdXNjYXIgZWxlbWVudG9zIGRlIGNvbG9yIHVzYW5kbyBlbCBzZWxlY3RvciBkZWwgb3JpZ2luYWxcbiAgY29uc3QgY29sb3JFbGVtZW50cyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ1tpZF49XCJjb2xvci1cIl0nKTtcbiAgY29uc3QgY29sb3JzID0gW107XG4gIFxuICBmb3IgKGNvbnN0IGVsZW1lbnQgb2YgY29sb3JFbGVtZW50cykge1xuICAgIC8vIEZpbHRyYXIgZWxlbWVudG9zIHF1ZSB0aWVuZW4gU1ZHIChwcm9iYWJsZW1lbnRlIGljb25vcyBkZSBibG9xdWVvKVxuICAgIGlmIChlbGVtZW50LnF1ZXJ5U2VsZWN0b3IoJ3N2ZycpKSB7XG4gICAgICBjb250aW51ZTtcbiAgICB9XG4gICAgXG4gICAgY29uc3QgaWRTdHIgPSBlbGVtZW50LmlkLnJlcGxhY2UoJ2NvbG9yLScsICcnKTtcbiAgICBjb25zdCBpZCA9IHBhcnNlSW50KGlkU3RyKTtcbiAgICBcbiAgICAvLyBGaWx0cmFyIHNvbG8gZWwgY29sb3IgMCAobWFudGVuZXIgZWwgY29sb3IgYmxhbmNvIElEIDUgZGlzcG9uaWJsZSlcbiAgICBpZiAoaWQgPT09IDApIHtcbiAgICAgIGNvbnRpbnVlO1xuICAgIH1cbiAgICBcbiAgICAvLyBPYnRlbmVyIGNvbG9yIFJHQiBkZWwgc3R5bGVcbiAgICBjb25zdCBiYWNrZ3JvdW5kU3R5bGUgPSBlbGVtZW50LnN0eWxlLmJhY2tncm91bmRDb2xvcjtcbiAgICBpZiAoYmFja2dyb3VuZFN0eWxlKSB7XG4gICAgICBjb25zdCByZ2JNYXRjaCA9IGJhY2tncm91bmRTdHlsZS5tYXRjaCgvXFxkKy9nKTtcbiAgICAgIGlmIChyZ2JNYXRjaCAmJiByZ2JNYXRjaC5sZW5ndGggPj0gMykge1xuICAgICAgICBjb25zdCByZ2IgPSB7XG4gICAgICAgICAgcjogcGFyc2VJbnQocmdiTWF0Y2hbMF0pLFxuICAgICAgICAgIGc6IHBhcnNlSW50KHJnYk1hdGNoWzFdKSxcbiAgICAgICAgICBiOiBwYXJzZUludChyZ2JNYXRjaFsyXSlcbiAgICAgICAgfTtcbiAgICAgICAgXG4gICAgICAgIGNvbG9ycy5wdXNoKHtcbiAgICAgICAgICBpZCxcbiAgICAgICAgICBlbGVtZW50LFxuICAgICAgICAgIC4uLnJnYlxuICAgICAgICB9KTtcbiAgICAgICAgXG4gICAgICAgIGxvZyhgQ29sb3IgZGV0ZWN0YWRvOiBpZD0ke2lkfSwgcmdiKCR7cmdiLnJ9LCR7cmdiLmd9LCR7cmdiLmJ9KWApO1xuICAgICAgfVxuICAgIH1cbiAgfVxuICBcbiAgbG9nKGBcdTI3MDUgJHtjb2xvcnMubGVuZ3RofSBjb2xvcmVzIGRpc3BvbmlibGVzIGRldGVjdGFkb3NgKTtcbiAgcmV0dXJuIGNvbG9ycztcbn1cbiIsICIvLyA9PT0gW1Byb2Nlc2Fkb3IgZGUgaW1cdTAwRTFnZW5lcyBiYXNhZG8gZW4gQmx1ZSBNYXJibGVdID09PVxuaW1wb3J0IHsgbG9nIH0gZnJvbSBcIi4uL2NvcmUvbG9nZ2VyLmpzXCI7XG5cbi8qKlxuICogUHJvY2VzYWRvciBkZSBpbVx1MDBFMWdlbmVzIGNvbiBhcnF1aXRlY3R1cmEgQmx1ZSBNYXJibGVcbiAqIE1hbmVqYSBjaHVua2luZyBlbiB0aWxlcywgZmFjdG9yIGRlIGVzY2FsYWRvLCB5IHNpc3RlbWEgZGUgY29vcmRlbmFkYXMgY29tcGF0aWJsZVxuICovXG5leHBvcnQgY2xhc3MgQmx1ZU1hcmJsZWxJbWFnZVByb2Nlc3NvciB7XG4gIGNvbnN0cnVjdG9yKGltYWdlU3JjKSB7XG4gICAgdGhpcy5pbWFnZVNyYyA9IGltYWdlU3JjO1xuICAgIHRoaXMuaW1nID0gbmV3IHdpbmRvdy5JbWFnZSgpO1xuICAgIHRoaXMub3JpZ2luYWxOYW1lID0gbnVsbDtcbiAgICBcbiAgICAvLyBDb25maWd1cmFjaVx1MDBGM24gQmx1ZSBNYXJibGVcbiAgICB0aGlzLnRpbGVTaXplID0gMTAwMDsgLy8gVGFtYVx1MDBGMW8gZGUgdGlsZSBlbiBwXHUwMEVEeGVsZXMgKGNvbW8gQmx1ZSBNYXJibGUpXG4gICAgdGhpcy5kcmF3TXVsdCA9IDM7IC8vIEZhY3RvciBkZSBlc2NhbGFkbyAoREVCRSBzZXIgaW1wYXIpXG4gICAgdGhpcy5zaHJlYWRTaXplID0gMzsgLy8gQWxpYXMgcGFyYSBkcmF3TXVsdCBwYXJhIGNvbXBhdGliaWxpZGFkXG4gICAgXG4gICAgLy8gRXN0YWRvIGRlbCBwcm9jZXNhbWllbnRvXG4gICAgdGhpcy5iaXRtYXAgPSBudWxsO1xuICAgIHRoaXMuaW1hZ2VXaWR0aCA9IDA7XG4gICAgdGhpcy5pbWFnZUhlaWdodCA9IDA7XG4gICAgdGhpcy50b3RhbFBpeGVscyA9IDA7XG4gICAgdGhpcy5yZXF1aXJlZFBpeGVsQ291bnQgPSAwO1xuICAgIHRoaXMuZGVmYWNlUGl4ZWxDb3VudCA9IDA7XG4gICAgdGhpcy5jb2xvclBhbGV0dGUgPSB7fTtcbiAgICB0aGlzLmFsbG93ZWRDb2xvcnNTZXQgPSBuZXcgU2V0KCk7XG4gICAgdGhpcy5yZ2JUb01ldGEgPSBuZXcgTWFwKCk7XG4gICAgdGhpcy5jb29yZHMgPSBbMCwgMCwgMCwgMF07IC8vIFt0aWxlWCwgdGlsZVksIHBpeGVsWCwgcGl4ZWxZXVxuICAgIHRoaXMudGVtcGxhdGVUaWxlcyA9IHt9O1xuICAgIHRoaXMudGVtcGxhdGVUaWxlc0J1ZmZlcnMgPSB7fTtcbiAgICB0aGlzLnRpbGVQcmVmaXhlcyA9IG5ldyBTZXQoKTtcbiAgfVxuXG4gIGFzeW5jIGxvYWQoKSB7XG4gICAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlLCByZWplY3QpID0+IHtcbiAgICAgIHRoaXMuaW1nLm9ubG9hZCA9IGFzeW5jICgpID0+IHtcbiAgICAgICAgdHJ5IHtcbiAgICAgICAgICB0aGlzLmJpdG1hcCA9IGF3YWl0IGNyZWF0ZUltYWdlQml0bWFwKHRoaXMuaW1nKTtcbiAgICAgICAgICB0aGlzLmltYWdlV2lkdGggPSB0aGlzLmJpdG1hcC53aWR0aDtcbiAgICAgICAgICB0aGlzLmltYWdlSGVpZ2h0ID0gdGhpcy5iaXRtYXAuaGVpZ2h0O1xuICAgICAgICAgIHRoaXMudG90YWxQaXhlbHMgPSB0aGlzLmltYWdlV2lkdGggKiB0aGlzLmltYWdlSGVpZ2h0O1xuICAgICAgICAgIFxuICAgICAgICAgIGxvZyhgW0JMVUUgTUFSQkxFXSBJbWFnZW4gY2FyZ2FkYTogJHt0aGlzLmltYWdlV2lkdGh9XHUwMEQ3JHt0aGlzLmltYWdlSGVpZ2h0fSA9ICR7dGhpcy50b3RhbFBpeGVscy50b0xvY2FsZVN0cmluZygpfSBwXHUwMEVEeGVsZXNgKTtcbiAgICAgICAgICByZXNvbHZlKCk7XG4gICAgICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICAgICAgcmVqZWN0KGVycm9yKTtcbiAgICAgICAgfVxuICAgICAgfTtcbiAgICAgIHRoaXMuaW1nLm9uZXJyb3IgPSByZWplY3Q7XG4gICAgICB0aGlzLmltZy5zcmMgPSB0aGlzLmltYWdlU3JjO1xuICAgIH0pO1xuICB9XG5cbiAgLyoqXG4gICAqIEluaWNpYWxpemEgbGEgcGFsZXRhIGRlIGNvbG9yZXMgZGVzZGUgV1BsYWNlIChjb21vIEJsdWUgTWFyYmxlKVxuICAgKi9cbiAgaW5pdGlhbGl6ZUNvbG9yUGFsZXR0ZSgpIHtcbiAgICBsb2coJ1tCTFVFIE1BUkJMRV0gSW5pY2lhbGl6YW5kbyBwYWxldGEgZGUgY29sb3Jlcy4uLicpO1xuICAgIFxuICAgIC8vIERldGVjdGFyIGNvbG9yZXMgZGlzcG9uaWJsZXMgZGVsIHNpdGlvIChtZWpvcmFkbylcbiAgICBjb25zdCBhdmFpbGFibGVDb2xvcnMgPSB0aGlzLmRldGVjdFNpdGVDb2xvcnMoKTtcbiAgICBcblxuICAgIFxuICAgIC8vIENvbnN0cnVpciBjb25qdW50byBkZSBjb2xvcmVzIHBlcm1pdGlkb3NcbiAgICBjb25zdCBmaWx0ZXJlZENvbG9ycyA9IGF2YWlsYWJsZUNvbG9yc1xuICAgICAgLmZpbHRlcihjID0+IGMubmFtZSAmJiBjLm5hbWUudG9Mb3dlckNhc2UoKSAhPT0gJ3RyYW5zcGFyZW50JyAmJiBBcnJheS5pc0FycmF5KGMucmdiKSk7XG4gICAgXG5cbiAgICBcbiAgICB0aGlzLmFsbG93ZWRDb2xvcnNTZXQgPSBuZXcgU2V0KFxuICAgICAgZmlsdGVyZWRDb2xvcnMubWFwKGMgPT4gYCR7Yy5yZ2JbMF19LCR7Yy5yZ2JbMV19LCR7Yy5yZ2JbMl19YClcbiAgICApO1xuICAgIFxuXG5cbiAgICAvLyBBc2VndXJhciBxdWUgI2RlZmFjZSAobWFyY2Fkb3IgZGUgdHJhbnNwYXJlbmNpYSkgc2UgdHJhdGUgY29tbyBwZXJtaXRpZG9cbiAgICBjb25zdCBkZWZhY2VLZXkgPSAnMjIyLDI1MCwyMDYnO1xuICAgIHRoaXMuYWxsb3dlZENvbG9yc1NldC5hZGQoZGVmYWNlS2V5KTtcblxuICAgIC8vIE1hcGVhciBSR0IgYSBtZXRhZGF0b3NcbiAgICB0aGlzLnJnYlRvTWV0YSA9IG5ldyBNYXAoXG4gICAgICBhdmFpbGFibGVDb2xvcnNcbiAgICAgICAgLmZpbHRlcihjID0+IEFycmF5LmlzQXJyYXkoYy5yZ2IpKVxuICAgICAgICAubWFwKGMgPT4gW1xuICAgICAgICAgIGAke2MucmdiWzBdfSwke2MucmdiWzFdfSwke2MucmdiWzJdfWAsIFxuICAgICAgICAgIHsgXG4gICAgICAgICAgICBpZDogYy5pZCwgXG4gICAgICAgICAgICBwcmVtaXVtOiAhIWMucHJlbWl1bSwgXG4gICAgICAgICAgICBuYW1lOiBjLm5hbWUgfHwgYENvbG9yICR7Yy5pZH1gIFxuICAgICAgICAgIH1cbiAgICAgICAgXSlcbiAgICApO1xuXG4gICAgLy8gTWFwZWFyICNkZWZhY2UgYSBUcmFuc3BhcmVudCBwYXJhIFVJXG4gICAgdHJ5IHtcbiAgICAgIGNvbnN0IHRyYW5zcGFyZW50ID0gYXZhaWxhYmxlQ29sb3JzLmZpbmQoYyA9PiBjLm5hbWUgJiYgYy5uYW1lLnRvTG93ZXJDYXNlKCkgPT09ICd0cmFuc3BhcmVudCcpO1xuICAgICAgaWYgKHRyYW5zcGFyZW50ICYmIEFycmF5LmlzQXJyYXkodHJhbnNwYXJlbnQucmdiKSkge1xuICAgICAgICB0aGlzLnJnYlRvTWV0YS5zZXQoZGVmYWNlS2V5LCB7IFxuICAgICAgICAgIGlkOiB0cmFuc3BhcmVudC5pZCwgXG4gICAgICAgICAgcHJlbWl1bTogISF0cmFuc3BhcmVudC5wcmVtaXVtLCBcbiAgICAgICAgICBuYW1lOiB0cmFuc3BhcmVudC5uYW1lIFxuICAgICAgICB9KTtcbiAgICAgIH1cbiAgICB9IGNhdGNoIChfZXJyb3IpIHtcbiAgICAgIC8vIElnbm9yYXIgZXJyb3JlcyBhbCBwcm9jZXNhciB0cmFuc3BhcmVuY2lhc1xuICAgIH1cblxuICAgIGxvZyhgW0JMVUUgTUFSQkxFXSBQYWxldGEgaW5pY2lhbGl6YWRhOiAke3RoaXMuYWxsb3dlZENvbG9yc1NldC5zaXplfSBjb2xvcmVzIHBlcm1pdGlkb3NgKTtcbiAgICByZXR1cm4gQXJyYXkuZnJvbShhdmFpbGFibGVDb2xvcnMpO1xuICB9XG5cbiAgLyoqXG4gICAqIERldGVjdGEgY29sb3JlcyBkaXNwb25pYmxlcyBkZWwgc2l0aW8gKHZlcnNpXHUwMEYzbiBtZWpvcmFkYSBkZSBCbHVlIE1hcmJsZSlcbiAgICovXG4gIGRldGVjdFNpdGVDb2xvcnMoKSB7XG4gICAgY29uc3QgY29sb3JFbGVtZW50cyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ1tpZF49XCJjb2xvci1cIl0nKTtcbiAgICBjb25zdCBjb2xvcnMgPSBbXTtcbiAgICBcbiAgICBmb3IgKGNvbnN0IGVsZW1lbnQgb2YgY29sb3JFbGVtZW50cykge1xuICAgICAgY29uc3QgaWRTdHIgPSBlbGVtZW50LmlkLnJlcGxhY2UoJ2NvbG9yLScsICcnKTtcbiAgICAgIGNvbnN0IGlkID0gcGFyc2VJbnQoaWRTdHIpO1xuICAgICAgXG4gICAgICAvLyBGaWx0cmFyIGVsZW1lbnRvcyBjb24gU1ZHIChwcm9iYWJsZW1lbnRlIGJsb3F1ZW9zKVxuICAgICAgaWYgKGVsZW1lbnQucXVlcnlTZWxlY3Rvcignc3ZnJykpIHtcbiAgICAgICAgY29udGludWU7XG4gICAgICB9XG4gICAgICBcbiAgICAgIC8vIEZpbHRyYXIgc29sbyBlbCBjb2xvciAwIChtYW50ZW5lciBlbCBjb2xvciBibGFuY28gSUQgNSBkaXNwb25pYmxlKVxuICAgICAgaWYgKGlkID09PSAwKSB7XG4gICAgICAgIGNvbnRpbnVlO1xuICAgICAgfVxuICAgICAgXG4gICAgICAvLyBPYnRlbmVyIGNvbG9yIFJHQiBkZWwgc3R5bGVcbiAgICAgIGNvbnN0IGJhY2tncm91bmRTdHlsZSA9IGVsZW1lbnQuc3R5bGUuYmFja2dyb3VuZENvbG9yO1xuICAgICAgaWYgKGJhY2tncm91bmRTdHlsZSkge1xuICAgICAgICBjb25zdCByZ2JNYXRjaCA9IGJhY2tncm91bmRTdHlsZS5tYXRjaCgvXFxkKy9nKTtcbiAgICAgICAgaWYgKHJnYk1hdGNoICYmIHJnYk1hdGNoLmxlbmd0aCA+PSAzKSB7XG4gICAgICAgICAgY29uc3QgcmdiID0gW1xuICAgICAgICAgICAgcGFyc2VJbnQocmdiTWF0Y2hbMF0pLFxuICAgICAgICAgICAgcGFyc2VJbnQocmdiTWF0Y2hbMV0pLFxuICAgICAgICAgICAgcGFyc2VJbnQocmdiTWF0Y2hbMl0pXG4gICAgICAgICAgXTtcbiAgICAgICAgICBcbiAgICAgICAgICBjb25zdCBjb2xvckluZm8gPSB7XG4gICAgICAgICAgICBpZCxcbiAgICAgICAgICAgIGVsZW1lbnQsXG4gICAgICAgICAgICByZ2IsXG4gICAgICAgICAgICBuYW1lOiBlbGVtZW50LnRpdGxlIHx8IGVsZW1lbnQuZ2V0QXR0cmlidXRlKCdhcmlhLWxhYmVsJykgfHwgYENvbG9yICR7aWR9YCxcbiAgICAgICAgICAgIHByZW1pdW06IGVsZW1lbnQuY2xhc3NMaXN0LmNvbnRhaW5zKCdwcmVtaXVtJykgfHwgZWxlbWVudC5xdWVyeVNlbGVjdG9yKCcucHJlbWl1bScpXG4gICAgICAgICAgfTtcbiAgICAgICAgICBcbiAgICAgICAgICBjb2xvcnMucHVzaChjb2xvckluZm8pO1xuICAgICAgICB9XG4gICAgICB9XG4gICAgfVxuICAgIFxuICAgIGxvZyhgW0JMVUUgTUFSQkxFXSAke2NvbG9ycy5sZW5ndGh9IGNvbG9yZXMgZGV0ZWN0YWRvcyBkZWwgc2l0aW9gKTtcbiAgICBcblxuICAgIFxuICAgIHJldHVybiBjb2xvcnM7XG4gIH1cblxuICAvKipcbiAgICogRXN0YWJsZWNlIGxhcyBjb29yZGVuYWRhcyBkZSBwb3NpY2lcdTAwRjNuIChjb21vIEJsdWUgTWFyYmxlKVxuICAgKi9cbiAgc2V0Q29vcmRzKHRpbGVYLCB0aWxlWSwgcGl4ZWxYLCBwaXhlbFkpIHtcbiAgICB0aGlzLmNvb3JkcyA9IFt0aWxlWCwgdGlsZVksIHBpeGVsWCwgcGl4ZWxZXTtcbiAgICBsb2coYFtCTFVFIE1BUkJMRV0gQ29vcmRlbmFkYXMgZXN0YWJsZWNpZGFzOiB0aWxlKCR7dGlsZVh9LCR7dGlsZVl9KSBwaXhlbCgke3BpeGVsWH0sJHtwaXhlbFl9KWApO1xuICB9XG5cbiAgLyoqXG4gICAqIEFuYWxpemEgcFx1MDBFRHhlbGVzIGRlIGxhIGltYWdlbiB5IGN1ZW50YSByZXF1ZXJpZG9zIHZzICNkZWZhY2UgKGNvbW8gQmx1ZSBNYXJibGUpXG4gICAqL1xuICBhc3luYyBhbmFseXplUGl4ZWxzKCkge1xuICAgIGlmICghdGhpcy5iaXRtYXApIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcignSW1hZ2VuIG5vIGNhcmdhZGEuIExsYW1hIGEgbG9hZCgpIHByaW1lcm8uJyk7XG4gICAgfVxuXG4gICAgbG9nKCdbQkxVRSBNQVJCTEVdIEFuYWxpemFuZG8gcFx1MDBFRHhlbGVzIGRlIGxhIGltYWdlbi4uLicpO1xuXG4gICAgdHJ5IHtcbiAgICAgIC8vIENyZWFyIGNhbnZhcyBkZSBpbnNwZWNjaVx1MDBGM24gYSBlc2NhbGEgMToxXG4gICAgICBjb25zdCBpbnNwZWN0Q2FudmFzID0gbmV3IE9mZnNjcmVlbkNhbnZhcyh0aGlzLmltYWdlV2lkdGgsIHRoaXMuaW1hZ2VIZWlnaHQpO1xuICAgICAgY29uc3QgaW5zcGVjdEN0eCA9IGluc3BlY3RDYW52YXMuZ2V0Q29udGV4dCgnMmQnLCB7IHdpbGxSZWFkRnJlcXVlbnRseTogdHJ1ZSB9KTtcbiAgICAgIGluc3BlY3RDdHguaW1hZ2VTbW9vdGhpbmdFbmFibGVkID0gZmFsc2U7XG4gICAgICBpbnNwZWN0Q3R4LmNsZWFyUmVjdCgwLCAwLCB0aGlzLmltYWdlV2lkdGgsIHRoaXMuaW1hZ2VIZWlnaHQpO1xuICAgICAgaW5zcGVjdEN0eC5kcmF3SW1hZ2UodGhpcy5iaXRtYXAsIDAsIDApO1xuICAgICAgY29uc3QgaW5zcGVjdERhdGEgPSBpbnNwZWN0Q3R4LmdldEltYWdlRGF0YSgwLCAwLCB0aGlzLmltYWdlV2lkdGgsIHRoaXMuaW1hZ2VIZWlnaHQpLmRhdGE7XG5cbiAgICAgIGxldCByZXF1aXJlZCA9IDA7XG4gICAgICBsZXQgZGVmYWNlID0gMDtcbiAgICAgIGNvbnN0IHBhbGV0dGVNYXAgPSBuZXcgTWFwKCk7XG5cblxuXG4gICAgICBmb3IgKGxldCB5ID0gMDsgeSA8IHRoaXMuaW1hZ2VIZWlnaHQ7IHkrKykge1xuICAgICAgICBmb3IgKGxldCB4ID0gMDsgeCA8IHRoaXMuaW1hZ2VXaWR0aDsgeCsrKSB7XG4gICAgICAgICAgY29uc3QgaWR4ID0gKHkgKiB0aGlzLmltYWdlV2lkdGggKyB4KSAqIDQ7XG4gICAgICAgICAgY29uc3QgciA9IGluc3BlY3REYXRhW2lkeF07XG4gICAgICAgICAgY29uc3QgZyA9IGluc3BlY3REYXRhW2lkeCArIDFdO1xuICAgICAgICAgIGNvbnN0IGIgPSBpbnNwZWN0RGF0YVtpZHggKyAyXTtcbiAgICAgICAgICBjb25zdCBhID0gaW5zcGVjdERhdGFbaWR4ICsgM107XG5cbiAgICAgICAgICBpZiAoYSA9PT0gMCkgY29udGludWU7IC8vIElnbm9yYXIgcFx1MDBFRHhlbGVzIHRyYW5zcGFyZW50ZXNcbiAgICAgICAgICBcbiAgICAgICAgICBjb25zdCBrZXkgPSBgJHtyfSwke2d9LCR7Yn1gO1xuXG4gICAgICAgICAgLy8gQ29udGFyIHBcdTAwRUR4ZWxlcyAjZGVmYWNlIChtYXJjYWRvciBkZSB0cmFuc3BhcmVuY2lhKVxuICAgICAgICAgIGlmIChyID09PSAyMjIgJiYgZyA9PT0gMjUwICYmIGIgPT09IDIwNikge1xuICAgICAgICAgICAgZGVmYWNlKys7XG4gICAgICAgICAgfVxuXG4gICAgICAgICAgLy8gRnVuY2lcdTAwRjNuIGRlIHRvbGVyYW5jaWEgcGFyYSBjb2xvcmVzIG11eSBwclx1MDBGM3hpbW9zIGFsIGJsYW5jb1xuICAgICAgICAgIGxldCBtYXRjaGVkS2V5ID0ga2V5O1xuICAgICAgICAgIGxldCBpc1ZhbGlkUGl4ZWwgPSB0aGlzLmFsbG93ZWRDb2xvcnNTZXQuaGFzKGtleSk7XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gU2kgbm8gZXMgdW4gY29sb3IgZXhhY3RvLCB2ZXJpZmljYXIgc2kgZXMgbXV5IHByXHUwMEYzeGltbyBhbCBibGFuY29cbiAgICAgICAgICBpZiAoIWlzVmFsaWRQaXhlbCAmJiB0aGlzLmFsbG93ZWRDb2xvcnNTZXQuaGFzKCcyNTUsMjU1LDI1NScpKSB7XG4gICAgICAgICAgICAvLyBUb2xlcmFuY2lhIHBhcmEgcFx1MDBFRHhlbGVzIG11eSBwclx1MDBGM3hpbW9zIGFsIGJsYW5jbyAoZGlmZXJlbmNpYSBtXHUwMEUxeGltYSBkZSAxMCBlbiBjYWRhIGNhbmFsKVxuICAgICAgICAgICAgaWYgKHIgPj0gMjQ1ICYmIGcgPj0gMjQ1ICYmIGIgPj0gMjQ1KSB7XG4gICAgICAgICAgICAgIG1hdGNoZWRLZXkgPSAnMjU1LDI1NSwyNTUnO1xuICAgICAgICAgICAgICBpc1ZhbGlkUGl4ZWwgPSB0cnVlO1xuICAgICAgICAgICAgfVxuICAgICAgICAgIH1cblxuICAgICAgICAgIC8vIFNvbG8gY29udGFyIGNvbG9yZXMgdlx1MDBFMWxpZG9zIChleGFjdG9zIG8gY29uIHRvbGVyYW5jaWEpXG4gICAgICAgICAgaWYgKCFpc1ZhbGlkUGl4ZWwpIGNvbnRpbnVlO1xuXG4gICAgICAgICAgcmVxdWlyZWQrKztcbiAgICAgICAgICBwYWxldHRlTWFwLnNldChtYXRjaGVkS2V5LCAocGFsZXR0ZU1hcC5nZXQobWF0Y2hlZEtleSkgfHwgMCkgKyAxKTtcbiAgICAgICAgfVxuICAgICAgfVxuXG4gICAgICB0aGlzLnJlcXVpcmVkUGl4ZWxDb3VudCA9IHJlcXVpcmVkO1xuICAgICAgdGhpcy5kZWZhY2VQaXhlbENvdW50ID0gZGVmYWNlO1xuXG4gICAgICAvLyBQZXJzaXN0aXIgcGFsZXRhIGNvbiB0b2RvcyBsb3MgY29sb3JlcyBoYWJpbGl0YWRvcyBwb3IgZGVmZWN0b1xuICAgICAgY29uc3QgcGFsZXR0ZU9iaiA9IHt9O1xuICAgICAgZm9yIChjb25zdCBba2V5LCBjb3VudF0gb2YgcGFsZXR0ZU1hcC5lbnRyaWVzKCkpIHtcbiAgICAgICAgcGFsZXR0ZU9ialtrZXldID0geyBjb3VudCwgZW5hYmxlZDogdHJ1ZSB9O1xuICAgICAgfVxuICAgICAgdGhpcy5jb2xvclBhbGV0dGUgPSBwYWxldHRlT2JqO1xuXG4gICAgICBsb2coYFtCTFVFIE1BUkJMRV0gQW5cdTAwRTFsaXNpcyBjb21wbGV0YWRvOmApO1xuICAgICAgbG9nKGAgIC0gUFx1MDBFRHhlbGVzIHJlcXVlcmlkb3M6ICR7cmVxdWlyZWQudG9Mb2NhbGVTdHJpbmcoKX1gKTtcbiAgICAgIGxvZyhgICAtIFBcdTAwRUR4ZWxlcyAjZGVmYWNlOiAke2RlZmFjZS50b0xvY2FsZVN0cmluZygpfWApO1xuICAgICAgbG9nKGAgIC0gQ29sb3JlcyBcdTAwRkFuaWNvczogJHtwYWxldHRlTWFwLnNpemV9YCk7XG5cbiAgICAgIHJldHVybiB7XG4gICAgICAgIHRvdGFsUGl4ZWxzOiB0aGlzLnRvdGFsUGl4ZWxzLFxuICAgICAgICByZXF1aXJlZFBpeGVsczogcmVxdWlyZWQsXG4gICAgICAgIGRlZmFjZVBpeGVsczogZGVmYWNlLFxuICAgICAgICB1bmlxdWVDb2xvcnM6IHBhbGV0dGVNYXAuc2l6ZSxcbiAgICAgICAgY29sb3JQYWxldHRlOiBwYWxldHRlT2JqXG4gICAgICB9O1xuXG4gICAgfSBjYXRjaCAoX2Vycikge1xuICAgICAgLy8gRmFsbGJhY2sgc2kgT2Zmc2NyZWVuQ2FudmFzIG5vIGVzdFx1MDBFMSBkaXNwb25pYmxlXG4gICAgICB0aGlzLnJlcXVpcmVkUGl4ZWxDb3VudCA9IE1hdGgubWF4KDAsIHRoaXMudG90YWxQaXhlbHMpO1xuICAgICAgdGhpcy5kZWZhY2VQaXhlbENvdW50ID0gMDtcbiAgICAgIGxvZygnW0JMVUUgTUFSQkxFXSBGYWxsYmFjazogdXNhbmRvIHRvdGFsIGRlIHBcdTAwRUR4ZWxlcyBjb21vIHJlcXVlcmlkb3MnKTtcbiAgICAgIFxuICAgICAgcmV0dXJuIHtcbiAgICAgICAgdG90YWxQaXhlbHM6IHRoaXMudG90YWxQaXhlbHMsXG4gICAgICAgIHJlcXVpcmVkUGl4ZWxzOiB0aGlzLnRvdGFsUGl4ZWxzLFxuICAgICAgICBkZWZhY2VQaXhlbHM6IDAsXG4gICAgICAgIHVuaXF1ZUNvbG9yczogMCxcbiAgICAgICAgY29sb3JQYWxldHRlOiB7fVxuICAgICAgfTtcbiAgICB9XG4gIH1cblxuICAvKipcbiAgICogQ3JlYSB0aWxlcyBkZSB0ZW1wbGF0ZSAocHJvY2VzbyBwcmluY2lwYWwgZGUgQmx1ZSBNYXJibGUpXG4gICAqL1xuICBhc3luYyBjcmVhdGVUZW1wbGF0ZVRpbGVzKCkge1xuICAgIGlmICghdGhpcy5iaXRtYXApIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcignSW1hZ2VuIG5vIGNhcmdhZGEuIExsYW1hIGEgbG9hZCgpIHByaW1lcm8uJyk7XG4gICAgfVxuXG4gICAgbG9nKCdbQkxVRSBNQVJCTEVdIENyZWFuZG8gdGlsZXMgZGUgdGVtcGxhdGUuLi4nKTtcblxuICAgIGNvbnN0IHRlbXBsYXRlVGlsZXMgPSB7fTtcbiAgICBjb25zdCB0ZW1wbGF0ZVRpbGVzQnVmZmVycyA9IHt9O1xuICAgIFxuICAgIGNvbnN0IGNhbnZhcyA9IG5ldyBPZmZzY3JlZW5DYW52YXModGhpcy50aWxlU2l6ZSwgdGhpcy50aWxlU2l6ZSk7XG4gICAgY29uc3QgY29udGV4dCA9IGNhbnZhcy5nZXRDb250ZXh0KCcyZCcsIHsgd2lsbFJlYWRGcmVxdWVudGx5OiB0cnVlIH0pO1xuXG4gICAgLy8gUGFyYSBjYWRhIHRpbGUgWS4uLlxuICAgIGZvciAobGV0IHBpeGVsWSA9IHRoaXMuY29vcmRzWzNdOyBwaXhlbFkgPCB0aGlzLmltYWdlSGVpZ2h0ICsgdGhpcy5jb29yZHNbM107ICkge1xuICAgICAgXG4gICAgICAvLyBDYWxjdWxhciB0YW1hXHUwMEYxbyBkZSBkaWJ1am8gWVxuICAgICAgY29uc3QgZHJhd1NpemVZID0gTWF0aC5taW4oXG4gICAgICAgIHRoaXMudGlsZVNpemUgLSAocGl4ZWxZICUgdGhpcy50aWxlU2l6ZSksIFxuICAgICAgICB0aGlzLmltYWdlSGVpZ2h0IC0gKHBpeGVsWSAtIHRoaXMuY29vcmRzWzNdKVxuICAgICAgKTtcblxuICAgICAgLy8gUGFyYSBjYWRhIHRpbGUgWC4uLlxuICAgICAgZm9yIChsZXQgcGl4ZWxYID0gdGhpcy5jb29yZHNbMl07IHBpeGVsWCA8IHRoaXMuaW1hZ2VXaWR0aCArIHRoaXMuY29vcmRzWzJdOyApIHtcbiAgICAgICAgXG4gICAgICAgIC8vIENhbGN1bGFyIHRhbWFcdTAwRjFvIGRlIGRpYnVqbyBYXG4gICAgICAgIGNvbnN0IGRyYXdTaXplWCA9IE1hdGgubWluKFxuICAgICAgICAgIHRoaXMudGlsZVNpemUgLSAocGl4ZWxYICUgdGhpcy50aWxlU2l6ZSksIFxuICAgICAgICAgIHRoaXMuaW1hZ2VXaWR0aCAtIChwaXhlbFggLSB0aGlzLmNvb3Jkc1syXSlcbiAgICAgICAgKTtcblxuICAgICAgICAvLyBDYW1iaWFyIHRhbWFcdTAwRjFvIGRlbCBjYW52YXMgeSBsaW1waWFyXG4gICAgICAgIGNvbnN0IGNhbnZhc1dpZHRoID0gZHJhd1NpemVYICogdGhpcy5zaHJlYWRTaXplO1xuICAgICAgICBjb25zdCBjYW52YXNIZWlnaHQgPSBkcmF3U2l6ZVkgKiB0aGlzLnNocmVhZFNpemU7XG4gICAgICAgIGNhbnZhcy53aWR0aCA9IGNhbnZhc1dpZHRoO1xuICAgICAgICBjYW52YXMuaGVpZ2h0ID0gY2FudmFzSGVpZ2h0O1xuXG4gICAgICAgIGNvbnRleHQuaW1hZ2VTbW9vdGhpbmdFbmFibGVkID0gZmFsc2U7IC8vIE5lYXJlc3QgbmVpZ2hib3JcblxuICAgICAgICAvLyBEaWJ1amFyIHNlZ21lbnRvIGRlIHRlbXBsYXRlIGVuIGVzdGUgc2VnbWVudG8gZGUgdGlsZVxuICAgICAgICBjb250ZXh0LmNsZWFyUmVjdCgwLCAwLCBjYW52YXNXaWR0aCwgY2FudmFzSGVpZ2h0KTtcbiAgICAgICAgY29udGV4dC5kcmF3SW1hZ2UoXG4gICAgICAgICAgdGhpcy5iaXRtYXAsIC8vIEJpdG1hcCBkZSBpbWFnZW4gYSBkaWJ1amFyXG4gICAgICAgICAgcGl4ZWxYIC0gdGhpcy5jb29yZHNbMl0sIC8vIENvb3JkZW5hZGEgWCBkZXNkZSBkb25kZSBkaWJ1amFyXG4gICAgICAgICAgcGl4ZWxZIC0gdGhpcy5jb29yZHNbM10sIC8vIENvb3JkZW5hZGEgWSBkZXNkZSBkb25kZSBkaWJ1amFyXG4gICAgICAgICAgZHJhd1NpemVYLCAvLyBBbmNobyBYIGEgZGlidWphciBkZXNkZVxuICAgICAgICAgIGRyYXdTaXplWSwgLy8gQWx0byBZIGEgZGlidWphciBkZXNkZVxuICAgICAgICAgIDAsIC8vIENvb3JkZW5hZGEgWCBkb25kZSBkaWJ1amFyXG4gICAgICAgICAgMCwgLy8gQ29vcmRlbmFkYSBZIGRvbmRlIGRpYnVqYXJcbiAgICAgICAgICBkcmF3U2l6ZVggKiB0aGlzLnNocmVhZFNpemUsIC8vIEFuY2hvIFggZG9uZGUgZGlidWphclxuICAgICAgICAgIGRyYXdTaXplWSAqIHRoaXMuc2hyZWFkU2l6ZSAvLyBBbHRvIFkgZG9uZGUgZGlidWphclxuICAgICAgICApO1xuXG4gICAgICAgIGNvbnN0IGltYWdlRGF0YSA9IGNvbnRleHQuZ2V0SW1hZ2VEYXRhKDAsIDAsIGNhbnZhc1dpZHRoLCBjYW52YXNIZWlnaHQpO1xuXG4gICAgICAgIC8vIFByb2Nlc2FyIHBcdTAwRUR4ZWxlcyAoY29tbyBCbHVlIE1hcmJsZSlcbiAgICAgICAgZm9yIChsZXQgeSA9IDA7IHkgPCBjYW52YXNIZWlnaHQ7IHkrKykge1xuICAgICAgICAgIGZvciAobGV0IHggPSAwOyB4IDwgY2FudmFzV2lkdGg7IHgrKykge1xuICAgICAgICAgICAgY29uc3QgcGl4ZWxJbmRleCA9ICh5ICogY2FudmFzV2lkdGggKyB4KSAqIDQ7XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIC8vIFNpIGVsIHBcdTAwRUR4ZWwgZXMgI2RlZmFjZSwgZGlidWphciBwYXRyXHUwMEYzbiBkZSB0YWJsZXJvIGRlIGFqZWRyZXogdHJhbnNsXHUwMEZBY2lkb1xuICAgICAgICAgICAgaWYgKFxuICAgICAgICAgICAgICBpbWFnZURhdGEuZGF0YVtwaXhlbEluZGV4XSA9PT0gMjIyICYmXG4gICAgICAgICAgICAgIGltYWdlRGF0YS5kYXRhW3BpeGVsSW5kZXggKyAxXSA9PT0gMjUwICYmXG4gICAgICAgICAgICAgIGltYWdlRGF0YS5kYXRhW3BpeGVsSW5kZXggKyAyXSA9PT0gMjA2XG4gICAgICAgICAgICApIHtcbiAgICAgICAgICAgICAgaWYgKCh4ICsgeSkgJSAyID09PSAwKSB7XG4gICAgICAgICAgICAgICAgaW1hZ2VEYXRhLmRhdGFbcGl4ZWxJbmRleF0gPSAwO1xuICAgICAgICAgICAgICAgIGltYWdlRGF0YS5kYXRhW3BpeGVsSW5kZXggKyAxXSA9IDA7XG4gICAgICAgICAgICAgICAgaW1hZ2VEYXRhLmRhdGFbcGl4ZWxJbmRleCArIDJdID0gMDtcbiAgICAgICAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAgICAgICBpbWFnZURhdGEuZGF0YVtwaXhlbEluZGV4XSA9IDI1NTtcbiAgICAgICAgICAgICAgICBpbWFnZURhdGEuZGF0YVtwaXhlbEluZGV4ICsgMV0gPSAyNTU7XG4gICAgICAgICAgICAgICAgaW1hZ2VEYXRhLmRhdGFbcGl4ZWxJbmRleCArIDJdID0gMjU1O1xuICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgIGltYWdlRGF0YS5kYXRhW3BpeGVsSW5kZXggKyAzXSA9IDMyOyAvLyBIYWNlcmxvIHRyYW5zbFx1MDBGQWNpZG9cbiAgICAgICAgICAgIH0gZWxzZSBpZiAoeCAlIHRoaXMuc2hyZWFkU2l6ZSAhPT0gMSB8fCB5ICUgdGhpcy5zaHJlYWRTaXplICE9PSAxKSB7XG4gICAgICAgICAgICAgIC8vIFNvbG8gZGlidWphciBlbCBwXHUwMEVEeGVsIGNlbnRyYWxcbiAgICAgICAgICAgICAgaW1hZ2VEYXRhLmRhdGFbcGl4ZWxJbmRleCArIDNdID0gMDsgLy8gSGFjZXIgcFx1MDBFRHhlbCB0cmFuc3BhcmVudGVcbiAgICAgICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgICAgIC8vIFBcdTAwRUR4ZWwgY2VudHJhbDogbWFudGVuZXIgc29sbyBzaSBlc3RcdTAwRTEgZW4gbGEgcGFsZXRhIHBlcm1pdGlkYSBkZWwgc2l0aW9cbiAgICAgICAgICAgICAgY29uc3QgciA9IGltYWdlRGF0YS5kYXRhW3BpeGVsSW5kZXhdO1xuICAgICAgICAgICAgICBjb25zdCBnID0gaW1hZ2VEYXRhLmRhdGFbcGl4ZWxJbmRleCArIDFdO1xuICAgICAgICAgICAgICBjb25zdCBiID0gaW1hZ2VEYXRhLmRhdGFbcGl4ZWxJbmRleCArIDJdO1xuICAgICAgICAgICAgICBpZiAoIXRoaXMuYWxsb3dlZENvbG9yc1NldC5oYXMoYCR7cn0sJHtnfSwke2J9YCkpIHtcbiAgICAgICAgICAgICAgICBpbWFnZURhdGEuZGF0YVtwaXhlbEluZGV4ICsgM10gPSAwOyAvLyBvY3VsdGFyIGNvbG9yZXMgbm8tcGFsZXRhXG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH1cbiAgICAgICAgICB9XG4gICAgICAgIH1cblxuICAgICAgICBjb250ZXh0LnB1dEltYWdlRGF0YShpbWFnZURhdGEsIDAsIDApO1xuXG4gICAgICAgIC8vIENyZWFyIG5vbWJyZSBkZSB0aWxlIHRlbXBsYXRlIFwiMDAwMCwwMDAwLDAwMCwwMDBcIlxuICAgICAgICBjb25zdCB0ZW1wbGF0ZVRpbGVOYW1lID0gYCR7KHRoaXMuY29vcmRzWzBdICsgTWF0aC5mbG9vcihwaXhlbFggLyAxMDAwKSlcbiAgICAgICAgICAudG9TdHJpbmcoKVxuICAgICAgICAgIC5wYWRTdGFydCg0LCAnMCcpfSwkeyh0aGlzLmNvb3Jkc1sxXSArIE1hdGguZmxvb3IocGl4ZWxZIC8gMTAwMCkpXG4gICAgICAgICAgLnRvU3RyaW5nKClcbiAgICAgICAgICAucGFkU3RhcnQoNCwgJzAnKX0sJHsocGl4ZWxYICUgMTAwMClcbiAgICAgICAgICAudG9TdHJpbmcoKVxuICAgICAgICAgIC5wYWRTdGFydCgzLCAnMCcpfSwkeyhwaXhlbFkgJSAxMDAwKS50b1N0cmluZygpLnBhZFN0YXJ0KDMsICcwJyl9YDtcblxuICAgICAgICB0ZW1wbGF0ZVRpbGVzW3RlbXBsYXRlVGlsZU5hbWVdID0gYXdhaXQgY3JlYXRlSW1hZ2VCaXRtYXAoY2FudmFzKTtcbiAgICAgICAgXG4gICAgICAgIC8vIFJlZ2lzdHJhciBwcmVmaWpvIGRlIHRpbGUgcGFyYSBiXHUwMEZBc3F1ZWRhIHJcdTAwRTFwaWRhXG4gICAgICAgIHRoaXMudGlsZVByZWZpeGVzLmFkZCh0ZW1wbGF0ZVRpbGVOYW1lLnNwbGl0KCcsJykuc2xpY2UoMCwgMikuam9pbignLCcpKTtcbiAgICAgICAgXG4gICAgICAgIC8vIEFsbWFjZW5hciBidWZmZXIgcGFyYSBzZXJpYWxpemFjaVx1MDBGM25cbiAgICAgICAgY29uc3QgY2FudmFzQmxvYiA9IGF3YWl0IGNhbnZhcy5jb252ZXJ0VG9CbG9iKCk7XG4gICAgICAgIGNvbnN0IGNhbnZhc0J1ZmZlciA9IGF3YWl0IGNhbnZhc0Jsb2IuYXJyYXlCdWZmZXIoKTtcbiAgICAgICAgdGVtcGxhdGVUaWxlc0J1ZmZlcnNbdGVtcGxhdGVUaWxlTmFtZV0gPSBjYW52YXNCdWZmZXI7XG5cbiAgICAgICAgcGl4ZWxYICs9IGRyYXdTaXplWDtcbiAgICAgIH1cblxuICAgICAgcGl4ZWxZICs9IGRyYXdTaXplWTtcbiAgICB9XG5cbiAgICB0aGlzLnRlbXBsYXRlVGlsZXMgPSB0ZW1wbGF0ZVRpbGVzO1xuICAgIHRoaXMudGVtcGxhdGVUaWxlc0J1ZmZlcnMgPSB0ZW1wbGF0ZVRpbGVzQnVmZmVycztcblxuICAgIGxvZyhgW0JMVUUgTUFSQkxFXSBUaWxlcyBjcmVhZG9zOiAke09iamVjdC5rZXlzKHRlbXBsYXRlVGlsZXMpLmxlbmd0aH0gdGlsZXNgKTtcbiAgICBsb2coYFtCTFVFIE1BUkJMRV0gUHJlZmlqb3MgcmVnaXN0cmFkb3M6ICR7dGhpcy50aWxlUHJlZml4ZXMuc2l6ZX0gdGlsZXMgXHUwMEZBbmljb3NgKTtcblxuICAgIHJldHVybiB7IHRlbXBsYXRlVGlsZXMsIHRlbXBsYXRlVGlsZXNCdWZmZXJzIH07XG4gIH1cblxuICAvKipcbiAgICogR2VuZXJhIGNvbGEgZGUgcFx1MDBFRHhlbGVzIHBhcmEgcGludGFyIChjb21wYXRpYmxlIGNvbiBBdXRvLUltYWdlKVxuICAgKi9cbiAgZ2VuZXJhdGVQaXhlbFF1ZXVlKCkge1xuICAgIGlmICghdGhpcy5iaXRtYXApIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcignSW1hZ2VuIG5vIGNhcmdhZGEuIExsYW1hIGEgbG9hZCgpIHByaW1lcm8uJyk7XG4gICAgfVxuXG4gICAgbG9nKCdbQkxVRSBNQVJCTEVdIEdlbmVyYW5kbyBjb2xhIGRlIHBcdTAwRUR4ZWxlcy4uLicpO1xuXG4gICAgY29uc3QgcXVldWUgPSBbXTtcbiAgICBjb25zdCBiYXNlWCA9IHRoaXMuY29vcmRzWzBdICogMTAwMCArICh0aGlzLmNvb3Jkc1syXSB8fCAwKTsgLy8gQ29vcmRlbmFkYSBnbG9iYWwgYmFzZSBYXG4gICAgY29uc3QgYmFzZVkgPSB0aGlzLmNvb3Jkc1sxXSAqIDEwMDAgKyAodGhpcy5jb29yZHNbM10gfHwgMCk7IC8vIENvb3JkZW5hZGEgZ2xvYmFsIGJhc2UgWVxuXG4gICAgLy8gVXNhciBjYW52YXMgMToxIHBhcmEgbGVlciBwXHUwMEVEeGVsZXMgZXhhY3Rvc1xuICAgIGNvbnN0IHJlYWRDYW52YXMgPSBuZXcgT2Zmc2NyZWVuQ2FudmFzKHRoaXMuaW1hZ2VXaWR0aCwgdGhpcy5pbWFnZUhlaWdodCk7XG4gICAgY29uc3QgcmVhZEN0eCA9IHJlYWRDYW52YXMuZ2V0Q29udGV4dCgnMmQnLCB7IHdpbGxSZWFkRnJlcXVlbnRseTogdHJ1ZSB9KTtcbiAgICByZWFkQ3R4LmltYWdlU21vb3RoaW5nRW5hYmxlZCA9IGZhbHNlO1xuICAgIHJlYWRDdHguZHJhd0ltYWdlKHRoaXMuYml0bWFwLCAwLCAwKTtcbiAgICBjb25zdCBwaXhlbERhdGEgPSByZWFkQ3R4LmdldEltYWdlRGF0YSgwLCAwLCB0aGlzLmltYWdlV2lkdGgsIHRoaXMuaW1hZ2VIZWlnaHQpLmRhdGE7XG5cbiAgICBmb3IgKGxldCB5ID0gMDsgeSA8IHRoaXMuaW1hZ2VIZWlnaHQ7IHkrKykge1xuICAgICAgZm9yIChsZXQgeCA9IDA7IHggPCB0aGlzLmltYWdlV2lkdGg7IHgrKykge1xuICAgICAgICBjb25zdCBpZHggPSAoeSAqIHRoaXMuaW1hZ2VXaWR0aCArIHgpICogNDtcbiAgICAgICAgY29uc3QgciA9IHBpeGVsRGF0YVtpZHhdO1xuICAgICAgICBjb25zdCBnID0gcGl4ZWxEYXRhW2lkeCArIDFdO1xuICAgICAgICBjb25zdCBiID0gcGl4ZWxEYXRhW2lkeCArIDJdO1xuICAgICAgICBjb25zdCBhbHBoYSA9IHBpeGVsRGF0YVtpZHggKyAzXTtcblxuICAgICAgICAvLyBGaWx0cmFyIHBcdTAwRUR4ZWxlcyB0cmFuc3BhcmVudGVzXG4gICAgICAgIGlmIChhbHBoYSA9PT0gMCkgY29udGludWU7XG5cbiAgICAgICAgLy8gRmlsdHJhciBwXHUwMEVEeGVsZXMgI2RlZmFjZSAoc2UgcmVuZGVyaXphbiBjb21vIHRyYW5zcGFyZW50ZXMpXG4gICAgICAgIGlmIChyID09PSAyMjIgJiYgZyA9PT0gMjUwICYmIGIgPT09IDIwNikgY29udGludWU7XG5cbiAgICAgICAgY29uc3QgY29sb3JLZXkgPSBgJHtyfSwke2d9LCR7Yn1gO1xuICAgICAgICBcbiAgICAgICAgLy8gU29sbyBpbmNsdWlyIGNvbG9yZXMgZGUgbGEgcGFsZXRhIGRlbCBzaXRpb1xuICAgICAgICBpZiAoIXRoaXMuYWxsb3dlZENvbG9yc1NldC5oYXMoY29sb3JLZXkpKSBjb250aW51ZTtcblxuICAgICAgICAvLyBDYWxjdWxhciBjb29yZGVuYWRhcyBnbG9iYWxlc1xuICAgICAgICBjb25zdCBnbG9iYWxYID0gYmFzZVggKyB4O1xuICAgICAgICBjb25zdCBnbG9iYWxZID0gYmFzZVkgKyB5O1xuXG4gICAgICAgIC8vIENhbGN1bGFyIGNvb3JkZW5hZGFzIGRlIHRpbGVcbiAgICAgICAgY29uc3QgdGlsZVggPSBNYXRoLmZsb29yKGdsb2JhbFggLyAxMDAwKTtcbiAgICAgICAgY29uc3QgdGlsZVkgPSBNYXRoLmZsb29yKGdsb2JhbFkgLyAxMDAwKTtcbiAgICAgICAgY29uc3QgbG9jYWxYID0gZ2xvYmFsWCAlIDEwMDA7XG4gICAgICAgIGNvbnN0IGxvY2FsWSA9IGdsb2JhbFkgJSAxMDAwO1xuXG4gICAgICAgIC8vIE9idGVuZXIgbWV0YWRhdG9zIGRlbCBjb2xvclxuICAgICAgICBjb25zdCBjb2xvck1ldGEgPSB0aGlzLnJnYlRvTWV0YS5nZXQoY29sb3JLZXkpIHx8IHsgaWQ6IDAsIG5hbWU6ICdVbmtub3duJyB9O1xuXG4gICAgICAgIHF1ZXVlLnB1c2goe1xuICAgICAgICAgIC8vIENvb3JkZW5hZGFzIGRlIGltYWdlbiAocmVsYXRpdmFzKVxuICAgICAgICAgIGltYWdlWDogeCxcbiAgICAgICAgICBpbWFnZVk6IHksXG4gICAgICAgICAgLy8gQ29vcmRlbmFkYXMgZ2xvYmFsZXNcbiAgICAgICAgICBnbG9iYWxYOiBnbG9iYWxYLFxuICAgICAgICAgIGdsb2JhbFk6IGdsb2JhbFksXG4gICAgICAgICAgLy8gQ29vcmRlbmFkYXMgZGUgdGlsZS9sb2NhbFxuICAgICAgICAgIHRpbGVYOiB0aWxlWCxcbiAgICAgICAgICB0aWxlWTogdGlsZVksXG4gICAgICAgICAgbG9jYWxYOiBsb2NhbFgsXG4gICAgICAgICAgbG9jYWxZOiBsb2NhbFksXG4gICAgICAgICAgLy8gSW5mb3JtYWNpXHUwMEYzbiBkZSBjb2xvclxuICAgICAgICAgIGNvbG9yOiB7XG4gICAgICAgICAgICByOiByLFxuICAgICAgICAgICAgZzogZyxcbiAgICAgICAgICAgIGI6IGIsXG4gICAgICAgICAgICBpZDogY29sb3JNZXRhLmlkLFxuICAgICAgICAgICAgbmFtZTogY29sb3JNZXRhLm5hbWVcbiAgICAgICAgICB9LFxuICAgICAgICAgIG9yaWdpbmFsQ29sb3I6IHsgciwgZywgYiwgYWxwaGEgfVxuICAgICAgICB9KTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICBsb2coYFtCTFVFIE1BUkJMRV0gQ29sYSBnZW5lcmFkYTogJHtxdWV1ZS5sZW5ndGh9IHBcdTAwRUR4ZWxlcyB2XHUwMEUxbGlkb3NgKTtcbiAgICByZXR1cm4gcXVldWU7XG4gIH1cblxuICAvKipcbiAgICogUmVkaW1lbnNpb25hIGxhIGltYWdlbiAocHJlc2VydmEgcHJvcG9yY2lvbmVzIHBvciBkZWZlY3RvKVxuICAgKi9cbiAgYXN5bmMgcmVzaXplKG5ld1dpZHRoLCBuZXdIZWlnaHQsIGtlZXBBc3BlY3RSYXRpbyA9IHRydWUpIHtcbiAgICBpZiAoIXRoaXMuaW1nKSB7XG4gICAgICB0aHJvdyBuZXcgRXJyb3IoJ0ltYWdlbiBubyBjYXJnYWRhLiBMbGFtYSBhIGxvYWQoKSBwcmltZXJvLicpO1xuICAgIH1cblxuICAgIGNvbnN0IG9yaWdpbmFsV2lkdGggPSB0aGlzLmltZy53aWR0aDtcbiAgICBjb25zdCBvcmlnaW5hbEhlaWdodCA9IHRoaXMuaW1nLmhlaWdodDtcblxuICAgIGlmIChrZWVwQXNwZWN0UmF0aW8pIHtcbiAgICAgIGNvbnN0IGFzcGVjdFJhdGlvID0gb3JpZ2luYWxXaWR0aCAvIG9yaWdpbmFsSGVpZ2h0O1xuICAgICAgaWYgKG5ld1dpZHRoIC8gbmV3SGVpZ2h0ID4gYXNwZWN0UmF0aW8pIHtcbiAgICAgICAgbmV3V2lkdGggPSBuZXdIZWlnaHQgKiBhc3BlY3RSYXRpbztcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIG5ld0hlaWdodCA9IG5ld1dpZHRoIC8gYXNwZWN0UmF0aW87XG4gICAgICB9XG4gICAgfVxuXG4gICAgLy8gQ3JlYXIgbnVldmEgaW1hZ2VuIHJlZGltZW5zaW9uYWRhXG4gICAgY29uc3QgdGVtcENhbnZhcyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2NhbnZhcycpO1xuICAgIHRlbXBDYW52YXMud2lkdGggPSBuZXdXaWR0aDtcbiAgICB0ZW1wQ2FudmFzLmhlaWdodCA9IG5ld0hlaWdodDtcbiAgICBjb25zdCB0ZW1wQ3R4ID0gdGVtcENhbnZhcy5nZXRDb250ZXh0KCcyZCcpO1xuICAgIHRlbXBDdHguaW1hZ2VTbW9vdGhpbmdFbmFibGVkID0gZmFsc2U7IC8vIFBpeGVsIGFydFxuICAgIHRlbXBDdHguZHJhd0ltYWdlKHRoaXMuaW1nLCAwLCAwLCBuZXdXaWR0aCwgbmV3SGVpZ2h0KTtcblxuICAgIC8vIEFjdHVhbGl6YXIgaW1hZ2VuIHkgYml0bWFwXG4gICAgY29uc3QgbmV3RGF0YVVybCA9IHRlbXBDYW52YXMudG9EYXRhVVJMKCk7XG4gICAgdGhpcy5pbWcuc3JjID0gbmV3RGF0YVVybDtcbiAgICB0aGlzLmltYWdlU3JjID0gbmV3RGF0YVVybDtcblxuICAgIGF3YWl0IG5ldyBQcm9taXNlKHJlc29sdmUgPT4ge1xuICAgICAgdGhpcy5pbWcub25sb2FkID0gYXN5bmMgKCkgPT4ge1xuICAgICAgICB0aGlzLmJpdG1hcCA9IGF3YWl0IGNyZWF0ZUltYWdlQml0bWFwKHRoaXMuaW1nKTtcbiAgICAgICAgdGhpcy5pbWFnZVdpZHRoID0gdGhpcy5iaXRtYXAud2lkdGg7XG4gICAgICAgIHRoaXMuaW1hZ2VIZWlnaHQgPSB0aGlzLmJpdG1hcC5oZWlnaHQ7XG4gICAgICAgIHRoaXMudG90YWxQaXhlbHMgPSB0aGlzLmltYWdlV2lkdGggKiB0aGlzLmltYWdlSGVpZ2h0O1xuICAgICAgICByZXNvbHZlKCk7XG4gICAgICB9O1xuICAgIH0pO1xuXG4gICAgbG9nKGBbQkxVRSBNQVJCTEVdIEltYWdlbiByZWRpbWVuc2lvbmFkYTogJHtvcmlnaW5hbFdpZHRofVx1MDBENyR7b3JpZ2luYWxIZWlnaHR9IFx1MjE5MiAke3RoaXMuaW1hZ2VXaWR0aH1cdTAwRDcke3RoaXMuaW1hZ2VIZWlnaHR9YCk7XG4gICAgXG4gICAgcmV0dXJuIHtcbiAgICAgIHdpZHRoOiB0aGlzLmltYWdlV2lkdGgsXG4gICAgICBoZWlnaHQ6IHRoaXMuaW1hZ2VIZWlnaHRcbiAgICB9O1xuICB9XG5cbiAgLyoqXG4gICAqIE9idGllbmUgaW5mb3JtYWNpXHUwMEYzbiBjb21wbGV0YSBkZSBsYSBpbWFnZW4gcHJvY2VzYWRhXG4gICAqL1xuICBnZXRJbWFnZURhdGEoKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIHdpZHRoOiB0aGlzLmltYWdlV2lkdGgsXG4gICAgICBoZWlnaHQ6IHRoaXMuaW1hZ2VIZWlnaHQsXG4gICAgICB0b3RhbFBpeGVsczogdGhpcy50b3RhbFBpeGVscyxcbiAgICAgIHJlcXVpcmVkUGl4ZWxzOiB0aGlzLnJlcXVpcmVkUGl4ZWxDb3VudCxcbiAgICAgIGRlZmFjZVBpeGVsczogdGhpcy5kZWZhY2VQaXhlbENvdW50LFxuICAgICAgY29sb3JQYWxldHRlOiB0aGlzLmNvbG9yUGFsZXR0ZSxcbiAgICAgIGNvb3JkczogWy4uLnRoaXMuY29vcmRzXSxcbiAgICAgIG9yaWdpbmFsTmFtZTogdGhpcy5vcmlnaW5hbE5hbWUgfHwgJ2ltYWdlLnBuZycsXG4gICAgICAvLyBQYXJhIGNvbXBhdGliaWxpZGFkIGNvbiBBdXRvLUltYWdlIGFjdHVhbFxuICAgICAgcGl4ZWxzOiB0aGlzLmdlbmVyYXRlUGl4ZWxRdWV1ZSgpXG4gICAgfTtcbiAgfVxuXG4gIC8qKlxuICAgKiBHZW5lcmEgcHJldmlldyBkZSBsYSBpbWFnZW5cbiAgICovXG4gIGdlbmVyYXRlUHJldmlldyhtYXhXaWR0aCA9IDIwMCwgbWF4SGVpZ2h0ID0gMjAwKSB7XG4gICAgaWYgKCF0aGlzLmltZykgcmV0dXJuIG51bGw7XG5cbiAgICBjb25zdCBjYW52YXMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdjYW52YXMnKTtcbiAgICBjb25zdCBjdHggPSBjYW52YXMuZ2V0Q29udGV4dCgnMmQnKTtcblxuICAgIGNvbnN0IHsgd2lkdGg6IG9yaWdXaWR0aCwgaGVpZ2h0OiBvcmlnSGVpZ2h0IH0gPSB0aGlzLmltZztcbiAgICBjb25zdCBhc3BlY3RSYXRpbyA9IG9yaWdXaWR0aCAvIG9yaWdIZWlnaHQ7XG5cbiAgICBsZXQgbmV3V2lkdGgsIG5ld0hlaWdodDtcbiAgICBpZiAobWF4V2lkdGggLyBtYXhIZWlnaHQgPiBhc3BlY3RSYXRpbykge1xuICAgICAgbmV3SGVpZ2h0ID0gbWF4SGVpZ2h0O1xuICAgICAgbmV3V2lkdGggPSBtYXhIZWlnaHQgKiBhc3BlY3RSYXRpbztcbiAgICB9IGVsc2Uge1xuICAgICAgbmV3V2lkdGggPSBtYXhXaWR0aDtcbiAgICAgIG5ld0hlaWdodCA9IG1heFdpZHRoIC8gYXNwZWN0UmF0aW87XG4gICAgfVxuXG4gICAgY2FudmFzLndpZHRoID0gbmV3V2lkdGg7XG4gICAgY2FudmFzLmhlaWdodCA9IG5ld0hlaWdodDtcbiAgICBjdHguaW1hZ2VTbW9vdGhpbmdFbmFibGVkID0gZmFsc2U7XG4gICAgY3R4LmRyYXdJbWFnZSh0aGlzLmltZywgMCwgMCwgbmV3V2lkdGgsIG5ld0hlaWdodCk7XG5cbiAgICByZXR1cm4gY2FudmFzLnRvRGF0YVVSTCgpO1xuICB9XG5cbiAgZ2V0RGltZW5zaW9ucygpIHtcbiAgICByZXR1cm4ge1xuICAgICAgd2lkdGg6IHRoaXMuaW1hZ2VXaWR0aCxcbiAgICAgIGhlaWdodDogdGhpcy5pbWFnZUhlaWdodFxuICAgIH07XG4gIH1cbn1cblxuLy8gTWFudGVuZXIgZXhwb3J0cyBkZSBmdW5jaW9uZXMgcGFyYSBjb21wYXRpYmlsaWRhZFxuZXhwb3J0IHsgZGV0ZWN0QXZhaWxhYmxlQ29sb3JzIH0gZnJvbSBcIi4vcHJvY2Vzc29yLmpzXCI7XG5cbmV4cG9ydCBmdW5jdGlvbiBmaW5kQ2xvc2VzdENvbG9yKHJnYiwgcGFsZXR0ZSkge1xuICBpZiAoIXBhbGV0dGUgfHwgcGFsZXR0ZS5sZW5ndGggPT09IDApIHJldHVybiBudWxsO1xuICBcbiAgbGV0IGNsb3Nlc3RDb2xvciA9IG51bGw7XG4gIGxldCBtaW5EaXN0YW5jZSA9IEluZmluaXR5O1xuICBcbiAgZm9yIChjb25zdCBjb2xvciBvZiBwYWxldHRlKSB7XG4gICAgY29uc3QgY29sb3JSZ2IgPSBjb2xvci5yZ2IgfHwgY29sb3I7XG4gICAgY29uc3QgZGlzdGFuY2UgPSBNYXRoLnNxcnQoXG4gICAgICBNYXRoLnBvdyhyZ2IuciAtIGNvbG9yUmdiLnIsIDIpICtcbiAgICAgIE1hdGgucG93KHJnYi5nIC0gY29sb3JSZ2IuZywgMikgK1xuICAgICAgTWF0aC5wb3cocmdiLmIgLSBjb2xvclJnYi5iLCAyKVxuICAgICk7XG4gICAgXG4gICAgaWYgKGRpc3RhbmNlIDwgbWluRGlzdGFuY2UpIHtcbiAgICAgIG1pbkRpc3RhbmNlID0gZGlzdGFuY2U7XG4gICAgICBjbG9zZXN0Q29sb3IgPSBjb2xvcjtcbiAgICB9XG4gIH1cbiAgXG4gIHJldHVybiBjbG9zZXN0Q29sb3I7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBnZW5lcmF0ZVBpeGVsUXVldWUoaW1hZ2VEYXRhLCBzdGFydFBvc2l0aW9uLCB0aWxlWCwgdGlsZVkpIHtcbiAgLy8gRXN0YSBmdW5jaVx1MDBGM24gYWhvcmEgZXMgbWFuZWphZGEgcG9yIEJsdWVNYXJibGVsSW1hZ2VQcm9jZXNzb3IuZ2VuZXJhdGVQaXhlbFF1ZXVlKClcbiAgLy8gTWFudGVuaWRhIHBhcmEgY29tcGF0aWJpbGlkYWRcbiAgY29uc3QgeyBwaXhlbHMgfSA9IGltYWdlRGF0YTtcbiAgY29uc3QgeyB4OiBsb2NhbFN0YXJ0WCwgeTogbG9jYWxTdGFydFkgfSA9IHN0YXJ0UG9zaXRpb247XG4gIGNvbnN0IHF1ZXVlID0gW107XG5cbiAgZm9yIChjb25zdCBwaXhlbERhdGEgb2YgcGl4ZWxzKSB7XG4gICAgaWYgKCFwaXhlbERhdGEpIGNvbnRpbnVlO1xuICAgIFxuICAgIGNvbnN0IGdsb2JhbFggPSBsb2NhbFN0YXJ0WCArIHBpeGVsRGF0YS5pbWFnZVg7XG4gICAgY29uc3QgZ2xvYmFsWSA9IGxvY2FsU3RhcnRZICsgcGl4ZWxEYXRhLmltYWdlWTtcbiAgICBcbiAgICBxdWV1ZS5wdXNoKHtcbiAgICAgIGltYWdlWDogcGl4ZWxEYXRhLmltYWdlWCxcbiAgICAgIGltYWdlWTogcGl4ZWxEYXRhLmltYWdlWSxcbiAgICAgIGxvY2FsWDogZ2xvYmFsWCxcbiAgICAgIGxvY2FsWTogZ2xvYmFsWSxcbiAgICAgIHRpbGVYOiB0aWxlWCxcbiAgICAgIHRpbGVZOiB0aWxlWSxcbiAgICAgIGNvbG9yOiBwaXhlbERhdGEuY29sb3IsXG4gICAgICBvcmlnaW5hbENvbG9yOiBwaXhlbERhdGEub3JpZ2luYWxDb2xvclxuICAgIH0pO1xuICB9XG5cbiAgbG9nKGBDb2xhIGRlIHBcdTAwRUR4ZWxlcyBnZW5lcmFkYSAoY29tcGF0aWJpbGlkYWQpOiAke3F1ZXVlLmxlbmd0aH0gcFx1MDBFRHhlbGVzYCk7XG4gIHJldHVybiBxdWV1ZTtcbn1cbiIsICJleHBvcnQgY29uc3Qgc2xlZXAgPSAobXMpID0+IG5ldyBQcm9taXNlKHIgPT4gc2V0VGltZW91dChyLCBtcykpO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcmV0cnkoZm4sIHsgdHJpZXMgPSAzLCBiYXNlID0gNTAwIH0gPSB7fSkge1xuICBsZXQgbGFzdDtcbiAgZm9yIChsZXQgaSA9IDA7IGkgPCB0cmllczsgaSsrKSB7XG4gICAgdHJ5IHsgcmV0dXJuIGF3YWl0IGZuKCk7IH1cbiAgICBjYXRjaCAoZSkgeyBsYXN0ID0gZTsgYXdhaXQgc2xlZXAoYmFzZSAqIDIgKiogaSk7IH1cbiAgfVxuICB0aHJvdyBsYXN0O1xufVxuXG5leHBvcnQgY29uc3QgcmFuZEludCA9IChuKSA9PiBNYXRoLmZsb29yKE1hdGgucmFuZG9tKCkgKiBuKTtcblxuLy8gU2xlZXAgd2l0aCBjb3VudGRvd24gKGZyb20gZmFybSlcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBzbGVlcFdpdGhDb3VudGRvd24obXMsIG9uVXBkYXRlLCBzdGF0ZSkge1xuICBjb25zdCBzdGFydFRpbWUgPSBEYXRlLm5vdygpO1xuICBjb25zdCBlbmRUaW1lID0gc3RhcnRUaW1lICsgbXM7XG4gIFxuICB3aGlsZSAoRGF0ZS5ub3coKSA8IGVuZFRpbWUgJiYgKCFzdGF0ZSB8fCBzdGF0ZS5ydW5uaW5nKSkge1xuICAgIGNvbnN0IHJlbWFpbmluZyA9IGVuZFRpbWUgLSBEYXRlLm5vdygpO1xuICAgIFxuICAgIGlmIChvblVwZGF0ZSkge1xuICAgICAgb25VcGRhdGUocmVtYWluaW5nKTtcbiAgICB9XG4gICAgXG4gICAgYXdhaXQgc2xlZXAoTWF0aC5taW4oMTAwMCwgcmVtYWluaW5nKSk7XG4gIH1cbn1cbiIsICJpbXBvcnQgeyBmZXRjaFdpdGhUaW1lb3V0IH0gZnJvbSBcIi4vaHR0cC5qc1wiO1xuXG5jb25zdCBCQVNFID0gXCJodHRwczovL2JhY2tlbmQud3BsYWNlLmxpdmVcIjtcblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGdldFNlc3Npb24oKSB7XG4gIHRyeSB7XG4gICAgY29uc3QgbWUgPSBhd2FpdCBmZXRjaChgJHtCQVNFfS9tZWAsIHsgY3JlZGVudGlhbHM6ICdpbmNsdWRlJyB9KS50aGVuKHIgPT4gci5qc29uKCkpO1xuICAgIGNvbnN0IHVzZXIgPSBtZSB8fCBudWxsO1xuICAgIGNvbnN0IGMgPSBtZT8uY2hhcmdlcyB8fCB7fTtcbiAgICBjb25zdCBjaGFyZ2VzID0ge1xuICAgICAgY291bnQ6IGMuY291bnQgPz8gMCwgICAgICAgIC8vIE1hbnRlbmVyIHZhbG9yIGRlY2ltYWwgb3JpZ2luYWxcbiAgICAgIG1heDogYy5tYXggPz8gMCwgICAgICAgICAgICAvLyBNYW50ZW5lciB2YWxvciBvcmlnaW5hbCAocHVlZGUgdmFyaWFyIHBvciB1c3VhcmlvKVxuICAgICAgY29vbGRvd25NczogYy5jb29sZG93bk1zID8/IDMwMDAwXG4gICAgfTtcbiAgICBcbiAgICByZXR1cm4geyBcbiAgICAgIHN1Y2Nlc3M6IHRydWUsXG4gICAgICBkYXRhOiB7XG4gICAgICAgIHVzZXIsIFxuICAgICAgICBjaGFyZ2VzOiBjaGFyZ2VzLmNvdW50LFxuICAgICAgICBtYXhDaGFyZ2VzOiBjaGFyZ2VzLm1heCxcbiAgICAgICAgY2hhcmdlUmVnZW46IGNoYXJnZXMuY29vbGRvd25Nc1xuICAgICAgfVxuICAgIH07XG4gIH0gY2F0Y2ggKGVycm9yKSB7IFxuICAgIHJldHVybiB7IFxuICAgICAgc3VjY2VzczogZmFsc2UsXG4gICAgICBlcnJvcjogZXJyb3IubWVzc2FnZSxcbiAgICAgIGRhdGE6IHtcbiAgICAgICAgdXNlcjogbnVsbCwgXG4gICAgICAgIGNoYXJnZXM6IDAsXG4gICAgICAgIG1heENoYXJnZXM6IDAsXG4gICAgICAgIGNoYXJnZVJlZ2VuOiAzMDAwMFxuICAgICAgfVxuICAgIH07IFxuICB9XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBjaGVja0hlYWx0aCgpIHtcbiAgdHJ5IHtcbiAgICBjb25zdCByZXNwb25zZSA9IGF3YWl0IGZldGNoKGAke0JBU0V9L2hlYWx0aGAsIHtcbiAgICAgIG1ldGhvZDogJ0dFVCcsXG4gICAgICBjcmVkZW50aWFsczogJ2luY2x1ZGUnXG4gICAgfSk7XG4gICAgXG4gICAgaWYgKHJlc3BvbnNlLm9rKSB7XG4gICAgICBjb25zdCBoZWFsdGggPSBhd2FpdCByZXNwb25zZS5qc29uKCk7XG4gICAgICByZXR1cm4ge1xuICAgICAgICAuLi5oZWFsdGgsXG4gICAgICAgIGxhc3RDaGVjazogRGF0ZS5ub3coKSxcbiAgICAgICAgc3RhdHVzOiAnb25saW5lJ1xuICAgICAgfTtcbiAgICB9IGVsc2Uge1xuICAgICAgcmV0dXJuIHtcbiAgICAgICAgZGF0YWJhc2U6IGZhbHNlLFxuICAgICAgICB1cDogZmFsc2UsXG4gICAgICAgIHVwdGltZTogJ04vQScsXG4gICAgICAgIGxhc3RDaGVjazogRGF0ZS5ub3coKSxcbiAgICAgICAgc3RhdHVzOiAnZXJyb3InLFxuICAgICAgICBzdGF0dXNDb2RlOiByZXNwb25zZS5zdGF0dXNcbiAgICAgIH07XG4gICAgfVxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIHJldHVybiB7XG4gICAgICBkYXRhYmFzZTogZmFsc2UsXG4gICAgICB1cDogZmFsc2UsXG4gICAgICB1cHRpbWU6ICdOL0EnLFxuICAgICAgbGFzdENoZWNrOiBEYXRlLm5vdygpLFxuICAgICAgc3RhdHVzOiAnb2ZmbGluZScsXG4gICAgICBlcnJvcjogZXJyb3IubWVzc2FnZVxuICAgIH07XG4gIH1cbn1cblxuLy8gVW5pZmljYSBwb3N0IGRlIHBcdTAwRUR4ZWwgcG9yIGxvdGVzIChiYXRjaCBwb3IgdGlsZSkuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcG9zdFBpeGVsQmF0Y2goeyB0aWxlWCwgdGlsZVksIHBpeGVscywgdHVybnN0aWxlVG9rZW4gfSkge1xuICAvLyBwaXhlbHM6IFt7eCx5LGNvbG9yfSwgXHUyMDI2XSByZWxhdGl2b3MgYWwgdGlsZVxuICBjb25zdCBib2R5ID0gSlNPTi5zdHJpbmdpZnkoeyBwaXhlbHMsIHRva2VuOiB0dXJuc3RpbGVUb2tlbiB9KTtcbiAgY29uc3QgciA9IGF3YWl0IGZldGNoV2l0aFRpbWVvdXQoYCR7QkFTRX0vczAvcGl4ZWwvJHt0aWxlWH0vJHt0aWxlWX1gLCB7XG4gICAgbWV0aG9kOiBcIlBPU1RcIixcbiAgICBoZWFkZXJzOiB7IFwiQ29udGVudC1UeXBlXCI6IFwidGV4dC9wbGFpbjtjaGFyc2V0PVVURi04XCIgfSxcbiAgICBib2R5LFxuICAgIGNyZWRlbnRpYWxzOiBcImluY2x1ZGVcIlxuICB9KTtcbiAgXG4gIC8vIEFsZ3VuYXMgcmVzcHVlc3RhcyBwdWVkZW4gbm8gdHJhZXIgSlNPTiBhdW5xdWUgc2VhbiAyMDAuXG4gIGlmIChyLnN0YXR1cyA9PT0gMjAwKSB7XG4gICAgdHJ5IHsgcmV0dXJuIGF3YWl0IHIuanNvbigpOyB9IGNhdGNoIHsgcmV0dXJuIHsgb2s6IHRydWUgfTsgfVxuICB9XG4gIFxuICBsZXQgbXNnID0gYEhUVFAgJHtyLnN0YXR1c31gO1xuICB0cnkgeyBcbiAgICBjb25zdCBqID0gYXdhaXQgci5qc29uKCk7IFxuICAgIG1zZyA9IGo/Lm1lc3NhZ2UgfHwgbXNnOyBcbiAgfSBjYXRjaCB7XG4gICAgLy8gUmVzcG9uc2Ugbm90IEpTT05cbiAgfVxuICB0aHJvdyBuZXcgRXJyb3IoYHBhaW50IGZhaWxlZDogJHttc2d9YCk7XG59XG5cbi8vIFZlcnNpXHUwMEYzbiAnc2FmZScgcXVlIG5vIGFycm9qYSBleGNlcGNpb25lcyB5IHJldG9ybmEgc3RhdHVzL2pzb25cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwb3N0UGl4ZWxCYXRjaFNhZmUodGlsZVgsIHRpbGVZLCBwaXhlbHMsIHR1cm5zdGlsZVRva2VuKSB7XG4gIHRyeSB7XG4gICAgY29uc3QgYm9keSA9IEpTT04uc3RyaW5naWZ5KHsgcGl4ZWxzLCB0b2tlbjogdHVybnN0aWxlVG9rZW4gfSk7XG4gICAgY29uc3QgciA9IGF3YWl0IGZldGNoV2l0aFRpbWVvdXQoYCR7QkFTRX0vczAvcGl4ZWwvJHt0aWxlWH0vJHt0aWxlWX1gLCB7XG4gICAgICBtZXRob2Q6IFwiUE9TVFwiLFxuICAgICAgaGVhZGVyczogeyBcIkNvbnRlbnQtVHlwZVwiOiBcInRleHQvcGxhaW47Y2hhcnNldD1VVEYtOFwiIH0sXG4gICAgICBib2R5LFxuICAgICAgY3JlZGVudGlhbHM6IFwiaW5jbHVkZVwiXG4gICAgfSk7XG4gIGxldCBqc29uID0ge307XG4gIC8vIElmIHJlc3BvbnNlIGlzIG5vdCBKU09OLCBpZ25vcmUgcGFyc2UgZXJyb3JcbiAgdHJ5IHsganNvbiA9IGF3YWl0IHIuanNvbigpOyB9IGNhdGNoIHsgLyogaWdub3JlICovIH1cbiAgICByZXR1cm4geyBzdGF0dXM6IHIuc3RhdHVzLCBqc29uLCBzdWNjZXNzOiByLm9rIH07XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgcmV0dXJuIHsgc3RhdHVzOiAwLCBqc29uOiB7IGVycm9yOiBlcnJvci5tZXNzYWdlIH0sIHN1Y2Nlc3M6IGZhbHNlIH07XG4gIH1cbn1cblxuLy8gUG9zdCBwXHUwMEVEeGVsIHBhcmEgZmFybSAodmVyc2lcdTAwRjNuIGNvcnJlZ2lkYSBjb24gZm9ybWF0byBvcmlnaW5hbClcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwb3N0UGl4ZWwoY29vcmRzLCBjb2xvcnMsIHR1cm5zdGlsZVRva2VuLCB0aWxlWCwgdGlsZVkpIHtcbiAgdHJ5IHtcbiAgICBjb25zdCBib2R5ID0gSlNPTi5zdHJpbmdpZnkoeyBcbiAgICAgIGNvbG9yczogY29sb3JzLCBcbiAgICAgIGNvb3JkczogY29vcmRzLCBcbiAgICAgIHQ6IHR1cm5zdGlsZVRva2VuIFxuICAgIH0pO1xuICAgIFxuICAgIGNvbnN0IGNvbnRyb2xsZXIgPSBuZXcgQWJvcnRDb250cm9sbGVyKCk7XG4gICAgY29uc3QgdGltZW91dElkID0gc2V0VGltZW91dCgoKSA9PiBjb250cm9sbGVyLmFib3J0KCksIDE1MDAwKTsgLy8gVGltZW91dCBkZSAxNSBzZWd1bmRvc1xuXG4gICAgY29uc3QgcmVzcG9uc2UgPSBhd2FpdCBmZXRjaChgJHtCQVNFfS9zMC9waXhlbC8ke3RpbGVYfS8ke3RpbGVZfWAsIHtcbiAgICAgIG1ldGhvZDogJ1BPU1QnLFxuICAgICAgY3JlZGVudGlhbHM6ICdpbmNsdWRlJyxcbiAgICAgIGhlYWRlcnM6IHsgJ0NvbnRlbnQtVHlwZSc6ICd0ZXh0L3BsYWluO2NoYXJzZXQ9VVRGLTgnIH0sXG4gICAgICBib2R5OiBib2R5LFxuICAgICAgc2lnbmFsOiBjb250cm9sbGVyLnNpZ25hbFxuICAgIH0pO1xuXG4gICAgY2xlYXJUaW1lb3V0KHRpbWVvdXRJZCk7XG5cbiAgICBsZXQgcmVzcG9uc2VEYXRhID0gbnVsbDtcbiAgICB0cnkge1xuICAgICAgY29uc3QgdGV4dCA9IGF3YWl0IHJlc3BvbnNlLnRleHQoKTtcbiAgICAgIGlmICh0ZXh0KSB7XG4gICAgICAgIHJlc3BvbnNlRGF0YSA9IEpTT04ucGFyc2UodGV4dCk7XG4gICAgICB9XG4gICAgfSBjYXRjaCB7XG4gICAgICByZXNwb25zZURhdGEgPSB7fTsgLy8gSWdub3JhciBlcnJvcmVzIGRlIEpTT04gcGFyc2VcbiAgICB9XG5cbiAgICByZXR1cm4ge1xuICAgICAgc3RhdHVzOiByZXNwb25zZS5zdGF0dXMsXG4gICAgICBqc29uOiByZXNwb25zZURhdGEsXG4gICAgICBzdWNjZXNzOiByZXNwb25zZS5va1xuICAgIH07XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgcmV0dXJuIHtcbiAgICAgIHN0YXR1czogMCxcbiAgICAgIGpzb246IHsgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfSxcbiAgICAgIHN1Y2Nlc3M6IGZhbHNlXG4gICAgfTtcbiAgfVxufVxuXG4vLyBQb3N0IHBcdTAwRUR4ZWwgcGFyYSBBdXRvLUltYWdlIChmb3JtYXRvIG9yaWdpbmFsIGNvcnJlY3RvKVxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHBvc3RQaXhlbEJhdGNoSW1hZ2UodGlsZVgsIHRpbGVZLCBjb29yZHMsIGNvbG9ycywgdHVybnN0aWxlVG9rZW4pIHtcbiAgdHJ5IHtcbiAgICBjb25zdCBib2R5ID0gSlNPTi5zdHJpbmdpZnkoeyBcbiAgICAgIGNvbG9yczogY29sb3JzLCBcbiAgICAgIGNvb3JkczogY29vcmRzLCBcbiAgICAgIHQ6IHR1cm5zdGlsZVRva2VuIFxuICAgIH0pO1xuICAgIFxuICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgZmV0Y2goYCR7QkFTRX0vczAvcGl4ZWwvJHt0aWxlWH0vJHt0aWxlWX1gLCB7XG4gICAgICBtZXRob2Q6ICdQT1NUJyxcbiAgICAgIGNyZWRlbnRpYWxzOiAnaW5jbHVkZScsXG4gICAgICBoZWFkZXJzOiB7ICdDb250ZW50LVR5cGUnOiAndGV4dC9wbGFpbjtjaGFyc2V0PVVURi04JyB9LFxuICAgICAgYm9keTogYm9keVxuICAgIH0pO1xuXG4gICAgbGV0IHJlc3BvbnNlRGF0YSA9IG51bGw7XG4gICAgdHJ5IHtcbiAgICAgIHJlc3BvbnNlRGF0YSA9IGF3YWl0IHJlc3BvbnNlLmpzb24oKTtcbiAgICB9IGNhdGNoIHtcbiAgICAgIHJlc3BvbnNlRGF0YSA9IHt9OyAvLyBJZ25vcmFyIGVycm9yZXMgZGUgSlNPTiBwYXJzZVxuICAgIH1cblxuICAgIHJldHVybiB7XG4gICAgICBzdGF0dXM6IHJlc3BvbnNlLnN0YXR1cyxcbiAgICAgIGpzb246IHJlc3BvbnNlRGF0YSxcbiAgICAgIHN1Y2Nlc3M6IHJlc3BvbnNlLm9rLFxuICAgICAgcGFpbnRlZDogcmVzcG9uc2VEYXRhPy5wYWludGVkIHx8IDBcbiAgICB9O1xuICB9IGNhdGNoIChlcnJvcikge1xuICAgIHJldHVybiB7XG4gICAgICBzdGF0dXM6IDAsXG4gICAgICBqc29uOiB7IGVycm9yOiBlcnJvci5tZXNzYWdlIH0sXG4gICAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICAgIHBhaW50ZWQ6IDBcbiAgICB9O1xuICB9XG59XG4iLCAibGV0IGxvYWRlZCA9IGZhbHNlO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gbG9hZFR1cm5zdGlsZSgpIHtcbiAgaWYgKGxvYWRlZCB8fCB3aW5kb3cudHVybnN0aWxlKSByZXR1cm47XG4gIFxuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIGNvbnN0IHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzY3JpcHQnKTtcbiAgICBzLnNyYyA9ICdodHRwczovL2NoYWxsZW5nZXMuY2xvdWRmbGFyZS5jb20vdHVybnN0aWxlL3YwL2FwaS5qcz9yZW5kZXI9ZXhwbGljaXQnO1xuICAgIHMuYXN5bmMgPSB0cnVlOyBcbiAgICBzLmRlZmVyID0gdHJ1ZTtcbiAgICBzLm9ubG9hZCA9ICgpID0+IHtcbiAgICAgIGxvYWRlZCA9IHRydWU7XG4gICAgICByZXNvbHZlKCk7XG4gICAgfTtcbiAgICBzLm9uZXJyb3IgPSAoKSA9PiByZWplY3QobmV3IEVycm9yKCdObyBzZSBwdWRvIGNhcmdhciBUdXJuc3RpbGUnKSk7XG4gICAgZG9jdW1lbnQuaGVhZC5hcHBlbmRDaGlsZChzKTtcbiAgfSk7XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBleGVjdXRlVHVybnN0aWxlKHNpdGVLZXksIGFjdGlvbiA9IFwicGFpbnRcIikge1xuICBhd2FpdCBsb2FkVHVybnN0aWxlKCk7XG4gIFxuICBpZiAodHlwZW9mIHdpbmRvdy50dXJuc3RpbGU/LmV4ZWN1dGUgPT09ICdmdW5jdGlvbicpIHtcbiAgICB0cnkge1xuICAgICAgY29uc3QgdG9rZW4gPSBhd2FpdCB3aW5kb3cudHVybnN0aWxlLmV4ZWN1dGUoc2l0ZUtleSwgeyBhY3Rpb24gfSk7XG4gICAgICBpZiAodG9rZW4gJiYgdG9rZW4ubGVuZ3RoID4gMjApIHJldHVybiB0b2tlbjtcbiAgICB9IGNhdGNoIHsgXG4gICAgICAvKiBmYWxsYmFjayBhYmFqbyAqLyBcbiAgICB9XG4gIH1cbiAgXG4gIC8vIEZhbGxiYWNrOiByZW5kZXIgb2N1bHRvXG4gIHJldHVybiBhd2FpdCBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4ge1xuICAgIGNvbnN0IGhvc3QgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdkaXYnKTtcbiAgICBob3N0LnN0eWxlLnBvc2l0aW9uID0gJ2ZpeGVkJzsgXG4gICAgaG9zdC5zdHlsZS5sZWZ0ID0gJy05OTk5cHgnO1xuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQoaG9zdCk7XG4gICAgd2luZG93LnR1cm5zdGlsZS5yZW5kZXIoaG9zdCwgeyBcbiAgICAgIHNpdGVrZXk6IHNpdGVLZXksIFxuICAgICAgY2FsbGJhY2s6ICh0KSA9PiB7XG4gICAgICAgIGRvY3VtZW50LmJvZHkucmVtb3ZlQ2hpbGQoaG9zdCk7XG4gICAgICAgIHJlc29sdmUodCk7XG4gICAgICB9IFxuICAgIH0pO1xuICB9KTtcbn1cblxuLy8gVmVyc2lcdTAwRjNuIG9yaWdpbmFsIHBhcmEgY29tcGF0aWJpbGlkYWRcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBnZXRUdXJuc3RpbGVUb2tlbihzaXRlS2V5KSB7XG4gIHJldHVybiBleGVjdXRlVHVybnN0aWxlKHNpdGVLZXksICdwYWludCcpO1xufVxuXG4vLyBEZXRlY3RhIGRpblx1MDBFMW1pY2FtZW50ZSBsYSBzaXRla2V5IGRlIFR1cm5zdGlsZSBkZWwgRE9NIG8gZGVsIGNvbnRleHRvIGdsb2JhbC5cbi8vIFByaW9yaWRhZDogW2RhdGEtc2l0ZWtleV0gPiAuY2YtdHVybnN0aWxlW2RhdGEtc2l0ZWtleV0gPiB3aW5kb3cuX19UVVJOU1RJTEVfU0lURUtFWSA+IGZhbGxiYWNrXG5leHBvcnQgZnVuY3Rpb24gZGV0ZWN0U2l0ZUtleShmYWxsYmFjayA9ICcnKSB7XG4gIHRyeSB7XG4gICAgLy8gMSkgRWxlbWVudG8gY29uIGF0cmlidXRvIGRhdGEtc2l0ZWtleSAoY29tXHUwMEZBbiBlbiBpbnRlZ3JhY2lvbmVzIGV4cGxcdTAwRURjaXRhcylcbiAgICBjb25zdCBlbCA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJ1tkYXRhLXNpdGVrZXldJyk7XG4gICAgaWYgKGVsKSB7XG4gICAgICBjb25zdCBrZXkgPSBlbC5nZXRBdHRyaWJ1dGUoJ2RhdGEtc2l0ZWtleScpO1xuICAgICAgaWYgKGtleSAmJiBrZXkubGVuZ3RoID4gMTApIHJldHVybiBrZXk7XG4gICAgfVxuICAgIC8vIDIpIFdpZGdldCBUdXJuc3RpbGUgaW5zZXJ0YWRvICguY2YtdHVybnN0aWxlKVxuICAgIGNvbnN0IGNmID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvcignLmNmLXR1cm5zdGlsZScpO1xuICAgIGlmIChjZiAmJiBjZi5kYXRhc2V0Py5zaXRla2V5ICYmIGNmLmRhdGFzZXQuc2l0ZWtleS5sZW5ndGggPiAxMCkge1xuICAgICAgcmV0dXJuIGNmLmRhdGFzZXQuc2l0ZWtleTtcbiAgICB9XG4gICAgLy8gMykgVmFyaWFibGUgZ2xvYmFsIG9wY2lvbmFsXG4gICAgaWYgKHR5cGVvZiB3aW5kb3cgIT09ICd1bmRlZmluZWQnICYmIHdpbmRvdy5fX1RVUk5TVElMRV9TSVRFS0VZICYmIHdpbmRvdy5fX1RVUk5TVElMRV9TSVRFS0VZLmxlbmd0aCA+IDEwKSB7XG4gICAgICByZXR1cm4gd2luZG93Ll9fVFVSTlNUSUxFX1NJVEVLRVk7XG4gICAgfVxuICB9IGNhdGNoIHtcbiAgICAvLyBpZ25vcmVcbiAgfVxuICByZXR1cm4gZmFsbGJhY2s7XG59XG4iLCAiaW1wb3J0IHsgbG9nIH0gZnJvbSBcIi4uL2NvcmUvbG9nZ2VyLmpzXCI7XG5pbXBvcnQgeyBzbGVlcCB9IGZyb20gXCIuLi9jb3JlL3RpbWluZy5qc1wiO1xuaW1wb3J0IHsgcG9zdFBpeGVsQmF0Y2hJbWFnZSB9IGZyb20gXCIuLi9jb3JlL3dwbGFjZS1hcGkuanNcIjtcbmltcG9ydCB7IGdldFR1cm5zdGlsZVRva2VuLCBkZXRlY3RTaXRlS2V5IH0gZnJvbSBcIi4uL2NvcmUvdHVybnN0aWxlLmpzXCI7XG5pbXBvcnQgeyBpbWFnZVN0YXRlLCBJTUFHRV9ERUZBVUxUUyB9IGZyb20gXCIuL2NvbmZpZy5qc1wiO1xuaW1wb3J0IHsgdCB9IGZyb20gXCIuLi9sb2NhbGVzL2luZGV4LmpzXCI7XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwcm9jZXNzSW1hZ2UoaW1hZ2VEYXRhLCBzdGFydFBvc2l0aW9uLCBvblByb2dyZXNzLCBvbkNvbXBsZXRlLCBvbkVycm9yKSB7XG4gIGNvbnN0IHsgd2lkdGgsIGhlaWdodCB9ID0gaW1hZ2VEYXRhO1xuICBjb25zdCB7IHg6IGxvY2FsU3RhcnRYLCB5OiBsb2NhbFN0YXJ0WSB9ID0gc3RhcnRQb3NpdGlvbjtcbiAgXG4gIGxvZyhgSW5pY2lhbmRvIHBpbnRhZG86IGltYWdlbigke3dpZHRofXgke2hlaWdodH0pIGluaWNpbyBMT0NBTCgke2xvY2FsU3RhcnRYfSwke2xvY2FsU3RhcnRZfSkgdGlsZSgke2ltYWdlU3RhdGUudGlsZVh9LCR7aW1hZ2VTdGF0ZS50aWxlWX0pYCk7XG4gIFxuICAvLyBHZW5lcmFyIGNvbGEgZGUgcFx1MDBFRHhlbGVzIHNpIG5vIGV4aXN0ZVxuICBpZiAoIWltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzIHx8IGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzLmxlbmd0aCA9PT0gMCB8fCAoaW1hZ2VTdGF0ZS5sYXN0UG9zaXRpb24ueCA9PT0gMCAmJiBpbWFnZVN0YXRlLmxhc3RQb3NpdGlvbi55ID09PSAwKSkge1xuICAgIGxvZygnR2VuZXJhbmRvIGNvbGEgZGUgcFx1MDBFRHhlbGVzLi4uJyk7XG4gICAgaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMgPSBnZW5lcmF0ZVBpeGVsUXVldWUoaW1hZ2VEYXRhLCBzdGFydFBvc2l0aW9uLCBpbWFnZVN0YXRlLnRpbGVYLCBpbWFnZVN0YXRlLnRpbGVZKTtcbiAgICBcbiAgICAvLyBTaSBoYXkgdW5hIHBvc2ljaVx1MDBGM24gZGUgY29udGludWFjaVx1MDBGM24sIGZpbHRyYXIgcFx1MDBFRHhlbGVzIHlhIHBpbnRhZG9zXG4gICAgaWYgKGltYWdlU3RhdGUubGFzdFBvc2l0aW9uLnggPiAwIHx8IGltYWdlU3RhdGUubGFzdFBvc2l0aW9uLnkgPiAwKSB7XG4gICAgICBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscyA9IGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzLmZpbHRlcihwaXhlbCA9PiB7XG4gICAgICAgIGNvbnN0IHBpeGVsSW5kZXggPSBwaXhlbC5pbWFnZVkgKiB3aWR0aCArIHBpeGVsLmltYWdlWDtcbiAgICAgICAgY29uc3QgbGFzdEluZGV4ID0gaW1hZ2VTdGF0ZS5sYXN0UG9zaXRpb24ueSAqIHdpZHRoICsgaW1hZ2VTdGF0ZS5sYXN0UG9zaXRpb24ueDtcbiAgICAgICAgcmV0dXJuIHBpeGVsSW5kZXggPj0gbGFzdEluZGV4O1xuICAgICAgfSk7XG4gICAgfVxuICAgIFxuICAgIGxvZyhgQ29sYSBnZW5lcmFkYTogJHtpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5sZW5ndGh9IHBcdTAwRUR4ZWxlcyBwZW5kaWVudGVzYCk7XG4gICAgLy8gQWN0dWFsaXphciBvdmVybGF5IGRlbCBwbGFuIGFsIChyZSlnZW5lcmFyIGxhIGNvbGFcbiAgICB0cnkge1xuICAgICAgaWYgKHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXykge1xuICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uaW5qZWN0U3R5bGVzKCk7XG4gICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5zZXRFbmFibGVkKHRydWUpOyAvLyBBc2VndXJhciBxdWUgZXN0XHUwMEU5IGFjdGl2YWRvXG4gICAgICAgIFxuICAgICAgICAvLyBDb25maWd1cmFyIGFuY2xhIGNvbiBsYSBwb3NpY2lcdTAwRjNuIGRlIGluaWNpbyBzaSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICAgICAgICBpZiAoaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uICYmIGltYWdlU3RhdGUudGlsZVggIT09IHVuZGVmaW5lZCAmJiBpbWFnZVN0YXRlLnRpbGVZICE9PSB1bmRlZmluZWQpIHtcbiAgICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uc2V0QW5jaG9yKHtcbiAgICAgICAgICAgIHRpbGVYOiBpbWFnZVN0YXRlLnRpbGVYLFxuICAgICAgICAgICAgdGlsZVk6IGltYWdlU3RhdGUudGlsZVksXG4gICAgICAgICAgICBweFg6IGltYWdlU3RhdGUuc3RhcnRQb3NpdGlvbi54LFxuICAgICAgICAgICAgcHhZOiBpbWFnZVN0YXRlLnN0YXJ0UG9zaXRpb24ueVxuICAgICAgICAgIH0pO1xuICAgICAgICB9XG4gICAgICAgIFxuICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uc2V0UGxhbihpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscywge1xuICAgICAgICAgIGVuYWJsZWQ6IHRydWUsXG4gICAgICAgICAgbmV4dEJhdGNoQ291bnQ6IGltYWdlU3RhdGUucGl4ZWxzUGVyQmF0Y2hcbiAgICAgICAgfSk7XG4gICAgICAgIFxuICAgICAgICBsb2coYFx1MjcwNSBQbGFuIG92ZXJsYXkgYWN0dWFsaXphZG8gY29uICR7aW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMubGVuZ3RofSBwXHUwMEVEeGVsZXMgZW4gY29sYWApO1xuICAgICAgfVxuICAgIH0gY2F0Y2ggKGUpIHtcbiAgICAgIGxvZygnXHUyNkEwXHVGRTBGIEVycm9yIGFjdHVhbGl6YW5kbyBwbGFuIG92ZXJsYXk6JywgZSk7XG4gICAgfVxuICB9XG4gIFxuICB0cnkge1xuICAgIHdoaWxlIChpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5sZW5ndGggPiAwICYmICFpbWFnZVN0YXRlLnN0b3BGbGFnKSB7XG4gICAgICAvLyBWZXJpZmljYXIgY2FyZ2FzIGRpc3BvbmlibGVzXG4gICAgICBsZXQgYXZhaWxhYmxlQ2hhcmdlcyA9IE1hdGguZmxvb3IoaW1hZ2VTdGF0ZS5jdXJyZW50Q2hhcmdlcyk7XG4gICAgICBcbiAgICAgIC8vIERldGVybWluYXIgdGFtYVx1MDBGMW8gZGVsIGxvdGUgYmFzYWRvIGVuIGNvbmZpZ3VyYWNpXHUwMEYzblxuICAgICAgbGV0IHBpeGVsc1BlckJhdGNoO1xuICAgICAgaWYgKGltYWdlU3RhdGUuaXNGaXJzdEJhdGNoICYmIGltYWdlU3RhdGUudXNlQWxsQ2hhcmdlc0ZpcnN0ICYmIGF2YWlsYWJsZUNoYXJnZXMgPiAwKSB7XG4gICAgICAgIC8vIFByaW1lcmEgcGFzYWRhOiB1c2FyIHRvZGFzIGxhcyBjYXJnYXMgZGlzcG9uaWJsZXNcbiAgICAgICAgcGl4ZWxzUGVyQmF0Y2ggPSBNYXRoLm1pbihhdmFpbGFibGVDaGFyZ2VzLCBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5sZW5ndGgpO1xuICAgICAgICBpbWFnZVN0YXRlLmlzRmlyc3RCYXRjaCA9IGZhbHNlOyAvLyBNYXJjYXIgcXVlIHlhIG5vIGVzIGxhIHByaW1lcmEgcGFzYWRhXG4gICAgICAgIGxvZyhgUHJpbWVyYSBwYXNhZGE6IHVzYW5kbyAke3BpeGVsc1BlckJhdGNofSBjYXJnYXMgZGUgJHthdmFpbGFibGVDaGFyZ2VzfSBkaXNwb25pYmxlc2ApO1xuICAgICAgfSBlbHNlIHtcbiAgICAgICAgLy8gUGFzYWRhcyBzaWd1aWVudGVzOiB1c2FyIGNvbmZpZ3VyYWNpXHUwMEYzbiBub3JtYWxcbiAgICAgICAgcGl4ZWxzUGVyQmF0Y2ggPSBNYXRoLm1pbihpbWFnZVN0YXRlLnBpeGVsc1BlckJhdGNoLCBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5sZW5ndGgpO1xuICAgICAgfVxuICAgICAgXG4gICAgICBpZiAoYXZhaWxhYmxlQ2hhcmdlcyA8IHBpeGVsc1BlckJhdGNoKSB7XG4gICAgICAgIGxvZyhgQ2FyZ2FzIGluc3VmaWNpZW50ZXM6ICR7YXZhaWxhYmxlQ2hhcmdlc30vJHtwaXhlbHNQZXJCYXRjaH0gbmVjZXNhcmlhc2ApO1xuICAgICAgICBhd2FpdCB3YWl0Rm9yQ29vbGRvd24ocGl4ZWxzUGVyQmF0Y2ggLSBhdmFpbGFibGVDaGFyZ2VzLCBvblByb2dyZXNzKTtcbiAgICAgICAgLy8gVm9sdmVyIGEgdmVyaWZpY2FyIGNhcmdhcyBkZXNwdVx1MDBFOXMgZGVsIGNvb2xkb3duXG4gICAgICAgIGF2YWlsYWJsZUNoYXJnZXMgPSBNYXRoLmZsb29yKGltYWdlU3RhdGUuY3VycmVudENoYXJnZXMpO1xuICAgICAgICAvLyBSZWNhbGN1bGFyIGVsIHRhbWFcdTAwRjFvIGRlbCBsb3RlIHNpIGVzIG5lY2VzYXJpb1xuICAgICAgICBpZiAoIWltYWdlU3RhdGUuaXNGaXJzdEJhdGNoKSB7XG4gICAgICAgICAgcGl4ZWxzUGVyQmF0Y2ggPSBNYXRoLm1pbihpbWFnZVN0YXRlLnBpeGVsc1BlckJhdGNoLCBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5sZW5ndGgsIGF2YWlsYWJsZUNoYXJnZXMpO1xuICAgICAgICB9XG4gICAgICAgIGNvbnRpbnVlO1xuICAgICAgfVxuICAgICAgXG4gIC8vIFRvbWFyIGVsIHNpZ3VpZW50ZSBsb3RlIGRlIHBcdTAwRUR4ZWxlc1xuICAgICAgY29uc3QgYmF0Y2ggPSBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5zcGxpY2UoMCwgcGl4ZWxzUGVyQmF0Y2gpO1xuICAgICAgXG4gICAgICBsb2coYFBpbnRhbmRvIGxvdGUgZGUgJHtiYXRjaC5sZW5ndGh9IHBcdTAwRUR4ZWxlcy4uLmApO1xuICAgICAgXG4gICAgICAvLyBBY3R1YWxpemFyIG92ZXJsYXkgZGVsIHBsYW4gcGFyYSByZWZsZWphciBlbCBsb3RlIHNpZ3VpZW50ZSByZXNhbHRhZG9cbiAgICAgIHRyeSB7XG4gICAgICAgIGlmICh3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18pIHtcbiAgICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uc2V0UGxhbihpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscywge1xuICAgICAgICAgICAgZW5hYmxlZDogdHJ1ZSwgLy8gTWFudGVuZXIgaGFiaWxpdGFkb1xuICAgICAgICAgICAgbmV4dEJhdGNoQ291bnQ6IGltYWdlU3RhdGUucGl4ZWxzUGVyQmF0Y2hcbiAgICAgICAgICB9KTtcbiAgICAgICAgfVxuICAgICAgfSBjYXRjaCAoZSkge1xuICAgICAgICBsb2coJ1x1MjZBMFx1RkUwRiBFcnJvciBhY3R1YWxpemFuZG8gcGxhbiBvdmVybGF5IGR1cmFudGUgcGludGFkbzonLCBlKTtcbiAgICAgIH1cblxuICAgICAgLy8gUGludGFyIGVsIGxvdGUgY29uIHNpc3RlbWEgZGUgcmVpbnRlbnRvc1xuICAgICAgY29uc3QgcmVzdWx0ID0gYXdhaXQgcGFpbnRQaXhlbEJhdGNoV2l0aFJldHJ5KGJhdGNoLCBvblByb2dyZXNzKTtcbiAgICAgIFxuICAgICAgaWYgKHJlc3VsdC5zdWNjZXNzICYmIHJlc3VsdC5wYWludGVkID4gMCkge1xuICAgICAgICBpbWFnZVN0YXRlLnBhaW50ZWRQaXhlbHMgKz0gcmVzdWx0LnBhaW50ZWQ7XG4gICAgICAgIFxuICAgICAgICAvLyBBY3R1YWxpemFyIGNhcmdhcyBjb25zdW1pZGFzXG4gICAgICAgIGltYWdlU3RhdGUuY3VycmVudENoYXJnZXMgPSBNYXRoLm1heCgwLCBpbWFnZVN0YXRlLmN1cnJlbnRDaGFyZ2VzIC0gcmVzdWx0LnBhaW50ZWQpO1xuICAgICAgICBsb2coYENhcmdhcyBkZXNwdVx1MDBFOXMgZGVsIGxvdGU6ICR7aW1hZ2VTdGF0ZS5jdXJyZW50Q2hhcmdlcy50b0ZpeGVkKDEpfSAoY29uc3VtaWRhczogJHtyZXN1bHQucGFpbnRlZH0pYCk7XG4gICAgICAgIFxuICAgICAgICAvLyBBY3R1YWxpemFyIHBvc2ljaVx1MDBGM24gcGFyYSBjb250aW51YXIgZGVzZGUgYXF1XHUwMEVEIHNpIHNlIGludGVycnVtcGVcbiAgICAgICAgaWYgKGJhdGNoLmxlbmd0aCA+IDApIHtcbiAgICAgICAgICBjb25zdCBsYXN0UGl4ZWwgPSBiYXRjaFtiYXRjaC5sZW5ndGggLSAxXTtcbiAgICAgICAgICBpbWFnZVN0YXRlLmxhc3RQb3NpdGlvbiA9IHsgeDogbGFzdFBpeGVsLmltYWdlWCwgeTogbGFzdFBpeGVsLmltYWdlWSB9O1xuICAgICAgICB9XG4gICAgICAgIFxuICAgICAgICBsb2coYExvdGUgZXhpdG9zbzogJHtyZXN1bHQucGFpbnRlZH0vJHtiYXRjaC5sZW5ndGh9IHBcdTAwRUR4ZWxlcyBwaW50YWRvcy4gVG90YWw6ICR7aW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzfS8ke2ltYWdlU3RhdGUudG90YWxQaXhlbHN9YCk7XG4gICAgICAgIFxuICAgICAgICAvLyBDYWxjdWxhciB0aWVtcG8gZXN0aW1hZG9cbiAgICAgICAgY29uc3QgZXN0aW1hdGVkVGltZSA9IGNhbGN1bGF0ZUVzdGltYXRlZFRpbWUoKTtcbiAgICAgICAgXG4gICAgICAgIC8vIE1vc3RyYXIgbWVuc2FqZSBkZSBjb25maXJtYWNpXHUwMEYzbiBkZSBwYXNhZGEgY29tcGxldGFkYVxuICAgICAgICBjb25zdCBwcm9ncmVzc1BlcmNlbnQgPSAoKGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyAvIGltYWdlU3RhdGUudG90YWxQaXhlbHMpICogMTAwKS50b0ZpeGVkKDEpO1xuICAgICAgICBjb25zdCBzdWNjZXNzTWVzc2FnZSA9IHQoJ2ltYWdlLnBhc3NDb21wbGV0ZWQnLCB7XG4gICAgICAgICAgcGFpbnRlZDogcmVzdWx0LnBhaW50ZWQsXG4gICAgICAgICAgcGVyY2VudDogcHJvZ3Jlc3NQZXJjZW50LFxuICAgICAgICAgIGN1cnJlbnQ6IGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyxcbiAgICAgICAgICB0b3RhbDogaW1hZ2VTdGF0ZS50b3RhbFBpeGVsc1xuICAgICAgICB9KTtcbiAgICAgICAgXG4gICAgICAgIC8vIEFjdHVhbGl6YXIgcHJvZ3Jlc28gY29uIG1lbnNhamUgZGUgXHUwMEU5eGl0b1xuICAgICAgICBpZiAob25Qcm9ncmVzcykge1xuICAgICAgICAgIG9uUHJvZ3Jlc3MoaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzLCBpbWFnZVN0YXRlLnRvdGFsUGl4ZWxzLCBzdWNjZXNzTWVzc2FnZSwgZXN0aW1hdGVkVGltZSk7XG4gICAgICAgIH1cbiAgICAgICAgXG4gIC8vIFBhdXNhIHBhcmEgcXVlIGVsIHVzdWFyaW8gdmVhIGVsIG1lbnNhamUgZGUgXHUwMEU5eGl0byBhbnRlcyBkZWwgY29vbGRvd25cbiAgICAgICAgYXdhaXQgc2xlZXAoMjAwMCk7XG4gICAgICB9IGVsc2UgaWYgKHJlc3VsdC5zaG91bGRDb250aW51ZSkge1xuICAgICAgICAvLyBTaSBlbCBzaXN0ZW1hIGRlIHJlaW50ZW50b3MgZmFsbFx1MDBGMyBwZXJvIGRlYmUgY29udGludWFyXG4gICAgICAgIGxvZyhgTG90ZSBmYWxsXHUwMEYzIGRlc3B1XHUwMEU5cyBkZSB0b2RvcyBsb3MgcmVpbnRlbnRvcywgY29udGludWFuZG8gY29uIHNpZ3VpZW50ZSBsb3RlLi4uYCk7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICAvLyBFbiBjYXNvIGRlIGZhbGxvLCBkZXZvbHZlciBlbCBsb3RlIGEgbGEgY29sYVxuICAgICAgICBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy51bnNoaWZ0KC4uLmJhdGNoKTtcbiAgICAgICAgbG9nKGBMb3RlIGZhbGxcdTAwRjM6IHJlaW50ZW50YW5kbyBlbiA1IHNlZ3VuZG9zLi4uYCk7XG4gICAgICAgIGF3YWl0IHNsZWVwKDUwMDApO1xuICAgICAgfVxuICAgICAgXG4gIC8vIFBhdXNhIGJyZXZlIGVudHJlIGxvdGVzXG4gICAgICBhd2FpdCBzbGVlcCg1MDApO1xuICAgIH1cbiAgICBcbiAgICBpZiAoaW1hZ2VTdGF0ZS5zdG9wRmxhZykge1xuICAgICAgbG9nKGBQaW50YWRvIHBhdXNhZG8gZW4gcFx1MDBFRHhlbCBpbWFnZW4oJHtpbWFnZVN0YXRlLmxhc3RQb3NpdGlvbi54fSwke2ltYWdlU3RhdGUubGFzdFBvc2l0aW9uLnl9KWApO1xuICAgICAgaWYgKG9uQ29tcGxldGUpIHtcbiAgICAgICAgb25Db21wbGV0ZShmYWxzZSwgaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzKTtcbiAgICAgIH1cbiAgICB9IGVsc2Uge1xuICAgICAgbG9nKGBQaW50YWRvIGNvbXBsZXRhZG86ICR7aW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzfSBwXHUwMEVEeGVsZXMgcGludGFkb3NgKTtcbiAgICAgIGltYWdlU3RhdGUubGFzdFBvc2l0aW9uID0geyB4OiAwLCB5OiAwIH07XG4gICAgICBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscyA9IFtdO1xuICAgICAgLy8gTGltcGlhciBvdmVybGF5IGRlbCBwbGFuIGFsIGNvbXBsZXRhclxuICAgICAgdHJ5IHtcbiAgICAgICAgaWYgKHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXykge1xuICAgICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5zZXRQbGFuKFtdLCB7IFxuICAgICAgICAgICAgZW5hYmxlZDogdHJ1ZSwgLy8gTWFudGVuZXIgaGFiaWxpdGFkbyBwZXJvIHNpbiBwXHUwMEVEeGVsZXNcbiAgICAgICAgICAgIG5leHRCYXRjaENvdW50OiAwIFxuICAgICAgICAgIH0pO1xuICAgICAgICAgIGxvZygnXHUyNzA1IFBsYW4gb3ZlcmxheSBsaW1waWFkbyBhbCBjb21wbGV0YXIgcGludGFkbycpO1xuICAgICAgICB9XG4gICAgICB9IGNhdGNoIChlKSB7XG4gICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIEVycm9yIGxpbXBpYW5kbyBwbGFuIG92ZXJsYXk6JywgZSk7XG4gICAgICB9XG4gICAgICBpZiAob25Db21wbGV0ZSkge1xuICAgICAgICBvbkNvbXBsZXRlKHRydWUsIGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyk7XG4gICAgICB9XG4gICAgfVxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZygnRXJyb3IgZW4gcHJvY2VzbyBkZSBwaW50YWRvOicsIGVycm9yKTtcbiAgICBpZiAob25FcnJvcikge1xuICAgICAgb25FcnJvcihlcnJvcik7XG4gICAgfVxuICB9XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwYWludFBpeGVsQmF0Y2goYmF0Y2gpIHtcbiAgdHJ5IHtcbiAgICBpZiAoIWJhdGNoIHx8IGJhdGNoLmxlbmd0aCA9PT0gMCkge1xuICAgICAgcmV0dXJuIHsgc3VjY2VzczogZmFsc2UsIHBhaW50ZWQ6IDAsIGVycm9yOiAnTG90ZSB2YWNcdTAwRURvJyB9O1xuICAgIH1cbiAgICBcbiAgICAvLyBBZ3J1cGFyIGVsIGxvdGUgcG9yIHRpbGUgY29tbyBoYWNlIHdwbGFjZXJcbiAgICBjb25zdCBieVRpbGUgPSBuZXcgTWFwKCk7IC8vIGtleTogYCR7dHh9LCR7dHl9YCAtPiB7IGNvb3JkczogW10sIGNvbG9yczogW10sIHR4LCB0eSB9XG4gICAgZm9yIChjb25zdCBwIG9mIGJhdGNoKSB7XG4gICAgICBjb25zdCBrZXkgPSBgJHtwLnRpbGVYfSwke3AudGlsZVl9YDtcbiAgICAgIGlmICghYnlUaWxlLmhhcyhrZXkpKSBieVRpbGUuc2V0KGtleSwgeyBjb29yZHM6IFtdLCBjb2xvcnM6IFtdLCB0eDogcC50aWxlWCwgdHk6IHAudGlsZVkgfSk7XG4gICAgICBjb25zdCBidWNrZXQgPSBieVRpbGUuZ2V0KGtleSk7XG4gICAgICBidWNrZXQuY29vcmRzLnB1c2gocC5sb2NhbFgsIHAubG9jYWxZKTtcbiAgICAgIGJ1Y2tldC5jb2xvcnMucHVzaChwLmNvbG9yLmlkIHx8IHAuY29sb3IudmFsdWUgfHwgMSk7XG4gICAgfVxuXG4gICAgLy8gT2J0ZW5lciB1biBcdTAwRkFuaWNvIHRva2VuIGRlIFR1cm5zdGlsZSBwYXJhIGVsIGNvbmp1bnRvXG4gICAgY29uc3Qgc2l0ZUtleSA9IGRldGVjdFNpdGVLZXkoSU1BR0VfREVGQVVMVFMuU0lURUtFWSk7XG4gICAgY29uc3QgdG9rZW4gPSBhd2FpdCBnZXRUdXJuc3RpbGVUb2tlbihzaXRlS2V5KTtcblxuICAgIGxldCB0b3RhbFBhaW50ZWQgPSAwO1xuICAgIGZvciAoY29uc3QgeyBjb29yZHMsIGNvbG9ycywgdHgsIHR5IH0gb2YgYnlUaWxlLnZhbHVlcygpKSB7XG4gICAgICBpZiAoY29sb3JzLmxlbmd0aCA9PT0gMCkgY29udGludWU7XG4gICAgICAvLyBTYW5lYWRvIGV4dHJhIGRlIGNvb3JkcyAoMC4uOTk5KSB5IGRlcHVyYWNpXHUwMEYzbiBkZSByYW5nb3NcbiAgICAgIGNvbnN0IHNhbml0aXplZCA9IFtdO1xuICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCBjb29yZHMubGVuZ3RoOyBpICs9IDIpIHtcbiAgICAgICAgY29uc3QgeCA9ICgoTnVtYmVyKGNvb3Jkc1tpXSkgJSAxMDAwKSArIDEwMDApICUgMTAwMDtcbiAgICAgICAgY29uc3QgeSA9ICgoTnVtYmVyKGNvb3Jkc1tpICsgMV0pICUgMTAwMCkgKyAxMDAwKSAlIDEwMDA7XG4gICAgICAgIC8vIEZpbHRyYXIgTmFOL3VuZGVmaW5lZFxuICAgICAgICBpZiAoTnVtYmVyLmlzRmluaXRlKHgpICYmIE51bWJlci5pc0Zpbml0ZSh5KSkge1xuICAgICAgICAgIHNhbml0aXplZC5wdXNoKHgsIHkpO1xuICAgICAgICB9XG4gICAgICB9XG4gICAgICAvLyBMb2cgZGUgZGlhZ25cdTAwRjNzdGljb1xuICAgICAgdHJ5IHtcbiAgICAgICAgbGV0IG1pblggPSA5OTksIG1heFggPSAwLCBtaW5ZID0gOTk5LCBtYXhZID0gMDtcbiAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCBzYW5pdGl6ZWQubGVuZ3RoOyBpICs9IDIpIHtcbiAgICAgICAgICBjb25zdCB4ID0gc2FuaXRpemVkW2ldLCB5ID0gc2FuaXRpemVkW2kgKyAxXTtcbiAgICAgICAgICBpZiAoeCA8IG1pblgpIG1pblggPSB4OyBpZiAoeCA+IG1heFgpIG1heFggPSB4O1xuICAgICAgICAgIGlmICh5IDwgbWluWSkgbWluWSA9IHk7IGlmICh5ID4gbWF4WSkgbWF4WSA9IHk7XG4gICAgICAgIH1cbiAgICAgICAgbG9nKGBbSU1HXSBFbnZpYW5kbyB0aWxlICR7dHh9LCR7dHl9OiAke2NvbG9ycy5sZW5ndGh9IHB4IHwgeDpbJHttaW5YfSwke21heFh9XSB5Olske21pbll9LCR7bWF4WX1dYCk7XG4gICAgICB9IGNhdGNoIChlKSB7XG4gICAgICAgIC8vIG5vb3AgKHNvbG8gZGlhZ25cdTAwRjNzdGljbylcbiAgICAgIH1cblxuICAgICAgY29uc3QgcmVzcCA9IGF3YWl0IHBvc3RQaXhlbEJhdGNoSW1hZ2UodHgsIHR5LCBzYW5pdGl6ZWQsIGNvbG9ycywgdG9rZW4pO1xuICAgICAgaWYgKHJlc3Auc3RhdHVzICE9PSAyMDApIHtcbiAgICAgICAgcmV0dXJuIHtcbiAgICAgICAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICAgICAgICBwYWludGVkOiB0b3RhbFBhaW50ZWQsXG4gICAgICAgICAgZXJyb3I6IHJlc3AuanNvbj8ubWVzc2FnZSB8fCBgSFRUUCAke3Jlc3Auc3RhdHVzfWAsXG4gICAgICAgICAgc3RhdHVzOiByZXNwLnN0YXR1c1xuICAgICAgICB9O1xuICAgICAgfVxuICAgICAgdG90YWxQYWludGVkICs9IHJlc3AucGFpbnRlZCB8fCAwO1xuICAgIH1cblxuICAgIHJldHVybiB7IHN1Y2Nlc3M6IHRydWUsIHBhaW50ZWQ6IHRvdGFsUGFpbnRlZCB9O1xuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZygnRXJyb3IgZW4gcGFpbnRQaXhlbEJhdGNoOicsIGVycm9yKTtcbiAgICByZXR1cm4ge1xuICAgICAgc3VjY2VzczogZmFsc2UsXG4gICAgICBwYWludGVkOiAwLFxuICAgICAgZXJyb3I6IGVycm9yLm1lc3NhZ2VcbiAgICB9O1xuICB9XG59XG5cbi8vIEZ1bmNpXHUwMEYzbiBkZSBwaW50YWRvIGNvbiBzaXN0ZW1hIGRlIHJlaW50ZW50b3MgKGFkYXB0YWRvIGRlbCBBdXRvLUZhcm0pXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcGFpbnRQaXhlbEJhdGNoV2l0aFJldHJ5KGJhdGNoLCBvblByb2dyZXNzKSB7XG4gIGNvbnN0IG1heEF0dGVtcHRzID0gNTsgLy8gNSBpbnRlbnRvcyBjb21vIGVuIGVsIEZhcm1cbiAgY29uc3QgYmFzZURlbGF5ID0gMzAwMDsgLy8gRGVsYXkgYmFzZSBkZSAzIHNlZ3VuZG9zXG4gIFxuICBmb3IgKGxldCBhdHRlbXB0ID0gMTsgYXR0ZW1wdCA8PSBtYXhBdHRlbXB0czsgYXR0ZW1wdCsrKSB7XG4gICAgdHJ5IHtcbiAgICAgIGNvbnN0IHJlc3VsdCA9IGF3YWl0IHBhaW50UGl4ZWxCYXRjaChiYXRjaCk7XG4gICAgICBcbiAgICAgIGlmIChyZXN1bHQuc3VjY2Vzcykge1xuICAgICAgICBpbWFnZVN0YXRlLnJldHJ5Q291bnQgPSAwOyAvLyBSZXNldCBlbiBcdTAwRTl4aXRvXG4gICAgICAgIHJldHVybiByZXN1bHQ7XG4gICAgICB9XG4gICAgICBcbiAgICAgIGltYWdlU3RhdGUucmV0cnlDb3VudCA9IGF0dGVtcHQ7XG4gICAgICBcbiAgICAgIGlmIChhdHRlbXB0IDwgbWF4QXR0ZW1wdHMpIHtcbiAgICAgICAgY29uc3QgZGVsYXkgPSBiYXNlRGVsYXkgKiBNYXRoLnBvdygyLCBhdHRlbXB0IC0gMSk7IC8vIEJhY2tvZmYgZXhwb25lbmNpYWxcbiAgICAgICAgY29uc3QgZGVsYXlTZWNvbmRzID0gTWF0aC5yb3VuZChkZWxheSAvIDEwMDApO1xuICAgICAgICBcbiAgICAgICAgLy8gRGV0ZXJtaW5hciB0aXBvIGRlIGVycm9yIHBhcmEgbWVuc2FqZSBlc3BlY1x1MDBFRGZpY29cbiAgICAgICAgbGV0IGVycm9yTWVzc2FnZTtcbiAgICAgICAgaWYgKHJlc3VsdC5zdGF0dXMgPT09IDAgfHwgcmVzdWx0LnN0YXR1cyA9PT0gJ05ldHdvcmtFcnJvcicpIHtcbiAgICAgICAgICBlcnJvck1lc3NhZ2UgPSB0KCdpbWFnZS5uZXR3b3JrRXJyb3InKTtcbiAgICAgICAgfSBlbHNlIGlmIChyZXN1bHQuc3RhdHVzID49IDUwMCkge1xuICAgICAgICAgIGVycm9yTWVzc2FnZSA9IHQoJ2ltYWdlLnNlcnZlckVycm9yJyk7XG4gICAgICAgIH0gZWxzZSBpZiAocmVzdWx0LnN0YXR1cyA9PT0gNDA4KSB7XG4gICAgICAgICAgZXJyb3JNZXNzYWdlID0gdCgnaW1hZ2UudGltZW91dEVycm9yJyk7XG4gICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgZXJyb3JNZXNzYWdlID0gdCgnaW1hZ2UucmV0cnlBdHRlbXB0JywgeyBcbiAgICAgICAgICAgIGF0dGVtcHQsIFxuICAgICAgICAgICAgbWF4QXR0ZW1wdHMsIFxuICAgICAgICAgICAgZGVsYXk6IGRlbGF5U2Vjb25kcyBcbiAgICAgICAgICB9KTtcbiAgICAgICAgfVxuICAgICAgICBcbiAgICAgICAgaWYgKG9uUHJvZ3Jlc3MpIHtcbiAgICAgICAgICBvblByb2dyZXNzKGltYWdlU3RhdGUucGFpbnRlZFBpeGVscywgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscywgZXJyb3JNZXNzYWdlKTtcbiAgICAgICAgfVxuICAgICAgICBcbiAgICAgICAgbG9nKGBSZWludGVudG8gJHthdHRlbXB0fS8ke21heEF0dGVtcHRzfSBkZXNwdVx1MDBFOXMgZGUgJHtkZWxheVNlY29uZHN9cy4gRXJyb3I6ICR7cmVzdWx0LmVycm9yfWApO1xuICAgICAgICBhd2FpdCBzbGVlcChkZWxheSk7XG4gICAgICB9XG4gICAgICBcbiAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgbG9nKGBFcnJvciBlbiBpbnRlbnRvICR7YXR0ZW1wdH06YCwgZXJyb3IpO1xuICAgICAgaW1hZ2VTdGF0ZS5yZXRyeUNvdW50ID0gYXR0ZW1wdDtcbiAgICAgIFxuICAgICAgaWYgKGF0dGVtcHQgPCBtYXhBdHRlbXB0cykge1xuICAgICAgICBjb25zdCBkZWxheSA9IGJhc2VEZWxheSAqIE1hdGgucG93KDIsIGF0dGVtcHQgLSAxKTtcbiAgICAgICAgY29uc3QgZGVsYXlTZWNvbmRzID0gTWF0aC5yb3VuZChkZWxheSAvIDEwMDApO1xuICAgICAgICBcbiAgICAgICAgY29uc3QgZXJyb3JNZXNzYWdlID0gdCgnaW1hZ2UucmV0cnlFcnJvcicsIHsgXG4gICAgICAgICAgYXR0ZW1wdCwgXG4gICAgICAgICAgbWF4QXR0ZW1wdHMsIFxuICAgICAgICAgIGRlbGF5OiBkZWxheVNlY29uZHMgXG4gICAgICAgIH0pO1xuICAgICAgICBcbiAgICAgICAgaWYgKG9uUHJvZ3Jlc3MpIHtcbiAgICAgICAgICBvblByb2dyZXNzKGltYWdlU3RhdGUucGFpbnRlZFBpeGVscywgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscywgZXJyb3JNZXNzYWdlKTtcbiAgICAgICAgfVxuICAgICAgICBcbiAgICAgICAgYXdhaXQgc2xlZXAoZGVsYXkpO1xuICAgICAgfVxuICAgIH1cbiAgfVxuICBcbiAgaW1hZ2VTdGF0ZS5yZXRyeUNvdW50ID0gbWF4QXR0ZW1wdHM7XG4gIGNvbnN0IGZhaWxNZXNzYWdlID0gdCgnaW1hZ2UucmV0cnlGYWlsZWQnLCB7IG1heEF0dGVtcHRzIH0pO1xuICBcbiAgaWYgKG9uUHJvZ3Jlc3MpIHtcbiAgICBvblByb2dyZXNzKGltYWdlU3RhdGUucGFpbnRlZFBpeGVscywgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscywgZmFpbE1lc3NhZ2UpO1xuICB9XG4gIFxuICBsb2coYEZhbGxcdTAwRjMgZGVzcHVcdTAwRTlzIGRlICR7bWF4QXR0ZW1wdHN9IGludGVudG9zLCBjb250aW51YW5kbyBjb24gc2lndWllbnRlIGxvdGVgKTtcbiAgXG4gIC8vIFJldG9ybmFyIHVuIHJlc3VsdGFkbyBkZSBmYWxsbyBxdWUgcGVybWl0YSBjb250aW51YXJcbiAgcmV0dXJuIHtcbiAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICBwYWludGVkOiAwLFxuICAgIGVycm9yOiBgRmFsbFx1MDBGMyBkZXNwdVx1MDBFOXMgZGUgJHttYXhBdHRlbXB0c30gaW50ZW50b3NgLFxuICAgIHNob3VsZENvbnRpbnVlOiB0cnVlIC8vIEluZGljYSBxdWUgZGViZSBjb250aW51YXIgY29uIGVsIHNpZ3VpZW50ZSBsb3RlXG4gIH07XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBwYWludFBpeGVsQmF0Y2hfT1JJR0lOQUwoYmF0Y2gpIHtcbiAgdHJ5IHtcbiAgICBpZiAoIWJhdGNoIHx8IGJhdGNoLmxlbmd0aCA9PT0gMCkge1xuICAgICAgcmV0dXJuIHsgc3VjY2VzczogZmFsc2UsIHBhaW50ZWQ6IDAsIGVycm9yOiAnTG90ZSB2YWNcdTAwRURvJyB9O1xuICAgIH1cbiAgICBcbiAgICAvLyBDb252ZXJ0aXIgZWwgbG90ZSBhbCBmb3JtYXRvIGVzcGVyYWRvIHBvciBsYSBBUElcbiAgICBjb25zdCBjb29yZHMgPSBbXTtcbiAgICBjb25zdCBjb2xvcnMgPSBbXTtcbiAgICBsZXQgdGlsZVggPSBudWxsO1xuICAgIGxldCB0aWxlWSA9IG51bGw7XG4gICAgXG4gICAgZm9yIChjb25zdCBwaXhlbCBvZiBiYXRjaCkge1xuICAgICAgY29vcmRzLnB1c2gocGl4ZWwubG9jYWxYLCBwaXhlbC5sb2NhbFkpO1xuICAgICAgY29sb3JzLnB1c2gocGl4ZWwuY29sb3IuaWQgfHwgcGl4ZWwuY29sb3IudmFsdWUgfHwgMSk7XG4gICAgICBcbiAgICAgIC8vIFRvbWFyIHRpbGVYL3RpbGVZIGRlbCBwcmltZXIgcFx1MDBFRHhlbCAodG9kb3MgZGViZXJcdTAwRURhbiB0ZW5lciBlbCBtaXNtbyB0aWxlKVxuICAgICAgaWYgKHRpbGVYID09PSBudWxsKSB7XG4gICAgICAgIHRpbGVYID0gcGl4ZWwudGlsZVg7XG4gICAgICAgIHRpbGVZID0gcGl4ZWwudGlsZVk7XG4gICAgICB9XG4gICAgfVxuICAgIFxuICAgIC8vIE9idGVuZXIgdG9rZW4gZGUgVHVybnN0aWxlXG4gICAgY29uc3QgdG9rZW4gPSBhd2FpdCBnZXRUdXJuc3RpbGVUb2tlbihJTUFHRV9ERUZBVUxUUy5TSVRFS0VZKTtcbiAgICBcbiAgICAvLyBFbnZpYXIgcFx1MDBFRHhlbGVzIHVzYW5kbyBlbCBmb3JtYXRvIGNvcnJlY3RvXG4gICAgY29uc3QgcmVzcG9uc2UgPSBhd2FpdCBwb3N0UGl4ZWxCYXRjaEltYWdlKHRpbGVYLCB0aWxlWSwgY29vcmRzLCBjb2xvcnMsIHRva2VuKTtcbiAgICBcbiAgICBpZiAocmVzcG9uc2Uuc3RhdHVzID09PSAyMDApIHtcbiAgICAgIHJldHVybiB7XG4gICAgICAgIHN1Y2Nlc3M6IHRydWUsXG4gICAgICAgIHBhaW50ZWQ6IHJlc3BvbnNlLnBhaW50ZWQsXG4gICAgICAgIHJlc3BvbnNlOiByZXNwb25zZS5qc29uXG4gICAgICB9O1xuICAgIH0gZWxzZSB7XG4gICAgICByZXR1cm4ge1xuICAgICAgICBzdWNjZXNzOiBmYWxzZSxcbiAgICAgICAgcGFpbnRlZDogMCxcbiAgICAgICAgZXJyb3I6IHJlc3BvbnNlLmpzb24/Lm1lc3NhZ2UgfHwgYEhUVFAgJHtyZXNwb25zZS5zdGF0dXN9YCxcbiAgICAgICAgc3RhdHVzOiByZXNwb25zZS5zdGF0dXNcbiAgICAgIH07XG4gICAgfVxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZygnRXJyb3IgZW4gcGFpbnRQaXhlbEJhdGNoOicsIGVycm9yKTtcbiAgICByZXR1cm4ge1xuICAgICAgc3VjY2VzczogZmFsc2UsXG4gICAgICBwYWludGVkOiAwLFxuICAgICAgZXJyb3I6IGVycm9yLm1lc3NhZ2VcbiAgICB9O1xuICB9XG59XG5cbmFzeW5jIGZ1bmN0aW9uIHdhaXRGb3JDb29sZG93bihjaGFyZ2VzTmVlZGVkLCBvblByb2dyZXNzKSB7XG4gIGNvbnN0IGNoYXJnZVRpbWUgPSBJTUFHRV9ERUZBVUxUUy5DSEFSR0VfUkVHRU5fTVMgKiBjaGFyZ2VzTmVlZGVkO1xuICBjb25zdCB3YWl0VGltZSA9IGNoYXJnZVRpbWUgKyA1MDAwOyAvLyBUaWVtcG8gbmVjZXNhcmlvICsgNSBzZWd1bmRvcyBkZSBzZWd1cmlkYWRcbiAgXG4gIGxvZyhgRXNwZXJhbmRvICR7TWF0aC5yb3VuZCh3YWl0VGltZS8xMDAwKX1zIHBhcmEgb2J0ZW5lciAke2NoYXJnZXNOZWVkZWR9IGNhcmdhc2ApO1xuICBcbiAgLy8gQWN0dWFsaXphciBlc3RhZG8gZGUgY29vbGRvd25cbiAgaW1hZ2VTdGF0ZS5pbkNvb2xkb3duID0gdHJ1ZTtcbiAgaW1hZ2VTdGF0ZS5jb29sZG93bkVuZFRpbWUgPSBEYXRlLm5vdygpICsgd2FpdFRpbWU7XG4gIGltYWdlU3RhdGUubmV4dEJhdGNoQ29vbGRvd24gPSBNYXRoLnJvdW5kKHdhaXRUaW1lIC8gMTAwMCk7XG4gIFxuICBpZiAob25Qcm9ncmVzcykge1xuICAgIGNvbnN0IG1pbnV0ZXMgPSBNYXRoLmZsb29yKHdhaXRUaW1lIC8gNjAwMDApO1xuICAgIGNvbnN0IHNlY29uZHMgPSBNYXRoLmZsb29yKCh3YWl0VGltZSAlIDYwMDAwKSAvIDEwMDApO1xuICAgIGNvbnN0IHRpbWVUZXh0ID0gbWludXRlcyA+IDAgPyBgJHttaW51dGVzfW0gJHtzZWNvbmRzfXNgIDogYCR7c2Vjb25kc31zYDtcbiAgICBjb25zdCBtZXNzYWdlID0gdCgnaW1hZ2Uud2FpdGluZ0NoYXJnZXNSZWdlbicsIHtcbiAgICAgIGN1cnJlbnQ6IE1hdGguZmxvb3IoaW1hZ2VTdGF0ZS5jdXJyZW50Q2hhcmdlcyksXG4gICAgICBuZWVkZWQ6IGNoYXJnZXNOZWVkZWQsXG4gICAgICB0aW1lOiB0aW1lVGV4dFxuICAgIH0pO1xuICAgIG9uUHJvZ3Jlc3MoaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzLCBpbWFnZVN0YXRlLnRvdGFsUGl4ZWxzLCBtZXNzYWdlKTtcbiAgfVxuICBcbiAgLy8gQ29udGFyIGhhY2lhIGF0clx1MDBFMXNcbiAgZm9yIChsZXQgaSA9IE1hdGgucm91bmQod2FpdFRpbWUvMTAwMCk7IGkgPiAwOyBpLS0pIHtcbiAgICBpZiAoaW1hZ2VTdGF0ZS5zdG9wRmxhZykgYnJlYWs7XG4gICAgXG4gICAgaW1hZ2VTdGF0ZS5uZXh0QmF0Y2hDb29sZG93biA9IGk7XG4gICAgXG4gICAgLy8gU29sbyBhY3R1YWxpemFyIGVsIG1lbnNhamUgY2FkYSA1IHNlZ3VuZG9zIG8gZW4gbG9zIFx1MDBGQWx0aW1vcyAxMCBzZWd1bmRvcyBwYXJhIHJlZHVjaXIgcGFycGFkZW9cbiAgICBpZiAob25Qcm9ncmVzcyAmJiAoaSAlIDUgPT09IDAgfHwgaSA8PSAxMCB8fCBpID09PSBNYXRoLnJvdW5kKHdhaXRUaW1lLzEwMDApKSkge1xuICAgICAgY29uc3QgbWludXRlcyA9IE1hdGguZmxvb3IoaSAvIDYwKTtcbiAgICAgIGNvbnN0IHNlY29uZHMgPSBpICUgNjA7XG4gICAgICBjb25zdCB0aW1lVGV4dCA9IG1pbnV0ZXMgPiAwID8gYCR7bWludXRlc31tICR7c2Vjb25kc31zYCA6IGAke3NlY29uZHN9c2A7XG4gICAgICBjb25zdCBtZXNzYWdlID0gdCgnaW1hZ2Uud2FpdGluZ0NoYXJnZXNDb3VudGRvd24nLCB7XG4gICAgICAgIGN1cnJlbnQ6IE1hdGguZmxvb3IoaW1hZ2VTdGF0ZS5jdXJyZW50Q2hhcmdlcyksXG4gICAgICAgIG5lZWRlZDogY2hhcmdlc05lZWRlZCxcbiAgICAgICAgdGltZTogdGltZVRleHRcbiAgICAgIH0pO1xuICAgICAgb25Qcm9ncmVzcyhpbWFnZVN0YXRlLnBhaW50ZWRQaXhlbHMsIGltYWdlU3RhdGUudG90YWxQaXhlbHMsIG1lc3NhZ2UpO1xuICAgIH1cbiAgICBcbiAgICBhd2FpdCBzbGVlcCgxMDAwKTtcbiAgfVxuICBcbiAgaW1hZ2VTdGF0ZS5pbkNvb2xkb3duID0gZmFsc2U7XG4gIGltYWdlU3RhdGUubmV4dEJhdGNoQ29vbGRvd24gPSAwO1xuICBcbiAgLy8gU2ltdWxhciByZWdlbmVyYWNpXHUwMEYzbiBkZSBjYXJnYXNcbiAgaW1hZ2VTdGF0ZS5jdXJyZW50Q2hhcmdlcyA9IE1hdGgubWluKFxuICAgIGltYWdlU3RhdGUubWF4Q2hhcmdlcyB8fCA1MCwgLy8gdXNhciBtYXhDaGFyZ2VzIGRlbCBlc3RhZG9cbiAgICBpbWFnZVN0YXRlLmN1cnJlbnRDaGFyZ2VzICsgKHdhaXRUaW1lIC8gSU1BR0VfREVGQVVMVFMuQ0hBUkdFX1JFR0VOX01TKVxuICApO1xufVxuXG5mdW5jdGlvbiBnZW5lcmF0ZVBpeGVsUXVldWUoaW1hZ2VEYXRhLCBzdGFydFBvc2l0aW9uLCBiYXNlVGlsZVgsIGJhc2VUaWxlWSkge1xuICBjb25zdCB7IHBpeGVscyB9ID0gaW1hZ2VEYXRhO1xuICBjb25zdCB7IHg6IGxvY2FsU3RhcnRYLCB5OiBsb2NhbFN0YXJ0WSB9ID0gc3RhcnRQb3NpdGlvbjtcbiAgY29uc3QgcXVldWUgPSBbXTtcblxuICAvLyBWZXJpZmljYXIgc2kgcGl4ZWxzIGVzIHVuIGFycmF5IGl0ZXJhYmxlXG4gIGlmICghQXJyYXkuaXNBcnJheShwaXhlbHMpKSB7XG4gICAgbG9nKGBcdTI3NEMgRXJyb3I6IHBpeGVscyBubyBlcyB1biBhcnJheSBpdGVyYWJsZS4gVGlwbzogJHt0eXBlb2YgcGl4ZWxzfWAsIHBpeGVscyk7XG4gICAgcmV0dXJuIFtdO1xuICB9XG5cbiAgZm9yIChjb25zdCBwaXhlbERhdGEgb2YgcGl4ZWxzKSB7XG4gICAgaWYgKCFwaXhlbERhdGEpIGNvbnRpbnVlO1xuICAgIFxuICAgIC8vIE1hbmVqYXIgZGlmZXJlbnRlcyBmb3JtYXRvcyBkZSBwXHUwMEVEeGVsXG4gICAgLy8gRm9ybWF0byBCbHVlIE1hcmJsZTogaW1hZ2VYLCBpbWFnZVksIGNvbG9yXG4gICAgLy8gRm9ybWF0byBjbFx1MDBFMXNpY286IHgsIHksIHRhcmdldENvbG9yXG4gICAgY29uc3QgcGl4ZWxYID0gcGl4ZWxEYXRhLmltYWdlWCAhPT0gdW5kZWZpbmVkID8gcGl4ZWxEYXRhLmltYWdlWCA6IHBpeGVsRGF0YS54O1xuICAgIGNvbnN0IHBpeGVsWSA9IHBpeGVsRGF0YS5pbWFnZVkgIT09IHVuZGVmaW5lZCA/IHBpeGVsRGF0YS5pbWFnZVkgOiBwaXhlbERhdGEueTtcbiAgICBjb25zdCBwaXhlbENvbG9yID0gcGl4ZWxEYXRhLmNvbG9yICE9PSB1bmRlZmluZWQgPyBwaXhlbERhdGEuY29sb3IgOiBwaXhlbERhdGEudGFyZ2V0Q29sb3I7XG4gICAgXG4gICAgaWYgKHBpeGVsWCA9PT0gdW5kZWZpbmVkIHx8IHBpeGVsWSA9PT0gdW5kZWZpbmVkKSB7XG4gICAgICBsb2coYFx1MjZBMFx1RkUwRiBQXHUwMEVEeGVsIGNvbiBjb29yZGVuYWRhcyBpbnZcdTAwRTFsaWRhczpgLCBwaXhlbERhdGEpO1xuICAgICAgY29udGludWU7XG4gICAgfVxuICAgIFxuICAgIC8vIGdsb2JhbCBkZW50cm8gZGVsIG1vc2FpY28gYmFzZSwgcHVlZGUgZXhjZWRlciAwLi45OTkgeSBjcnV6YXIgYSBvdHJvcyB0aWxlc1xuICAgIGNvbnN0IGdsb2JhbFggPSBsb2NhbFN0YXJ0WCArIHBpeGVsWDtcbiAgICBjb25zdCBnbG9iYWxZID0gbG9jYWxTdGFydFkgKyBwaXhlbFk7XG4gICAgY29uc3QgdGlsZU9mZnNldFggPSBNYXRoLmZsb29yKGdsb2JhbFggLyAxMDAwKTtcbiAgICBjb25zdCB0aWxlT2Zmc2V0WSA9IE1hdGguZmxvb3IoZ2xvYmFsWSAvIDEwMDApO1xuICAgIGNvbnN0IHR4ID0gYmFzZVRpbGVYICsgdGlsZU9mZnNldFg7XG4gICAgY29uc3QgdHkgPSBiYXNlVGlsZVkgKyB0aWxlT2Zmc2V0WTtcbiAgICBjb25zdCBsb2NhbFggPSAoKGdsb2JhbFggJSAxMDAwKSArIDEwMDApICUgMTAwMDsgLy8gYXNlZ3VyYXIgMC4uOTk5XG4gICAgY29uc3QgbG9jYWxZID0gKChnbG9iYWxZICUgMTAwMCkgKyAxMDAwKSAlIDEwMDA7XG4gICAgXG4gICAgcXVldWUucHVzaCh7XG4gICAgICBpbWFnZVg6IHBpeGVsWCxcbiAgICAgIGltYWdlWTogcGl4ZWxZLFxuICAgICAgbG9jYWxYLFxuICAgICAgbG9jYWxZLFxuICAgICAgdGlsZVg6IHR4LFxuICAgICAgdGlsZVk6IHR5LFxuICAgICAgY29sb3I6IHBpeGVsQ29sb3IsXG4gICAgICBvcmlnaW5hbENvbG9yOiBwaXhlbERhdGEub3JpZ2luYWxDb2xvclxuICAgIH0pO1xuICB9XG5cbiAgbG9nKGBDb2xhIGRlIHBcdTAwRUR4ZWxlcyBnZW5lcmFkYTogJHtxdWV1ZS5sZW5ndGh9IHBcdTAwRUR4ZWxlcyBwYXJhIHBpbnRhcmApO1xuICByZXR1cm4gcXVldWU7XG59XG5cbmZ1bmN0aW9uIGNhbGN1bGF0ZUVzdGltYXRlZFRpbWUoKSB7XG4gIGlmICghaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMgfHwgaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMubGVuZ3RoID09PSAwKSB7XG4gICAgcmV0dXJuIDA7XG4gIH1cbiAgXG4gIGNvbnN0IHJlbWFpbmluZ1BpeGVscyA9IGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzLmxlbmd0aDtcbiAgY29uc3QgYmF0Y2hTaXplID0gaW1hZ2VTdGF0ZS5waXhlbHNQZXJCYXRjaDtcbiAgY29uc3QgY2hhcmdlUmVnZW5UaW1lID0gSU1BR0VfREVGQVVMVFMuQ0hBUkdFX1JFR0VOX01TIC8gMTAwMDsgLy8gZW4gc2VndW5kb3NcbiAgXG4gIC8vIENhbGN1bGFyIG5cdTAwRkFtZXJvIGRlIGxvdGVzIG5lY2VzYXJpb3NcbiAgY29uc3QgYmF0Y2hlc05lZWRlZCA9IE1hdGguY2VpbChyZW1haW5pbmdQaXhlbHMgLyBiYXRjaFNpemUpO1xuICBcbiAgLy8gVGllbXBvIGRlIGVzcGVyYSBlbnRyZSBsb3RlcyAoY2FkYSBwXHUwMEVEeGVsIG5lY2VzaXRhIDEgY2FyZ2EsIGNhZGEgY2FyZ2EgdGFyZGEgMzBzKVxuICBjb25zdCB3YWl0VGltZUJldHdlZW5CYXRjaGVzID0gYmF0Y2hTaXplICogY2hhcmdlUmVnZW5UaW1lO1xuICBcbiAgLy8gVGllbXBvIHRvdGFsIGVzdGltYWRvXG4gIGNvbnN0IHRvdGFsV2FpdFRpbWUgPSAoYmF0Y2hlc05lZWRlZCAtIDEpICogd2FpdFRpbWVCZXR3ZWVuQmF0Y2hlcztcbiAgY29uc3QgZXhlY3V0aW9uVGltZSA9IGJhdGNoZXNOZWVkZWQgKiAyOyAvLyB+MiBzZWd1bmRvcyBwb3IgbG90ZSBkZSBlamVjdWNpXHUwMEYzblxuICBcbiAgcmV0dXJuIE1hdGguY2VpbCh0b3RhbFdhaXRUaW1lICsgZXhlY3V0aW9uVGltZSk7XG59XG5cbmV4cG9ydCB7IGNhbGN1bGF0ZUVzdGltYXRlZFRpbWUgfTtcblxuZXhwb3J0IGZ1bmN0aW9uIHN0b3BQYWludGluZygpIHtcbiAgaW1hZ2VTdGF0ZS5zdG9wRmxhZyA9IHRydWU7XG4gIGltYWdlU3RhdGUucnVubmluZyA9IGZhbHNlO1xuICBsb2coJ1x1RDgzRFx1REVEMSBEZXRlbmllbmRvIHByb2Nlc28gZGUgcGludGFkby4uLicpO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gcGF1c2VQYWludGluZygpIHtcbiAgaW1hZ2VTdGF0ZS5zdG9wRmxhZyA9IHRydWU7XG4gIGxvZygnXHUyM0Y4XHVGRTBGIFBhdXNhbmRvIHByb2Nlc28gZGUgcGludGFkby4uLicpO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gcmVzdW1lUGFpbnRpbmcoKSB7XG4gIGltYWdlU3RhdGUuc3RvcEZsYWcgPSBmYWxzZTtcbiAgaW1hZ2VTdGF0ZS5ydW5uaW5nID0gdHJ1ZTtcbiAgbG9nKCdcdTI1QjZcdUZFMEYgUmVhbnVkYW5kbyBwcm9jZXNvIGRlIHBpbnRhZG8uLi4nKTtcbn1cbiIsICJpbXBvcnQgeyBsb2cgfSBmcm9tIFwiLi4vY29yZS9sb2dnZXIuanNcIjtcbmltcG9ydCB7IGltYWdlU3RhdGUgfSBmcm9tIFwiLi9jb25maWcuanNcIjtcblxuZXhwb3J0IGZ1bmN0aW9uIHNhdmVQcm9ncmVzcyhmaWxlbmFtZSA9IG51bGwpIHtcbiAgdHJ5IHtcbiAgICBpZiAoIWltYWdlU3RhdGUuaW1hZ2VEYXRhIHx8IGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyA9PT0gMCkge1xuICAgICAgdGhyb3cgbmV3IEVycm9yKCdObyBoYXkgcHJvZ3Jlc28gcGFyYSBndWFyZGFyJyk7XG4gICAgfVxuICAgIFxuICAgIGNvbnN0IHByb2dyZXNzRGF0YSA9IHtcbiAgICAgIHZlcnNpb246IFwiMS4wXCIsXG4gICAgICB0aW1lc3RhbXA6IERhdGUubm93KCksXG4gICAgICBpbWFnZURhdGE6IHtcbiAgICAgICAgd2lkdGg6IGltYWdlU3RhdGUuaW1hZ2VEYXRhLndpZHRoLFxuICAgICAgICBoZWlnaHQ6IGltYWdlU3RhdGUuaW1hZ2VEYXRhLmhlaWdodCxcbiAgICAgICAgb3JpZ2luYWxOYW1lOiBpbWFnZVN0YXRlLm9yaWdpbmFsSW1hZ2VOYW1lXG4gICAgICB9LFxuICAgICAgcHJvZ3Jlc3M6IHtcbiAgICAgICAgcGFpbnRlZFBpeGVsczogaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzLFxuICAgICAgICB0b3RhbFBpeGVsczogaW1hZ2VTdGF0ZS50b3RhbFBpeGVscyxcbiAgICAgICAgbGFzdFBvc2l0aW9uOiB7IC4uLmltYWdlU3RhdGUubGFzdFBvc2l0aW9uIH1cbiAgICAgIH0sXG4gICAgICBwb3NpdGlvbjoge1xuICAgICAgICBzdGFydFBvc2l0aW9uOiB7IC4uLmltYWdlU3RhdGUuc3RhcnRQb3NpdGlvbiB9LFxuICAgICAgICB0aWxlWDogaW1hZ2VTdGF0ZS50aWxlWCxcbiAgICAgICAgdGlsZVk6IGltYWdlU3RhdGUudGlsZVlcbiAgICAgIH0sXG4gICAgICBjb25maWc6IHtcbiAgICAgICAgcGl4ZWxzUGVyQmF0Y2g6IGltYWdlU3RhdGUucGl4ZWxzUGVyQmF0Y2gsXG4gICAgICAgIHVzZUFsbENoYXJnZXNGaXJzdDogaW1hZ2VTdGF0ZS51c2VBbGxDaGFyZ2VzRmlyc3QsXG4gICAgICAgIGlzRmlyc3RCYXRjaDogaW1hZ2VTdGF0ZS5pc0ZpcnN0QmF0Y2gsXG4gICAgICAgIG1heENoYXJnZXM6IGltYWdlU3RhdGUubWF4Q2hhcmdlc1xuICAgICAgfSxcbiAgICAgIC8vIEZpbHRyYXIgc29sbyBsb3MgZGF0b3Mgc2VyaWFsaXphYmxlcyBkZSBsb3MgY29sb3JlcyAoc2luIGVsZW1lbnRvcyBET00pXG4gICAgICBjb2xvcnM6IGltYWdlU3RhdGUuYXZhaWxhYmxlQ29sb3JzLm1hcChjb2xvciA9PiAoe1xuICAgICAgICBpZDogY29sb3IuaWQsXG4gICAgICAgIHI6IGNvbG9yLnIsXG4gICAgICAgIGc6IGNvbG9yLmcsXG4gICAgICAgIGI6IGNvbG9yLmJcbiAgICAgIH0pKSxcbiAgICAgIHJlbWFpbmluZ1BpeGVsczogaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMgfHwgW11cbiAgICB9O1xuXG4gICAgLy8gUGVyc2lzdGVuY2lhIGRlbCBvdmVybGF5IGRlIGltYWdlbiBlbGltaW5hZGE7IGVsIG92ZXJsYXkgZGUgcGxhbiBzZSBpbmZpZXJlIGRlc2RlIHJlbWFpbmluZ1BpeGVsc1xuICAgIFxuICAgIGNvbnN0IGRhdGFTdHIgPSBKU09OLnN0cmluZ2lmeShwcm9ncmVzc0RhdGEsIG51bGwsIDIpO1xuICAgIGNvbnN0IGJsb2IgPSBuZXcgd2luZG93LkJsb2IoW2RhdGFTdHJdLCB7IHR5cGU6ICdhcHBsaWNhdGlvbi9qc29uJyB9KTtcbiAgICBcbiAgICBjb25zdCBmaW5hbEZpbGVuYW1lID0gZmlsZW5hbWUgfHwgYHdwbGFjZV9wcm9ncmVzc18ke2ltYWdlU3RhdGUub3JpZ2luYWxJbWFnZU5hbWUgfHwgJ2ltYWdlJ31fJHtuZXcgRGF0ZSgpLnRvSVNPU3RyaW5nKCkuc2xpY2UoMCwgMTkpLnJlcGxhY2UoLzovZywgJy0nKX0uanNvbmA7XG4gICAgXG4gICAgLy8gQ3JlYXIgeSBkaXNwYXJhciBkZXNjYXJnYVxuICAgIGNvbnN0IHVybCA9IHdpbmRvdy5VUkwuY3JlYXRlT2JqZWN0VVJMKGJsb2IpO1xuICAgIGNvbnN0IGxpbmsgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdhJyk7XG4gICAgbGluay5ocmVmID0gdXJsO1xuICAgIGxpbmsuZG93bmxvYWQgPSBmaW5hbEZpbGVuYW1lO1xuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQobGluayk7XG4gICAgbGluay5jbGljaygpO1xuICAgIGRvY3VtZW50LmJvZHkucmVtb3ZlQ2hpbGQobGluayk7XG4gICAgd2luZG93LlVSTC5yZXZva2VPYmplY3RVUkwodXJsKTtcbiAgICBcbiAgICBsb2coYFx1MjcwNSBQcm9ncmVzbyBndWFyZGFkbzogJHtmaW5hbEZpbGVuYW1lfWApO1xuICAgIHJldHVybiB7IHN1Y2Nlc3M6IHRydWUsIGZpbGVuYW1lOiBmaW5hbEZpbGVuYW1lIH07XG4gICAgXG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgbG9nKCdcdTI3NEMgRXJyb3IgZ3VhcmRhbmRvIHByb2dyZXNvOicsIGVycm9yKTtcbiAgICByZXR1cm4geyBzdWNjZXNzOiBmYWxzZSwgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfTtcbiAgfVxufVxuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gbG9hZFByb2dyZXNzKGZpbGUpIHtcbiAgcmV0dXJuIG5ldyBQcm9taXNlKChyZXNvbHZlKSA9PiB7XG4gICAgdHJ5IHtcbiAgICAgIGNvbnN0IHJlYWRlciA9IG5ldyB3aW5kb3cuRmlsZVJlYWRlcigpO1xuICAgICAgXG4gICAgICByZWFkZXIub25sb2FkID0gKGUpID0+IHtcbiAgICAgICAgdHJ5IHtcbiAgICAgICAgICBjb25zdCBwcm9ncmVzc0RhdGEgPSBKU09OLnBhcnNlKGUudGFyZ2V0LnJlc3VsdCk7XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gVmFsaWRhciBlc3RydWN0dXJhIGRlbCBhcmNoaXZvXG4gICAgICAgICAgY29uc3QgcmVxdWlyZWRGaWVsZHMgPSBbJ2ltYWdlRGF0YScsICdwcm9ncmVzcycsICdwb3NpdGlvbicsICdjb2xvcnMnXTtcbiAgICAgICAgICBjb25zdCBtaXNzaW5nRmllbGRzID0gcmVxdWlyZWRGaWVsZHMuZmlsdGVyKGZpZWxkID0+ICEoZmllbGQgaW4gcHJvZ3Jlc3NEYXRhKSk7XG4gICAgICAgICAgXG4gICAgICAgICAgaWYgKG1pc3NpbmdGaWVsZHMubGVuZ3RoID4gMCkge1xuICAgICAgICAgICAgdGhyb3cgbmV3IEVycm9yKGBDYW1wb3MgcmVxdWVyaWRvcyBmYWx0YW50ZXM6ICR7bWlzc2luZ0ZpZWxkcy5qb2luKCcsICcpfWApO1xuICAgICAgICAgIH1cbiAgICAgICAgICBcbiAgICAgICAgICAvLyBWZXJpZmljYXIgY29tcGF0aWJpbGlkYWQgZGUgY29sb3Jlc1xuICAgICAgICAgIGlmIChpbWFnZVN0YXRlLmF2YWlsYWJsZUNvbG9ycy5sZW5ndGggPiAwKSB7XG4gICAgICAgICAgICBjb25zdCBzYXZlZENvbG9ySWRzID0gcHJvZ3Jlc3NEYXRhLmNvbG9ycy5tYXAoYyA9PiBjLmlkKTtcbiAgICAgICAgICAgIGNvbnN0IGN1cnJlbnRDb2xvcklkcyA9IGltYWdlU3RhdGUuYXZhaWxhYmxlQ29sb3JzLm1hcChjID0+IGMuaWQpO1xuICAgICAgICAgICAgY29uc3QgY29tbW9uQ29sb3JzID0gc2F2ZWRDb2xvcklkcy5maWx0ZXIoaWQgPT4gY3VycmVudENvbG9ySWRzLmluY2x1ZGVzKGlkKSk7XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIGlmIChjb21tb25Db2xvcnMubGVuZ3RoIDwgc2F2ZWRDb2xvcklkcy5sZW5ndGggKiAwLjgpIHtcbiAgICAgICAgICAgICAgbG9nKCdcdTI2QTBcdUZFMEYgTG9zIGNvbG9yZXMgZ3VhcmRhZG9zIG5vIGNvaW5jaWRlbiBjb21wbGV0YW1lbnRlIGNvbiBsb3MgYWN0dWFsZXMnKTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgICB9XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gUmVzdGF1cmFyIGVzdGFkb1xuICAgICAgICAgIGltYWdlU3RhdGUuaW1hZ2VEYXRhID0ge1xuICAgICAgICAgICAgLi4ucHJvZ3Jlc3NEYXRhLmltYWdlRGF0YSxcbiAgICAgICAgICAgIHBpeGVsczogW10gLy8gTG9zIHBcdTAwRUR4ZWxlcyBzZSByZWdlbmVyYXJcdTAwRTFuIHNpIGVzIG5lY2VzYXJpb1xuICAgICAgICAgIH07XG4gICAgICAgICAgXG4gICAgICAgICAgaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzID0gcHJvZ3Jlc3NEYXRhLnByb2dyZXNzLnBhaW50ZWRQaXhlbHM7XG4gICAgICAgICAgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscyA9IHByb2dyZXNzRGF0YS5wcm9ncmVzcy50b3RhbFBpeGVscztcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBNYW5lamFyIHRhbnRvIGZvcm1hdG8gb3JpZ2luYWwgY29tbyBtb2R1bGFyIHBhcmEgcG9zaWNpb25lc1xuICAgICAgICAgIGlmIChwcm9ncmVzc0RhdGEucHJvZ3Jlc3MubGFzdFBvc2l0aW9uKSB7XG4gICAgICAgICAgICAvLyBGb3JtYXRvIG1vZHVsYXJcbiAgICAgICAgICAgIGltYWdlU3RhdGUubGFzdFBvc2l0aW9uID0gcHJvZ3Jlc3NEYXRhLnByb2dyZXNzLmxhc3RQb3NpdGlvbjtcbiAgICAgICAgICB9IGVsc2UgaWYgKHByb2dyZXNzRGF0YS5wb3NpdGlvbi5sYXN0WCAhPT0gdW5kZWZpbmVkICYmIHByb2dyZXNzRGF0YS5wb3NpdGlvbi5sYXN0WSAhPT0gdW5kZWZpbmVkKSB7XG4gICAgICAgICAgICAvLyBGb3JtYXRvIG9yaWdpbmFsXG4gICAgICAgICAgICBpbWFnZVN0YXRlLmxhc3RQb3NpdGlvbiA9IHsgeDogcHJvZ3Jlc3NEYXRhLnBvc2l0aW9uLmxhc3RYLCB5OiBwcm9ncmVzc0RhdGEucG9zaXRpb24ubGFzdFkgfTtcbiAgICAgICAgICB9XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gTWFuZWphciB0YW50byBmb3JtYXRvIG9yaWdpbmFsIGNvbW8gbW9kdWxhciBwYXJhIHN0YXJ0UG9zaXRpb25cbiAgICAgICAgICBpZiAocHJvZ3Jlc3NEYXRhLnBvc2l0aW9uLnN0YXJ0UG9zaXRpb24pIHtcbiAgICAgICAgICAgIC8vIEZvcm1hdG8gbW9kdWxhclxuICAgICAgICAgICAgaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uID0gcHJvZ3Jlc3NEYXRhLnBvc2l0aW9uLnN0YXJ0UG9zaXRpb247XG4gICAgICAgICAgfSBlbHNlIGlmIChwcm9ncmVzc0RhdGEucG9zaXRpb24uc3RhcnRYICE9PSB1bmRlZmluZWQgJiYgcHJvZ3Jlc3NEYXRhLnBvc2l0aW9uLnN0YXJ0WSAhPT0gdW5kZWZpbmVkKSB7XG4gICAgICAgICAgICAvLyBGb3JtYXRvIG9yaWdpbmFsXG4gICAgICAgICAgICBpbWFnZVN0YXRlLnN0YXJ0UG9zaXRpb24gPSB7IHg6IHByb2dyZXNzRGF0YS5wb3NpdGlvbi5zdGFydFgsIHk6IHByb2dyZXNzRGF0YS5wb3NpdGlvbi5zdGFydFkgfTtcbiAgICAgICAgICB9XG4gICAgICAgICAgXG4gICAgICAgICAgaW1hZ2VTdGF0ZS50aWxlWCA9IHByb2dyZXNzRGF0YS5wb3NpdGlvbi50aWxlWDtcbiAgICAgICAgICBpbWFnZVN0YXRlLnRpbGVZID0gcHJvZ3Jlc3NEYXRhLnBvc2l0aW9uLnRpbGVZO1xuICAgICAgICAgIGltYWdlU3RhdGUub3JpZ2luYWxJbWFnZU5hbWUgPSBwcm9ncmVzc0RhdGEuaW1hZ2VEYXRhLm9yaWdpbmFsTmFtZTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBNYW5lamFyIHJlbWFpbmluZ1BpeGVscyB0YW50byBlbiBwcm9ncmVzcyBjb21vIGVuIHJhXHUwMEVEelxuICAgICAgICAgIGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzID0gcHJvZ3Jlc3NEYXRhLnJlbWFpbmluZ1BpeGVscyB8fCBwcm9ncmVzc0RhdGEucHJvZ3Jlc3MucmVtYWluaW5nUGl4ZWxzIHx8IFtdO1xuXG4gICAgICAgICAgLy8gQWN0dWFsaXphciBvdmVybGF5IGRlbCBwbGFuIGNvbiBsb3MgcFx1MDBFRHhlbGVzIHJlc3RhbnRlcyAoc2kgbG9zIGhheSlcbiAgICAgICAgICB0cnkge1xuICAgICAgICAgICAgaWYgKHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXykge1xuICAgICAgICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uaW5qZWN0U3R5bGVzKCk7XG4gICAgICAgICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5zZXRFbmFibGVkKHRydWUpOyAvLyBBY3RpdmFyIGF1dG9tXHUwMEUxdGljYW1lbnRlIGFsIGNhcmdhciBwcm9ncmVzb1xuICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgLy8gQ29uZmlndXJhciBhbmNsYSBzaSB0ZW5lbW9zIHBvc2ljaVx1MDBGM24gZGUgaW5pY2lvXG4gICAgICAgICAgICAgIGlmIChpbWFnZVN0YXRlLnN0YXJ0UG9zaXRpb24gJiYgaW1hZ2VTdGF0ZS50aWxlWCAhPT0gdW5kZWZpbmVkICYmIGltYWdlU3RhdGUudGlsZVkgIT09IHVuZGVmaW5lZCkge1xuICAgICAgICAgICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5zZXRBbmNob3Ioe1xuICAgICAgICAgICAgICAgICAgdGlsZVg6IGltYWdlU3RhdGUudGlsZVgsXG4gICAgICAgICAgICAgICAgICB0aWxlWTogaW1hZ2VTdGF0ZS50aWxlWSxcbiAgICAgICAgICAgICAgICAgIHB4WDogaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uLngsXG4gICAgICAgICAgICAgICAgICBweFk6IGltYWdlU3RhdGUuc3RhcnRQb3NpdGlvbi55XG4gICAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgICAgbG9nKGBcdTI3MDUgUGxhbiBvdmVybGF5IGFuY2xhZG8gY29uIHBvc2ljaVx1MDBGM24gY2FyZ2FkYTogdGlsZSgke2ltYWdlU3RhdGUudGlsZVh9LCR7aW1hZ2VTdGF0ZS50aWxlWX0pIGxvY2FsKCR7aW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uLnh9LCR7aW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uLnl9KWApO1xuICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgIFxuICAgICAgICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uc2V0UGxhbihpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscywge1xuICAgICAgICAgICAgICAgIGVuYWJsZWQ6IHRydWUsXG4gICAgICAgICAgICAgICAgbmV4dEJhdGNoQ291bnQ6IGltYWdlU3RhdGUucGl4ZWxzUGVyQmF0Y2hcbiAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgIFxuICAgICAgICAgICAgICBsb2coYFx1MjcwNSBQbGFuIG92ZXJsYXkgYWN0aXZhZG8gY29uICR7aW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMubGVuZ3RofSBwXHUwMEVEeGVsZXMgcmVzdGFudGVzYCk7XG4gICAgICAgICAgICB9XG4gICAgICAgICAgfSBjYXRjaCAoZSkge1xuICAgICAgICAgICAgbG9nKCdcdTI2QTBcdUZFMEYgRXJyb3IgYWN0aXZhbmRvIHBsYW4gb3ZlcmxheSBhbCBjYXJnYXIgcHJvZ3Jlc286JywgZSk7XG4gICAgICAgICAgfVxuICAgICAgICAgIFxuICAgICAgICAgIGlmIChwcm9ncmVzc0RhdGEuY29uZmlnKSB7XG4gICAgICAgICAgICBpbWFnZVN0YXRlLnBpeGVsc1BlckJhdGNoID0gcHJvZ3Jlc3NEYXRhLmNvbmZpZy5waXhlbHNQZXJCYXRjaCB8fCBpbWFnZVN0YXRlLnBpeGVsc1BlckJhdGNoO1xuICAgICAgICAgICAgaW1hZ2VTdGF0ZS51c2VBbGxDaGFyZ2VzRmlyc3QgPSBwcm9ncmVzc0RhdGEuY29uZmlnLnVzZUFsbENoYXJnZXNGaXJzdCAhPT0gdW5kZWZpbmVkID8gXG4gICAgICAgICAgICAgIHByb2dyZXNzRGF0YS5jb25maWcudXNlQWxsQ2hhcmdlc0ZpcnN0IDogaW1hZ2VTdGF0ZS51c2VBbGxDaGFyZ2VzRmlyc3Q7XG4gICAgICAgICAgICBpbWFnZVN0YXRlLmlzRmlyc3RCYXRjaCA9IHByb2dyZXNzRGF0YS5jb25maWcuaXNGaXJzdEJhdGNoICE9PSB1bmRlZmluZWQgPyBcbiAgICAgICAgICAgICAgcHJvZ3Jlc3NEYXRhLmNvbmZpZy5pc0ZpcnN0QmF0Y2ggOiB0cnVlOyAvLyBQb3IgZGVmZWN0bywgY29udGludWFyIGNvbW8gbm8gcHJpbWVyYSBwYXNhZGFcbiAgICAgICAgICAgIGltYWdlU3RhdGUubWF4Q2hhcmdlcyA9IHByb2dyZXNzRGF0YS5jb25maWcubWF4Q2hhcmdlcyB8fCBpbWFnZVN0YXRlLm1heENoYXJnZXM7XG4gICAgICAgICAgfVxuICAgICAgICAgIFxuICAgICAgICAgIC8vIE1hcmNhciBjb21vIGltYWdlbiBjYXJnYWRhIHkgbGlzdG8gcGFyYSBjb250aW51YXJcbiAgICAgICAgICBpbWFnZVN0YXRlLmltYWdlTG9hZGVkID0gdHJ1ZTtcbiAgICAgICAgICBpbWFnZVN0YXRlLmNvbG9yc0NoZWNrZWQgPSB0cnVlO1xuXG4gICAgICAgICAgLy8gWWEgbm8gc2UgcmVzdGF1cmEgb3ZlcmxheSBkZSBpbWFnZW47IGVsIG92ZXJsYXkgZGUgcGxhbiBzZSBsbGVuYSBtXHUwMEUxcyBhYmFqb1xuICAgICAgICAgIFxuICAgICAgICAgIGxvZyhgXHUyNzA1IFByb2dyZXNvIGNhcmdhZG86ICR7aW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzfS8ke2ltYWdlU3RhdGUudG90YWxQaXhlbHN9IHBcdTAwRUR4ZWxlc2ApO1xuICAgICAgICAgIFxuICAgICAgICAgIHJlc29sdmUoeyBcbiAgICAgICAgICAgIHN1Y2Nlc3M6IHRydWUsIFxuICAgICAgICAgICAgZGF0YTogcHJvZ3Jlc3NEYXRhLFxuICAgICAgICAgICAgcGFpbnRlZDogaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzLFxuICAgICAgICAgICAgdG90YWw6IGltYWdlU3RhdGUudG90YWxQaXhlbHMsXG4gICAgICAgICAgICBjYW5Db250aW51ZTogaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMubGVuZ3RoID4gMFxuICAgICAgICAgIH0pO1xuICAgICAgICAgIFxuICAgICAgICB9IGNhdGNoIChwYXJzZUVycm9yKSB7XG4gICAgICAgICAgbG9nKCdcdTI3NEMgRXJyb3IgcGFyc2VhbmRvIGFyY2hpdm8gZGUgcHJvZ3Jlc286JywgcGFyc2VFcnJvcik7XG4gICAgICAgICAgcmVzb2x2ZSh7IHN1Y2Nlc3M6IGZhbHNlLCBlcnJvcjogcGFyc2VFcnJvci5tZXNzYWdlIH0pO1xuICAgICAgICB9XG4gICAgICB9O1xuICAgICAgXG4gICAgICByZWFkZXIub25lcnJvciA9ICgpID0+IHtcbiAgICAgICAgY29uc3QgZXJyb3IgPSAnRXJyb3IgbGV5ZW5kbyBhcmNoaXZvJztcbiAgICAgICAgbG9nKCdcdTI3NEMnLCBlcnJvcik7XG4gICAgICAgIHJlc29sdmUoeyBzdWNjZXNzOiBmYWxzZSwgZXJyb3IgfSk7XG4gICAgICB9O1xuICAgICAgXG4gICAgICByZWFkZXIucmVhZEFzVGV4dChmaWxlKTtcbiAgICAgIFxuICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICBsb2coJ1x1Mjc0QyBFcnJvciBjYXJnYW5kbyBwcm9ncmVzbzonLCBlcnJvcik7XG4gICAgICByZXNvbHZlKHsgc3VjY2VzczogZmFsc2UsIGVycm9yOiBlcnJvci5tZXNzYWdlIH0pO1xuICAgIH1cbiAgfSk7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBjbGVhclByb2dyZXNzKCkge1xuICBpbWFnZVN0YXRlLnBhaW50ZWRQaXhlbHMgPSAwO1xuICBpbWFnZVN0YXRlLnRvdGFsUGl4ZWxzID0gMDtcbiAgaW1hZ2VTdGF0ZS5sYXN0UG9zaXRpb24gPSB7IHg6IDAsIHk6IDAgfTtcbiAgaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMgPSBbXTtcbiAgaW1hZ2VTdGF0ZS5pbWFnZURhdGEgPSBudWxsO1xuICBpbWFnZVN0YXRlLnN0YXJ0UG9zaXRpb24gPSBudWxsO1xuICBpbWFnZVN0YXRlLmltYWdlTG9hZGVkID0gZmFsc2U7XG4gIGltYWdlU3RhdGUub3JpZ2luYWxJbWFnZU5hbWUgPSBudWxsO1xuICBpbWFnZVN0YXRlLmlzRmlyc3RCYXRjaCA9IHRydWU7IC8vIFJlc2V0ZWFyIHBhcmEgbnVldmEgaW1hZ2VuXG4gIGltYWdlU3RhdGUubmV4dEJhdGNoQ29vbGRvd24gPSAwO1xuICBcbiAgbG9nKCdcdUQ4M0VcdURERjkgUHJvZ3Jlc28gbGltcGlhZG8nKTtcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGhhc1Byb2dyZXNzKCkge1xuICByZXR1cm4gaW1hZ2VTdGF0ZS5pbWFnZUxvYWRlZCAmJiBcbiAgICAgICAgIGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyA+IDAgJiYgXG4gICAgICAgICBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscyAmJiBcbiAgICAgICAgIGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzLmxlbmd0aCA+IDA7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBnZXRQcm9ncmVzc0luZm8oKSB7XG4gIHJldHVybiB7XG4gICAgaGFzUHJvZ3Jlc3M6IGhhc1Byb2dyZXNzKCksXG4gICAgcGFpbnRlZDogaW1hZ2VTdGF0ZS5wYWludGVkUGl4ZWxzLFxuICAgIHRvdGFsOiBpbWFnZVN0YXRlLnRvdGFsUGl4ZWxzLFxuICAgIHJlbWFpbmluZzogaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMgPyBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscy5sZW5ndGggOiAwLFxuICAgIHBlcmNlbnRhZ2U6IGltYWdlU3RhdGUudG90YWxQaXhlbHMgPiAwID8gKGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyAvIGltYWdlU3RhdGUudG90YWxQaXhlbHMgKiAxMDApIDogMCxcbiAgICBsYXN0UG9zaXRpb246IHsgLi4uaW1hZ2VTdGF0ZS5sYXN0UG9zaXRpb24gfSxcbiAgICBjYW5Db250aW51ZTogaGFzUHJvZ3Jlc3MoKVxuICB9O1xufVxuIiwgImV4cG9ydCBmdW5jdGlvbiBjcmVhdGVTaGFkb3dSb290KGhvc3RJZCA9IG51bGwpIHtcbiAgY29uc3QgaG9zdCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICBpZiAoaG9zdElkKSB7XG4gICAgaG9zdC5pZCA9IGhvc3RJZDtcbiAgfVxuICBob3N0LnN0eWxlLmNzc1RleHQgPSBgXG4gICAgcG9zaXRpb246IGZpeGVkO1xuICAgIHRvcDogMTBweDtcbiAgICByaWdodDogMTBweDtcbiAgICB6LWluZGV4OiAyMTQ3NDgzNjQ3O1xuICAgIGZvbnQtZmFtaWx5OiAtYXBwbGUtc3lzdGVtLCBCbGlua01hY1N5c3RlbUZvbnQsICdTZWdvZSBVSScsICdSb2JvdG8nLCBzYW5zLXNlcmlmO1xuICBgO1xuICBcbiAgY29uc3Qgcm9vdCA9IGhvc3QuYXR0YWNoU2hhZG93KHsgbW9kZTogJ29wZW4nIH0pO1xuICBkb2N1bWVudC5ib2R5LmFwcGVuZENoaWxkKGhvc3QpO1xuICBcbiAgcmV0dXJuIHsgaG9zdCwgcm9vdCB9O1xufVxuXG5leHBvcnQgZnVuY3Rpb24gbWFrZURyYWdnYWJsZShkcmFnSGFuZGxlLCBlbGVtZW50KSB7XG4gIGxldCBwb3MxID0gMCwgcG9zMiA9IDAsIHBvczMgPSAwLCBwb3M0ID0gMDtcbiAgXG4gIGRyYWdIYW5kbGUuc3R5bGUuY3Vyc29yID0gJ21vdmUnO1xuICBkcmFnSGFuZGxlLmFkZEV2ZW50TGlzdGVuZXIoJ21vdXNlZG93bicsIGRyYWdNb3VzZURvd24pO1xuICBcbiAgZnVuY3Rpb24gZHJhZ01vdXNlRG93bihlKSB7XG4gICAgLy8gRXZpdGFyIGFycmFzdHJhIHNpIGVzIHVuIGJvdFx1MDBGM24gZGUgbGEgY2FiZWNlcmFcbiAgICBpZiAoZS50YXJnZXQuY2xvc2VzdCgnLmhlYWRlci1idG4sIC53cGxhY2UtaGVhZGVyLWJ0bicpKSByZXR1cm47XG4gICAgXG4gICAgZS5wcmV2ZW50RGVmYXVsdCgpO1xuICAgIHBvczMgPSBlLmNsaWVudFg7XG4gICAgcG9zNCA9IGUuY2xpZW50WTtcbiAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdtb3VzZXVwJywgY2xvc2VEcmFnRWxlbWVudCk7XG4gICAgZG9jdW1lbnQuYWRkRXZlbnRMaXN0ZW5lcignbW91c2Vtb3ZlJywgZWxlbWVudERyYWcpO1xuICB9XG4gIFxuICBmdW5jdGlvbiBlbGVtZW50RHJhZyhlKSB7XG4gICAgZS5wcmV2ZW50RGVmYXVsdCgpO1xuICAgIHBvczEgPSBwb3MzIC0gZS5jbGllbnRYO1xuICAgIHBvczIgPSBwb3M0IC0gZS5jbGllbnRZO1xuICAgIHBvczMgPSBlLmNsaWVudFg7XG4gICAgcG9zNCA9IGUuY2xpZW50WTtcbiAgICBlbGVtZW50LnN0eWxlLnRvcCA9IChlbGVtZW50Lm9mZnNldFRvcCAtIHBvczIpICsgXCJweFwiO1xuICAgIGVsZW1lbnQuc3R5bGUubGVmdCA9IChlbGVtZW50Lm9mZnNldExlZnQgLSBwb3MxKSArIFwicHhcIjtcbiAgfVxuICBcbiAgZnVuY3Rpb24gY2xvc2VEcmFnRWxlbWVudCgpIHtcbiAgICBkb2N1bWVudC5yZW1vdmVFdmVudExpc3RlbmVyKCdtb3VzZXVwJywgY2xvc2VEcmFnRWxlbWVudCk7XG4gICAgZG9jdW1lbnQucmVtb3ZlRXZlbnRMaXN0ZW5lcignbW91c2Vtb3ZlJywgZWxlbWVudERyYWcpO1xuICB9XG59XG4iLCAiaW1wb3J0IHsgbG9nIH0gZnJvbSBcIi4uL2NvcmUvbG9nZ2VyLmpzXCI7XG5pbXBvcnQgeyBjcmVhdGVTaGFkb3dSb290LCBtYWtlRHJhZ2dhYmxlIH0gZnJvbSBcIi4uL2NvcmUvdWktdXRpbHMuanNcIjtcblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIGNyZWF0ZUltYWdlVUkoeyB0ZXh0cywgLi4uaGFuZGxlcnMgfSkge1xuICBsb2coJ1x1RDgzQ1x1REZBOCBDcmVhbmRvIGludGVyZmF6IGRlIEF1dG8tSW1hZ2UnKTtcbiAgXG4gIC8vIEFncmVnYXIgRm9udEF3ZXNvbWUgYWwgZG9jdW1lbnQuaGVhZCBzaSBubyBleGlzdGVcbiAgaWYgKCFkb2N1bWVudC5xdWVyeVNlbGVjdG9yKCdsaW5rW2hyZWYqPVwiZm9udC1hd2Vzb21lXCJdJykpIHtcbiAgICBjb25zdCBmb250QXdlc29tZSA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2xpbmsnKTtcbiAgICBmb250QXdlc29tZS5yZWwgPSAnc3R5bGVzaGVldCc7XG4gICAgZm9udEF3ZXNvbWUuaHJlZiA9ICdodHRwczovL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9mb250LWF3ZXNvbWUvNi40LjAvY3NzL2FsbC5taW4uY3NzJztcbiAgICBkb2N1bWVudC5oZWFkLmFwcGVuZENoaWxkKGZvbnRBd2Vzb21lKTtcbiAgICBsb2coJ1x1RDgzRFx1RENFNiBGb250QXdlc29tZSBhXHUwMEYxYWRpZG8gYWwgZG9jdW1lbnQuaGVhZCcpO1xuICB9XG4gIFxuICAvLyBDcmVhciBzaGFkb3cgcm9vdCBwYXJhIGFpc2xhbWllbnRvIGRlIGVzdGlsb3NcbiAgY29uc3QgeyBob3N0LCByb290IH0gPSBjcmVhdGVTaGFkb3dSb290KCk7XG4gIFxuICAvLyBDcmVhciBlc3RpbG9zXG4gIGNvbnN0IHN0eWxlID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc3R5bGUnKTtcbiAgc3R5bGUudGV4dENvbnRlbnQgPSBgXG4gICAgQGtleWZyYW1lcyBzbGlkZUluIHtcbiAgICAgIGZyb20geyB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoMjBweCk7IG9wYWNpdHk6IDA7IH1cbiAgICAgIHRvIHsgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDApOyBvcGFjaXR5OiAxOyB9XG4gICAgfVxuICAgIEBrZXlmcmFtZXMgcHVsc2Uge1xuICAgICAgMCUgeyBib3gtc2hhZG93OiAwIDAgMCAwIHJnYmEoMCwgMjU1LCAwLCAwLjcpOyB9XG4gICAgICA3MCUgeyBib3gtc2hhZG93OiAwIDAgMCAxMHB4IHJnYmEoMCwgMjU1LCAwLCAwKTsgfVxuICAgICAgMTAwJSB7IGJveC1zaGFkb3c6IDAgMCAwIDAgcmdiYSgwLCAyNTUsIDAsIDApOyB9XG4gICAgfVxuICAgIFxuICAgIC5jb250YWluZXIge1xuICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgdG9wOiAyMHB4O1xuICAgICAgcmlnaHQ6IDIwcHg7XG4gICAgICB3aWR0aDogMzAwcHg7XG4gICAgICBiYWNrZ3JvdW5kOiAjMWExYTFhO1xuICAgICAgYm9yZGVyOiAxcHggc29saWQgIzMzMztcbiAgICAgIGJvcmRlci1yYWRpdXM6IDhweDtcbiAgICAgIHBhZGRpbmc6IDA7XG4gICAgICBib3gtc2hhZG93OiAwIDVweCAxNXB4IHJnYmEoMCwwLDAsMC41KTtcbiAgICAgIHotaW5kZXg6IDk5OTg7XG4gICAgICBmb250LWZhbWlseTogJ1NlZ29lIFVJJywgUm9ib3RvLCBzYW5zLXNlcmlmO1xuICAgICAgY29sb3I6ICNlZWU7XG4gICAgICBhbmltYXRpb246IHNsaWRlSW4gMC40cyBlYXNlLW91dDtcbiAgICAgIG92ZXJmbG93OiBoaWRkZW47XG4gICAgfVxuICAgIFxuICAgIC5oZWFkZXIge1xuICAgICAgcGFkZGluZzogMTJweCAxNXB4O1xuICAgICAgYmFja2dyb3VuZDogIzJkMzc0ODtcbiAgICAgIGNvbG9yOiAjNjBhNWZhO1xuICAgICAgZm9udC1zaXplOiAxNnB4O1xuICAgICAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG4gICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgY3Vyc29yOiBtb3ZlO1xuICAgICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgfVxuICAgIFxuICAgIC5oZWFkZXItdGl0bGUge1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICBnYXA6IDhweDtcbiAgICB9XG4gICAgXG4gICAgLmhlYWRlci1jb250cm9scyB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgZ2FwOiAxMHB4O1xuICAgIH1cbiAgICBcbiAgICAuaGVhZGVyLWJ0biB7XG4gICAgICBiYWNrZ3JvdW5kOiBub25lO1xuICAgICAgYm9yZGVyOiBub25lO1xuICAgICAgY29sb3I6ICNlZWU7XG4gICAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgICBvcGFjaXR5OiAwLjc7XG4gICAgICB0cmFuc2l0aW9uOiBvcGFjaXR5IDAuMnM7XG4gICAgICBwYWRkaW5nOiA1cHg7XG4gICAgfVxuICAgIFxuICAgIC5oZWFkZXItYnRuOmhvdmVyIHtcbiAgICAgIG9wYWNpdHk6IDE7XG4gICAgfVxuICAgIFxuICAgIC5jb250ZW50IHtcbiAgICAgIHBhZGRpbmc6IDE1cHg7XG4gICAgICBkaXNwbGF5OiBibG9jaztcbiAgICB9XG4gICAgXG4gICAgLmNvbnRyb2xzIHtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuICAgICAgZ2FwOiAxMHB4O1xuICAgICAgbWFyZ2luLWJvdHRvbTogMTVweDtcbiAgICB9XG4gICAgXG4gICAgLmNvbmZpZy1wYW5lbCB7XG4gICAgICBkaXNwbGF5OiBub25lO1xuICAgICAgYmFja2dyb3VuZDogIzJkMzc0ODtcbiAgICAgIHBhZGRpbmc6IDEwcHg7XG4gICAgICBib3JkZXItcmFkaXVzOiA2cHg7XG4gICAgICBtYXJnaW4tYm90dG9tOiAxMHB4O1xuICAgIH1cbiAgICBcbiAgICAuY29uZmlnLXBhbmVsLnZpc2libGUge1xuICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgfVxuICAgIFxuICAgIC5jb25maWctaXRlbSB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIG1hcmdpbi1ib3R0b206IDhweDtcbiAgICAgIGZvbnQtc2l6ZTogMTRweDtcbiAgICB9XG4gICAgXG4gICAgLmNvbmZpZy1pbnB1dCB7XG4gICAgICB3aWR0aDogNjBweDtcbiAgICAgIHBhZGRpbmc6IDRweDtcbiAgICAgIGJvcmRlcjogMXB4IHNvbGlkICMzMzM7XG4gICAgICBib3JkZXItcmFkaXVzOiA0cHg7XG4gICAgICBiYWNrZ3JvdW5kOiAjMWExYTFhO1xuICAgICAgY29sb3I6ICNlZWU7XG4gICAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gICAgfVxuICAgIFxuICAgIC5jb25maWctY2hlY2tib3gge1xuICAgICAgbWFyZ2luLXJpZ2h0OiA4cHg7XG4gICAgfVxuICAgIFxuICAgIC5tYWluLWNvbmZpZyB7XG4gICAgICBiYWNrZ3JvdW5kOiAjMmQzNzQ4O1xuICAgICAgcGFkZGluZzogMTBweDtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDZweDtcbiAgICAgIG1hcmdpbi1ib3R0b206IDEwcHg7XG4gICAgICBib3JkZXI6IDFweCBzb2xpZCAjM2E0NTUzO1xuICAgIH1cbiAgICBcbiAgICAuY29uZmlnLXJvdyB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIGdhcDogMTBweDtcbiAgICB9XG4gICAgXG4gICAgLmNvbmZpZy1sYWJlbCB7XG4gICAgICBmb250LXNpemU6IDEzcHg7XG4gICAgICBjb2xvcjogI2NiZDVlMDtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgZ2FwOiA0cHg7XG4gICAgfVxuICAgIFxuICAgIC5iYXRjaC12YWx1ZSwgLmNvb2xkb3duLXZhbHVlIHtcbiAgICAgIGZvbnQtd2VpZ2h0OiBib2xkO1xuICAgICAgY29sb3I6ICM2MGE1ZmE7XG4gICAgfVxuICAgIFxuICAgIC5idG4ge1xuICAgICAgcGFkZGluZzogMTBweDtcbiAgICAgIGJvcmRlcjogbm9uZTtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDZweDtcbiAgICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIGp1c3RpZnktY29udGVudDogY2VudGVyO1xuICAgICAgZ2FwOiA4cHg7XG4gICAgICB0cmFuc2l0aW9uOiBhbGwgMC4ycztcbiAgICAgIGZvbnQtc2l6ZTogMTRweDtcbiAgICB9XG4gICAgXG4gICAgLmJ0bjpob3Zlcjpub3QoOmRpc2FibGVkKSB7XG4gICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTJweCk7XG4gICAgfVxuICAgIFxuICAgIC5idG46ZGlzYWJsZWQge1xuICAgICAgb3BhY2l0eTogMC41O1xuICAgICAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgICAgIHRyYW5zZm9ybTogbm9uZSAhaW1wb3J0YW50O1xuICAgIH1cbiAgICBcbiAgICAuYnRuLXByaW1hcnkge1xuICAgICAgYmFja2dyb3VuZDogIzYwYTVmYTtcbiAgICAgIGNvbG9yOiB3aGl0ZTtcbiAgICB9XG4gICAgXG4gICAgLmJ0bi11cGxvYWQge1xuICAgICAgYmFja2dyb3VuZDogIzJkMzc0ODtcbiAgICAgIGNvbG9yOiB3aGl0ZTtcbiAgICAgIGJvcmRlcjogMXB4IGRhc2hlZCAjZWVlO1xuICAgIH1cbiAgICBcbiAgICAuYnRuLWxvYWQge1xuICAgICAgYmFja2dyb3VuZDogIzIxOTZGMztcbiAgICAgIGNvbG9yOiB3aGl0ZTtcbiAgICB9XG4gICAgXG4gICAgLmJ0bi1zdGFydCB7XG4gICAgICBiYWNrZ3JvdW5kOiAjMTBiOTgxO1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgIH1cbiAgICBcbiAgICAuYnRuLXN0b3Age1xuICAgICAgYmFja2dyb3VuZDogI2VmNDQ0NDtcbiAgICAgIGNvbG9yOiB3aGl0ZTtcbiAgICB9XG4gICAgXG4gICAgLmJ0bi1zZWxlY3Qge1xuICAgICAgYmFja2dyb3VuZDogI2Y1OWUwYjtcbiAgICAgIGNvbG9yOiBibGFjaztcbiAgICB9XG4gICAgXG4gICAgLnByb2dyZXNzIHtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgYmFja2dyb3VuZDogIzJkMzc0ODtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDRweDtcbiAgICAgIG1hcmdpbjogMTBweCAwO1xuICAgICAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgICAgIGhlaWdodDogMTBweDtcbiAgICB9XG4gICAgXG4gICAgLnByb2dyZXNzLWJhciB7XG4gICAgICBoZWlnaHQ6IDEwMCU7XG4gICAgICBiYWNrZ3JvdW5kOiAjNjBhNWZhO1xuICAgICAgdHJhbnNpdGlvbjogd2lkdGggMC4zcztcbiAgICAgIHdpZHRoOiAwJTtcbiAgICB9XG4gICAgXG4gICAgLnN0YXRzIHtcbiAgICAgIGJhY2tncm91bmQ6ICMyZDM3NDg7XG4gICAgICBwYWRkaW5nOiAxMnB4O1xuICAgICAgYm9yZGVyLXJhZGl1czogNnB4O1xuICAgICAgbWFyZ2luLWJvdHRvbTogMTVweDtcbiAgICB9XG4gICAgXG4gICAgLnN0YXQtaXRlbSB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuICAgICAgcGFkZGluZzogNnB4IDA7XG4gICAgICBmb250LXNpemU6IDE0cHg7XG4gICAgfVxuICAgIFxuICAgIC5zdGF0LWxhYmVsIHtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgZ2FwOiA2cHg7XG4gICAgICBvcGFjaXR5OiAwLjg7XG4gICAgfVxuICAgIFxuICAgIC5zdGF0dXMge1xuICAgICAgcGFkZGluZzogOHB4O1xuICAgICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICAgICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgICAgZm9udC1zaXplOiAxM3B4O1xuICAgIH1cbiAgICBcbiAgICAuc3RhdHVzLWRlZmF1bHQge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgyNTUsMjU1LDI1NSwwLjEpO1xuICAgIH1cbiAgICBcbiAgICAuc3RhdHVzLXN1Y2Nlc3Mge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgwLCAyNTUsIDAsIDAuMSk7XG4gICAgICBjb2xvcjogIzEwYjk4MTtcbiAgICB9XG4gICAgXG4gICAgLnN0YXR1cy1lcnJvciB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwgMCwgMCwgMC4xKTtcbiAgICAgIGNvbG9yOiAjZWY0NDQ0O1xuICAgIH1cbiAgICBcbiAgICAuc3RhdHVzLXdhcm5pbmcge1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgyNTUsIDE2NSwgMCwgMC4xKTtcbiAgICAgIGNvbG9yOiBvcmFuZ2U7XG4gICAgfVxuICAgIFxuICAgIC5zdGF0dXMtaW5mbyB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDAsIDE1MCwgMjU1LCAwLjEpO1xuICAgICAgY29sb3I6ICM2MGE1ZmE7XG4gICAgfVxuICAgIFxuICAgIC5taW5pbWl6ZWQgLmNvbnRlbnQge1xuICAgICAgZGlzcGxheTogbm9uZTtcbiAgICB9XG4gICAgXG4gICAgLm1vZGFsLW92ZXJsYXkge1xuICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgdG9wOiAwO1xuICAgICAgbGVmdDogMDtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgaGVpZ2h0OiAxMDAlO1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjcpO1xuICAgICAgei1pbmRleDogMTAwMDE7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIGp1c3RpZnktY29udGVudDogY2VudGVyO1xuICAgIH1cbiAgICBcbiAgICAubW9kYWwge1xuICAgICAgYmFja2dyb3VuZDogIzFhMWExYTtcbiAgICAgIGJvcmRlcjogMnB4IHNvbGlkICMzMzM7XG4gICAgICBib3JkZXItcmFkaXVzOiAxNXB4O1xuICAgICAgcGFkZGluZzogMjVweDtcbiAgICAgIGNvbG9yOiAjZWVlO1xuICAgICAgbWluLXdpZHRoOiAzNTBweDtcbiAgICAgIG1heC13aWR0aDogNDAwcHg7XG4gICAgICBib3gtc2hhZG93OiAwIDEwcHggMzBweCByZ2JhKDAsMCwwLDAuNSk7XG4gICAgfVxuICAgIFxuICAgIC5tb2RhbCBoMyB7XG4gICAgICBtYXJnaW46IDAgMCAxNXB4IDA7XG4gICAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gICAgICBmb250LXNpemU6IDE4cHg7XG4gICAgfVxuICAgIFxuICAgIC5tb2RhbCBwIHtcbiAgICAgIG1hcmdpbjogMCAwIDIwcHggMDtcbiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICAgIGxpbmUtaGVpZ2h0OiAxLjQ7XG4gICAgfVxuICAgIFxuICAgIC5tb2RhbC1idXR0b25zIHtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBnYXA6IDEwcHg7XG4gICAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgICB9XG4gICAgXG4gICAgLm1vZGFsLWJ0biB7XG4gICAgICBwYWRkaW5nOiAxMHB4IDIwcHg7XG4gICAgICBib3JkZXI6IG5vbmU7XG4gICAgICBib3JkZXItcmFkaXVzOiA4cHg7XG4gICAgICBmb250LXNpemU6IDE0cHg7XG4gICAgICBmb250LXdlaWdodDogYm9sZDtcbiAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICAgIHRyYW5zaXRpb246IGFsbCAwLjNzO1xuICAgICAgbWluLXdpZHRoOiAxMDBweDtcbiAgICB9XG4gICAgXG4gICAgLm1vZGFsLWJ0bi1zYXZlIHtcbiAgICAgIGJhY2tncm91bmQ6ICMxMGI5ODE7XG4gICAgICBjb2xvcjogd2hpdGU7XG4gICAgfVxuICAgIFxuICAgIC5tb2RhbC1idG4tZGlzY2FyZCB7XG4gICAgICBiYWNrZ3JvdW5kOiAjZWY0NDQ0O1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgIH1cbiAgICBcbiAgICAubW9kYWwtYnRuLWNhbmNlbCB7XG4gICAgICBiYWNrZ3JvdW5kOiAjMmQzNzQ4O1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgIH1cbiAgICBcbiAgICAubW9kYWwtYnRuOmhvdmVyIHtcbiAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgtMnB4KTtcbiAgICB9XG4gICAgXG4gICAgLyogUmVzaXplIERpYWxvZyBTdHlsZXMgKi9cbiAgICAucmVzaXplLW92ZXJsYXkge1xuICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgdG9wOiAwO1xuICAgICAgbGVmdDogMDtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgaGVpZ2h0OiAxMDAlO1xuICAgICAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjcpO1xuICAgICAgei1pbmRleDogOTk5OTtcbiAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgfVxuICAgIFxuICAgIC5yZXNpemUtY29udGFpbmVyIHtcbiAgICAgIHBvc2l0aW9uOiBmaXhlZDtcbiAgICAgIHRvcDogNTAlO1xuICAgICAgbGVmdDogNTAlO1xuICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGUoLTUwJSwgLTUwJSk7XG4gICAgICBiYWNrZ3JvdW5kOiAjMWExYTFhO1xuICAgICAgcGFkZGluZzogMjBweDtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDhweDtcbiAgICAgIHotaW5kZXg6IDEwMDAwO1xuICAgICAgYm94LXNoYWRvdzogMCAwIDIwcHggcmdiYSgwLDAsMCwwLjUpO1xuICAgICAgbWF4LXdpZHRoOiA5MCU7XG4gICAgICBtYXgtaGVpZ2h0OiA5MCU7XG4gICAgICBvdmVyZmxvdzogYXV0bztcbiAgICAgIGNvbG9yOiAjZmZmZmZmO1xuICAgICAgZGlzcGxheTogbm9uZTtcbiAgICB9XG4gICAgXG4gICAgLnJlc2l6ZS1jb250YWluZXIgaDMge1xuICAgICAgbWFyZ2luOiAwIDAgMTVweCAwO1xuICAgICAgY29sb3I6ICNmZmZmZmY7XG4gICAgfVxuICAgIFxuICAgIC5yZXNpemUtY29udHJvbHMge1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gICAgICBnYXA6IDEwcHg7XG4gICAgICBtYXJnaW4tdG9wOiAxNXB4O1xuICAgIH1cbiAgICBcbiAgICAucmVzaXplLWNvbnRyb2xzIGxhYmVsIHtcbiAgICAgIGNvbG9yOiAjZmZmZmZmO1xuICAgICAgZm9udC1zaXplOiAxNHB4O1xuICAgIH1cbiAgICBcbiAgICAucmVzaXplLXNsaWRlciB7XG4gICAgICB3aWR0aDogMTAwJTtcbiAgICAgIG1hcmdpbjogNXB4IDA7XG4gICAgfVxuICAgIFxuICAgIC5yZXNpemUtcHJldmlldyB7XG4gICAgICBtYXgtd2lkdGg6IDEwMCU7XG4gICAgICBtYXgtaGVpZ2h0OiAzMDBweDtcbiAgICAgIG1hcmdpbjogMTBweCAwO1xuICAgICAgYm9yZGVyOiAxcHggc29saWQgIzMzMztcbiAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIH1cbiAgICBcbiAgICAucmVzaXplLWJ1dHRvbnMge1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGdhcDogMTBweDtcbiAgICAgIG1hcmdpbi10b3A6IDE1cHg7XG4gICAgfVxuICBgO1xuICByb290LmFwcGVuZENoaWxkKHN0eWxlKTtcbiAgXG4gIC8vIENyZWFyIGNvbnRlbmVkb3IgcHJpbmNpcGFsXG4gIGNvbnN0IGNvbnRhaW5lciA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICBjb250YWluZXIuY2xhc3NOYW1lID0gJ2NvbnRhaW5lcic7XG4gIGNvbnRhaW5lci5pbm5lckhUTUwgPSBgXG4gICAgPGRpdiBjbGFzcz1cImhlYWRlclwiPlxuICAgICAgPGRpdiBjbGFzcz1cImhlYWRlci10aXRsZVwiPlxuICAgICAgICBcdUQ4M0RcdUREQkNcdUZFMEZcbiAgICAgICAgPHNwYW4+JHt0ZXh0cy50aXRsZX08L3NwYW4+XG4gICAgICA8L2Rpdj5cbiAgICAgIDxkaXYgY2xhc3M9XCJoZWFkZXItY29udHJvbHNcIj5cbiAgICAgICAgPGJ1dHRvbiBjbGFzcz1cImhlYWRlci1idG4gY29uZmlnLWJ0blwiIHRpdGxlPVwiQ29uZmlndXJhY2lcdTAwRjNuXCI+XG4gICAgICAgICAgXHUyNjk5XHVGRTBGXG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgICA8YnV0dG9uIGNsYXNzPVwiaGVhZGVyLWJ0biBtaW5pbWl6ZS1idG5cIiB0aXRsZT1cIiR7dGV4dHMubWluaW1pemV9XCI+XG4gICAgICAgICAgXHUyNzk2XG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgPC9kaXY+XG4gICAgPC9kaXY+XG4gICAgPGRpdiBjbGFzcz1cImNvbnRlbnRcIj5cbiAgICAgIDxkaXYgY2xhc3M9XCJjb25maWctcGFuZWxcIj5cbiAgICAgICAgPGRpdiBjbGFzcz1cImNvbmZpZy1pdGVtXCI+XG4gICAgICAgICAgPGxhYmVsPiR7dGV4dHMuYmF0Y2hTaXplfTo8L2xhYmVsPlxuICAgICAgICAgIDxpbnB1dCBjbGFzcz1cImNvbmZpZy1pbnB1dCBwaXhlbHMtcGVyLWJhdGNoXCIgdHlwZT1cIm51bWJlclwiIG1pbj1cIjFcIiBtYXg9XCI1MFwiIHZhbHVlPVwiMjBcIj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJjb25maWctaXRlbVwiPlxuICAgICAgICAgIDxsYWJlbD5cbiAgICAgICAgICAgIDxpbnB1dCBjbGFzcz1cImNvbmZpZy1jaGVja2JveCB1c2UtYWxsLWNoYXJnZXNcIiB0eXBlPVwiY2hlY2tib3hcIiBjaGVja2VkPlxuICAgICAgICAgICAgJHt0ZXh0cy51c2VBbGxDaGFyZ2VzfVxuICAgICAgICAgIDwvbGFiZWw+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICA8ZGl2IGNsYXNzPVwiY29uZmlnLWl0ZW1cIj5cbiAgICAgICAgICA8bGFiZWw+XG4gICAgICAgICAgICA8aW5wdXQgY2xhc3M9XCJjb25maWctY2hlY2tib3ggc2hvdy1vdmVybGF5XCIgdHlwZT1cImNoZWNrYm94XCIgY2hlY2tlZD5cbiAgICAgICAgICAgICR7dGV4dHMuc2hvd092ZXJsYXkgfHwgJ01vc3RyYXIgb3ZlcmxheSd9XG4gICAgICAgICAgPC9sYWJlbD5cbiAgICAgICAgPC9kaXY+XG4gICAgICA8L2Rpdj5cbiAgICAgIFxuICAgICAgPCEtLSBDb25maWd1cmFjaVx1MDBGM24gdmlzaWJsZSBlbiBsYSBpbnRlcmZheiBwcmluY2lwYWwgLS0+XG4gICAgICA8ZGl2IGNsYXNzPVwibWFpbi1jb25maWdcIj5cbiAgICAgICAgPGRpdiBjbGFzcz1cImNvbmZpZy1yb3dcIj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwiY29uZmlnLWxhYmVsXCI+XG4gICAgICAgICAgICBcdUQ4M0NcdURGQUYgJHt0ZXh0cy5iYXRjaFNpemV9OlxuICAgICAgICAgICAgPHNwYW4gY2xhc3M9XCJiYXRjaC12YWx1ZVwiPjIwPC9zcGFuPlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJjb25maWctbGFiZWxcIj5cbiAgICAgICAgICAgIFx1MjNGMVx1RkUwRiAke3RleHRzLm5leHRCYXRjaFRpbWV9OlxuICAgICAgICAgICAgPHNwYW4gY2xhc3M9XCJjb29sZG93bi12YWx1ZVwiPi0tPC9zcGFuPlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICA8L2Rpdj5cbiAgICAgIDwvZGl2PlxuICAgICAgXG4gICAgICA8ZGl2IGNsYXNzPVwiY29udHJvbHNcIj5cbiAgICAgICAgPGJ1dHRvbiBjbGFzcz1cImJ0biBidG4tcHJpbWFyeSBpbml0LWJ0blwiPlxuICAgICAgICAgIFx1RDgzRVx1REQxNlxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMuaW5pdEJvdH08L3NwYW4+XG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgICA8YnV0dG9uIGNsYXNzPVwiYnRuIGJ0bi11cGxvYWQgdXBsb2FkLWJ0blwiIGRpc2FibGVkPlxuICAgICAgICAgIFx1RDgzRFx1RENFNFxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMudXBsb2FkSW1hZ2V9PC9zcGFuPlxuICAgICAgICA8L2J1dHRvbj5cbiAgICAgICAgPGJ1dHRvbiBjbGFzcz1cImJ0biBidG4tbG9hZCBsb2FkLXByb2dyZXNzLWJ0blwiIGRpc2FibGVkPlxuICAgICAgICAgIFx1RDgzRFx1RENDMVxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMubG9hZFByb2dyZXNzfTwvc3Bhbj5cbiAgICAgICAgPC9idXR0b24+XG4gICAgICAgIDxidXR0b24gY2xhc3M9XCJidG4gYnRuLXByaW1hcnkgcmVzaXplLWJ0blwiIGRpc2FibGVkPlxuICAgICAgICAgIFx1RDgzRFx1REQwNFxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMucmVzaXplSW1hZ2V9PC9zcGFuPlxuICAgICAgICA8L2J1dHRvbj5cbiAgICAgICAgPGJ1dHRvbiBjbGFzcz1cImJ0biBidG4tc2VsZWN0IHNlbGVjdC1wb3MtYnRuXCIgZGlzYWJsZWQ+XG4gICAgICAgICAgXHVEODNDXHVERkFGXG4gICAgICAgICAgPHNwYW4+JHt0ZXh0cy5zZWxlY3RQb3NpdGlvbn08L3NwYW4+XG4gICAgICAgIDwvYnV0dG9uPlxuICAgICAgICA8YnV0dG9uIGNsYXNzPVwiYnRuIGJ0bi1zdGFydCBzdGFydC1idG5cIiBkaXNhYmxlZD5cbiAgICAgICAgICBcdTI1QjZcdUZFMEZcbiAgICAgICAgICA8c3Bhbj4ke3RleHRzLnN0YXJ0UGFpbnRpbmd9PC9zcGFuPlxuICAgICAgICA8L2J1dHRvbj5cbiAgICAgICAgPGJ1dHRvbiBjbGFzcz1cImJ0biBidG4tc3RvcCBzdG9wLWJ0blwiIGRpc2FibGVkPlxuICAgICAgICAgIFx1MjNGOVx1RkUwRlxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMuc3RvcFBhaW50aW5nfTwvc3Bhbj5cbiAgICAgICAgPC9idXR0b24+XG4gICAgICA8L2Rpdj5cbiAgICAgIFxuICAgICAgPGRpdiBjbGFzcz1cInByb2dyZXNzXCI+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJwcm9ncmVzcy1iYXJcIj48L2Rpdj5cbiAgICAgIDwvZGl2PlxuICAgICAgXG4gICAgICA8ZGl2IGNsYXNzPVwic3RhdHNcIj5cbiAgICAgICAgPGRpdiBjbGFzcz1cInN0YXRzLWFyZWFcIj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1pdGVtXCI+XG4gICAgICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1sYWJlbFwiPlx1MjEzOVx1RkUwRiAke3RleHRzLmluaXRNZXNzYWdlfTwvZGl2PlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICA8L2Rpdj5cbiAgICAgIDwvZGl2PlxuICAgICAgXG4gICAgICA8ZGl2IGNsYXNzPVwic3RhdHVzIHN0YXR1cy1kZWZhdWx0XCI+XG4gICAgICAgICR7dGV4dHMud2FpdGluZ0luaXR9XG4gICAgICA8L2Rpdj5cbiAgICA8L2Rpdj5cbiAgYDtcbiAgXG4gIHJvb3QuYXBwZW5kQ2hpbGQoY29udGFpbmVyKTtcbiAgXG4gIC8vIElucHV0IG9jdWx0byBwYXJhIGFyY2hpdm9zXG4gIGNvbnN0IGZpbGVJbnB1dCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2lucHV0Jyk7XG4gIGZpbGVJbnB1dC50eXBlID0gJ2ZpbGUnO1xuICBmaWxlSW5wdXQuYWNjZXB0ID0gJ2ltYWdlL3BuZyxpbWFnZS9qcGVnJztcbiAgZmlsZUlucHV0LnN0eWxlLmRpc3BsYXkgPSAnbm9uZSc7XG4gIHJvb3QuYXBwZW5kQ2hpbGQoZmlsZUlucHV0KTtcbiAgXG4gIGNvbnN0IHByb2dyZXNzRmlsZUlucHV0ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnaW5wdXQnKTtcbiAgcHJvZ3Jlc3NGaWxlSW5wdXQudHlwZSA9ICdmaWxlJztcbiAgcHJvZ3Jlc3NGaWxlSW5wdXQuYWNjZXB0ID0gJy5qc29uJztcbiAgcHJvZ3Jlc3NGaWxlSW5wdXQuc3R5bGUuZGlzcGxheSA9ICdub25lJztcbiAgcm9vdC5hcHBlbmRDaGlsZChwcm9ncmVzc0ZpbGVJbnB1dCk7XG4gIFxuICAvLyBNb2RhbCBkZSByZXNpemVcbiAgY29uc3QgcmVzaXplT3ZlcmxheSA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICByZXNpemVPdmVybGF5LmNsYXNzTmFtZSA9ICdyZXNpemUtb3ZlcmxheSc7XG4gIHJvb3QuYXBwZW5kQ2hpbGQocmVzaXplT3ZlcmxheSk7XG4gIFxuICBjb25zdCByZXNpemVDb250YWluZXIgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdkaXYnKTtcbiAgcmVzaXplQ29udGFpbmVyLmNsYXNzTmFtZSA9ICdyZXNpemUtY29udGFpbmVyJztcbiAgcmVzaXplQ29udGFpbmVyLmlubmVySFRNTCA9IGBcbiAgICA8aDM+JHt0ZXh0cy5yZXNpemVJbWFnZX08L2gzPlxuICAgIDxkaXYgY2xhc3M9XCJyZXNpemUtY29udHJvbHNcIj5cbiAgICAgIDxsYWJlbD5cbiAgICAgICAgJHt0ZXh0cy53aWR0aH06IDxzcGFuIGNsYXNzPVwid2lkdGgtdmFsdWVcIj4wPC9zcGFuPnB4XG4gICAgICAgIDxpbnB1dCB0eXBlPVwicmFuZ2VcIiBjbGFzcz1cInJlc2l6ZS1zbGlkZXIgd2lkdGgtc2xpZGVyXCIgbWluPVwiMTBcIiBtYXg9XCI1MDBcIiB2YWx1ZT1cIjEwMFwiPlxuICAgICAgPC9sYWJlbD5cbiAgICAgIDxsYWJlbD5cbiAgICAgICAgJHt0ZXh0cy5oZWlnaHR9OiA8c3BhbiBjbGFzcz1cImhlaWdodC12YWx1ZVwiPjA8L3NwYW4+cHhcbiAgICAgICAgPGlucHV0IHR5cGU9XCJyYW5nZVwiIGNsYXNzPVwicmVzaXplLXNsaWRlciBoZWlnaHQtc2xpZGVyXCIgbWluPVwiMTBcIiBtYXg9XCI1MDBcIiB2YWx1ZT1cIjEwMFwiPlxuICAgICAgPC9sYWJlbD5cbiAgICAgIDxsYWJlbD5cbiAgICAgICAgPGlucHV0IHR5cGU9XCJjaGVja2JveFwiIGNsYXNzPVwia2VlcC1hc3BlY3RcIiBjaGVja2VkPlxuICAgICAgICAke3RleHRzLmtlZXBBc3BlY3R9XG4gICAgICA8L2xhYmVsPlxuICAgICAgPGltZyBjbGFzcz1cInJlc2l6ZS1wcmV2aWV3XCIgc3JjPVwiXCIgYWx0PVwiUHJldmlld1wiPlxuICAgICAgPGRpdiBjbGFzcz1cInJlc2l6ZS1idXR0b25zXCI+XG4gICAgICAgIDxidXR0b24gY2xhc3M9XCJidG4gYnRuLXByaW1hcnkgY29uZmlybS1yZXNpemVcIj5cbiAgICAgICAgICBcdTI3MDVcbiAgICAgICAgICA8c3Bhbj4ke3RleHRzLmFwcGx5fTwvc3Bhbj5cbiAgICAgICAgPC9idXR0b24+XG4gICAgICAgIDxidXR0b24gY2xhc3M9XCJidG4gYnRuLXN0b3AgY2FuY2VsLXJlc2l6ZVwiPlxuICAgICAgICAgIFx1Mjc0Q1xuICAgICAgICAgIDxzcGFuPiR7dGV4dHMuY2FuY2VsfTwvc3Bhbj5cbiAgICAgICAgPC9idXR0b24+XG4gICAgICA8L2Rpdj5cbiAgICA8L2Rpdj5cbiAgYDtcbiAgcm9vdC5hcHBlbmRDaGlsZChyZXNpemVDb250YWluZXIpO1xuICBcbiAgLy8gUmVmZXJlbmNpYXMgYSBlbGVtZW50b3NcbiAgY29uc3QgZWxlbWVudHMgPSB7XG4gICAgaGVhZGVyOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignLmhlYWRlcicpLFxuICAgIGNvbmZpZ0J0bjogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5jb25maWctYnRuJyksXG4gICAgbWluaW1pemVCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcubWluaW1pemUtYnRuJyksXG4gICAgY29uZmlnUGFuZWw6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuY29uZmlnLXBhbmVsJyksXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcucGl4ZWxzLXBlci1iYXRjaCcpLFxuICAgIHVzZUFsbENoYXJnZXM6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcudXNlLWFsbC1jaGFyZ2VzJyksXG4gICAgc2hvd092ZXJsYXk6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuc2hvdy1vdmVybGF5JyksXG4gICAgYmF0Y2hWYWx1ZTogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5iYXRjaC12YWx1ZScpLFxuICAgIGNvb2xkb3duVmFsdWU6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuY29vbGRvd24tdmFsdWUnKSxcbiAgICBpbml0QnRuOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignLmluaXQtYnRuJyksXG4gICAgdXBsb2FkQnRuOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignLnVwbG9hZC1idG4nKSxcbiAgICBsb2FkUHJvZ3Jlc3NCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcubG9hZC1wcm9ncmVzcy1idG4nKSxcbiAgICByZXNpemVCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcucmVzaXplLWJ0bicpLFxuICAgIHNlbGVjdFBvc0J0bjogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5zZWxlY3QtcG9zLWJ0bicpLFxuICAgIHN0YXJ0QnRuOiBjb250YWluZXIucXVlcnlTZWxlY3RvcignLnN0YXJ0LWJ0bicpLFxuICAgIHN0b3BCdG46IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuc3RvcC1idG4nKSxcbiAgICBwcm9ncmVzc0JhcjogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5wcm9ncmVzcy1iYXInKSxcbiAgICBzdGF0c0FyZWE6IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuc3RhdHMtYXJlYScpLFxuICAgIHN0YXR1czogY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5zdGF0dXMnKSxcbiAgICBjb250ZW50OiBjb250YWluZXIucXVlcnlTZWxlY3RvcignLmNvbnRlbnQnKVxuICB9O1xuICBcbiAgLy8gUmVmZXJlbmNpYXMgYSBlbGVtZW50b3MgZGVsIHJlc2l6ZSBkaWFsb2dcbiAgY29uc3QgcmVzaXplRWxlbWVudHMgPSB7XG4gICAgb3ZlcmxheTogcmVzaXplT3ZlcmxheSxcbiAgICBjb250YWluZXI6IHJlc2l6ZUNvbnRhaW5lcixcbiAgICB3aWR0aFNsaWRlcjogcmVzaXplQ29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy53aWR0aC1zbGlkZXInKSxcbiAgICBoZWlnaHRTbGlkZXI6IHJlc2l6ZUNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuaGVpZ2h0LXNsaWRlcicpLFxuICAgIHdpZHRoVmFsdWU6IHJlc2l6ZUNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcud2lkdGgtdmFsdWUnKSxcbiAgICBoZWlnaHRWYWx1ZTogcmVzaXplQ29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5oZWlnaHQtdmFsdWUnKSxcbiAgICBrZWVwQXNwZWN0OiByZXNpemVDb250YWluZXIucXVlcnlTZWxlY3RvcignLmtlZXAtYXNwZWN0JyksXG4gICAgcHJldmlldzogcmVzaXplQ29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoJy5yZXNpemUtcHJldmlldycpLFxuICAgIGNvbmZpcm1CdG46IHJlc2l6ZUNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuY29uZmlybS1yZXNpemUnKSxcbiAgICBjYW5jZWxCdG46IHJlc2l6ZUNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcuY2FuY2VsLXJlc2l6ZScpXG4gIH07XG4gIFxuICAvLyBFc3RhZG8gZGUgbGEgVUlcbiAgbGV0IHN0YXRlID0ge1xuICAgIG1pbmltaXplZDogZmFsc2UsXG4gICAgY29uZmlnVmlzaWJsZTogZmFsc2VcbiAgfTtcbiAgXG4gIC8vIEhhY2VyIGRyYWdnYWJsZVxuICBtYWtlRHJhZ2dhYmxlKGVsZW1lbnRzLmhlYWRlciwgY29udGFpbmVyKTtcbiAgXG4gIC8vIEV2ZW50IGxpc3RlbmVyc1xuICBlbGVtZW50cy5taW5pbWl6ZUJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsICgpID0+IHtcbiAgICBzdGF0ZS5taW5pbWl6ZWQgPSAhc3RhdGUubWluaW1pemVkO1xuICAgIGlmIChzdGF0ZS5taW5pbWl6ZWQpIHtcbiAgICAgIGNvbnRhaW5lci5jbGFzc0xpc3QuYWRkKCdtaW5pbWl6ZWQnKTtcbiAgICAgIGVsZW1lbnRzLm1pbmltaXplQnRuLmlubmVySFRNTCA9ICdcdUQ4M0RcdUREM0MnO1xuICAgIH0gZWxzZSB7XG4gICAgICBjb250YWluZXIuY2xhc3NMaXN0LnJlbW92ZSgnbWluaW1pemVkJyk7XG4gICAgICBlbGVtZW50cy5taW5pbWl6ZUJ0bi5pbm5lckhUTUwgPSAnXHVEODNEXHVERDNEJztcbiAgICB9XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuY29uZmlnQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIHN0YXRlLmNvbmZpZ1Zpc2libGUgPSAhc3RhdGUuY29uZmlnVmlzaWJsZTtcbiAgICBpZiAoc3RhdGUuY29uZmlnVmlzaWJsZSkge1xuICAgICAgZWxlbWVudHMuY29uZmlnUGFuZWwuY2xhc3NMaXN0LmFkZCgndmlzaWJsZScpO1xuICAgICAgZWxlbWVudHMuY29uZmlnQnRuLmlubmVySFRNTCA9ICdcdTI3NEMnO1xuICAgIH0gZWxzZSB7XG4gICAgICBlbGVtZW50cy5jb25maWdQYW5lbC5jbGFzc0xpc3QucmVtb3ZlKCd2aXNpYmxlJyk7XG4gICAgICBlbGVtZW50cy5jb25maWdCdG4uaW5uZXJIVE1MID0gJ1x1MjY5OVx1RkUwRic7XG4gICAgfVxuICB9KTtcbiAgXG4gIC8vIEV2ZW50IGxpc3RlbmVycyBwYXJhIGNvbmZpZ3VyYWNpXHUwMEYzblxuICBlbGVtZW50cy5waXhlbHNQZXJCYXRjaC5hZGRFdmVudExpc3RlbmVyKCdjaGFuZ2UnLCAoKSA9PiB7XG4gICAgY29uc3QgdmFsdWUgPSBwYXJzZUludChlbGVtZW50cy5waXhlbHNQZXJCYXRjaC52YWx1ZSkgfHwgMjA7XG4gICAgZWxlbWVudHMuYmF0Y2hWYWx1ZS50ZXh0Q29udGVudCA9IHZhbHVlO1xuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgY29uZmlndXJhY2lcdTAwRjNuIHNpIGhheSBoYW5kbGVyc1xuICAgIGlmIChoYW5kbGVycy5vbkNvbmZpZ0NoYW5nZSkge1xuICAgICAgaGFuZGxlcnMub25Db25maWdDaGFuZ2UoeyBwaXhlbHNQZXJCYXRjaDogdmFsdWUgfSk7XG4gICAgfVxuICB9KTtcbiAgXG4gIGVsZW1lbnRzLnVzZUFsbENoYXJnZXMuYWRkRXZlbnRMaXN0ZW5lcignY2hhbmdlJywgKCkgPT4ge1xuICAgIGlmIChoYW5kbGVycy5vbkNvbmZpZ0NoYW5nZSkge1xuICAgICAgaGFuZGxlcnMub25Db25maWdDaGFuZ2UoeyB1c2VBbGxDaGFyZ2VzOiBlbGVtZW50cy51c2VBbGxDaGFyZ2VzLmNoZWNrZWQgfSk7XG4gICAgfVxuICB9KTtcbiAgXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIGhhYmlsaXRhciBib3RvbmVzIGRlc3B1XHUwMEU5cyBkZSBpbmljaWFsaXphY2lcdTAwRjNuIGV4aXRvc2FcbiAgZnVuY3Rpb24gZW5hYmxlQnV0dG9uc0FmdGVySW5pdCgpIHtcbiAgICBlbGVtZW50cy51cGxvYWRCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgICBlbGVtZW50cy5sb2FkUHJvZ3Jlc3NCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgfVxuICBcbiAgZWxlbWVudHMuaW5pdEJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIGFzeW5jICgpID0+IHtcbiAgICBlbGVtZW50cy5pbml0QnRuLmRpc2FibGVkID0gdHJ1ZTtcbiAgICBpZiAoaGFuZGxlcnMub25Jbml0Qm90KSB7XG4gICAgICBjb25zdCBzdWNjZXNzID0gYXdhaXQgaGFuZGxlcnMub25Jbml0Qm90KCk7XG4gICAgICBpZiAoc3VjY2Vzcykge1xuICAgICAgICBlbmFibGVCdXR0b25zQWZ0ZXJJbml0KCk7XG4gICAgICB9XG4gICAgfVxuICAgIGVsZW1lbnRzLmluaXRCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgfSk7XG4gIFxuICBlbGVtZW50cy51cGxvYWRCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgZmlsZUlucHV0LmNsaWNrKCk7XG4gIH0pO1xuICBcbiAgZmlsZUlucHV0LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIGFzeW5jICgpID0+IHtcbiAgICBpZiAoZmlsZUlucHV0LmZpbGVzLmxlbmd0aCA+IDAgJiYgaGFuZGxlcnMub25VcGxvYWRJbWFnZSkge1xuICAgICAgY29uc3Qgc3VjY2VzcyA9IGF3YWl0IGhhbmRsZXJzLm9uVXBsb2FkSW1hZ2UoZmlsZUlucHV0LmZpbGVzWzBdKTtcbiAgICAgIGlmIChzdWNjZXNzKSB7XG4gICAgICAgIGVsZW1lbnRzLnNlbGVjdFBvc0J0bi5kaXNhYmxlZCA9IGZhbHNlO1xuICAgICAgICBlbGVtZW50cy5yZXNpemVCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgICAgIH1cbiAgICB9XG4gIH0pO1xuICBcbiAgZWxlbWVudHMubG9hZFByb2dyZXNzQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgIHByb2dyZXNzRmlsZUlucHV0LmNsaWNrKCk7XG4gIH0pO1xuICBcbiAgcHJvZ3Jlc3NGaWxlSW5wdXQuYWRkRXZlbnRMaXN0ZW5lcignY2hhbmdlJywgYXN5bmMgKCkgPT4ge1xuICAgIGlmIChwcm9ncmVzc0ZpbGVJbnB1dC5maWxlcy5sZW5ndGggPiAwICYmIGhhbmRsZXJzLm9uTG9hZFByb2dyZXNzKSB7XG4gICAgICBjb25zdCBzdWNjZXNzID0gYXdhaXQgaGFuZGxlcnMub25Mb2FkUHJvZ3Jlc3MocHJvZ3Jlc3NGaWxlSW5wdXQuZmlsZXNbMF0pO1xuICAgICAgaWYgKHN1Y2Nlc3MpIHtcbiAgICAgICAgZWxlbWVudHMuc2VsZWN0UG9zQnRuLmRpc2FibGVkID0gZmFsc2U7XG4gICAgICAgIGVsZW1lbnRzLnN0YXJ0QnRuLmRpc2FibGVkID0gZmFsc2U7XG4gICAgICAgIGVsZW1lbnRzLnJlc2l6ZUJ0bi5kaXNhYmxlZCA9IGZhbHNlO1xuICAgICAgfVxuICAgIH1cbiAgfSk7XG4gIFxuICBlbGVtZW50cy5yZXNpemVCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgaWYgKGhhbmRsZXJzLm9uUmVzaXplSW1hZ2UpIHtcbiAgICAgIGhhbmRsZXJzLm9uUmVzaXplSW1hZ2UoKTtcbiAgICB9XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuc2VsZWN0UG9zQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgYXN5bmMgKCkgPT4ge1xuICAgIGlmIChoYW5kbGVycy5vblNlbGVjdFBvc2l0aW9uKSB7XG4gICAgICBlbGVtZW50cy5zZWxlY3RQb3NCdG4uZGlzYWJsZWQgPSB0cnVlO1xuICAgICAgY29uc3Qgc3VjY2VzcyA9IGF3YWl0IGhhbmRsZXJzLm9uU2VsZWN0UG9zaXRpb24oKTtcbiAgICAgIGlmIChzdWNjZXNzKSB7XG4gICAgICAgIGVsZW1lbnRzLnN0YXJ0QnRuLmRpc2FibGVkID0gZmFsc2U7XG4gICAgICB9XG4gICAgICBlbGVtZW50cy5zZWxlY3RQb3NCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgICB9XG4gIH0pO1xuXG4gIC8vIENoZWNrYm94IG1vc3RyYXIgb3ZlcmxheVxuICBlbGVtZW50cy5zaG93T3ZlcmxheS5hZGRFdmVudExpc3RlbmVyKCdjaGFuZ2UnLCAoKSA9PiB7XG4gICAgaWYgKCF3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18pIHJldHVybjtcbiAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uaW5qZWN0U3R5bGVzKCk7XG4gICAgY29uc3QgaXNFbmFibGVkID0gZWxlbWVudHMuc2hvd092ZXJsYXkuY2hlY2tlZDtcbiAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uc2V0RW5hYmxlZChpc0VuYWJsZWQpO1xuICB9KTtcbiAgXG4gIGVsZW1lbnRzLnN0YXJ0QnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgYXN5bmMgKCkgPT4ge1xuICAgIGlmIChoYW5kbGVycy5vblN0YXJ0UGFpbnRpbmcpIHtcbiAgICAgIGVsZW1lbnRzLnN0YXJ0QnRuLmRpc2FibGVkID0gdHJ1ZTtcbiAgICAgIGVsZW1lbnRzLnN0b3BCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgICAgIGNvbnN0IHN1Y2Nlc3MgPSBhd2FpdCBoYW5kbGVycy5vblN0YXJ0UGFpbnRpbmcoKTtcbiAgICAgIGlmICghc3VjY2Vzcykge1xuICAgICAgICBlbGVtZW50cy5zdGFydEJ0bi5kaXNhYmxlZCA9IGZhbHNlO1xuICAgICAgICBlbGVtZW50cy5zdG9wQnRuLmRpc2FibGVkID0gdHJ1ZTtcbiAgICAgIH1cbiAgICB9XG4gIH0pO1xuICBcbiAgZWxlbWVudHMuc3RvcEJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIGFzeW5jICgpID0+IHtcbiAgICBpZiAoaGFuZGxlcnMub25TdG9wUGFpbnRpbmcpIHtcbiAgICAgIGNvbnN0IHNob3VsZFN0b3AgPSBhd2FpdCBoYW5kbGVycy5vblN0b3BQYWludGluZygpO1xuICAgICAgaWYgKHNob3VsZFN0b3ApIHtcbiAgICAgICAgZWxlbWVudHMuc3RhcnRCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgICAgICAgZWxlbWVudHMuc3RvcEJ0bi5kaXNhYmxlZCA9IHRydWU7XG4gICAgICB9XG4gICAgfVxuICB9KTtcbiAgXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIGFjdHVhbGl6YXIgZWwgZXN0YWRvXG4gIGZ1bmN0aW9uIHNldFN0YXR1cyhtZXNzYWdlLCB0eXBlID0gJ2RlZmF1bHQnKSB7XG4gICAgZWxlbWVudHMuc3RhdHVzLnRleHRDb250ZW50ID0gbWVzc2FnZTtcbiAgICBlbGVtZW50cy5zdGF0dXMuY2xhc3NOYW1lID0gYHN0YXR1cyBzdGF0dXMtJHt0eXBlfWA7XG4gICAgZWxlbWVudHMuc3RhdHVzLnN0eWxlLmFuaW1hdGlvbiA9ICdub25lJztcbiAgICB2b2lkIGVsZW1lbnRzLnN0YXR1cy5vZmZzZXRXaWR0aDtcbiAgICBlbGVtZW50cy5zdGF0dXMuc3R5bGUuYW5pbWF0aW9uID0gJ3NsaWRlSW4gMC4zcyBlYXNlLW91dCc7XG4gIH1cbiAgXG4gIGZ1bmN0aW9uIHNob3dSZXNpemVEaWFsb2cocHJvY2Vzc29yKSB7XG4gICAgY29uc3QgeyB3aWR0aCwgaGVpZ2h0IH0gPSBwcm9jZXNzb3IuZ2V0RGltZW5zaW9ucygpO1xuICAgIGNvbnN0IGFzcGVjdFJhdGlvID0gd2lkdGggLyBoZWlnaHQ7XG4gICAgXG4gICAgLy8gSW5pY2lhbGl6YXIgdmFsb3Jlc1xuICAgIHJlc2l6ZUVsZW1lbnRzLndpZHRoU2xpZGVyLnZhbHVlID0gd2lkdGg7XG4gICAgcmVzaXplRWxlbWVudHMuaGVpZ2h0U2xpZGVyLnZhbHVlID0gaGVpZ2h0O1xuICAgIHJlc2l6ZUVsZW1lbnRzLndpZHRoVmFsdWUudGV4dENvbnRlbnQgPSB3aWR0aDtcbiAgICByZXNpemVFbGVtZW50cy5oZWlnaHRWYWx1ZS50ZXh0Q29udGVudCA9IGhlaWdodDtcbiAgICByZXNpemVFbGVtZW50cy5wcmV2aWV3LnNyYyA9IHByb2Nlc3Nvci5pbWcuc3JjO1xuICAgIFxuICAgIC8vIE1vc3RyYXIgbW9kYWxcbiAgICByZXNpemVFbGVtZW50cy5vdmVybGF5LnN0eWxlLmRpc3BsYXkgPSAnYmxvY2snO1xuICAgIHJlc2l6ZUVsZW1lbnRzLmNvbnRhaW5lci5zdHlsZS5kaXNwbGF5ID0gJ2Jsb2NrJztcbiAgICBcbiAgICBjb25zdCB1cGRhdGVQcmV2aWV3ID0gKCkgPT4ge1xuICAgICAgY29uc3QgbmV3V2lkdGggPSBwYXJzZUludChyZXNpemVFbGVtZW50cy53aWR0aFNsaWRlci52YWx1ZSk7XG4gICAgICBjb25zdCBuZXdIZWlnaHQgPSBwYXJzZUludChyZXNpemVFbGVtZW50cy5oZWlnaHRTbGlkZXIudmFsdWUpO1xuICAgICAgXG4gICAgICByZXNpemVFbGVtZW50cy53aWR0aFZhbHVlLnRleHRDb250ZW50ID0gbmV3V2lkdGg7XG4gICAgICByZXNpemVFbGVtZW50cy5oZWlnaHRWYWx1ZS50ZXh0Q29udGVudCA9IG5ld0hlaWdodDtcbiAgICAgIFxuICAgICAgcmVzaXplRWxlbWVudHMucHJldmlldy5zcmMgPSBwcm9jZXNzb3IuZ2VuZXJhdGVQcmV2aWV3KG5ld1dpZHRoLCBuZXdIZWlnaHQpO1xuICAgIH07XG4gICAgXG4gICAgLy8gRXZlbnQgbGlzdGVuZXJzIHBhcmEgc2xpZGVyc1xuICAgIGNvbnN0IG9uV2lkdGhDaGFuZ2UgPSAoKSA9PiB7XG4gICAgICBpZiAocmVzaXplRWxlbWVudHMua2VlcEFzcGVjdC5jaGVja2VkKSB7XG4gICAgICAgIGNvbnN0IG5ld1dpZHRoID0gcGFyc2VJbnQocmVzaXplRWxlbWVudHMud2lkdGhTbGlkZXIudmFsdWUpO1xuICAgICAgICBjb25zdCBuZXdIZWlnaHQgPSBNYXRoLnJvdW5kKG5ld1dpZHRoIC8gYXNwZWN0UmF0aW8pO1xuICAgICAgICByZXNpemVFbGVtZW50cy5oZWlnaHRTbGlkZXIudmFsdWUgPSBuZXdIZWlnaHQ7XG4gICAgICB9XG4gICAgICB1cGRhdGVQcmV2aWV3KCk7XG4gICAgfTtcbiAgICBcbiAgICBjb25zdCBvbkhlaWdodENoYW5nZSA9ICgpID0+IHtcbiAgICAgIGlmIChyZXNpemVFbGVtZW50cy5rZWVwQXNwZWN0LmNoZWNrZWQpIHtcbiAgICAgICAgY29uc3QgbmV3SGVpZ2h0ID0gcGFyc2VJbnQocmVzaXplRWxlbWVudHMuaGVpZ2h0U2xpZGVyLnZhbHVlKTtcbiAgICAgICAgY29uc3QgbmV3V2lkdGggPSBNYXRoLnJvdW5kKG5ld0hlaWdodCAqIGFzcGVjdFJhdGlvKTtcbiAgICAgICAgcmVzaXplRWxlbWVudHMud2lkdGhTbGlkZXIudmFsdWUgPSBuZXdXaWR0aDtcbiAgICAgIH1cbiAgICAgIHVwZGF0ZVByZXZpZXcoKTtcbiAgICB9O1xuICAgIFxuICAgIC8vIEFcdTAwRjFhZGlyIGV2ZW50IGxpc3RlbmVycyB0ZW1wb3JhbGVzXG4gICAgcmVzaXplRWxlbWVudHMud2lkdGhTbGlkZXIuYWRkRXZlbnRMaXN0ZW5lcignaW5wdXQnLCBvbldpZHRoQ2hhbmdlKTtcbiAgICByZXNpemVFbGVtZW50cy5oZWlnaHRTbGlkZXIuYWRkRXZlbnRMaXN0ZW5lcignaW5wdXQnLCBvbkhlaWdodENoYW5nZSk7XG4gICAgXG4gICAgLy8gRXZlbnQgbGlzdGVuZXIgcGFyYSBjb25maXJtYXJcbiAgICBjb25zdCBvbkNvbmZpcm0gPSAoKSA9PiB7XG4gICAgICBjb25zdCBuZXdXaWR0aCA9IHBhcnNlSW50KHJlc2l6ZUVsZW1lbnRzLndpZHRoU2xpZGVyLnZhbHVlKTtcbiAgICAgIGNvbnN0IG5ld0hlaWdodCA9IHBhcnNlSW50KHJlc2l6ZUVsZW1lbnRzLmhlaWdodFNsaWRlci52YWx1ZSk7XG4gICAgICBcbiAgICAgIGlmIChoYW5kbGVycy5vbkNvbmZpcm1SZXNpemUpIHtcbiAgICAgICAgaGFuZGxlcnMub25Db25maXJtUmVzaXplKHByb2Nlc3NvciwgbmV3V2lkdGgsIG5ld0hlaWdodCk7XG4gICAgICB9XG4gICAgICBcbiAgICAgIGNsb3NlUmVzaXplRGlhbG9nKCk7XG4gICAgfTtcbiAgICBcbiAgICAvLyBFdmVudCBsaXN0ZW5lciBwYXJhIGNhbmNlbGFyXG4gICAgY29uc3Qgb25DYW5jZWwgPSAoKSA9PiB7XG4gICAgICBjbG9zZVJlc2l6ZURpYWxvZygpO1xuICAgIH07XG4gICAgXG4gICAgcmVzaXplRWxlbWVudHMuY29uZmlybUJ0bi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIG9uQ29uZmlybSk7XG4gICAgcmVzaXplRWxlbWVudHMuY2FuY2VsQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgb25DYW5jZWwpO1xuICAgIHJlc2l6ZUVsZW1lbnRzLm92ZXJsYXkuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCBvbkNhbmNlbCk7XG4gICAgXG4gICAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgbGltcGlhciBsaXN0ZW5lcnNcbiAgICB3aW5kb3cuY2xlYW51cFJlc2l6ZURpYWxvZyA9ICgpID0+IHtcbiAgICAgIHJlc2l6ZUVsZW1lbnRzLndpZHRoU2xpZGVyLnJlbW92ZUV2ZW50TGlzdGVuZXIoJ2lucHV0Jywgb25XaWR0aENoYW5nZSk7XG4gICAgICByZXNpemVFbGVtZW50cy5oZWlnaHRTbGlkZXIucmVtb3ZlRXZlbnRMaXN0ZW5lcignaW5wdXQnLCBvbkhlaWdodENoYW5nZSk7XG4gICAgICByZXNpemVFbGVtZW50cy5jb25maXJtQnRuLnJlbW92ZUV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgb25Db25maXJtKTtcbiAgICAgIHJlc2l6ZUVsZW1lbnRzLmNhbmNlbEJ0bi5yZW1vdmVFdmVudExpc3RlbmVyKCdjbGljaycsIG9uQ2FuY2VsKTtcbiAgICAgIHJlc2l6ZUVsZW1lbnRzLm92ZXJsYXkucmVtb3ZlRXZlbnRMaXN0ZW5lcignY2xpY2snLCBvbkNhbmNlbCk7XG4gICAgfTtcbiAgICBcbiAgICAvLyBHZW5lcmFyIHByZXZpZXcgaW5pY2lhbFxuICAgIHVwZGF0ZVByZXZpZXcoKTtcbiAgfVxuICBcbiAgZnVuY3Rpb24gY2xvc2VSZXNpemVEaWFsb2coKSB7XG4gICAgcmVzaXplRWxlbWVudHMub3ZlcmxheS5zdHlsZS5kaXNwbGF5ID0gJ25vbmUnO1xuICAgIHJlc2l6ZUVsZW1lbnRzLmNvbnRhaW5lci5zdHlsZS5kaXNwbGF5ID0gJ25vbmUnO1xuICAgIFxuICAgIC8vIExpbXBpYXIgZXZlbnQgbGlzdGVuZXJzXG4gICAgaWYgKHdpbmRvdy5jbGVhbnVwUmVzaXplRGlhbG9nKSB7XG4gICAgICB3aW5kb3cuY2xlYW51cFJlc2l6ZURpYWxvZygpO1xuICAgICAgZGVsZXRlIHdpbmRvdy5jbGVhbnVwUmVzaXplRGlhbG9nO1xuICAgIH1cbiAgfVxuICBcbiAgZnVuY3Rpb24gdXBkYXRlUHJvZ3Jlc3MoY3VycmVudCwgdG90YWwsIHVzZXJJbmZvID0gbnVsbCkge1xuICAgIGNvbnN0IHBlcmNlbnRhZ2UgPSB0b3RhbCA+IDAgPyAoY3VycmVudCAvIHRvdGFsKSAqIDEwMCA6IDA7XG4gICAgZWxlbWVudHMucHJvZ3Jlc3NCYXIuc3R5bGUud2lkdGggPSBgJHtwZXJjZW50YWdlfSVgO1xuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgc3RhdHNcbiAgICBsZXQgc3RhdHNIVE1MID0gYFxuICAgICAgPGRpdiBjbGFzcz1cInN0YXQtaXRlbVwiPlxuICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1sYWJlbFwiPlx1RDgzQ1x1REZBOCAke3RleHRzLnByb2dyZXNzfTwvZGl2PlxuICAgICAgICA8ZGl2PiR7Y3VycmVudH0vJHt0b3RhbH0gKCR7cGVyY2VudGFnZS50b0ZpeGVkKDEpfSUpPC9kaXY+XG4gICAgICA8L2Rpdj5cbiAgICBgO1xuICAgIFxuICAgIC8vIEFncmVnYXIgaW5mb3JtYWNpXHUwMEYzbiBkZWwgdXN1YXJpbyBzaSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICAgIGlmICh1c2VySW5mbykge1xuICAgICAgLy8gTW9zdHJhciBub21icmUgZGUgdXN1YXJpb1xuICAgICAgaWYgKHVzZXJJbmZvLnVzZXJuYW1lKSB7XG4gICAgICAgIHN0YXRzSFRNTCArPSBgXG4gICAgICAgICAgPGRpdiBjbGFzcz1cInN0YXQtaXRlbVwiPlxuICAgICAgICAgICAgPGRpdiBjbGFzcz1cInN0YXQtbGFiZWxcIj5cdUQ4M0RcdURDNjQgJHt0ZXh0cy51c2VyTmFtZX08L2Rpdj5cbiAgICAgICAgICAgIDxkaXY+JHt1c2VySW5mby51c2VybmFtZX08L2Rpdj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgYDtcbiAgICAgIH1cbiAgICAgIFxuICAgICAgLy8gTW9zdHJhciBjYXJnYXMgKG5cdTAwRkFtZXJvIGVudGVybylcbiAgICAgIGlmICh1c2VySW5mby5jaGFyZ2VzICE9PSB1bmRlZmluZWQpIHtcbiAgICAgICAgc3RhdHNIVE1MICs9IGBcbiAgICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1pdGVtXCI+XG4gICAgICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1sYWJlbFwiPlx1MjZBMSAke3RleHRzLmNoYXJnZXN9PC9kaXY+XG4gICAgICAgICAgICA8ZGl2PiR7TWF0aC5mbG9vcih1c2VySW5mby5jaGFyZ2VzKX08L2Rpdj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgYDtcbiAgICAgIH1cbiAgICAgIFxuICAgICAgLy8gTW9zdHJhciBwXHUwMEVEeGVsZXMgcGludGFkb3MgZGVsIHVzdWFyaW9cbiAgICAgIGlmICh1c2VySW5mby5waXhlbHMgIT09IHVuZGVmaW5lZCkge1xuICAgICAgICBzdGF0c0hUTUwgKz0gYFxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJzdGF0LWl0ZW1cIj5cbiAgICAgICAgICAgIDxkaXYgY2xhc3M9XCJzdGF0LWxhYmVsXCI+XHVEODNEXHVERDMzICR7dGV4dHMucGl4ZWxzfTwvZGl2PlxuICAgICAgICAgICAgPGRpdj4ke3VzZXJJbmZvLnBpeGVscy50b0xvY2FsZVN0cmluZygpfTwvZGl2PlxuICAgICAgICAgIDwvZGl2PlxuICAgICAgICBgO1xuICAgICAgfVxuICAgICAgXG4gICAgICAvLyBNb3N0cmFyIHRpZW1wbyBlc3RpbWFkbyBzaSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICAgICAgaWYgKHVzZXJJbmZvLmVzdGltYXRlZFRpbWUgIT09IHVuZGVmaW5lZCAmJiB1c2VySW5mby5lc3RpbWF0ZWRUaW1lID4gMCkge1xuICAgICAgICBjb25zdCBob3VycyA9IE1hdGguZmxvb3IodXNlckluZm8uZXN0aW1hdGVkVGltZSAvIDM2MDApO1xuICAgICAgICBjb25zdCBtaW51dGVzID0gTWF0aC5mbG9vcigodXNlckluZm8uZXN0aW1hdGVkVGltZSAlIDM2MDApIC8gNjApO1xuICAgICAgICBjb25zdCB0aW1lU3RyID0gaG91cnMgPiAwID8gYCR7aG91cnN9aCAke21pbnV0ZXN9bWAgOiBgJHttaW51dGVzfW1gO1xuICAgICAgICBcbiAgICAgICAgc3RhdHNIVE1MICs9IGBcbiAgICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1pdGVtXCI+XG4gICAgICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdC1sYWJlbFwiPlx1MjNGMCAke3RleHRzLnRpbWVSZW1haW5pbmd9PC9kaXY+XG4gICAgICAgICAgICA8ZGl2PiR7dGltZVN0cn08L2Rpdj5cbiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgYDtcbiAgICAgIH1cbiAgICB9XG4gICAgXG4gICAgZWxlbWVudHMuc3RhdHNBcmVhLmlubmVySFRNTCA9IHN0YXRzSFRNTDtcbiAgfVxuICBcbiAgZnVuY3Rpb24gdXBkYXRlQ29vbGRvd25EaXNwbGF5KHNlY29uZHMpIHtcbiAgICBpZiAoc2Vjb25kcyA+IDApIHtcbiAgICAgIGNvbnN0IG1pbnV0ZXMgPSBNYXRoLmZsb29yKHNlY29uZHMgLyA2MCk7XG4gICAgICBjb25zdCBzZWNzID0gc2Vjb25kcyAlIDYwO1xuICAgICAgY29uc3QgdGltZVN0ciA9IG1pbnV0ZXMgPiAwID8gYCR7bWludXRlc31tICR7c2Vjc31zYCA6IGAke3NlY3N9c2A7XG4gICAgICBlbGVtZW50cy5jb29sZG93blZhbHVlLnRleHRDb250ZW50ID0gdGltZVN0cjtcbiAgICB9IGVsc2Uge1xuICAgICAgZWxlbWVudHMuY29vbGRvd25WYWx1ZS50ZXh0Q29udGVudCA9ICctLSc7XG4gICAgfVxuICB9XG4gIFxuICAvLyBOdWV2YSBmdW5jaVx1MDBGM24gcGFyYSBhY3R1YWxpemFyIHNvbG8gZWwgbWVuc2FqZSBkZSBjb29sZG93biBzaW4gcGFycGFkZW9cbiAgZnVuY3Rpb24gdXBkYXRlQ29vbGRvd25NZXNzYWdlKG1lc3NhZ2UpIHtcbiAgICBpZiAobWVzc2FnZSAmJiBtZXNzYWdlLmluY2x1ZGVzKCdcdTIzRjMnKSkge1xuICAgICAgLy8gRXMgdW4gbWVuc2FqZSBkZSBjb29sZG93biwgYWN0dWFsaXphciBzb2xvIGVsIHRleHRvIHNpbiByZWNhcmdhciB0b2RvXG4gICAgICBlbGVtZW50cy5zdGF0dXMudGV4dENvbnRlbnQgPSBtZXNzYWdlO1xuICAgICAgZWxlbWVudHMuc3RhdHVzLmNsYXNzTmFtZSA9ICdzdGF0dXMgc3RhdHVzLWluZm8nO1xuICAgICAgLy8gTm8gaGFjZXIgYW5pbWFjaVx1MDBGM24gcGFyYSBldml0YXIgcGFycGFkZW9cbiAgICB9IGVsc2UgaWYgKG1lc3NhZ2UpIHtcbiAgICAgIC8vIE1lbnNhamUgbm9ybWFsLCB1c2FyIHNldFN0YXR1cyBjb21wbGV0b1xuICAgICAgc2V0U3RhdHVzKG1lc3NhZ2UsICdpbmZvJyk7XG4gICAgfVxuICB9XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBjb250cm9sYXIgZWwgZXN0YWRvIGRlbCBib3RcdTAwRjNuIGRlIGluaWNpYWxpemFjaVx1MDBGM25cbiAgZnVuY3Rpb24gc2V0SW5pdGlhbGl6ZWQoaXNJbml0aWFsaXplZCkge1xuICAgIGlmIChpc0luaXRpYWxpemVkKSB7XG4gICAgICBlbGVtZW50cy5pbml0QnRuLmRpc2FibGVkID0gdHJ1ZTtcbiAgICAgIGVsZW1lbnRzLmluaXRCdG4uc3R5bGUub3BhY2l0eSA9ICcwLjYnO1xuICAgICAgZWxlbWVudHMuaW5pdEJ0bi5pbm5lckhUTUwgPSBgXHUyNzA1IDxzcGFuPiR7dGV4dHMuaW5pdEJvdH0gLSBDb21wbGV0YWRvPC9zcGFuPmA7XG4gICAgfSBlbHNlIHtcbiAgICAgIGVsZW1lbnRzLmluaXRCdG4uZGlzYWJsZWQgPSBmYWxzZTtcbiAgICAgIGVsZW1lbnRzLmluaXRCdG4uc3R5bGUub3BhY2l0eSA9ICcxJztcbiAgICAgIGVsZW1lbnRzLmluaXRCdG4uaW5uZXJIVE1MID0gYFx1RDgzRVx1REQxNiA8c3Bhbj4ke3RleHRzLmluaXRCb3R9PC9zcGFuPmA7XG4gICAgfVxuICB9XG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSBvY3VsdGFyL21vc3RyYXIgZWwgYm90XHUwMEYzbiBkZSBpbmljaWFsaXphY2lcdTAwRjNuXG4gIGZ1bmN0aW9uIHNldEluaXRCdXR0b25WaXNpYmxlKHZpc2libGUpIHtcbiAgICBlbGVtZW50cy5pbml0QnRuLnN0eWxlLmRpc3BsYXkgPSB2aXNpYmxlID8gJ2ZsZXgnIDogJ25vbmUnO1xuICB9XG4gIFxuICBmdW5jdGlvbiBkZXN0cm95KCkge1xuICAgIGhvc3QucmVtb3ZlKCk7XG4gIH1cbiAgXG4gIGxvZygnXHUyNzA1IEludGVyZmF6IGRlIEF1dG8tSW1hZ2UgY3JlYWRhJyk7XG4gIFxuICByZXR1cm4ge1xuICAgIHNldFN0YXR1cyxcbiAgICB1cGRhdGVQcm9ncmVzcyxcbiAgICB1cGRhdGVDb29sZG93bkRpc3BsYXksXG4gICAgdXBkYXRlQ29vbGRvd25NZXNzYWdlLFxuICAgIHNldEluaXRpYWxpemVkLFxuICAgIHNldEluaXRCdXR0b25WaXNpYmxlLFxuICAgIGVuYWJsZUJ1dHRvbnNBZnRlckluaXQsXG4gICAgc2hvd1Jlc2l6ZURpYWxvZyxcbiAgICBjbG9zZVJlc2l6ZURpYWxvZyxcbiAgICBkZXN0cm95XG4gIH07XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBzaG93Q29uZmlybURpYWxvZyhtZXNzYWdlLCB0aXRsZSwgYnV0dG9ucyA9IHt9KSB7XG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4ge1xuICAgIGNvbnN0IG92ZXJsYXkgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdkaXYnKTtcbiAgICBvdmVybGF5LmNsYXNzTmFtZSA9ICdtb2RhbC1vdmVybGF5JztcbiAgICBvdmVybGF5LnN0eWxlLnBvc2l0aW9uID0gJ2ZpeGVkJztcbiAgICBvdmVybGF5LnN0eWxlLnRvcCA9ICcwJztcbiAgICBvdmVybGF5LnN0eWxlLmxlZnQgPSAnMCc7XG4gICAgb3ZlcmxheS5zdHlsZS53aWR0aCA9ICcxMDAlJztcbiAgICBvdmVybGF5LnN0eWxlLmhlaWdodCA9ICcxMDAlJztcbiAgICBvdmVybGF5LnN0eWxlLmJhY2tncm91bmQgPSAncmdiYSgwLDAsMCwwLjcpJztcbiAgICBvdmVybGF5LnN0eWxlLnpJbmRleCA9ICcxMDAwMSc7XG4gICAgb3ZlcmxheS5zdHlsZS5kaXNwbGF5ID0gJ2ZsZXgnO1xuICAgIG92ZXJsYXkuc3R5bGUuYWxpZ25JdGVtcyA9ICdjZW50ZXInO1xuICAgIG92ZXJsYXkuc3R5bGUuanVzdGlmeUNvbnRlbnQgPSAnY2VudGVyJztcbiAgICBcbiAgICBjb25zdCBtb2RhbCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICAgIG1vZGFsLnN0eWxlLmJhY2tncm91bmQgPSAnIzFhMWExYSc7XG4gICAgbW9kYWwuc3R5bGUuYm9yZGVyID0gJzJweCBzb2xpZCAjMzMzJztcbiAgICBtb2RhbC5zdHlsZS5ib3JkZXJSYWRpdXMgPSAnMTVweCc7XG4gICAgbW9kYWwuc3R5bGUucGFkZGluZyA9ICcyNXB4JztcbiAgICBtb2RhbC5zdHlsZS5jb2xvciA9ICcjZWVlJztcbiAgICBtb2RhbC5zdHlsZS5taW5XaWR0aCA9ICczNTBweCc7XG4gICAgbW9kYWwuc3R5bGUubWF4V2lkdGggPSAnNDAwcHgnO1xuICAgIG1vZGFsLnN0eWxlLmJveFNoYWRvdyA9ICcwIDEwcHggMzBweCByZ2JhKDAsMCwwLDAuNSknO1xuICAgIG1vZGFsLnN0eWxlLmZvbnRGYW1pbHkgPSBcIidTZWdvZSBVSScsIFJvYm90bywgc2Fucy1zZXJpZlwiO1xuICAgIFxuICAgIG1vZGFsLmlubmVySFRNTCA9IGBcbiAgICAgIDxoMyBzdHlsZT1cIm1hcmdpbjogMCAwIDE1cHggMDsgdGV4dC1hbGlnbjogY2VudGVyOyBmb250LXNpemU6IDE4cHg7XCI+JHt0aXRsZX08L2gzPlxuICAgICAgPHAgc3R5bGU9XCJtYXJnaW46IDAgMCAyMHB4IDA7IHRleHQtYWxpZ246IGNlbnRlcjsgbGluZS1oZWlnaHQ6IDEuNDtcIj4ke21lc3NhZ2V9PC9wPlxuICAgICAgPGRpdiBzdHlsZT1cImRpc3BsYXk6IGZsZXg7IGdhcDogMTBweDsganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XCI+XG4gICAgICAgICR7YnV0dG9ucy5zYXZlID8gYDxidXR0b24gY2xhc3M9XCJzYXZlLWJ0blwiIHN0eWxlPVwicGFkZGluZzogMTBweCAyMHB4OyBib3JkZXI6IG5vbmU7IGJvcmRlci1yYWRpdXM6IDhweDsgZm9udC1zaXplOiAxNHB4OyBmb250LXdlaWdodDogYm9sZDsgY3Vyc29yOiBwb2ludGVyOyBtaW4td2lkdGg6IDEwMHB4OyBiYWNrZ3JvdW5kOiAjMTBiOTgxOyBjb2xvcjogd2hpdGU7XCI+JHtidXR0b25zLnNhdmV9PC9idXR0b24+YCA6ICcnfVxuICAgICAgICAke2J1dHRvbnMuZGlzY2FyZCA/IGA8YnV0dG9uIGNsYXNzPVwiZGlzY2FyZC1idG5cIiBzdHlsZT1cInBhZGRpbmc6IDEwcHggMjBweDsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA4cHg7IGZvbnQtc2l6ZTogMTRweDsgZm9udC13ZWlnaHQ6IGJvbGQ7IGN1cnNvcjogcG9pbnRlcjsgbWluLXdpZHRoOiAxMDBweDsgYmFja2dyb3VuZDogI2VmNDQ0NDsgY29sb3I6IHdoaXRlO1wiPiR7YnV0dG9ucy5kaXNjYXJkfTwvYnV0dG9uPmAgOiAnJ31cbiAgICAgICAgJHtidXR0b25zLmNhbmNlbCA/IGA8YnV0dG9uIGNsYXNzPVwiY2FuY2VsLWJ0blwiIHN0eWxlPVwicGFkZGluZzogMTBweCAyMHB4OyBib3JkZXI6IG5vbmU7IGJvcmRlci1yYWRpdXM6IDhweDsgZm9udC1zaXplOiAxNHB4OyBmb250LXdlaWdodDogYm9sZDsgY3Vyc29yOiBwb2ludGVyOyBtaW4td2lkdGg6IDEwMHB4OyBiYWNrZ3JvdW5kOiAjMmQzNzQ4OyBjb2xvcjogd2hpdGU7XCI+JHtidXR0b25zLmNhbmNlbH08L2J1dHRvbj5gIDogJyd9XG4gICAgICA8L2Rpdj5cbiAgICBgO1xuICAgIFxuICAgIG92ZXJsYXkuYXBwZW5kQ2hpbGQobW9kYWwpO1xuICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQob3ZlcmxheSk7XG4gICAgXG4gICAgLy8gRXZlbnQgbGlzdGVuZXJzXG4gICAgY29uc3Qgc2F2ZUJ0biA9IG1vZGFsLnF1ZXJ5U2VsZWN0b3IoJy5zYXZlLWJ0bicpO1xuICAgIGNvbnN0IGRpc2NhcmRCdG4gPSBtb2RhbC5xdWVyeVNlbGVjdG9yKCcuZGlzY2FyZC1idG4nKTtcbiAgICBjb25zdCBjYW5jZWxCdG4gPSBtb2RhbC5xdWVyeVNlbGVjdG9yKCcuY2FuY2VsLWJ0bicpO1xuICAgIFxuICAgIGNvbnN0IGNsZWFudXAgPSAoKSA9PiB7XG4gICAgICBkb2N1bWVudC5ib2R5LnJlbW92ZUNoaWxkKG92ZXJsYXkpO1xuICAgIH07XG4gICAgXG4gICAgaWYgKHNhdmVCdG4pIHtcbiAgICAgIHNhdmVCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgICAgIGNsZWFudXAoKTtcbiAgICAgICAgcmVzb2x2ZSgnc2F2ZScpO1xuICAgICAgfSk7XG4gICAgfVxuICAgIFxuICAgIGlmIChkaXNjYXJkQnRuKSB7XG4gICAgICBkaXNjYXJkQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4ge1xuICAgICAgICBjbGVhbnVwKCk7XG4gICAgICAgIHJlc29sdmUoJ2Rpc2NhcmQnKTtcbiAgICAgIH0pO1xuICAgIH1cbiAgICBcbiAgICBpZiAoY2FuY2VsQnRuKSB7XG4gICAgICBjYW5jZWxCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgICAgIGNsZWFudXAoKTtcbiAgICAgICAgcmVzb2x2ZSgnY2FuY2VsJyk7XG4gICAgICB9KTtcbiAgICB9XG4gICAgXG4gICAgLy8gQ2VycmFyIGNvbiBvdmVybGF5XG4gICAgb3ZlcmxheS5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7XG4gICAgICBpZiAoZS50YXJnZXQgPT09IG92ZXJsYXkpIHtcbiAgICAgICAgY2xlYW51cCgpO1xuICAgICAgICByZXNvbHZlKCdjYW5jZWwnKTtcbiAgICAgIH1cbiAgICB9KTtcbiAgfSk7XG59XG4iLCAiZXhwb3J0IGNvbnN0ICQgPSAoc2VsLCByb290ID0gZG9jdW1lbnQpID0+IHJvb3QucXVlcnlTZWxlY3RvcihzZWwpO1xuXG5leHBvcnQgZnVuY3Rpb24gY3JlYXRlU3R5bGUoY3NzKSB7XG4gIGNvbnN0IHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KFwic3R5bGVcIik7XG4gIHMudGV4dENvbnRlbnQgPSBjc3M7IGRvY3VtZW50LmhlYWQuYXBwZW5kQ2hpbGQocyk7IHJldHVybiBzO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gbW91bnRTaGFkb3coY29udGFpbmVyID0gZG9jdW1lbnQuYm9keSkge1xuICBjb25zdCBob3N0ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudChcImRpdlwiKTtcbiAgaG9zdC5pZCA9IFwid3BsYWNlLWJvdC1yb290XCI7XG4gIGNvbnRhaW5lci5hcHBlbmRDaGlsZChob3N0KTtcbiAgY29uc3Qgcm9vdCA9IGhvc3QuYXR0YWNoU2hhZG93ID8gaG9zdC5hdHRhY2hTaGFkb3coeyBtb2RlOiBcIm9wZW5cIiB9KSA6IGhvc3Q7XG4gIHJldHVybiB7IGhvc3QsIHJvb3QgfTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgZGV0ZWN0YXIgc2kgbGEgcGFsZXRhIGRlIGNvbG9yZXMgZXN0XHUwMEUxIGFiaWVydGFcbmV4cG9ydCBmdW5jdGlvbiBpc1BhbGV0dGVPcGVuKGRlYnVnID0gZmFsc2UpIHtcbiAgLy8gQnVzY2FyIGVsZW1lbnRvcyBjb211bmVzIGRlIGxhIHBhbGV0YSBkZSBjb2xvcmVzIChtXHUwMEU5dG9kbyBvcmlnaW5hbClcbiAgY29uc3QgcGFsZXR0ZVNlbGVjdG9ycyA9IFtcbiAgICAnW2RhdGEtdGVzdGlkPVwiY29sb3ItcGlja2VyXCJdJyxcbiAgICAnLmNvbG9yLXBpY2tlcicsXG4gICAgJy5wYWxldHRlJyxcbiAgICAnW2NsYXNzKj1cImNvbG9yXCJdW2NsYXNzKj1cInBpY2tlclwiXScsXG4gICAgJ1tjbGFzcyo9XCJwYWxldHRlXCJdJ1xuICBdO1xuICBcbiAgZm9yIChjb25zdCBzZWxlY3RvciBvZiBwYWxldHRlU2VsZWN0b3JzKSB7XG4gICAgY29uc3QgZWxlbWVudCA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3Ioc2VsZWN0b3IpO1xuICAgIGlmIChlbGVtZW50ICYmIGVsZW1lbnQub2Zmc2V0UGFyZW50ICE9PSBudWxsKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQTggUGFsZXRhIGRldGVjdGFkYSBwb3Igc2VsZWN0b3I6ICR7c2VsZWN0b3J9YCk7XG4gICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIEJ1c2NhciBwb3IgY29sb3JlcyBlbiB1biBncmlkIG8gbGlzdGEgKG1cdTAwRTl0b2RvIG9yaWdpbmFsKVxuICBjb25zdCBjb2xvckVsZW1lbnRzID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbCgnW3N0eWxlKj1cImJhY2tncm91bmQtY29sb3JcIl0sIFtzdHlsZSo9XCJiYWNrZ3JvdW5kOlwiXSwgLmNvbG9yLCBbY2xhc3MqPVwiY29sb3JcIl0nKTtcbiAgbGV0IHZpc2libGVDb2xvcnMgPSAwO1xuICBmb3IgKGNvbnN0IGVsIG9mIGNvbG9yRWxlbWVudHMpIHtcbiAgICBpZiAoZWwub2Zmc2V0UGFyZW50ICE9PSBudWxsICYmIGVsLm9mZnNldFdpZHRoID4gMTAgJiYgZWwub2Zmc2V0SGVpZ2h0ID4gMTApIHtcbiAgICAgIHZpc2libGVDb2xvcnMrKztcbiAgICAgIGlmICh2aXNpYmxlQ29sb3JzID49IDUpIHtcbiAgICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkE4IFBhbGV0YSBkZXRlY3RhZGEgcG9yIGNvbG9yZXMgdmlzaWJsZXM6ICR7dmlzaWJsZUNvbG9yc31gKTtcbiAgICAgICAgcmV0dXJuIHRydWU7IC8vIFNpIGhheSA1KyBlbGVtZW50b3MgZGUgY29sb3IgdmlzaWJsZXNcbiAgICAgIH1cbiAgICB9XG4gIH1cbiAgXG4gIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzRFx1REQwRCBQYWxldGEgbm8gZGV0ZWN0YWRhLiBDb2xvcmVzIHZpc2libGVzOiAke3Zpc2libGVDb2xvcnN9YCk7XG4gIHJldHVybiBmYWxzZTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgZW5jb250cmFyIHkgaGFjZXIgY2xpYyBlbiBlbCBib3RcdTAwRjNuIGRlIFBhaW50XG5leHBvcnQgZnVuY3Rpb24gZmluZEFuZENsaWNrUGFpbnRCdXR0b24oZGVidWcgPSBmYWxzZSwgZG91YmxlQ2xpY2sgPSBmYWxzZSkge1xuICAvLyBNXHUwMEU5dG9kbyAxOiBCXHUwMEZBc3F1ZWRhIGVzcGVjXHUwMEVEZmljYSBwb3IgY2xhc2VzIChtXHUwMEU5dG9kbyBvcmlnaW5hbCwgbVx1MDBFMXMgY29uZmlhYmxlKVxuICBjb25zdCBzcGVjaWZpY0J1dHRvbiA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJ2J1dHRvbi5idG4uYnRuLXByaW1hcnkuYnRuLWxnLCBidXR0b24uYnRuLmJ0bi1wcmltYXJ5LnNtXFxcXDpidG4teGwnKTtcbiAgXG4gIGlmIChzcGVjaWZpY0J1dHRvbikge1xuICAgIGNvbnN0IGJ1dHRvblRleHQgPSBzcGVjaWZpY0J1dHRvbi50ZXh0Q29udGVudC50b0xvd2VyQ2FzZSgpO1xuICAgIGNvbnN0IGhhc1BhaW50VGV4dCA9IGJ1dHRvblRleHQuaW5jbHVkZXMoJ3BhaW50JykgfHwgYnV0dG9uVGV4dC5pbmNsdWRlcygncGludGFyJyk7XG4gICAgY29uc3QgaGFzUGFpbnRJY29uID0gc3BlY2lmaWNCdXR0b24ucXVlcnlTZWxlY3Rvcignc3ZnIHBhdGhbZCo9XCIyNDAtMTIwXCJdJykgfHwgXG4gICAgICAgICAgICAgICAgICAgICAgICBzcGVjaWZpY0J1dHRvbi5xdWVyeVNlbGVjdG9yKCdzdmcgcGF0aFtkKj1cIk0xNVwiXScpO1xuICAgIFxuICAgIGlmIChoYXNQYWludFRleHQgfHwgaGFzUGFpbnRJY29uKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQUYgQm90XHUwMEYzbiBQYWludCBlbmNvbnRyYWRvIHBvciBzZWxlY3RvciBlc3BlY1x1MDBFRGZpY286IFwiJHtidXR0b25UZXh0fVwiYCk7XG4gICAgICBzcGVjaWZpY0J1dHRvbi5jbGljaygpO1xuICAgICAgXG4gICAgICAvLyBTaSBzZSByZXF1aWVyZSBkb2JsZSBjbGljLCBoYWNlciBzZWd1bmRvIGNsaWMgZGVzcHVcdTAwRTlzIGRlIHVuIGRlbGF5XG4gICAgICBpZiAoZG91YmxlQ2xpY2spIHtcbiAgICAgICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkFGIFNlZ3VuZG8gY2xpYyBlbiBib3RcdTAwRjNuIFBhaW50YCk7XG4gICAgICAgICAgc3BlY2lmaWNCdXR0b24uY2xpY2soKTtcbiAgICAgICAgfSwgNTAwKTtcbiAgICAgIH1cbiAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbiAgfVxuICBcbiAgLy8gTVx1MDBFOXRvZG8gMjogQlx1MDBGQXNxdWVkYSBzaW1wbGUgcG9yIHRleHRvIChtXHUwMEU5dG9kbyBvcmlnaW5hbClcbiAgY29uc3QgYnV0dG9ucyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2J1dHRvbicpO1xuICBmb3IgKGNvbnN0IGJ1dHRvbiBvZiBidXR0b25zKSB7XG4gICAgY29uc3QgYnV0dG9uVGV4dCA9IGJ1dHRvbi50ZXh0Q29udGVudC50b0xvd2VyQ2FzZSgpO1xuICAgIGlmICgoYnV0dG9uVGV4dC5pbmNsdWRlcygncGFpbnQnKSB8fCBidXR0b25UZXh0LmluY2x1ZGVzKCdwaW50YXInKSkgJiYgXG4gICAgICAgIGJ1dHRvbi5vZmZzZXRQYXJlbnQgIT09IG51bGwgJiZcbiAgICAgICAgIWJ1dHRvbi5kaXNhYmxlZCkge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNDXHVERkFGIEJvdFx1MDBGM24gUGFpbnQgZW5jb250cmFkbyBwb3IgdGV4dG86IFwiJHtidXR0b24udGV4dENvbnRlbnQudHJpbSgpfVwiYCk7XG4gICAgICBidXR0b24uY2xpY2soKTtcbiAgICAgIFxuICAgICAgLy8gU2kgc2UgcmVxdWllcmUgZG9ibGUgY2xpYywgaGFjZXIgc2VndW5kbyBjbGljIGRlc3B1XHUwMEU5cyBkZSB1biBkZWxheVxuICAgICAgaWYgKGRvdWJsZUNsaWNrKSB7XG4gICAgICAgIHNldFRpbWVvdXQoKCkgPT4ge1xuICAgICAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1RDgzQ1x1REZBRiBTZWd1bmRvIGNsaWMgZW4gYm90XHUwMEYzbiBQYWludGApO1xuICAgICAgICAgIGJ1dHRvbi5jbGljaygpO1xuICAgICAgICB9LCA1MDApO1xuICAgICAgfVxuICAgICAgcmV0dXJuIHRydWU7XG4gICAgfVxuICB9XG4gIFxuICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3NEMgQm90XHUwMEYzbiBQYWludCBubyBlbmNvbnRyYWRvYCk7XG4gIHJldHVybiBmYWxzZTtcbn1cblxuLy8gRnVuY2lcdTAwRjNuIHBhcmEgcmVhbGl6YXIgYXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludCBjb24gc2VjdWVuY2lhIGNvcnJlY3RhXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gYXV0b0NsaWNrUGFpbnRCdXR0b24obWF4QXR0ZW1wdHMgPSAzLCBkZWJ1ZyA9IHRydWUpIHtcbiAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHVEODNFXHVERDE2IEluaWNpYW5kbyBhdXRvLWNsaWNrIGRlbCBib3RcdTAwRjNuIFBhaW50IChtXHUwMEUxeGltbyAke21heEF0dGVtcHRzfSBpbnRlbnRvcylgKTtcbiAgXG4gIGZvciAobGV0IGF0dGVtcHQgPSAxOyBhdHRlbXB0IDw9IG1heEF0dGVtcHRzOyBhdHRlbXB0KyspIHtcbiAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0NcdURGQUYgSW50ZW50byAke2F0dGVtcHR9LyR7bWF4QXR0ZW1wdHN9IC0gQnVzY2FuZG8gYm90XHUwMEYzbiBQYWludC4uLmApO1xuICAgIFxuICAgIC8vIFZlcmlmaWNhciBzaSBsYSBwYWxldGEgeWEgZXN0XHUwMEUxIGFiaWVydGFcbiAgICBpZiAoaXNQYWxldHRlT3BlbigpKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3MDUgUGFsZXRhIHlhIGVzdFx1MDBFMSBhYmllcnRhLCBhdXRvLWNsaWNrIGNvbXBsZXRhZG9gKTtcbiAgICAgIHJldHVybiB0cnVlO1xuICAgIH1cbiAgICBcbiAgICAvLyBDTElDIFx1MDBEQU5JQ086IFByZXNpb25hciBQYWludCB1bmEgc29sYSB2ZXogKHNvbG8gcGFyYSBtb3N0cmFyIHBhbGV0YS9kZXRlY3RhciBjb2xvcmVzKVxuICAgIGlmIChmaW5kQW5kQ2xpY2tQYWludEJ1dHRvbihkZWJ1ZywgZmFsc2UpKSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdUQ4M0RcdURDNDYgQ2xpYyBlbiBib3RcdTAwRjNuIFBhaW50IHJlYWxpemFkbyAoc2luIHNlZ3VuZG8gY2xpYylgKTtcbiAgICAgIFxuICAgICAgLy8gRXNwZXJhciB1biBwb2NvIHBhcmEgcXVlIGxhIFVJL3BhbGV0YSBhcGFyZXpjYSBlbiBwYW50YWxsYVxuICAgICAgYXdhaXQgbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIDE1MDApKTtcbiAgICAgIFxuICAgICAgLy8gVmVyaWZpY2FyIHNpIGxhIHBhbGV0YSBzZSBhYnJpXHUwMEYzXG4gICAgICBpZiAoaXNQYWxldHRlT3BlbigpKSB7XG4gICAgICAgIGlmIChkZWJ1ZykgY29uc29sZS5sb2coYFtXUEEtVUldIFx1MjcwNSBQYWxldGEgYWJpZXJ0YSBleGl0b3NhbWVudGUgZGVzcHVcdTAwRTlzIGRlbCBpbnRlbnRvICR7YXR0ZW1wdH1gKTtcbiAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI2QTBcdUZFMEYgUGFsZXRhIG5vIGRldGVjdGFkYSB0cmFzIGVsIGNsaWMgZW4gaW50ZW50byAke2F0dGVtcHR9LiBSZWludGVudGFyXHUwMEUxLmApO1xuICAgICAgfVxuICAgIH0gZWxzZSB7XG4gICAgICBpZiAoZGVidWcpIGNvbnNvbGUubG9nKGBbV1BBLVVJXSBcdTI3NEMgQm90XHUwMEYzbiBQYWludCBubyBlbmNvbnRyYWRvIHBhcmEgY2xpYyBlbiBpbnRlbnRvICR7YXR0ZW1wdH1gKTtcbiAgICB9XG4gICAgXG4gICAgLy8gRXNwZXJhciBhbnRlcyBkZWwgc2lndWllbnRlIGludGVudG9cbiAgICBpZiAoYXR0ZW1wdCA8IG1heEF0dGVtcHRzKSB7XG4gICAgICBhd2FpdCBuZXcgUHJvbWlzZShyZXNvbHZlID0+IHNldFRpbWVvdXQocmVzb2x2ZSwgMTAwMCkpO1xuICAgIH1cbiAgfVxuICBcbiAgaWYgKGRlYnVnKSBjb25zb2xlLmxvZyhgW1dQQS1VSV0gXHUyNzRDIEF1dG8tY2xpY2sgZmFsbFx1MDBGMyBkZXNwdVx1MDBFOXMgZGUgJHttYXhBdHRlbXB0c30gaW50ZW50b3NgKTtcbiAgcmV0dXJuIGZhbHNlO1xufVxuIiwgIi8vID09PSBbU2lzdGVtYSBkZSBvdmVybGF5IGJhc2FkbyBlbiBCbHVlIE1hcmJsZSAtIEludGVyY2VwY2lcdTAwRjNuIGRlIHRpbGVzXSA9PT1cbigoKSA9PiB7XG4gIGNvbnN0IFRJTEVfU0laRSA9IDMwMDA7IC8vIFRhbWFcdTAwRjFvIGRlIHRpbGUgZW4gV1BsYWNlXG5cbiAgY29uc3Qgc3RhdGUgPSB7XG4gICAgZW5hYmxlZDogZmFsc2UsXG4gICAgdGVtcGxhdGVzOiBbXSwgLy8gUGxhbnRpbGxhcyBlc3RpbG8gQmx1ZSBNYXJibGVcbiAgICB0ZW1wbGF0ZXNTaG91bGRCZURyYXduOiB0cnVlLFxuICAgIHRpbGVTaXplOiAxMDAwLCAvLyBUYW1hXHUwMEYxbyBkZSB0aWxlIChjb21vIEJsdWUgTWFyYmxlKVxuICAgIGRyYXdNdWx0OiAzLCAvLyBNdWx0aXBsaWNhZG9yIGRlIGRpYnVqb1xuICAgIC8vIFBsYW4gZGUgcFx1MDBFRHhlbGVzIGFjdHVhbFxuICAgIHBpeGVsUGxhbjogbnVsbCxcbiAgICBuZXh0QmF0Y2hDb3VudDogMCxcbiAgICBhbmNob3I6IG51bGwsIC8vIHsgdGlsZVgsIHRpbGVZLCBweFgsIHB4WSB9XG4gICAgaW1hZ2VXaWR0aDogbnVsbCxcbiAgICBpbWFnZUhlaWdodDogbnVsbCxcbiAgICAvLyBTaXN0ZW1hIGRlIGludGVyY2VwY2lcdTAwRjNuXG4gICAgb3JpZ2luYWxGZXRjaDogbnVsbCxcbiAgICBmZXRjaGVkQmxvYlF1ZXVlOiBuZXcgTWFwKCksXG4gICAgaXNJbnRlcmNlcHRpbmc6IGZhbHNlXG4gIH07XG5cbiAgZnVuY3Rpb24gaW5qZWN0U3R5bGVzKCkge1xuICAgIC8vIE5vIG5lY2VzaXRhbW9zIGVzdGlsb3MgQ1NTIGFkaWNpb25hbGVzIC0gQmx1ZSBNYXJibGUgdXNhIGVsIHNpc3RlbWEgZGUgdGlsZXMgbmF0aXZvXG4gICAgY29uc29sZS5sb2coJ1tQTEFOIE9WRVJMQVldIEJsdWUgTWFyYmxlIHRpbGUgc3lzdGVtIGluaXRpYWxpemVkJyk7XG4gIH1cblxuICAvLyA9PT0gU0lTVEVNQSBERSBJTlRFUkNFUENJXHUwMEQzTiBERSBGRVRDSCAoY29tbyBCbHVlIE1hcmJsZSkgPT09XG4gIGZ1bmN0aW9uIHN0YXJ0RmV0Y2hJbnRlcmNlcHRpb24oKSB7XG4gICAgaWYgKHN0YXRlLmlzSW50ZXJjZXB0aW5nKSByZXR1cm47XG5cbiAgICBzdGF0ZS5vcmlnaW5hbEZldGNoID0gd2luZG93LmZldGNoO1xuICAgIHN0YXRlLmlzSW50ZXJjZXB0aW5nID0gdHJ1ZTtcblxuICAgIHdpbmRvdy5mZXRjaCA9IGFzeW5jIGZ1bmN0aW9uKC4uLmFyZ3MpIHtcbiAgICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgc3RhdGUub3JpZ2luYWxGZXRjaC5hcHBseSh0aGlzLCBhcmdzKTtcbiAgICAgIGNvbnN0IGNsb25lZCA9IHJlc3BvbnNlLmNsb25lKCk7XG5cbiAgICAgIGNvbnN0IGVuZHBvaW50TmFtZSA9ICgoYXJnc1swXSBpbnN0YW5jZW9mIFJlcXVlc3QpID8gYXJnc1swXT8udXJsIDogYXJnc1swXSkgfHwgJ2lnbm9yZSc7XG4gICAgICBjb25zdCBjb250ZW50VHlwZSA9IGNsb25lZC5oZWFkZXJzLmdldCgnY29udGVudC10eXBlJykgfHwgJyc7XG5cbiAgICAgIC8vIEludGVyY2VwdGFyIHNvbG8gdGlsZXMgZGUgaW1hZ2VuIChjb21vIEJsdWUgTWFyYmxlKVxuICAgICAgaWYgKGNvbnRlbnRUeXBlLmluY2x1ZGVzKCdpbWFnZS8nKSAmJiBcbiAgICAgICAgICBlbmRwb2ludE5hbWUuaW5jbHVkZXMoJy90aWxlcy8nKSAmJiBcbiAgICAgICAgICAhZW5kcG9pbnROYW1lLmluY2x1ZGVzKCdvcGVuZnJlZW1hcCcpICYmIFxuICAgICAgICAgICFlbmRwb2ludE5hbWUuaW5jbHVkZXMoJ21hcHMnKSkge1xuXG4gICAgICAgIGNvbnNvbGUubG9nKCdbUExBTiBPVkVSTEFZXSBJbnRlcmNlcHRpbmcgdGlsZSByZXF1ZXN0OicsIGVuZHBvaW50TmFtZSk7XG5cbiAgICAgICAgdHJ5IHtcbiAgICAgICAgICBjb25zdCBibG9iID0gYXdhaXQgY2xvbmVkLmJsb2IoKTtcbiAgICAgICAgICBjb25zdCBwcm9jZXNzZWRCbG9iID0gYXdhaXQgZHJhd1BsYW5PblRpbGUoYmxvYiwgZW5kcG9pbnROYW1lKTtcbiAgICAgICAgICBcbiAgICAgICAgICByZXR1cm4gbmV3IFJlc3BvbnNlKHByb2Nlc3NlZEJsb2IsIHtcbiAgICAgICAgICAgIGhlYWRlcnM6IGNsb25lZC5oZWFkZXJzLFxuICAgICAgICAgICAgc3RhdHVzOiBjbG9uZWQuc3RhdHVzLFxuICAgICAgICAgICAgc3RhdHVzVGV4dDogY2xvbmVkLnN0YXR1c1RleHRcbiAgICAgICAgICB9KTtcbiAgICAgICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgICAgICBjb25zb2xlLmVycm9yKCdbUExBTiBPVkVSTEFZXSBFcnJvciBwcm9jZXNzaW5nIHRpbGU6JywgZXJyb3IpO1xuICAgICAgICAgIHJldHVybiByZXNwb25zZTtcbiAgICAgICAgfVxuICAgICAgfVxuXG4gICAgICByZXR1cm4gcmVzcG9uc2U7XG4gICAgfTtcblxuICAgIGNvbnNvbGUubG9nKCdbUExBTiBPVkVSTEFZXSBGZXRjaCBpbnRlcmNlcHRpb24gc3RhcnRlZCcpO1xuICB9XG5cbiAgZnVuY3Rpb24gc3RvcEZldGNoSW50ZXJjZXB0aW9uKCkge1xuICAgIGlmICghc3RhdGUuaXNJbnRlcmNlcHRpbmcgfHwgIXN0YXRlLm9yaWdpbmFsRmV0Y2gpIHJldHVybjtcblxuICAgIHdpbmRvdy5mZXRjaCA9IHN0YXRlLm9yaWdpbmFsRmV0Y2g7XG4gICAgc3RhdGUuaXNJbnRlcmNlcHRpbmcgPSBmYWxzZTtcblxuICAgIGNvbnNvbGUubG9nKCdbUExBTiBPVkVSTEFZXSBGZXRjaCBpbnRlcmNlcHRpb24gc3RvcHBlZCcpO1xuICB9XG5cbiAgLy8gPT09IFBST0NFU0FNSUVOVE8gREUgVElMRVMgKGNvbW8gQmx1ZSBNYXJibGUpID09PVxuICBhc3luYyBmdW5jdGlvbiBkcmF3UGxhbk9uVGlsZSh0aWxlQmxvYiwgZW5kcG9pbnRVcmwpIHtcbiAgICBpZiAoIXN0YXRlLmVuYWJsZWQgfHwgIXN0YXRlLnRlbXBsYXRlc1Nob3VsZEJlRHJhd24gfHwgIXN0YXRlLnBpeGVsUGxhbikge1xuICAgICAgcmV0dXJuIHRpbGVCbG9iO1xuICAgIH1cblxuICAgIC8vIEV4dHJhZXIgY29vcmRlbmFkYXMgZGVsIHRpbGUgZGVzZGUgbGEgVVJMXG4gICAgLy8gRm9ybWF0bzogXCIuLi4vdGlsZXMvdGlsZVgvdGlsZVkvem9vbS5wbmdcIlxuICAgIGNvbnN0IHVybFBhcnRzID0gZW5kcG9pbnRVcmwuc3BsaXQoJy8nKTtcbiAgICBjb25zdCB0aWxlWSA9IHBhcnNlSW50KHVybFBhcnRzW3VybFBhcnRzLmxlbmd0aCAtIDFdLnJlcGxhY2UoJy5wbmcnLCAnJykpO1xuICAgIGNvbnN0IHRpbGVYID0gcGFyc2VJbnQodXJsUGFydHNbdXJsUGFydHMubGVuZ3RoIC0gMl0pO1xuXG4gICAgaWYgKGlzTmFOKHRpbGVYKSB8fCBpc05hTih0aWxlWSkpIHtcbiAgICAgIGNvbnNvbGUud2FybignW1BMQU4gT1ZFUkxBWV0gQ291bGQgbm90IGV4dHJhY3QgdGlsZSBjb29yZGluYXRlcyBmcm9tIFVSTDonLCBlbmRwb2ludFVybCk7XG4gICAgICByZXR1cm4gdGlsZUJsb2I7XG4gICAgfVxuXG4gICAgY29uc29sZS5sb2coYFtQTEFOIE9WRVJMQVldIFByb2Nlc3NpbmcgdGlsZTogJHt0aWxlWH0sJHt0aWxlWX1gKTtcblxuICAgIC8vIFZlcmlmaWNhciBzaSBlc3RlIHRpbGUgY29udGllbmUgcFx1MDBFRHhlbGVzIGRlIG51ZXN0cm8gcGxhblxuICAgIGNvbnN0IHRpbGVQaXhlbHMgPSBnZXRQaXhlbHNGb3JUaWxlKHRpbGVYLCB0aWxlWSk7XG4gICAgaWYgKHRpbGVQaXhlbHMubGVuZ3RoID09PSAwKSB7XG4gICAgICByZXR1cm4gdGlsZUJsb2I7IC8vIE5vIGhheSBwXHUwMEVEeGVsZXMgZW4gZXN0ZSB0aWxlXG4gICAgfVxuXG4gICAgY29uc29sZS5sb2coYFtQTEFOIE9WRVJMQVldIEZvdW5kICR7dGlsZVBpeGVscy5sZW5ndGh9IHBpeGVscyBmb3IgdGlsZSAke3RpbGVYfSwke3RpbGVZfWApO1xuXG4gICAgLy8gUHJvY2VzYXIgZWwgdGlsZSAoY29tbyBCbHVlIE1hcmJsZSlcbiAgICBjb25zdCBkcmF3U2l6ZSA9IHN0YXRlLnRpbGVTaXplICogc3RhdGUuZHJhd011bHQ7XG4gICAgY29uc3QgdGlsZUJpdG1hcCA9IGF3YWl0IGNyZWF0ZUltYWdlQml0bWFwKHRpbGVCbG9iKTtcbiAgICBcbiAgICBjb25zdCBjYW52YXMgPSBuZXcgT2Zmc2NyZWVuQ2FudmFzKGRyYXdTaXplLCBkcmF3U2l6ZSk7XG4gICAgY29uc3QgY29udGV4dCA9IGNhbnZhcy5nZXRDb250ZXh0KCcyZCcpO1xuICAgIFxuICAgIGNvbnRleHQuaW1hZ2VTbW9vdGhpbmdFbmFibGVkID0gZmFsc2U7XG4gICAgY29udGV4dC5jbGVhclJlY3QoMCwgMCwgZHJhd1NpemUsIGRyYXdTaXplKTtcbiAgICBjb250ZXh0LmRyYXdJbWFnZSh0aWxlQml0bWFwLCAwLCAwLCBkcmF3U2l6ZSwgZHJhd1NpemUpO1xuXG4gICAgLy8gRGlidWphciBwXHUwMEVEeGVsZXMgZGVsIHBsYW4gKGNvbW8gQmx1ZSBNYXJibGUgZGlidWphIHRlbXBsYXRlcylcbiAgICBkcmF3UGl4ZWxzT25UaWxlKGNvbnRleHQsIHRpbGVQaXhlbHMsIHRpbGVYLCB0aWxlWSk7XG5cbiAgICByZXR1cm4gYXdhaXQgY2FudmFzLmNvbnZlcnRUb0Jsb2IoeyB0eXBlOiAnaW1hZ2UvcG5nJyB9KTtcbiAgfVxuXG4gIGZ1bmN0aW9uIGdldFBpeGVsc0ZvclRpbGUodGlsZVgsIHRpbGVZKSB7XG4gICAgaWYgKCFzdGF0ZS5waXhlbFBsYW4gfHwgIXN0YXRlLnBpeGVsUGxhbi5waXhlbHMpIHJldHVybiBbXTtcblxuICAgIHJldHVybiBzdGF0ZS5waXhlbFBsYW4ucGl4ZWxzLmZpbHRlcihwaXhlbCA9PiB7XG4gICAgICAvLyBDYWxjdWxhciBlbiBxdVx1MDBFOSB0aWxlIGVzdFx1MDBFMSBlc3RlIHBcdTAwRUR4ZWxcbiAgICAgIGNvbnN0IHBpeGVsVGlsZVggPSBNYXRoLmZsb29yKHBpeGVsLmdsb2JhbFggLyBUSUxFX1NJWkUpO1xuICAgICAgY29uc3QgcGl4ZWxUaWxlWSA9IE1hdGguZmxvb3IocGl4ZWwuZ2xvYmFsWSAvIFRJTEVfU0laRSk7XG4gICAgICByZXR1cm4gcGl4ZWxUaWxlWCA9PT0gdGlsZVggJiYgcGl4ZWxUaWxlWSA9PT0gdGlsZVk7XG4gICAgfSk7XG4gIH1cblxuICBmdW5jdGlvbiBkcmF3UGl4ZWxzT25UaWxlKGNvbnRleHQsIHBpeGVscywgdGlsZVgsIHRpbGVZKSB7XG4gICAgY29uc3QgdGlsZVN0YXJ0WCA9IHRpbGVYICogVElMRV9TSVpFO1xuICAgIGNvbnN0IHRpbGVTdGFydFkgPSB0aWxlWSAqIFRJTEVfU0laRTtcblxuICAgIC8vIENvbmZpZ3VyYXIgdHJhbnNwYXJlbmNpYSBkZWwgb3ZlcmxheVxuICAgIGNvbnRleHQuZ2xvYmFsQWxwaGEgPSAwLjc7XG5cbiAgICBmb3IgKGNvbnN0IHBpeGVsIG9mIHBpeGVscykge1xuICAgICAgLy8gQ29udmVydGlyIGNvb3JkZW5hZGFzIGdsb2JhbGVzIGEgY29vcmRlbmFkYXMgbG9jYWxlcyBkZWwgdGlsZVxuICAgICAgY29uc3QgbG9jYWxYID0gKHBpeGVsLmdsb2JhbFggLSB0aWxlU3RhcnRYKSAqIHN0YXRlLmRyYXdNdWx0ICsgMTsgLy8gKzEgcGFyYSBjZW50cmFyIGNvbW8gQmx1ZSBNYXJibGVcbiAgICAgIGNvbnN0IGxvY2FsWSA9IChwaXhlbC5nbG9iYWxZIC0gdGlsZVN0YXJ0WSkgKiBzdGF0ZS5kcmF3TXVsdCArIDE7XG5cbiAgICAgIC8vIFNvbG8gZGlidWphciBzaSBlc3RcdTAwRTEgZGVudHJvIGRlbCB0aWxlXG4gICAgICBpZiAobG9jYWxYID49IDAgJiYgbG9jYWxYIDwgc3RhdGUudGlsZVNpemUgKiBzdGF0ZS5kcmF3TXVsdCAmJiBcbiAgICAgICAgICBsb2NhbFkgPj0gMCAmJiBsb2NhbFkgPCBzdGF0ZS50aWxlU2l6ZSAqIHN0YXRlLmRyYXdNdWx0KSB7XG4gICAgICAgIFxuICAgICAgICBjb250ZXh0LmZpbGxTdHlsZSA9IGByZ2IoJHtwaXhlbC5yfSwke3BpeGVsLmd9LCR7cGl4ZWwuYn0pYDtcbiAgICAgICAgY29udGV4dC5maWxsUmVjdChsb2NhbFgsIGxvY2FsWSwgMSwgMSk7XG4gICAgICB9XG4gICAgfVxuXG4gICAgLy8gUmVzYWx0YXIgcHJcdTAwRjN4aW1vIGJhdGNoIGNvbiBtYXlvciBvcGFjaWRhZFxuICAgIGlmIChzdGF0ZS5uZXh0QmF0Y2hDb3VudCA+IDApIHtcbiAgICAgIGNvbnRleHQuZ2xvYmFsQWxwaGEgPSAxLjA7XG4gICAgICBjb25zdCBiYXRjaFBpeGVscyA9IHBpeGVscy5zbGljZSgwLCBzdGF0ZS5uZXh0QmF0Y2hDb3VudCk7XG4gICAgICBcbiAgICAgIGZvciAoY29uc3QgcGl4ZWwgb2YgYmF0Y2hQaXhlbHMpIHtcbiAgICAgICAgY29uc3QgbG9jYWxYID0gKHBpeGVsLmdsb2JhbFggLSB0aWxlU3RhcnRYKSAqIHN0YXRlLmRyYXdNdWx0ICsgMTtcbiAgICAgICAgY29uc3QgbG9jYWxZID0gKHBpeGVsLmdsb2JhbFkgLSB0aWxlU3RhcnRZKSAqIHN0YXRlLmRyYXdNdWx0ICsgMTtcblxuICAgICAgICBpZiAobG9jYWxYID49IDAgJiYgbG9jYWxYIDwgc3RhdGUudGlsZVNpemUgKiBzdGF0ZS5kcmF3TXVsdCAmJiBcbiAgICAgICAgICAgIGxvY2FsWSA+PSAwICYmIGxvY2FsWSA8IHN0YXRlLnRpbGVTaXplICogc3RhdGUuZHJhd011bHQpIHtcbiAgICAgICAgICBcbiAgICAgICAgICBjb250ZXh0LmZpbGxTdHlsZSA9IGByZ2IoJHtwaXhlbC5yfSwke3BpeGVsLmd9LCR7cGl4ZWwuYn0pYDtcbiAgICAgICAgICBjb250ZXh0LmZpbGxSZWN0KGxvY2FsWCwgbG9jYWxZLCAxLCAxKTtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIC8vID09PSBBUEkgUFx1MDBEQUJMSUNBIChjb21wYXRpYmxlIGNvbiBsYSBhbnRlcmlvcikgPT09XG4gIGZ1bmN0aW9uIHNldEVuYWJsZWQoZW5hYmxlZCkge1xuICAgIHN0YXRlLmVuYWJsZWQgPSAhIWVuYWJsZWQ7XG4gICAgXG4gICAgaWYgKHN0YXRlLmVuYWJsZWQpIHtcbiAgICAgIHN0YXJ0RmV0Y2hJbnRlcmNlcHRpb24oKTtcbiAgICB9IGVsc2Uge1xuICAgICAgc3RvcEZldGNoSW50ZXJjZXB0aW9uKCk7XG4gICAgfVxuICAgIFxuICAgIGNvbnNvbGUubG9nKGBbUExBTiBPVkVSTEFZXSBzZXRFbmFibGVkOiAke3N0YXRlLmVuYWJsZWR9YCk7XG4gIH1cblxuICBmdW5jdGlvbiBzZXRQbGFuKHBsYW5JdGVtcywgb3B0cyA9IHt9KSB7XG4gICAgaWYgKCFwbGFuSXRlbXMgfHwgcGxhbkl0ZW1zLmxlbmd0aCA9PT0gMCkge1xuICAgICAgc3RhdGUucGl4ZWxQbGFuID0gbnVsbDtcbiAgICAgIGNvbnNvbGUubG9nKCdbUExBTiBPVkVSTEFZXSBQbGFuIGNsZWFyZWQnKTtcbiAgICAgIHJldHVybjtcbiAgICB9XG5cbiAgICAvLyBDb252ZXJ0aXIgZm9ybWF0byBBdXRvLUltYWdlIGEgZm9ybWF0byBpbnRlcm5vXG4gICAgY29uc3QgcGl4ZWxzID0gW107XG4gICAgZm9yIChjb25zdCBpdGVtIG9mIHBsYW5JdGVtcykge1xuICAgICAgbGV0IGdsb2JhbFgsIGdsb2JhbFk7XG4gICAgICBcbiAgICAgIGlmICh0eXBlb2YgaXRlbS50aWxlWCA9PT0gJ251bWJlcicgJiYgdHlwZW9mIGl0ZW0ubG9jYWxYID09PSAnbnVtYmVyJykge1xuICAgICAgICAvLyBGb3JtYXRvIHRpbGUvbG9jYWxcbiAgICAgICAgZ2xvYmFsWCA9IGl0ZW0udGlsZVggKiBUSUxFX1NJWkUgKyBpdGVtLmxvY2FsWDtcbiAgICAgICAgZ2xvYmFsWSA9IGl0ZW0udGlsZVkgKiBUSUxFX1NJWkUgKyBpdGVtLmxvY2FsWTtcbiAgICAgIH0gZWxzZSBpZiAob3B0cy5hbmNob3IgJiYgdHlwZW9mIGl0ZW0uaW1hZ2VYID09PSAnbnVtYmVyJykge1xuICAgICAgICAvLyBGb3JtYXRvIGltYWdlWC9ZIGNvbiBhbmNsYVxuICAgICAgICBjb25zdCBiYXNlWCA9IG9wdHMuYW5jaG9yLnRpbGVYICogVElMRV9TSVpFICsgKG9wdHMuYW5jaG9yLnB4WCB8fCAwKTtcbiAgICAgICAgY29uc3QgYmFzZVkgPSBvcHRzLmFuY2hvci50aWxlWSAqIFRJTEVfU0laRSArIChvcHRzLmFuY2hvci5weFkgfHwgMCk7XG4gICAgICAgIGdsb2JhbFggPSBiYXNlWCArIGl0ZW0uaW1hZ2VYO1xuICAgICAgICBnbG9iYWxZID0gYmFzZVkgKyBpdGVtLmltYWdlWTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIGNvbnRpbnVlO1xuICAgICAgfVxuXG4gICAgICBwaXhlbHMucHVzaCh7XG4gICAgICAgIGdsb2JhbFg6IGdsb2JhbFgsXG4gICAgICAgIGdsb2JhbFk6IGdsb2JhbFksXG4gICAgICAgIHI6IGl0ZW0uY29sb3I/LnIgfHwgMCxcbiAgICAgICAgZzogaXRlbS5jb2xvcj8uZyB8fCAwLFxuICAgICAgICBiOiBpdGVtLmNvbG9yPy5iIHx8IDBcbiAgICAgIH0pO1xuICAgIH1cblxuICAgIHN0YXRlLnBpeGVsUGxhbiA9IHsgcGl4ZWxzIH07XG4gICAgc3RhdGUubmV4dEJhdGNoQ291bnQgPSBvcHRzLm5leHRCYXRjaENvdW50IHx8IDA7XG4gICAgc3RhdGUuYW5jaG9yID0gb3B0cy5hbmNob3IgfHwgbnVsbDtcbiAgICBzdGF0ZS5pbWFnZVdpZHRoID0gb3B0cy5pbWFnZVdpZHRoIHx8IG51bGw7XG4gICAgc3RhdGUuaW1hZ2VIZWlnaHQgPSBvcHRzLmltYWdlSGVpZ2h0IHx8IG51bGw7XG5cbiAgICBjb25zb2xlLmxvZyhgW1BMQU4gT1ZFUkxBWV0gUGxhbiBzZXQ6ICR7cGl4ZWxzLmxlbmd0aH0gcGl4ZWxzYCk7XG4gICAgXG4gICAgaWYgKHR5cGVvZiBvcHRzLmVuYWJsZWQgPT09ICdib29sZWFuJykge1xuICAgICAgc2V0RW5hYmxlZChvcHRzLmVuYWJsZWQpO1xuICAgIH1cbiAgfVxuXG4gIGZ1bmN0aW9uIHNldE5leHRCYXRjaENvdW50KGNvdW50KSB7XG4gICAgc3RhdGUubmV4dEJhdGNoQ291bnQgPSBNYXRoLm1heCgwLCBOdW1iZXIoY291bnQgfHwgMCkpO1xuICAgIGNvbnNvbGUubG9nKGBbUExBTiBPVkVSTEFZXSBOZXh0IGJhdGNoIGNvdW50OiAke3N0YXRlLm5leHRCYXRjaENvdW50fWApO1xuICB9XG5cbiAgZnVuY3Rpb24gc2V0QW5jaG9yKGFuY2hvcikge1xuICAgIHN0YXRlLmFuY2hvciA9IGFuY2hvcjtcbiAgICBjb25zb2xlLmxvZygnW1BMQU4gT1ZFUkxBWV0gQW5jaG9yIHNldDonLCBhbmNob3IpO1xuICB9XG5cbiAgZnVuY3Rpb24gc2V0QW5jaG9yQ3NzKHgsIHkpIHtcbiAgICAvLyBFbiBlbCBzaXN0ZW1hIGRlIHRpbGVzIG5vIG5lY2VzaXRhbW9zIGFuY2xhIENTUyAtIGVzIHNvbG8gcGFyYSBjb21wYXRpYmlsaWRhZFxuICAgIGNvbnNvbGUubG9nKCdbUExBTiBPVkVSTEFZXSBDU1MgYW5jaG9yIHNldCAoaWdub3JlZCBpbiB0aWxlIHN5c3RlbSk6JywgeyB4LCB5IH0pO1xuICB9XG5cbiAgZnVuY3Rpb24gZW5kU2VsZWN0aW9uTW9kZSgpIHtcbiAgICAvLyBFbiBlbCBzaXN0ZW1hIGRlIHRpbGVzIG5vIGhheSBtb2RvIHNlbGVjY2lcdTAwRjNuIC0gZXMgc29sbyBwYXJhIGNvbXBhdGliaWxpZGFkXG4gICAgY29uc29sZS5sb2coJ1tQTEFOIE9WRVJMQVldIFNlbGVjdGlvbiBtb2RlIGVuZGVkIChpZ25vcmVkIGluIHRpbGUgc3lzdGVtKScpO1xuICB9XG5cbiAgZnVuY3Rpb24gY2xlYW51cCgpIHtcbiAgICBzdG9wRmV0Y2hJbnRlcmNlcHRpb24oKTtcbiAgICBzdGF0ZS5waXhlbFBsYW4gPSBudWxsO1xuICAgIHN0YXRlLmZldGNoZWRCbG9iUXVldWUuY2xlYXIoKTtcbiAgICBjb25zb2xlLmxvZygnW1BMQU4gT1ZFUkxBWV0gQ2xlYW51cCBjb21wbGV0ZWQnKTtcbiAgfVxuXG4gIC8vID09PSBBUEkgR0xPQkFMIChjb21wYXRpYmxlIGNvbiBsYSBhbnRlcmlvcikgPT09XG4gIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXyA9IHtcbiAgICBpbmplY3RTdHlsZXMsXG4gICAgc2V0RW5hYmxlZCxcbiAgICBzZXRQbGFuLFxuICAgIHNldFBsYW5JdGVtc0Zyb21UaWxlTGlzdDogc2V0UGxhbiwgLy8gQWxpYXNcbiAgICBzZXROZXh0QmF0Y2hDb3VudCxcbiAgICBzZXRBbmNob3IsXG4gICAgc2V0QW5jaG9yQ3NzLFxuICAgIGVuZFNlbGVjdGlvbk1vZGUsXG4gICAgcmVuZGVyOiAoKSA9PiB7fSwgLy8gTm8tb3AgZW4gc2lzdGVtYSBkZSB0aWxlc1xuICAgIGNsZWFudXAsXG4gICAgZ2V0IHN0YXRlKCkgeyByZXR1cm4gc3RhdGU7IH1cbiAgfTtcblxuICBjb25zb2xlLmxvZygnW1BMQU4gT1ZFUkxBWV0gQmx1ZSBNYXJibGUgdGlsZSBzeXN0ZW0gcmVhZHknKTtcbn0pKCk7XG4iLCAiaW1wb3J0IHsgbG9nIH0gZnJvbSBcIi4uL2NvcmUvbG9nZ2VyLmpzXCI7XG5pbXBvcnQgeyBpbWFnZVN0YXRlLCBJTUFHRV9ERUZBVUxUUyB9IGZyb20gXCIuL2NvbmZpZy5qc1wiO1xuaW1wb3J0IHsgQmx1ZU1hcmJsZWxJbWFnZVByb2Nlc3NvciwgZGV0ZWN0QXZhaWxhYmxlQ29sb3JzIH0gZnJvbSBcIi4vYmx1ZS1tYXJibGUtcHJvY2Vzc29yLmpzXCI7XG5pbXBvcnQgeyBwcm9jZXNzSW1hZ2UsIHN0b3BQYWludGluZyB9IGZyb20gXCIuL3BhaW50ZXIuanNcIjtcbmltcG9ydCB7IHNhdmVQcm9ncmVzcywgbG9hZFByb2dyZXNzLCBjbGVhclByb2dyZXNzLCBnZXRQcm9ncmVzc0luZm8gfSBmcm9tIFwiLi9zYXZlLWxvYWQuanNcIjtcbmltcG9ydCB7IGNyZWF0ZUltYWdlVUksIHNob3dDb25maXJtRGlhbG9nIH0gZnJvbSBcIi4vdWkuanNcIjtcbmltcG9ydCB7IGdldFNlc3Npb24gfSBmcm9tIFwiLi4vY29yZS93cGxhY2UtYXBpLmpzXCI7XG5pbXBvcnQgeyBpbml0aWFsaXplTGFuZ3VhZ2UsIGdldFNlY3Rpb24sIHQsIGdldEN1cnJlbnRMYW5ndWFnZSB9IGZyb20gXCIuLi9sb2NhbGVzL2luZGV4LmpzXCI7XG5pbXBvcnQgeyBpc1BhbGV0dGVPcGVuLCBhdXRvQ2xpY2tQYWludEJ1dHRvbiB9IGZyb20gXCIuLi9jb3JlL2RvbS5qc1wiO1xuaW1wb3J0IFwiLi9wbGFuLW92ZXJsYXktYmx1ZS1tYXJibGUuanNcIjtcblxuZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHJ1bkltYWdlKCkge1xuICBsb2coJ1x1RDgzRFx1REU4MCBJbmljaWFuZG8gV1BsYWNlIEF1dG8tSW1hZ2UgKHZlcnNpXHUwMEYzbiBtb2R1bGFyKScpO1xuICBcbiAgLy8gSW5pY2lhbGl6YXIgc2lzdGVtYSBkZSBpZGlvbWFzXG4gIGluaXRpYWxpemVMYW5ndWFnZSgpO1xuICBcbiAgLy8gQXNlZ3VyYXJzZSBxdWUgZWwgZXN0YWRvIGdsb2JhbCBleGlzdGVcbiAgd2luZG93Ll9fd3BsYWNlQm90ID0geyAuLi53aW5kb3cuX193cGxhY2VCb3QsIGltYWdlUnVubmluZzogdHJ1ZSB9O1xuXG4gIGxldCBjdXJyZW50VXNlckluZm8gPSBudWxsOyAvLyBWYXJpYWJsZSBnbG9iYWwgcGFyYSBpbmZvcm1hY2lcdTAwRjNuIGRlbCB1c3VhcmlvXG4gIGxldCBvcmlnaW5hbEZldGNoID0gd2luZG93LmZldGNoOyAvLyBHdWFyZGFyIGZldGNoIG9yaWdpbmFsIGdsb2JhbG1lbnRlXG4gIFxuICAvLyBGdW5jaVx1MDBGM24gcGFyYSByZXN0YXVyYXIgZmV0Y2ggb3JpZ2luYWwgZGUgZm9ybWEgc2VndXJhXG4gIGNvbnN0IHJlc3RvcmVGZXRjaCA9ICgpID0+IHtcbiAgICBpZiAod2luZG93LmZldGNoICE9PSBvcmlnaW5hbEZldGNoKSB7XG4gICAgICB3aW5kb3cuZmV0Y2ggPSBvcmlnaW5hbEZldGNoO1xuICAgICAgbG9nKCdcdUQ4M0RcdUREMDQgRmV0Y2ggb3JpZ2luYWwgcmVzdGF1cmFkbycpO1xuICAgIH1cbiAgICBpZiAoaW1hZ2VTdGF0ZS5wb3NpdGlvblRpbWVvdXRJZCkge1xuICAgICAgY2xlYXJUaW1lb3V0KGltYWdlU3RhdGUucG9zaXRpb25UaW1lb3V0SWQpO1xuICAgICAgaW1hZ2VTdGF0ZS5wb3NpdGlvblRpbWVvdXRJZCA9IG51bGw7XG4gICAgfVxuICAgIGlmIChpbWFnZVN0YXRlLmNsZWFudXBPYnNlcnZlcikge1xuICAgICAgaW1hZ2VTdGF0ZS5jbGVhbnVwT2JzZXJ2ZXIoKTtcbiAgICAgIGltYWdlU3RhdGUuY2xlYW51cE9ic2VydmVyID0gbnVsbDtcbiAgICB9XG4gICAgaW1hZ2VTdGF0ZS5zZWxlY3RpbmdQb3NpdGlvbiA9IGZhbHNlO1xuICB9O1xuXG4gIHRyeSB7XG4gICAgLy8gSW5pY2lhbGl6YXIgY29uZmlndXJhY2lcdTAwRjNuXG4gICAgY29uc3QgY29uZmlnID0geyAuLi5JTUFHRV9ERUZBVUxUUyB9O1xuICAgIFxuICAgIC8vIE9idGVuZXIgdGV4dG9zIGVuIGVsIGlkaW9tYSBhY3R1YWxcbiAgICBjb25zdCB0ZXh0cyA9IGdldFNlY3Rpb24oJ2ltYWdlJyk7XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBlc3RhZG8gZGVsIGlkaW9tYVxuICAgIGltYWdlU3RhdGUubGFuZ3VhZ2UgPSBnZXRDdXJyZW50TGFuZ3VhZ2UoKTtcbiAgICBcbiAgICAvLyBWZXJpZmljYXIgc2l0ZWtleVxuICAgIGlmICghY29uZmlnLlNJVEVLRVkpIHtcbiAgICAgIGNvbnN0IHNpdGVLZXlFbGVtZW50ID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvcignKltkYXRhLXNpdGVrZXldJyk7XG4gICAgICBpZiAoc2l0ZUtleUVsZW1lbnQpIHtcbiAgICAgICAgY29uZmlnLlNJVEVLRVkgPSBzaXRlS2V5RWxlbWVudC5nZXRBdHRyaWJ1dGUoJ2RhdGEtc2l0ZWtleScpO1xuICAgICAgICBsb2coYFx1RDgzRFx1RENERCBTaXRla2V5IGVuY29udHJhZGEgYXV0b21cdTAwRTF0aWNhbWVudGU6ICR7Y29uZmlnLlNJVEVLRVkuc3Vic3RyaW5nKDAsIDIwKX0uLi5gKTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZG8gZW5jb250cmFyIGxhIHNpdGVrZXkgYXV0b21cdTAwRTF0aWNhbWVudGUnKTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICAvLyBGdW5jaVx1MDBGM24gcGFyYSBhdXRvLWluaWNpbyBkZWwgYm90XG4gICAgYXN5bmMgZnVuY3Rpb24gdHJ5QXV0b0luaXQoKSB7XG4gICAgICBsb2coJ1x1RDgzRVx1REQxNiBJbnRlbnRhbmRvIGF1dG8taW5pY2lvLi4uJyk7XG4gICAgICBcbiAgICAgIC8vIFZlcmlmaWNhciBzaSBsYSBwYWxldGEgeWEgZXN0XHUwMEUxIGFiaWVydGFcbiAgICAgIGlmIChpc1BhbGV0dGVPcGVuKCkpIHtcbiAgICAgICAgbG9nKCdcdUQ4M0NcdURGQTggUGFsZXRhIGRlIGNvbG9yZXMgeWEgZXN0XHUwMEUxIGFiaWVydGEnKTtcbiAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgICB9XG4gICAgICBcbiAgICAgIGxvZygnXHVEODNEXHVERDBEIFBhbGV0YSBubyBlbmNvbnRyYWRhLCBpbmljaWFuZG8gYXV0by1jbGljayBkZWwgYm90XHUwMEYzbiBQYWludC4uLicpO1xuICAgICAgXG4gICAgICAvLyBVc2FyIGxhIG51ZXZhIGZ1bmNpXHUwMEYzbiBkZSBhdXRvLWNsaWNrIHF1ZSBoYWNlIGRvYmxlIGNsaWMgYXV0b21cdTAwRTF0aWNhbWVudGVcbiAgICAgIGNvbnN0IHN1Y2Nlc3MgPSBhd2FpdCBhdXRvQ2xpY2tQYWludEJ1dHRvbigzLCB0cnVlKTtcbiAgICAgIFxuICAgICAgaWYgKHN1Y2Nlc3MpIHtcbiAgICAgICAgbG9nKCdcdTI3MDUgQXV0by1jbGljayBleGl0b3NvLCBwYWxldGEgYWJpZXJ0YScpO1xuICAgICAgICByZXR1cm4gdHJ1ZTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIGxvZygnXHUyNzRDIEF1dG8tY2xpY2sgZmFsbFx1MDBGMywgcmVxdWVyaXJcdTAwRTEgaW5pY2lvIG1hbnVhbCcpO1xuICAgICAgICByZXR1cm4gZmFsc2U7XG4gICAgICB9XG4gICAgfVxuXG4gICAgLy8gRnVuY2lcdTAwRjNuIHBhcmEgaW5pY2lhbGl6YXIgZWwgYm90ICh1c2FkYSB0YW50byBwYXJhIGF1dG8taW5pY2lvIGNvbW8gaW5pY2lvIG1hbnVhbClcbiAgICBhc3luYyBmdW5jdGlvbiBpbml0aWFsaXplQm90KGlzQXV0b0luaXQgPSBmYWxzZSkge1xuICAgICAgbG9nKCdcdUQ4M0VcdUREMTYgSW5pY2lhbGl6YW5kbyBBdXRvLUltYWdlLi4uJyk7XG4gICAgICBcbiAgICAgIC8vIFZlcmlmaWNhciBjb2xvcmVzIGRpc3BvbmlibGVzXG4gICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UuY2hlY2tpbmdDb2xvcnMnKSwgJ2luZm8nKTtcbiAgICAgIGNvbnN0IGNvbG9ycyA9IGRldGVjdEF2YWlsYWJsZUNvbG9ycygpO1xuICAgICAgXG4gICAgICBpZiAoY29sb3JzLmxlbmd0aCA9PT0gMCkge1xuICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2Uubm9Db2xvcnNGb3VuZCcpLCAnZXJyb3InKTtcbiAgICAgICAgcmV0dXJuIGZhbHNlO1xuICAgICAgfVxuICAgICAgXG4gICAgICAvLyBPYnRlbmVyIGluZm9ybWFjaVx1MDBGM24gZGVsIHVzdWFyaW9cbiAgICAgIGNvbnN0IHNlc3Npb25JbmZvID0gYXdhaXQgZ2V0U2Vzc2lvbigpO1xuICAgICAgbGV0IHVzZXJJbmZvID0gbnVsbDtcbiAgICAgIGlmIChzZXNzaW9uSW5mby5zdWNjZXNzICYmIHNlc3Npb25JbmZvLmRhdGEudXNlcikge1xuICAgICAgICB1c2VySW5mbyA9IHtcbiAgICAgICAgICB1c2VybmFtZTogc2Vzc2lvbkluZm8uZGF0YS51c2VyLm5hbWUgfHwgJ0FuXHUwMEYzbmltbycsXG4gICAgICAgICAgY2hhcmdlczogc2Vzc2lvbkluZm8uZGF0YS5jaGFyZ2VzLFxuICAgICAgICAgIG1heENoYXJnZXM6IHNlc3Npb25JbmZvLmRhdGEubWF4Q2hhcmdlcyxcbiAgICAgICAgICBwaXhlbHM6IHNlc3Npb25JbmZvLmRhdGEudXNlci5waXhlbHNQYWludGVkIHx8IDAgIC8vIFVzYXIgcGl4ZWxzUGFpbnRlZCBlbiBsdWdhciBkZSBwaXhlbHNcbiAgICAgICAgfTtcbiAgICAgICAgY3VycmVudFVzZXJJbmZvID0gdXNlckluZm87IC8vIEFjdHVhbGl6YXIgdmFyaWFibGUgZ2xvYmFsXG4gICAgICAgIGltYWdlU3RhdGUuY3VycmVudENoYXJnZXMgPSBzZXNzaW9uSW5mby5kYXRhLmNoYXJnZXM7XG4gICAgICAgIGltYWdlU3RhdGUubWF4Q2hhcmdlcyA9IHNlc3Npb25JbmZvLmRhdGEubWF4Q2hhcmdlcyB8fCA1MDsgLy8gR3VhcmRhciBtYXhDaGFyZ2VzIGVuIHN0YXRlXG4gICAgICAgIGxvZyhgXHVEODNEXHVEQzY0IFVzdWFyaW8gY29uZWN0YWRvOiAke3Nlc3Npb25JbmZvLmRhdGEudXNlci5uYW1lIHx8ICdBblx1MDBGM25pbW8nfSAtIENhcmdhczogJHt1c2VySW5mby5jaGFyZ2VzfS8ke3VzZXJJbmZvLm1heENoYXJnZXN9IC0gUFx1MDBFRHhlbGVzOiAke3VzZXJJbmZvLnBpeGVsc31gKTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZG8gb2J0ZW5lciBpbmZvcm1hY2lcdTAwRjNuIGRlbCB1c3VhcmlvJyk7XG4gICAgICB9XG4gICAgICBcbiAgICAgIGltYWdlU3RhdGUuYXZhaWxhYmxlQ29sb3JzID0gY29sb3JzO1xuICAgICAgaW1hZ2VTdGF0ZS5jb2xvcnNDaGVja2VkID0gdHJ1ZTtcbiAgICAgIFxuICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLmNvbG9yc0ZvdW5kJywgeyBjb3VudDogY29sb3JzLmxlbmd0aCB9KSwgJ3N1Y2Nlc3MnKTtcbiAgICAgIHVpLnVwZGF0ZVByb2dyZXNzKDAsIDAsIHVzZXJJbmZvKTtcbiAgICAgIFxuICAgICAgLy8gU29sbyBtb3N0cmFyIGxvZyB1bmEgdmV6IChldml0YXIgZHVwbGljYWRvIGVuIGF1dG8taW5pY2lvKVxuICAgICAgaWYgKCFpc0F1dG9Jbml0KSB7XG4gICAgICAgIGxvZyhgXHUyNzA1ICR7Y29sb3JzLmxlbmd0aH0gY29sb3JlcyBkaXNwb25pYmxlcyBkZXRlY3RhZG9zYCk7XG4gICAgICB9XG4gICAgICBcbiAgICAgIC8vIE1hcmNhciBjb21vIGluaWNpYWxpemFkbyBleGl0b3NhbWVudGUgcGFyYSBkZXNoYWJpbGl0YXIgZWwgYm90XHUwMEYzblxuICAgICAgdWkuc2V0SW5pdGlhbGl6ZWQodHJ1ZSk7XG4gICAgICBcbiAgICAgIC8vIEhhYmlsaXRhciBib3RvbmVzIGRlIHVwbG9hZCB5IGxvYWQgcHJvZ3Jlc3NcbiAgICAgIHVpLmVuYWJsZUJ1dHRvbnNBZnRlckluaXQoKTtcblxuICAgICAgLy8gSW5pY2lhbGl6YXIgcGxhbiBvdmVybGF5IHNpIHlhIGhheSBjb2xhIHByZXZpYSAocC5lai4gcmVhbnVkYWNpXHUwMEYzbilcbiAgICAgIHRyeSB7XG4gICAgLy8gUmVtb3ZlZCByZWZlcmVuY2VzIHRvIF9fV1BBX1BMQU5fT1ZFUkxBWV9fXG4gICAgICB9IGNhdGNoIHtcbiAgICAgICAgLy8gbm9vcFxuICAgICAgfVxuICAgICAgXG4gICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG5cbiAgICAvLyBDcmVhciBpbnRlcmZheiBkZSB1c3VhcmlvXG4gICAgY29uc3QgdWkgPSBhd2FpdCBjcmVhdGVJbWFnZVVJKHtcbiAgICAgIHRleHRzLFxuICAgICAgXG4gICAgICBvbkNvbmZpZ0NoYW5nZTogKGNvbmZpZykgPT4ge1xuICAgICAgICAvLyBNYW5lamFyIGNhbWJpb3MgZGUgY29uZmlndXJhY2lcdTAwRjNuXG4gICAgICAgIGlmIChjb25maWcucGl4ZWxzUGVyQmF0Y2ggIT09IHVuZGVmaW5lZCkge1xuICAgICAgICAgIGltYWdlU3RhdGUucGl4ZWxzUGVyQmF0Y2ggPSBjb25maWcucGl4ZWxzUGVyQmF0Y2g7XG4gICAgICAgIH1cbiAgICAgICAgaWYgKGNvbmZpZy51c2VBbGxDaGFyZ2VzICE9PSB1bmRlZmluZWQpIHtcbiAgICAgICAgICBpbWFnZVN0YXRlLnVzZUFsbENoYXJnZXNGaXJzdCA9IGNvbmZpZy51c2VBbGxDaGFyZ2VzO1xuICAgICAgICB9XG4gICAgICAgIGxvZyhgQ29uZmlndXJhY2lcdTAwRjNuIGFjdHVhbGl6YWRhOmAsIGNvbmZpZyk7XG4gICAgICB9LFxuICAgICAgXG4gICAgICBvbkluaXRCb3Q6IGluaXRpYWxpemVCb3QsXG4gICAgICBcbiAgICAgIG9uVXBsb2FkSW1hZ2U6IGFzeW5jIChmaWxlKSA9PiB7XG4gICAgICAgIHRyeSB7XG4gICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLmxvYWRpbmdJbWFnZScpLCAnaW5mbycpO1xuICAgICAgICAgIFxuICAgICAgICAgIGNvbnN0IGltYWdlVXJsID0gd2luZG93LlVSTC5jcmVhdGVPYmplY3RVUkwoZmlsZSk7XG4gICAgICAgICAgY29uc3QgcHJvY2Vzc29yID0gbmV3IEJsdWVNYXJibGVsSW1hZ2VQcm9jZXNzb3IoaW1hZ2VVcmwpO1xuICAgICAgICAgIHByb2Nlc3Nvci5vcmlnaW5hbE5hbWUgPSBmaWxlLm5hbWU7XG4gICAgICAgICAgXG4gICAgICAgICAgYXdhaXQgcHJvY2Vzc29yLmxvYWQoKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBJbmljaWFsaXphciBwYWxldGEgZGUgY29sb3JlcyBCbHVlIE1hcmJsZVxuICAgICAgICAgIGNvbnN0IGF2YWlsYWJsZUNvbG9ycyA9IHByb2Nlc3Nvci5pbml0aWFsaXplQ29sb3JQYWxldHRlKCk7XG4gICAgICAgICAgaW1hZ2VTdGF0ZS5hdmFpbGFibGVDb2xvcnMgPSBhdmFpbGFibGVDb2xvcnM7XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gQW5hbGl6YXIgcFx1MDBFRHhlbGVzIGRlIGxhIGltYWdlblxuICAgICAgICAgIGNvbnN0IGFuYWx5c2lzUmVzdWx0ID0gYXdhaXQgcHJvY2Vzc29yLmFuYWx5emVQaXhlbHMoKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBFc3RhYmxlY2VyIGNvb3JkZW5hZGFzIGJhc2UgKHNlIGFjdHVhbGl6YXJcdTAwRTFuIGFsIHNlbGVjY2lvbmFyIHBvc2ljaVx1MDBGM24pXG4gICAgICAgICAgcHJvY2Vzc29yLnNldENvb3JkcygwLCAwLCAwLCAwKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBPYnRlbmVyIGRhdG9zIGRlIGltYWdlbiBwcm9jZXNhZG9zXG4gICAgICAgICAgY29uc3QgcHJvY2Vzc2VkRGF0YSA9IHByb2Nlc3Nvci5nZXRJbWFnZURhdGEoKTtcbiAgICAgICAgICBcbiAgICAgICAgICBpbWFnZVN0YXRlLmltYWdlRGF0YSA9IHByb2Nlc3NlZERhdGE7XG4gICAgICAgICAgaW1hZ2VTdGF0ZS5pbWFnZURhdGEucHJvY2Vzc29yID0gcHJvY2Vzc29yOyAvLyBHdWFyZGFyIHJlZmVyZW5jaWEgYWwgcHJvY2Vzc29yIHBhcmEgcmVzaXplXG4gICAgICAgICAgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscyA9IGFuYWx5c2lzUmVzdWx0LnJlcXVpcmVkUGl4ZWxzO1xuICAgICAgICAgIGltYWdlU3RhdGUucGFpbnRlZFBpeGVscyA9IDA7XG4gICAgICAgICAgaW1hZ2VTdGF0ZS5vcmlnaW5hbEltYWdlTmFtZSA9IGZpbGUubmFtZTtcbiAgICAgICAgICBpbWFnZVN0YXRlLmltYWdlTG9hZGVkID0gdHJ1ZTtcbiAgICAgICAgICBcbiAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UuaW1hZ2VMb2FkZWQnLCB7IGNvdW50OiBhbmFseXNpc1Jlc3VsdC5yZXF1aXJlZFBpeGVscyB9KSwgJ3N1Y2Nlc3MnKTtcbiAgICAgICAgICB1aS51cGRhdGVQcm9ncmVzcygwLCBhbmFseXNpc1Jlc3VsdC5yZXF1aXJlZFBpeGVscywgY3VycmVudFVzZXJJbmZvKTtcbiAgICAgICAgICBcbiAgICAgICAgICBsb2coYFx1MjcwNSBbQkxVRSBNQVJCTEVdIEltYWdlbiBjYXJnYWRhOiAke3Byb2Nlc3NlZERhdGEud2lkdGh9eCR7cHJvY2Vzc2VkRGF0YS5oZWlnaHR9LCAke2FuYWx5c2lzUmVzdWx0LnJlcXVpcmVkUGl4ZWxzfSBwXHUwMEVEeGVsZXMgdlx1MDBFMWxpZG9zYCk7XG4gICAgICAgICAgbG9nKGBcdTI3MDUgW0JMVUUgTUFSQkxFXSBBblx1MDBFMWxpc2lzOiAke2FuYWx5c2lzUmVzdWx0LnVuaXF1ZUNvbG9yc30gY29sb3JlcyBcdTAwRkFuaWNvcywgJHthbmFseXNpc1Jlc3VsdC5kZWZhY2VQaXhlbHN9IHBcdTAwRUR4ZWxlcyAjZGVmYWNlYCk7XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gTGltcGlhciBVUkwgdGVtcG9yYWwgKGVsIG92ZXJsYXkgdXNhIHVuIGRhdGFVUkwgc2VwYXJhZG8pXG4gICAgICAgICAgd2luZG93LlVSTC5yZXZva2VPYmplY3RVUkwoaW1hZ2VVcmwpO1xuXG4gICAgICAgICAgLy8gQWN0aXZhciBvdmVybGF5IGRlIHBsYW4gYXV0b21cdTAwRTF0aWNhbWVudGUgY3VhbmRvIHNlIGNhcmdhIGltYWdlblxuICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICBpZiAod2luZG93Ll9fV1BBX1BMQU5fT1ZFUkxBWV9fKSB7XG4gICAgICAgICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5pbmplY3RTdHlsZXMoKTtcbiAgICAgICAgICAgICAgd2luZG93Ll9fV1BBX1BMQU5fT1ZFUkxBWV9fLnNldEVuYWJsZWQodHJ1ZSk7IC8vIEFjdGl2YXIgYXV0b21cdTAwRTF0aWNhbWVudGVcbiAgICAgICAgICAgICAgLy8gQ29uZmlndXJhciBhbmNsYSBiYXNlIGNvbiBsYSBwb3NpY2lcdTAwRjNuIGRlbCB0aWxlIChzZXJcdTAwRTEgYWp1c3RhZGEgYWwgc2VsZWNjaW9uYXIgcG9zaWNpXHUwMEYzbilcbiAgICAgICAgICAgICAgd2luZG93Ll9fV1BBX1BMQU5fT1ZFUkxBWV9fLnNldFBsYW4oW10sIHtcbiAgICAgICAgICAgICAgICBlbmFibGVkOiB0cnVlLFxuICAgICAgICAgICAgICAgIG5leHRCYXRjaENvdW50OiAwXG4gICAgICAgICAgICAgIH0pO1xuICAgICAgICAgICAgICBsb2coJ1x1MjcwNSBQbGFuIG92ZXJsYXkgYWN0aXZhZG8gYXV0b21cdTAwRTF0aWNhbWVudGUgYWwgY2FyZ2FyIGltYWdlbicpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgIH0gY2F0Y2ggKGUpIHtcbiAgICAgICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIEVycm9yIGFjdGl2YW5kbyBwbGFuIG92ZXJsYXk6JywgZSk7XG4gICAgICAgICAgfVxuICAgICAgICAgIFxuICAgICAgICAgIHJldHVybiB0cnVlO1xuICAgICAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5pbWFnZUVycm9yJyksICdlcnJvcicpO1xuICAgICAgICAgIGxvZygnXHUyNzRDIEVycm9yIGNhcmdhbmRvIGltYWdlbjonLCBlcnJvcik7XG4gICAgICAgICAgcmV0dXJuIGZhbHNlO1xuICAgICAgICB9XG4gICAgICB9LFxuICAgICAgXG4gICAgICBvblNlbGVjdFBvc2l0aW9uOiBhc3luYyAoKSA9PiB7XG4gICAgICAgIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4ge1xuICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5zZWxlY3RQb3NpdGlvbkFsZXJ0JyksICdpbmZvJyk7XG4gICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLndhaXRpbmdQb3NpdGlvbicpLCAnaW5mbycpO1xuICAgICAgICAgIFxuICAgICAgICAgIGltYWdlU3RhdGUuc2VsZWN0aW5nUG9zaXRpb24gPSB0cnVlO1xuICAgICAgICAgIGxldCBwb3NpdGlvbkNhcHR1cmVkID0gZmFsc2U7XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gTVx1MDBFOXRvZG8gMTogSW50ZXJjZXB0YXIgZmV0Y2ggKG1cdTAwRTl0b2RvIG9yaWdpbmFsIG1lam9yYWRvKVxuICAgICAgICAgIGNvbnN0IHNldHVwRmV0Y2hJbnRlcmNlcHRpb24gPSAoKSA9PiB7XG4gICAgICAgICAgICB3aW5kb3cuZmV0Y2ggPSBhc3luYyAodXJsLCBvcHRpb25zKSA9PiB7XG4gICAgICAgICAgICAgIC8vIFNvbG8gaW50ZXJjZXB0YXIgcmVxdWVzdHMgZXNwZWNcdTAwRURmaWNvcyBkZSBwaW50YWRvIGN1YW5kbyBlc3RhbW9zIHNlbGVjY2lvbmFuZG8gcG9zaWNpXHUwMEYzblxuICAgICAgICAgICAgICBpZiAoaW1hZ2VTdGF0ZS5zZWxlY3RpbmdQb3NpdGlvbiAmJiBcbiAgICAgICAgICAgICAgICAgICFwb3NpdGlvbkNhcHR1cmVkICYmXG4gICAgICAgICAgICAgICAgICB0eXBlb2YgdXJsID09PSAnc3RyaW5nJyAmJiBcbiAgICAgICAgICAgICAgICAgIHVybC5pbmNsdWRlcygnL3MwL3BpeGVsLycpICYmIFxuICAgICAgICAgICAgICAgICAgb3B0aW9ucyAmJiBcbiAgICAgICAgICAgICAgICAgIG9wdGlvbnMubWV0aG9kID09PSAnUE9TVCcpIHtcbiAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICB0cnkge1xuICAgICAgICAgICAgICAgICAgbG9nKGBcdUQ4M0NcdURGQUYgSW50ZXJjZXB0YW5kbyByZXF1ZXN0IGRlIHBpbnRhZG86ICR7dXJsfWApO1xuICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICBjb25zdCByZXNwb25zZSA9IGF3YWl0IG9yaWdpbmFsRmV0Y2godXJsLCBvcHRpb25zKTtcbiAgICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgICAgaWYgKHJlc3BvbnNlLm9rICYmIG9wdGlvbnMuYm9keSkge1xuICAgICAgICAgICAgICAgICAgICBsZXQgYm9keURhdGE7XG4gICAgICAgICAgICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICAgICAgICAgICAgYm9keURhdGEgPSBKU09OLnBhcnNlKG9wdGlvbnMuYm9keSk7XG4gICAgICAgICAgICAgICAgICAgIH0gY2F0Y2ggKHBhcnNlRXJyb3IpIHtcbiAgICAgICAgICAgICAgICAgICAgICBsb2coJ0Vycm9yIHBhcnNlYW5kbyBib2R5IGRlbCByZXF1ZXN0OicsIHBhcnNlRXJyb3IpO1xuICAgICAgICAgICAgICAgICAgICAgIHJldHVybiByZXNwb25zZTtcbiAgICAgICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgICAgaWYgKGJvZHlEYXRhLmNvb3JkcyAmJiBBcnJheS5pc0FycmF5KGJvZHlEYXRhLmNvb3JkcykgJiYgYm9keURhdGEuY29vcmRzLmxlbmd0aCA+PSAyKSB7XG4gICAgICAgICAgICAgICAgICAgICAgY29uc3QgbG9jYWxYID0gYm9keURhdGEuY29vcmRzWzBdO1xuICAgICAgICAgICAgICAgICAgICAgIGNvbnN0IGxvY2FsWSA9IGJvZHlEYXRhLmNvb3Jkc1sxXTtcbiAgICAgICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgICAgICAvLyBFeHRyYWVyIHRpbGUgZGUgbGEgVVJMIGRlIGZvcm1hIG1cdTAwRTFzIHJvYnVzdGFcbiAgICAgICAgICAgICAgICAgICAgICBjb25zdCB0aWxlTWF0Y2ggPSB1cmwubWF0Y2goL1xcL3MwXFwvcGl4ZWxcXC8oLT9cXGQrKVxcLygtP1xcZCspLyk7XG4gICAgICAgICAgICAgICAgICAgICAgaWYgKHRpbGVNYXRjaCAmJiAhcG9zaXRpb25DYXB0dXJlZCkge1xuICAgICAgICAgICAgICAgICAgICAgICAgcG9zaXRpb25DYXB0dXJlZCA9IHRydWU7XG4gICAgICAgICAgICAgICAgICAgICAgICBjb25zdCB0aWxlWCA9IHBhcnNlSW50KHRpbGVNYXRjaFsxXSk7XG4gICAgICAgICAgICAgICAgICAgICAgICBjb25zdCB0aWxlWSA9IHBhcnNlSW50KHRpbGVNYXRjaFsyXSk7XG4gICAgICAgICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgICAgICAgIC8vIEd1YXJkYXIgY29vcmRlbmFkYXMgdGlsZS9waXhlbFxuICAgICAgICAgICAgICAgICAgICAgICAgaW1hZ2VTdGF0ZS50aWxlWCA9IHRpbGVYO1xuICAgICAgICAgICAgICAgICAgICAgICAgaW1hZ2VTdGF0ZS50aWxlWSA9IHRpbGVZO1xuICAgICAgICAgICAgICAgICAgICAgICAgaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uID0geyB4OiBsb2NhbFgsIHk6IGxvY2FsWSB9O1xuICAgICAgICAgICAgICAgICAgICAgICAgaW1hZ2VTdGF0ZS5zZWxlY3RpbmdQb3NpdGlvbiA9IGZhbHNlO1xuICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICAvLyBBY3R1YWxpemFyIGNvb3JkZW5hZGFzIGRlbCBwcm9jZXNhZG9yIEJsdWUgTWFyYmxlXG4gICAgICAgICAgICAgICAgICAgICAgICBpZiAoaW1hZ2VTdGF0ZS5pbWFnZURhdGEgJiYgaW1hZ2VTdGF0ZS5pbWFnZURhdGEucHJvY2Vzc29yKSB7XG4gICAgICAgICAgICAgICAgICAgICAgICAgIGNvbnN0IHByb2Nlc3NvciA9IGltYWdlU3RhdGUuaW1hZ2VEYXRhLnByb2Nlc3NvcjtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgcHJvY2Vzc29yLnNldENvb3Jkcyh0aWxlWCwgdGlsZVksIGxvY2FsWCwgbG9jYWxZKTtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICAgIC8vIEdlbmVyYXIgdGlsZXMgZGUgdGVtcGxhdGUgdW5hIHZleiBxdWUgdGVuZW1vcyBjb29yZGVuYWRhc1xuICAgICAgICAgICAgICAgICAgICAgICAgICB0cnkge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIGF3YWl0IHByb2Nlc3Nvci5jcmVhdGVUZW1wbGF0ZVRpbGVzKCk7XG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgbG9nKGBcdTI3MDUgW0JMVUUgTUFSQkxFXSBUZW1wbGF0ZSB0aWxlcyBjcmVhZG9zIHBhcmEgcG9zaWNpXHUwMEYzbiB0aWxlKCR7dGlsZVh9LCR7dGlsZVl9KSBwaXhlbCgke2xvY2FsWH0sJHtsb2NhbFl9KWApO1xuICAgICAgICAgICAgICAgICAgICAgICAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIGxvZyhgXHUyNzRDIFtCTFVFIE1BUkJMRV0gRXJyb3IgY3JlYW5kbyB0ZW1wbGF0ZSB0aWxlczogJHtlcnJvci5tZXNzYWdlfWApO1xuICAgICAgICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgICAgICAgICAgICAvLyBSZWdlbmVyYXIgY29sYSBkZSBwXHUwMEVEeGVsZXMgY29uIGNvb3JkZW5hZGFzIGFjdHVhbGl6YWRhc1xuICAgICAgICAgICAgICAgICAgICAgICAgICBjb25zdCBwaXhlbFF1ZXVlID0gcHJvY2Vzc29yLmdlbmVyYXRlUGl4ZWxRdWV1ZSgpO1xuICAgICAgICAgICAgICAgICAgICAgICAgICBpbWFnZVN0YXRlLnJlbWFpbmluZ1BpeGVscyA9IHBpeGVsUXVldWU7XG4gICAgICAgICAgICAgICAgICAgICAgICAgIGltYWdlU3RhdGUudG90YWxQaXhlbHMgPSBwaXhlbFF1ZXVlLmxlbmd0aDtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICAgIGxvZyhgXHUyNzA1IENvbGEgZGUgcFx1MDBFRHhlbGVzIGdlbmVyYWRhOiAke3BpeGVsUXVldWUubGVuZ3RofSBwXHUwMEVEeGVsZXMgcGFyYSBvdmVybGF5YCk7XG4gICAgICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgICAgICAgIC8vIENvbmZpZ3VyYXIgb3ZlcmxheSBkZWwgcGxhbiBjb24gbGEgcG9zaWNpXHUwMEYzbiBzZWxlY2Npb25hZGFcbiAgICAgICAgICAgICAgICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICAgICAgICAgICAgICAgIGlmICh3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18pIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uaW5qZWN0U3R5bGVzKCk7XG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgd2luZG93Ll9fV1BBX1BMQU5fT1ZFUkxBWV9fLnNldEVuYWJsZWQodHJ1ZSk7XG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgLy8gQ29uZmlndXJhciBhbmNsYSBsXHUwMEYzZ2ljYSAodGlsZS9waXhlbCkgcGFyYSBwb3NpY2lvbmFtaWVudG9cbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3aW5kb3cuX19XUEFfUExBTl9PVkVSTEFZX18uc2V0QW5jaG9yKHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRpbGVYOiB0aWxlWCxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRpbGVZOiB0aWxlWSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHB4WDogbG9jYWxYLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgcHhZOiBsb2NhbFlcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB9KTtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAvLyBVc2FyIGxhIGNvbGEgZGUgcFx1MDBFRHhlbGVzIHJlZ2VuZXJhZGFcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBpZiAoaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMgJiYgaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMubGVuZ3RoID4gMCkge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgd2luZG93Ll9fV1BBX1BMQU5fT1ZFUkxBWV9fLnNldFBsYW4oaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHMsIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYW5jaG9yOiB7IHRpbGVYOiB0aWxlWCwgdGlsZVk6IHRpbGVZLCBweFg6IGxvY2FsWCwgcHhZOiBsb2NhbFkgfSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgaW1hZ2VXaWR0aDogaW1hZ2VTdGF0ZS5pbWFnZURhdGEud2lkdGgsXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGltYWdlSGVpZ2h0OiBpbWFnZVN0YXRlLmltYWdlRGF0YS5oZWlnaHQsXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGVuYWJsZWQ6IHRydWVcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0pO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsb2coYFx1MjcwNSBQbGFuIG92ZXJsYXkgYW5jbGFkbyBlbiB0aWxlKCR7dGlsZVh9LCR7dGlsZVl9KSBsb2NhbCgke2xvY2FsWH0sJHtsb2NhbFl9KWApO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsb2coYFx1MjZBMFx1RkUwRiBObyBoYXkgcFx1MDBFRHhlbGVzIHBhcmEgbW9zdHJhciBlbiBvdmVybGF5YCk7XG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICAgICAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgICAgICAgICAgICAgICAgICAgICBsb2coYFx1Mjc0QyBFcnJvciBjb25maWd1cmFuZG8gb3ZlcmxheTogJHtlcnJvci5tZXNzYWdlfWApO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICAvLyBSZXN0YXVyYXIgZmV0Y2ggb3JpZ2luYWwgaW5tZWRpYXRhbWVudGVcbiAgICAgICAgICAgICAgICAgICAgICAgIHJlc3RvcmVGZXRjaCgpO1xuICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucG9zaXRpb25TZXQnKSwgJ3N1Y2Nlc3MnKTtcbiAgICAgICAgICAgICAgICAgICAgICAgIGxvZyhgXHUyNzA1IFBvc2ljaVx1MDBGM24gZXN0YWJsZWNpZGE6IHRpbGUoJHtpbWFnZVN0YXRlLnRpbGVYfSwke2ltYWdlU3RhdGUudGlsZVl9KSBsb2NhbCgke2xvY2FsWH0sJHtsb2NhbFl9KWApO1xuICAgICAgICAgICAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgICAgICAgICAgICByZXNvbHZlKHRydWUpO1xuICAgICAgICAgICAgICAgICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgICAgICAgICAgICAgICBsb2coJ1x1MjZBMFx1RkUwRiBObyBzZSBwdWRvIGV4dHJhZXIgdGlsZSBkZSBsYSBVUkw6JywgdXJsKTtcbiAgICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgICAgcmV0dXJuIHJlc3BvbnNlO1xuICAgICAgICAgICAgICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICAgICAgICAgICAgICBsb2coJ1x1Mjc0QyBFcnJvciBpbnRlcmNlcHRhbmRvIHBpeGVsOicsIGVycm9yKTtcbiAgICAgICAgICAgICAgICAgIC8vIEVuIGNhc28gZGUgZXJyb3IsIHJlc3RhdXJhciBmZXRjaCB5IGNvbnRpbnVhciBjb24gZWwgb3JpZ2luYWxcbiAgICAgICAgICAgICAgICAgIGlmICghcG9zaXRpb25DYXB0dXJlZCkge1xuICAgICAgICAgICAgICAgICAgICByZXN0b3JlRmV0Y2goKTtcbiAgICAgICAgICAgICAgICAgICAgcmV0dXJuIG9yaWdpbmFsRmV0Y2godXJsLCBvcHRpb25zKTtcbiAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgXG4gICAgICAgICAgICAgIC8vIFBhcmEgdG9kb3MgbG9zIGRlbVx1MDBFMXMgcmVxdWVzdHMsIHVzYXIgZmV0Y2ggb3JpZ2luYWxcbiAgICAgICAgICAgICAgcmV0dXJuIG9yaWdpbmFsRmV0Y2godXJsLCBvcHRpb25zKTtcbiAgICAgICAgICAgIH07XG4gICAgICAgICAgfTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBNXHUwMEU5dG9kbyAyOiBPYnNlcnZlciBkZSBjYW52YXMgcGFyYSBkZXRlY3RhciBjYW1iaW9zIHZpc3VhbGVzXG4gICAgICAgICAgY29uc3Qgc2V0dXBDYW52YXNPYnNlcnZlciA9ICgpID0+IHtcbiAgICAgICAgICAgIGNvbnN0IGNhbnZhc0VsZW1lbnRzID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbCgnY2FudmFzJyk7XG4gICAgICAgICAgICBpZiAoY2FudmFzRWxlbWVudHMubGVuZ3RoID09PSAwKSB7XG4gICAgICAgICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIE5vIHNlIGVuY29udHJhcm9uIGVsZW1lbnRvcyBjYW52YXMnKTtcbiAgICAgICAgICAgICAgcmV0dXJuO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgXG4gICAgICAgICAgICBsb2coYFx1RDgzRFx1RENDQSBDb25maWd1cmFuZG8gb2JzZXJ2ZXIgcGFyYSAke2NhbnZhc0VsZW1lbnRzLmxlbmd0aH0gY2FudmFzYCk7XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIC8vIEVzY3VjaGFyIGV2ZW50b3MgZGUgY2xpY2sgZW4gZWwgZG9jdW1lbnRvIHBhcmEgZGV0ZWN0YXIgcGludGFkb1xuICAgICAgICAgICAgY29uc3QgY2xpY2tIYW5kbGVyID0gKGV2ZW50KSA9PiB7XG4gICAgICAgICAgICAgIGlmICghaW1hZ2VTdGF0ZS5zZWxlY3RpbmdQb3NpdGlvbiB8fCBwb3NpdGlvbkNhcHR1cmVkKSByZXR1cm47XG4gICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAvLyBWZXJpZmljYXIgc2kgZWwgY2xpY2sgZnVlIGVuIHVuIGNhbnZhc1xuICAgICAgICAgICAgICBjb25zdCB0YXJnZXQgPSBldmVudC50YXJnZXQ7XG4gICAgICAgICAgICAgIGlmICh0YXJnZXQgJiYgdGFyZ2V0LnRhZ05hbWUgPT09ICdDQU5WQVMnKSB7XG4gICAgICAgICAgICAgICAgbG9nKCdcdUQ4M0RcdUREQjFcdUZFMEYgQ2xpY2sgZGV0ZWN0YWRvIGVuIGNhbnZhcyBkdXJhbnRlIHNlbGVjY2lcdTAwRjNuJyk7XG4gICAgICAgICAgICAgICAgLy8gQ2FsY3VsYXIgY29vcmRlbmFkYXMgQ1NTIHJlbGF0aXZhcyBhbCBjb250ZW5lZG9yIGRlbCBib2FyZCBwYXJhIGFuY2xhIENTU1xuICAgICAgICAgICAgICAgIHRyeSB7XG4gICAgICAgICAgICAgICAgICBjb25zdCBib2FyZCA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJ2NhbnZhcycpPy5wYXJlbnRFbGVtZW50IHx8IGRvY3VtZW50LmJvZHk7XG4gICAgICAgICAgICAgICAgICBjb25zdCByZWN0ID0gYm9hcmQuZ2V0Qm91bmRpbmdDbGllbnRSZWN0KCk7XG4gICAgICAgICAgICAgICAgICBjb25zdCBjc3NYID0gZXZlbnQuY2xpZW50WCAtIHJlY3QubGVmdDtcbiAgICAgICAgICAgICAgICAgIGNvbnN0IGNzc1kgPSBldmVudC5jbGllbnRZIC0gcmVjdC50b3A7XG4gICAgICAgICAgICAgICAgICBpZiAod2luZG93Ll9fV1BBX1BMQU5fT1ZFUkxBWV9fKSB7XG4gICAgICAgICAgICAgICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5zZXRBbmNob3JDc3MoY3NzWCwgY3NzWSk7XG4gICAgICAgICAgICAgICAgICAgIGxvZyhgUGxhbiBvdmVybGF5OiBhbmNsYSBDU1MgZXN0YWJsZWNpZGEgZW4gKCR7Y3NzWH0sICR7Y3NzWX0pYCk7XG4gICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfSBjYXRjaCAoZSkge1xuICAgICAgICAgICAgICAgICAgbG9nKCdQbGFuIE92ZXJsYXk6IGVycm9yIGNhbGN1bGFuZG8gYW5jbGEgQ1NTJywgZSk7XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAgIC8vIERhciB0aWVtcG8gcGFyYSBxdWUgc2UgcHJvY2VzZSBlbCBwaW50YWRvXG4gICAgICAgICAgICAgICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICAgICAgICAgICAgICBpZiAoIXBvc2l0aW9uQ2FwdHVyZWQgJiYgaW1hZ2VTdGF0ZS5zZWxlY3RpbmdQb3NpdGlvbikge1xuICAgICAgICAgICAgICAgICAgICBsb2coJ1x1RDgzRFx1REQwRCBCdXNjYW5kbyByZXF1ZXN0cyByZWNpZW50ZXMgZGUgcGludGFkby4uLicpO1xuICAgICAgICAgICAgICAgICAgICAvLyBFbCBmZXRjaCBpbnRlcmNlcHRvciBtYW5lamFyXHUwMEUxIGxhIGNhcHR1cmFcbiAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9LCA1MDApO1xuICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9O1xuICAgICAgICAgICAgXG4gICAgICAgICAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIGNsaWNrSGFuZGxlcik7XG4gICAgICAgICAgICBcbiAgICAgICAgICAgIC8vIExpbXBpYXIgb2JzZXJ2ZXIgYWwgZmluYWxpemFyXG4gICAgICAgICAgICBpbWFnZVN0YXRlLmNsZWFudXBPYnNlcnZlciA9ICgpID0+IHtcbiAgICAgICAgICAgICAgZG9jdW1lbnQucmVtb3ZlRXZlbnRMaXN0ZW5lcignY2xpY2snLCBjbGlja0hhbmRsZXIpO1xuICAgICAgICAgICAgfTtcbiAgICAgICAgICB9O1xuICAgICAgICAgIFxuICAgICAgICAgIC8vIENvbmZpZ3VyYXIgYW1ib3MgbVx1MDBFOXRvZG9zXG4gICAgICAgICAgc2V0dXBGZXRjaEludGVyY2VwdGlvbigpO1xuICAgICAgICAgIHNldHVwQ2FudmFzT2JzZXJ2ZXIoKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBUaW1lb3V0IHBhcmEgc2VsZWNjaVx1MDBGM24gZGUgcG9zaWNpXHUwMEYzbiBjb24gY2xlYW51cCBtZWpvcmFkb1xuICAgICAgICAgIGNvbnN0IHRpbWVvdXRJZCA9IHNldFRpbWVvdXQoKCkgPT4ge1xuICAgICAgICAgICAgaWYgKGltYWdlU3RhdGUuc2VsZWN0aW5nUG9zaXRpb24gJiYgIXBvc2l0aW9uQ2FwdHVyZWQpIHtcbiAgICAgICAgICAgICAgcmVzdG9yZUZldGNoKCk7XG4gICAgICAgICAgICAgIGlmIChpbWFnZVN0YXRlLmNsZWFudXBPYnNlcnZlcikge1xuICAgICAgICAgICAgICAgIGltYWdlU3RhdGUuY2xlYW51cE9ic2VydmVyKCk7XG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLnBvc2l0aW9uVGltZW91dCcpLCAnZXJyb3InKTtcbiAgICAgICAgICAgICAgbG9nKCdcdTIzRjAgVGltZW91dCBlbiBzZWxlY2NpXHUwMEYzbiBkZSBwb3NpY2lcdTAwRjNuJyk7XG4gICAgICAgICAgICAgIHJlc29sdmUoZmFsc2UpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgIH0sIDEyMDAwMCk7IC8vIDIgbWludXRvc1xuICAgICAgICAgIFxuICAgICAgICAgIC8vIEd1YXJkYXIgdGltZW91dCBwYXJhIHBvZGVyIGNhbmNlbGFybG9cbiAgICAgICAgICBpbWFnZVN0YXRlLnBvc2l0aW9uVGltZW91dElkID0gdGltZW91dElkO1xuICAgICAgICB9KTtcbiAgICAgIH0sXG4gICAgICBcbiAgICAgIG9uU3RhcnRQYWludGluZzogYXN5bmMgKCkgPT4ge1xuICAgICAgICAvLyBEZWJ1ZzogdmVyaWZpY2FyIGVzdGFkbyBhbnRlcyBkZSB2YWxpZGFyXG4gICAgICAgIGxvZyhgXHVEODNEXHVERDBEIEVzdGFkbyBwYXJhIGluaWNpYXIgcGludHVyYTpgLCB7XG4gICAgICAgICAgaW1hZ2VMb2FkZWQ6IGltYWdlU3RhdGUuaW1hZ2VMb2FkZWQsXG4gICAgICAgICAgc3RhcnRQb3NpdGlvbjogaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uLFxuICAgICAgICAgIHRpbGVYOiBpbWFnZVN0YXRlLnRpbGVYLFxuICAgICAgICAgIHRpbGVZOiBpbWFnZVN0YXRlLnRpbGVZLFxuICAgICAgICAgIHRvdGFsUGl4ZWxzOiBpbWFnZVN0YXRlLnRvdGFsUGl4ZWxzLFxuICAgICAgICAgIHJlbWFpbmluZ1BpeGVsczogaW1hZ2VTdGF0ZS5yZW1haW5pbmdQaXhlbHM/Lmxlbmd0aCB8fCAwXG4gICAgICAgIH0pO1xuICAgICAgICBcbiAgICAgICAgaWYgKCFpbWFnZVN0YXRlLmltYWdlTG9hZGVkIHx8ICFpbWFnZVN0YXRlLnN0YXJ0UG9zaXRpb24pIHtcbiAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UubWlzc2luZ1JlcXVpcmVtZW50cycpLCAnZXJyb3InKTtcbiAgICAgICAgICBsb2coYFx1Mjc0QyBWYWxpZGFjaVx1MDBGM24gZmFsbGlkYTogaW1hZ2VMb2FkZWQ9JHtpbWFnZVN0YXRlLmltYWdlTG9hZGVkfSwgc3RhcnRQb3NpdGlvbj0keyEhaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9ufWApO1xuICAgICAgICAgIHJldHVybiBmYWxzZTtcbiAgICAgICAgfVxuICAgICAgICBcbiAgICAgICAgaW1hZ2VTdGF0ZS5ydW5uaW5nID0gdHJ1ZTtcbiAgICAgICAgaW1hZ2VTdGF0ZS5zdG9wRmxhZyA9IGZhbHNlO1xuICAgICAgICBpbWFnZVN0YXRlLmlzRmlyc3RCYXRjaCA9IHRydWU7IC8vIFJlc2V0ZWFyIGZsYWcgZGUgcHJpbWVyYSBwYXNhZGFcbiAgICAgICAgXG4gICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5zdGFydFBhaW50aW5nTXNnJyksICdzdWNjZXNzJyk7XG4gICAgICAgIFxuICAgICAgICB0cnkge1xuICAgICAgICAgIGF3YWl0IHByb2Nlc3NJbWFnZShcbiAgICAgICAgICAgIGltYWdlU3RhdGUuaW1hZ2VEYXRhLFxuICAgICAgICAgICAgaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uLFxuICAgICAgICAgICAgLy8gb25Qcm9ncmVzcyAtIGFob3JhIGluY2x1eWUgdGllbXBvIGVzdGltYWRvXG4gICAgICAgICAgICAocGFpbnRlZCwgdG90YWwsIG1lc3NhZ2UsIGVzdGltYXRlZFRpbWUpID0+IHtcbiAgICAgICAgICAgICAgLy8gQWN0dWFsaXphciBjYXJnYXMgZW4gdXNlckluZm8gc2kgZXhpc3RlXG4gICAgICAgICAgICAgIGlmIChjdXJyZW50VXNlckluZm8pIHtcbiAgICAgICAgICAgICAgICBjdXJyZW50VXNlckluZm8uY2hhcmdlcyA9IE1hdGguZmxvb3IoaW1hZ2VTdGF0ZS5jdXJyZW50Q2hhcmdlcyk7XG4gICAgICAgICAgICAgICAgaWYgKGVzdGltYXRlZFRpbWUgIT09IHVuZGVmaW5lZCkge1xuICAgICAgICAgICAgICAgICAgY3VycmVudFVzZXJJbmZvLmVzdGltYXRlZFRpbWUgPSBlc3RpbWF0ZWRUaW1lO1xuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgdWkudXBkYXRlUHJvZ3Jlc3MocGFpbnRlZCwgdG90YWwsIGN1cnJlbnRVc2VySW5mbyk7XG4gICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAvLyBBY3R1YWxpemFyIGRpc3BsYXkgZGUgY29vbGRvd24gc2kgaGF5IGNvb2xkb3duIGFjdGl2b1xuICAgICAgICAgICAgICBpZiAoaW1hZ2VTdGF0ZS5pbkNvb2xkb3duICYmIGltYWdlU3RhdGUubmV4dEJhdGNoQ29vbGRvd24gPiAwKSB7XG4gICAgICAgICAgICAgICAgdWkudXBkYXRlQ29vbGRvd25EaXNwbGF5KGltYWdlU3RhdGUubmV4dEJhdGNoQ29vbGRvd24pO1xuICAgICAgICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgICAgICAgIHVpLnVwZGF0ZUNvb2xkb3duRGlzcGxheSgwKTtcbiAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgaWYgKG1lc3NhZ2UpIHtcbiAgICAgICAgICAgICAgICAvLyBVc2FyIGZ1bmNpXHUwMEYzbiBvcHRpbWl6YWRhIHBhcmEgbWVuc2FqZXMgZGUgY29vbGRvd24gcGFyYSBldml0YXIgcGFycGFkZW9cbiAgICAgICAgICAgICAgICBpZiAobWVzc2FnZS5pbmNsdWRlcygnXHUyM0YzJykgJiYgaW1hZ2VTdGF0ZS5pbkNvb2xkb3duKSB7XG4gICAgICAgICAgICAgICAgICB1aS51cGRhdGVDb29sZG93bk1lc3NhZ2UobWVzc2FnZSk7XG4gICAgICAgICAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAgICAgICAgIHVpLnNldFN0YXR1cyhtZXNzYWdlLCAnaW5mbycpO1xuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucGFpbnRpbmdQcm9ncmVzcycsIHsgcGFpbnRlZCwgdG90YWwgfSksICdpbmZvJyk7XG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH0sXG4gICAgICAgICAgICAvLyBvbkNvbXBsZXRlXG4gICAgICAgICAgICAoY29tcGxldGVkLCBwaXhlbHNQYWludGVkKSA9PiB7XG4gICAgICAgICAgICAgIGlmIChjb21wbGV0ZWQpIHtcbiAgICAgICAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucGFpbnRpbmdDb21wbGV0ZScsIHsgY291bnQ6IHBpeGVsc1BhaW50ZWQgfSksICdzdWNjZXNzJyk7XG4gICAgICAgICAgICAgICAgY2xlYXJQcm9ncmVzcygpO1xuICAgICAgICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5wYWludGluZ1N0b3BwZWQnKSwgJ3dhcm5pbmcnKTtcbiAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICBpbWFnZVN0YXRlLnJ1bm5pbmcgPSBmYWxzZTtcbiAgICAgICAgICAgIH0sXG4gICAgICAgICAgICAvLyBvbkVycm9yXG4gICAgICAgICAgICAoZXJyb3IpID0+IHtcbiAgICAgICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLnBhaW50aW5nRXJyb3InKSwgJ2Vycm9yJyk7XG4gICAgICAgICAgICAgIGxvZygnXHUyNzRDIEVycm9yIGVuIHByb2Nlc28gZGUgcGludGFkbzonLCBlcnJvcik7XG4gICAgICAgICAgICAgIGltYWdlU3RhdGUucnVubmluZyA9IGZhbHNlO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICk7XG4gICAgICAgICAgXG4gICAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLnBhaW50aW5nRXJyb3InKSwgJ2Vycm9yJyk7XG4gICAgICAgICAgbG9nKCdcdTI3NEMgRXJyb3IgaW5pY2lhbmRvIHBpbnRhZG86JywgZXJyb3IpO1xuICAgICAgICAgIGltYWdlU3RhdGUucnVubmluZyA9IGZhbHNlO1xuICAgICAgICAgIHJldHVybiBmYWxzZTtcbiAgICAgICAgfVxuICAgICAgfSxcbiAgICAgIFxuICAgICAgb25TdG9wUGFpbnRpbmc6IGFzeW5jICgpID0+IHtcbiAgICAgICAgY29uc3QgcHJvZ3Jlc3NJbmZvID0gZ2V0UHJvZ3Jlc3NJbmZvKCk7XG4gICAgICAgIFxuICAgICAgICBpZiAocHJvZ3Jlc3NJbmZvLmhhc1Byb2dyZXNzKSB7XG4gICAgICAgICAgY29uc3Qgc2hvdWxkU2F2ZSA9IGF3YWl0IHNob3dDb25maXJtRGlhbG9nKFxuICAgICAgICAgICAgdCgnaW1hZ2UuY29uZmlybVNhdmVQcm9ncmVzcycpLFxuICAgICAgICAgICAgdCgnaW1hZ2Uuc2F2ZVByb2dyZXNzVGl0bGUnKSxcbiAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgc2F2ZTogdCgnaW1hZ2Uuc2F2ZVByb2dyZXNzJyksXG4gICAgICAgICAgICAgIGRpc2NhcmQ6IHQoJ2ltYWdlLmRpc2NhcmRQcm9ncmVzcycpLFxuICAgICAgICAgICAgICBjYW5jZWw6IHQoJ2ltYWdlLmNhbmNlbCcpXG4gICAgICAgICAgICB9XG4gICAgICAgICAgKTtcbiAgICAgICAgICBcbiAgICAgICAgICBpZiAoc2hvdWxkU2F2ZSA9PT0gJ3NhdmUnKSB7XG4gICAgICAgICAgICBjb25zdCByZXN1bHQgPSBzYXZlUHJvZ3Jlc3MoKTtcbiAgICAgICAgICAgIGlmIChyZXN1bHQuc3VjY2Vzcykge1xuICAgICAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucHJvZ3Jlc3NTYXZlZCcsIHsgZmlsZW5hbWU6IHJlc3VsdC5maWxlbmFtZSB9KSwgJ3N1Y2Nlc3MnKTtcbiAgICAgICAgICAgIH0gZWxzZSB7XG4gICAgICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5wcm9ncmVzc1NhdmVFcnJvcicsIHsgZXJyb3I6IHJlc3VsdC5lcnJvciB9KSwgJ2Vycm9yJyk7XG4gICAgICAgICAgICB9XG4gICAgICAgICAgfSBlbHNlIGlmIChzaG91bGRTYXZlID09PSAnY2FuY2VsJykge1xuICAgICAgICAgICAgcmV0dXJuIGZhbHNlOyAvLyBObyBkZXRlbmVyXG4gICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgIFxuICAgICAgICBzdG9wUGFpbnRpbmcoKTtcbiAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLnBhaW50aW5nU3RvcHBlZCcpLCAnd2FybmluZycpO1xuICAgICAgICByZXR1cm4gdHJ1ZTtcbiAgICAgIH0sXG4gICAgICBcbiAgICAgIG9uU2F2ZVByb2dyZXNzOiBhc3luYyAoKSA9PiB7XG4gICAgICAgIGNvbnN0IHJlc3VsdCA9IHNhdmVQcm9ncmVzcygpO1xuICAgICAgICBpZiAocmVzdWx0LnN1Y2Nlc3MpIHtcbiAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucHJvZ3Jlc3NTYXZlZCcsIHsgZmlsZW5hbWU6IHJlc3VsdC5maWxlbmFtZSB9KSwgJ3N1Y2Nlc3MnKTtcbiAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucHJvZ3Jlc3NTYXZlRXJyb3InLCB7IGVycm9yOiByZXN1bHQuZXJyb3IgfSksICdlcnJvcicpO1xuICAgICAgICB9XG4gICAgICAgIHJldHVybiByZXN1bHQuc3VjY2VzcztcbiAgICAgIH0sXG4gICAgICBcbiAgICAgIG9uTG9hZFByb2dyZXNzOiBhc3luYyAoZmlsZSkgPT4ge1xuICAgICAgICB0cnkge1xuICAgICAgICAgIGNvbnN0IHJlc3VsdCA9IGF3YWl0IGxvYWRQcm9ncmVzcyhmaWxlKTtcbiAgICAgICAgICBpZiAocmVzdWx0LnN1Y2Nlc3MpIHtcbiAgICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5wcm9ncmVzc0xvYWRlZCcsIHsgcGFpbnRlZDogcmVzdWx0LnBhaW50ZWQsIHRvdGFsOiByZXN1bHQudG90YWwgfSksICdzdWNjZXNzJyk7XG4gICAgICAgICAgICB1aS51cGRhdGVQcm9ncmVzcyhyZXN1bHQucGFpbnRlZCwgcmVzdWx0LnRvdGFsLCBjdXJyZW50VXNlckluZm8pO1xuICAgICAgICAgICAgXG4gICAgICAgICAgICAvLyBIYWJpbGl0YXIgYm90b25lcyBkZXNwdVx1MDBFOXMgZGUgY2FyZ2FyIHByb2dyZXNvIGV4aXRvc2FtZW50ZVxuICAgICAgICAgICAgLy8gTm8gZXMgbmVjZXNhcmlvIHN1YmlyIGltYWdlbiBuaSBzZWxlY2Npb25hciBwb3NpY2lcdTAwRjNuIGRlIG51ZXZvXG4gICAgICAgICAgICBsb2coJ1x1MjcwNSBQcm9ncmVzbyBjYXJnYWRvIC0gaGFiaWxpdGFuZG8gYm90b25lcyBkZSBpbmljaW8nKTtcbiAgICAgICAgICAgIFxuICAgICAgICAgICAgcmV0dXJuIHRydWU7XG4gICAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5wcm9ncmVzc0xvYWRFcnJvcicsIHsgZXJyb3I6IHJlc3VsdC5lcnJvciB9KSwgJ2Vycm9yJyk7XG4gICAgICAgICAgICByZXR1cm4gZmFsc2U7XG4gICAgICAgICAgfVxuICAgICAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5wcm9ncmVzc0xvYWRFcnJvcicsIHsgZXJyb3I6IGVycm9yLm1lc3NhZ2UgfSksICdlcnJvcicpO1xuICAgICAgICAgIHJldHVybiBmYWxzZTtcbiAgICAgICAgfVxuICAgICAgfSxcbiAgICAgIFxuICAgICAgb25SZXNpemVJbWFnZTogKCkgPT4ge1xuICAgICAgICBpZiAoaW1hZ2VTdGF0ZS5pbWFnZUxvYWRlZCAmJiBpbWFnZVN0YXRlLmltYWdlRGF0YSAmJiBpbWFnZVN0YXRlLmltYWdlRGF0YS5wcm9jZXNzb3IpIHtcbiAgICAgICAgICB1aS5zaG93UmVzaXplRGlhbG9nKGltYWdlU3RhdGUuaW1hZ2VEYXRhLnByb2Nlc3Nvcik7XG4gICAgICAgIH1cbiAgICAgIH0sXG4gICAgICBcbiAgICAgIG9uQ29uZmlybVJlc2l6ZTogYXN5bmMgKHByb2Nlc3NvciwgbmV3V2lkdGgsIG5ld0hlaWdodCkgPT4ge1xuICAgICAgICBsb2coYFx1RDgzRFx1REQwNCBSZWRpbWVuc2lvbmFuZG8gaW1hZ2VuIGRlICR7cHJvY2Vzc29yLmdldERpbWVuc2lvbnMoKS53aWR0aH14JHtwcm9jZXNzb3IuZ2V0RGltZW5zaW9ucygpLmhlaWdodH0gYSAke25ld1dpZHRofXgke25ld0hlaWdodH1gKTtcbiAgICAgICAgXG4gICAgICAgIHRyeSB7XG4gICAgICAgICAgLy8gUmVkaW1lbnNpb25hciBsYSBpbWFnZW4gdXNhbmRvIEJsdWUgTWFyYmxlXG4gICAgICAgICAgYXdhaXQgcHJvY2Vzc29yLnJlc2l6ZShuZXdXaWR0aCwgbmV3SGVpZ2h0KTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBSZWFuYWxpemFyIGltYWdlbiBjb24gbnVldm8gdGFtYVx1MDBGMW8gdXNhbmRvIEJsdWUgTWFyYmxlXG4gICAgICAgICAgY29uc3QgYW5hbHlzaXNSZXN1bHQgPSBhd2FpdCBwcm9jZXNzb3IuYW5hbHl6ZVBpeGVscygpO1xuICAgICAgICAgIFxuICAgICAgICAgIC8vIEFjdHVhbGl6YXIgaW1hZ2VTdGF0ZSBjb24gcmVzdWx0YWRvcyBkZSBCbHVlIE1hcmJsZVxuICAgICAgICAgIGltYWdlU3RhdGUuaW1hZ2VEYXRhID0ge1xuICAgICAgICAgICAgcHJvY2Vzc29yOiBwcm9jZXNzb3IsXG4gICAgICAgICAgICB3aWR0aDogbmV3V2lkdGgsXG4gICAgICAgICAgICBoZWlnaHQ6IG5ld0hlaWdodCxcbiAgICAgICAgICAgIHZhbGlkUGl4ZWxDb3VudDogYW5hbHlzaXNSZXN1bHQudmFsaWRQaXhlbENvdW50LFxuICAgICAgICAgICAgdG90YWxQaXhlbHM6IGFuYWx5c2lzUmVzdWx0LnRvdGFsUGl4ZWxzLFxuICAgICAgICAgICAgdW5rbm93blBpeGVsczogYW5hbHlzaXNSZXN1bHQudW5rbm93blBpeGVsc1xuICAgICAgICAgIH07XG4gICAgICAgICAgXG4gICAgICAgICAgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscyA9IGFuYWx5c2lzUmVzdWx0LnZhbGlkUGl4ZWxDb3VudDtcbiAgICAgICAgICBpbWFnZVN0YXRlLnBhaW50ZWRQaXhlbHMgPSAwO1xuICAgICAgICAgIGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzID0gW107IC8vIFJlc2V0ZWFyIGNvbGEgYWwgcmVkaW1lbnNpb25hclxuICAgICAgICAgIGltYWdlU3RhdGUubGFzdFBvc2l0aW9uID0geyB4OiAwLCB5OiAwIH07XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gQWN0dWFsaXphciBVSVxuICAgICAgICAgIHVpLnVwZGF0ZVByb2dyZXNzKDAsIGFuYWx5c2lzUmVzdWx0LnZhbGlkUGl4ZWxDb3VudCwgY3VycmVudFVzZXJJbmZvKTtcbiAgICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UucmVzaXplU3VjY2VzcycsIHsgd2lkdGg6IG5ld1dpZHRoLCBoZWlnaHQ6IG5ld0hlaWdodCB9KSwgJ3N1Y2Nlc3MnKTtcbiAgICAgICAgICBcbiAgICAgICAgICBsb2coYFx1MjcwNSBJbWFnZW4gcmVkaW1lbnNpb25hZGE6ICR7YW5hbHlzaXNSZXN1bHQudmFsaWRQaXhlbENvdW50fSBwXHUwMEVEeGVsZXMgdlx1MDBFMWxpZG9zIGRlICR7YW5hbHlzaXNSZXN1bHQudG90YWxQaXhlbHN9IHRvdGFsZXNgKTtcblxuICAgICAgICAgIC8vIEFjdHVhbGl6YXIgb3ZlcmxheSBzaSB5YSBoYXkgcG9zaWNpXHUwMEYzbiBzZWxlY2Npb25hZGFcbiAgICAgICAgICB0cnkge1xuICAgICAgICAgICAgaWYgKHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXyAmJiBpbWFnZVN0YXRlLnN0YXJ0UG9zaXRpb24gJiYgaW1hZ2VTdGF0ZS50aWxlWCAhPSBudWxsICYmIGltYWdlU3RhdGUudGlsZVkgIT0gbnVsbCkge1xuICAgICAgICAgICAgICAvLyBSZWdlbmVyYXIgdGVtcGxhdGUgdGlsZXMgY29uIG51ZXZvIHRhbWFcdTAwRjFvXG4gICAgICAgICAgICAgIGF3YWl0IHByb2Nlc3Nvci5jcmVhdGVUZW1wbGF0ZVRpbGVzKCk7XG4gICAgICAgICAgICAgIFxuICAgICAgICAgICAgICAvLyBSZWdlbmVyYXIgY29sYSBkZSBwXHUwMEVEeGVsZXMgY29uIEJsdWUgTWFyYmxlXG4gICAgICAgICAgICAgIGNvbnN0IHBpeGVsUXVldWUgPSBwcm9jZXNzb3IuZ2VuZXJhdGVQaXhlbFF1ZXVlKCk7XG4gICAgICAgICAgICAgIGltYWdlU3RhdGUucmVtYWluaW5nUGl4ZWxzID0gcGl4ZWxRdWV1ZTtcbiAgICAgICAgICAgICAgaW1hZ2VTdGF0ZS50b3RhbFBpeGVscyA9IHBpeGVsUXVldWUubGVuZ3RoO1xuICAgICAgICAgICAgICBcbiAgICAgICAgICAgICAgLy8gQWN0dWFsaXphciBvdmVybGF5IGNvbiBudWV2YSBjb2xhXG4gICAgICAgICAgICAgIHdpbmRvdy5fX1dQQV9QTEFOX09WRVJMQVlfXy5zZXRQbGFuKHBpeGVsUXVldWUsIHtcbiAgICAgICAgICAgICAgICBhbmNob3I6IHsgXG4gICAgICAgICAgICAgICAgICB0aWxlWDogaW1hZ2VTdGF0ZS50aWxlWCwgXG4gICAgICAgICAgICAgICAgICB0aWxlWTogaW1hZ2VTdGF0ZS50aWxlWSwgXG4gICAgICAgICAgICAgICAgICBweFg6IGltYWdlU3RhdGUuc3RhcnRQb3NpdGlvbi54LCBcbiAgICAgICAgICAgICAgICAgIHB4WTogaW1hZ2VTdGF0ZS5zdGFydFBvc2l0aW9uLnkgXG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICBpbWFnZVdpZHRoOiBuZXdXaWR0aCxcbiAgICAgICAgICAgICAgICBpbWFnZUhlaWdodDogbmV3SGVpZ2h0LFxuICAgICAgICAgICAgICAgIGVuYWJsZWQ6IHRydWVcbiAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgIFxuICAgICAgICAgICAgICBsb2coYFx1MjcwNSBPdmVybGF5IGFjdHVhbGl6YWRvIGNvbiAke3BpeGVsUXVldWUubGVuZ3RofSBwXHUwMEVEeGVsZXMgZGVzcHVcdTAwRTlzIGRlbCByZXNpemVgKTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgICB9IGNhdGNoIChvdmVybGF5RXJyb3IpIHtcbiAgICAgICAgICAgIGxvZyhgXHUyNkEwXHVGRTBGIEVycm9yIGFjdHVhbGl6YW5kbyBvdmVybGF5IGRlc3B1XHUwMEU5cyBkZWwgcmVzaXplOiAke292ZXJsYXlFcnJvci5tZXNzYWdlfWApO1xuICAgICAgICAgIH1cbiAgICAgICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgICAgICBsb2coYFx1Mjc0QyBFcnJvciByZWRpbWVuc2lvbmFuZG8gaW1hZ2VuOiAke2Vycm9yLm1lc3NhZ2V9YCk7XG4gICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLmltYWdlRXJyb3InKSwgJ2Vycm9yJyk7XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9KTtcblxuICAgIC8vIEVzY3VjaGFyIGNhbWJpb3MgZGUgaWRpb21hIGRlc2RlIGVsIGxhdW5jaGVyXG4gICAgY29uc3QgaGFuZGxlTGF1bmNoZXJMYW5ndWFnZUNoYW5nZSA9IChldmVudCkgPT4ge1xuICAgICAgY29uc3QgeyBsYW5ndWFnZSB9ID0gZXZlbnQuZGV0YWlsO1xuICAgICAgbG9nKGBcdUQ4M0NcdURGMEQgSW1hZ2VuOiBEZXRlY3RhZG8gY2FtYmlvIGRlIGlkaW9tYSBkZXNkZSBsYXVuY2hlcjogJHtsYW5ndWFnZX1gKTtcbiAgICAgIFxuICAgICAgLy8gQWN0dWFsaXphciBlc3RhZG8gZGVsIGlkaW9tYVxuICAgICAgaW1hZ2VTdGF0ZS5sYW5ndWFnZSA9IGxhbmd1YWdlO1xuICAgICAgXG4gICAgICAvLyBBcXVcdTAwRUQgc2UgcG9kclx1MDBFRGEgYVx1MDBGMWFkaXIgbFx1MDBGM2dpY2EgYWRpY2lvbmFsIHBhcmEgYWN0dWFsaXphciBsYSBVSVxuICAgICAgLy8gUG9yIGVqZW1wbG8sIGFjdHVhbGl6YXIgdGV4dG9zIGRpblx1MDBFMW1pY29zLCByZS1yZW5kZXJpemFyIGVsZW1lbnRvcywgZXRjLlxuICAgIH07XG4gICAgXG4gICAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2xhdW5jaGVyTGFuZ3VhZ2VDaGFuZ2VkJywgaGFuZGxlTGF1bmNoZXJMYW5ndWFnZUNoYW5nZSk7XG4gICAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsIGhhbmRsZUxhdW5jaGVyTGFuZ3VhZ2VDaGFuZ2UpO1xuXG4gICAgLy8gQ2xlYW51cCBhbCBjZXJyYXIgbGEgcFx1MDBFMWdpbmFcbiAgICB3aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcignYmVmb3JldW5sb2FkJywgKCkgPT4ge1xuICAgICAgLy8gUmVzdGF1cmFyIGZldGNoIG9yaWdpbmFsIHNpIGVzdFx1MDBFMSBpbnRlcmNlcHRhZG9cbiAgICAgIHJlc3RvcmVGZXRjaCgpO1xuICAgICAgXG4gICAgICBzdG9wUGFpbnRpbmcoKTtcbiAgICAgIHVpLmRlc3Ryb3koKTtcbiAgICAgIHdpbmRvdy5yZW1vdmVFdmVudExpc3RlbmVyKCdsYXVuY2hlckxhbmd1YWdlQ2hhbmdlZCcsIGhhbmRsZUxhdW5jaGVyTGFuZ3VhZ2VDaGFuZ2UpO1xuICAgICAgd2luZG93LnJlbW92ZUV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsIGhhbmRsZUxhdW5jaGVyTGFuZ3VhZ2VDaGFuZ2UpO1xuICAgICAgaWYgKHdpbmRvdy5fX3dwbGFjZUJvdCkge1xuICAgICAgICB3aW5kb3cuX193cGxhY2VCb3QuaW1hZ2VSdW5uaW5nID0gZmFsc2U7XG4gICAgICB9XG4gICAgfSk7XG5cbiAgICBsb2coJ1x1MjcwNSBBdXRvLUltYWdlIGluaWNpYWxpemFkbyBjb3JyZWN0YW1lbnRlJyk7XG4gICAgXG4gICAgLy8gSW50ZW50YXIgYXV0by1pbmljaW8gZGVzcHVcdTAwRTlzIGRlIHF1ZSBsYSBVSSBlc3RcdTAwRTkgbGlzdGFcbiAgICBzZXRUaW1lb3V0KGFzeW5jICgpID0+IHtcbiAgICAgIHRyeSB7XG4gICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5hdXRvSW5pdGlhbGl6aW5nJyksICdpbmZvJyk7XG4gICAgICAgIGxvZygnXHVEODNFXHVERDE2IEludGVudGFuZG8gYXV0by1pbmljaW8uLi4nKTtcbiAgICAgICAgXG4gICAgICAgIGNvbnN0IGF1dG9Jbml0U3VjY2VzcyA9IGF3YWl0IHRyeUF1dG9Jbml0KCk7XG4gICAgICAgIFxuICAgICAgICBpZiAoYXV0b0luaXRTdWNjZXNzKSB7XG4gICAgICAgICAgdWkuc2V0U3RhdHVzKHQoJ2ltYWdlLmF1dG9Jbml0U3VjY2VzcycpLCAnc3VjY2VzcycpO1xuICAgICAgICAgIGxvZygnXHUyNzA1IEF1dG8taW5pY2lvIGV4aXRvc28nKTtcbiAgICAgICAgICBcbiAgICAgICAgICAvLyBPY3VsdGFyIGVsIGJvdFx1MDBGM24gZGUgaW5pY2lhbGl6YWNpXHUwMEYzbiBtYW51YWxcbiAgICAgICAgICB1aS5zZXRJbml0QnV0dG9uVmlzaWJsZShmYWxzZSk7XG4gICAgICAgICAgXG4gICAgICAgICAgLy8gRWplY3V0YXIgbGEgbFx1MDBGM2dpY2EgZGUgaW5pY2lhbGl6YWNpXHUwMEYzbiBkZWwgYm90XG4gICAgICAgICAgY29uc3QgaW5pdFJlc3VsdCA9IGF3YWl0IGluaXRpYWxpemVCb3QodHJ1ZSk7IC8vIHRydWUgPSBlcyBhdXRvLWluaWNpb1xuICAgICAgICAgIGlmIChpbml0UmVzdWx0KSB7XG4gICAgICAgICAgICBsb2coJ1x1RDgzRFx1REU4MCBCb3QgYXV0by1pbmljaWFkbyBjb21wbGV0YW1lbnRlJyk7XG4gICAgICAgICAgfVxuICAgICAgICB9IGVsc2Uge1xuICAgICAgICAgIHVpLnNldFN0YXR1cyh0KCdpbWFnZS5hdXRvSW5pdEZhaWxlZCcpLCAnd2FybmluZycpO1xuICAgICAgICAgIGxvZygnXHUyNkEwXHVGRTBGIEF1dG8taW5pY2lvIGZhbGxcdTAwRjMsIHNlIHJlcXVpZXJlIGluaWNpbyBtYW51YWwnKTtcbiAgICAgICAgICAvLyBFbCBib3RcdTAwRjNuIGRlIGluaWNpbyBtYW51YWwgcGVybWFuZWNlIHZpc2libGVcbiAgICAgICAgfVxuICAgICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgICAgbG9nKCdcdTI3NEMgRXJyb3IgZW4gYXV0by1pbmljaW86JywgZXJyb3IpO1xuICAgICAgICB1aS5zZXRTdGF0dXModCgnaW1hZ2UubWFudWFsSW5pdFJlcXVpcmVkJyksICd3YXJuaW5nJyk7XG4gICAgICB9XG4gICAgfSwgMTAwMCk7IC8vIEVzcGVyYXIgMSBzZWd1bmRvIHBhcmEgcXVlIGxhIFVJIGVzdFx1MDBFOSBjb21wbGV0YW1lbnRlIGNhcmdhZGFcbiAgICBcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1Mjc0QyBFcnJvciBpbmljaWFsaXphbmRvIEF1dG8tSW1hZ2U6JywgZXJyb3IpO1xuICAgIGlmICh3aW5kb3cuX193cGxhY2VCb3QpIHtcbiAgICAgIHdpbmRvdy5fX3dwbGFjZUJvdC5pbWFnZVJ1bm5pbmcgPSBmYWxzZTtcbiAgICB9XG4gICAgdGhyb3cgZXJyb3I7XG4gIH1cbn1cbiIsICJpbXBvcnQgeyBydW5JbWFnZSB9IGZyb20gXCIuLi9pbWFnZS9pbmRleC5qc1wiO1xuaW1wb3J0IHsgYXV0b0NsaWNrUGFpbnRCdXR0b24gfSBmcm9tIFwiLi4vY29yZS9kb20uanNcIjtcblxuKGFzeW5jICgpID0+IHtcbiAgXCJ1c2Ugc3RyaWN0XCI7XG4gIFxuICAvLyBBdXRvLWNsaWNrIGRlbCBib3RcdTAwRjNuIFBhaW50IGFsIGluaWNpb1xuICB0cnkge1xuICAgIGNvbnNvbGUubG9nKCdbV1BBLUltYWdlXSBcdUQ4M0VcdUREMTYgSW5pY2lhbmRvIGF1dG8tY2xpY2sgZGVsIGJvdFx1MDBGM24gUGFpbnQuLi4nKTtcbiAgICBhd2FpdCBhdXRvQ2xpY2tQYWludEJ1dHRvbigzLCB0cnVlKTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBjb25zb2xlLmxvZygnW1dQQS1JbWFnZV0gXHUyNkEwXHVGRTBGIEVycm9yIGVuIGF1dG8tY2xpY2sgZGVsIGJvdFx1MDBGM24gUGFpbnQ6JywgZXJyb3IpO1xuICB9XG4gIFxuICAvLyBWZXJpZmljYXIgc2kgZWwgYm90IGRlIGltYWdlbiB5YSBlc3RcdTAwRTEgZWplY3V0XHUwMEUxbmRvc2VcbiAgaWYgKHdpbmRvdy5fX3dwbGFjZUJvdD8uaW1hZ2VSdW5uaW5nKSB7XG4gICAgYWxlcnQoXCJBdXRvLUltYWdlIHlhIGVzdFx1MDBFMSBjb3JyaWVuZG8uXCIpO1xuICAgIHJldHVybjtcbiAgfVxuICBcbiAgLy8gVmVyaWZpY2FyIHNpIGhheSBvdHJvcyBib3RzIGVqZWN1dFx1MDBFMW5kb3NlXG4gIGlmICh3aW5kb3cuX193cGxhY2VCb3Q/LmZhcm1SdW5uaW5nKSB7XG4gICAgYWxlcnQoXCJBdXRvLUZhcm0gZXN0XHUwMEUxIGVqZWN1dFx1MDBFMW5kb3NlLiBDaVx1MDBFOXJyYWxvIGFudGVzIGRlIGluaWNpYXIgQXV0by1JbWFnZS5cIik7XG4gICAgcmV0dXJuO1xuICB9XG5cbiAgLy8gSW5pY2lhbGl6YXIgZWwgZXN0YWRvIGdsb2JhbCBzaSBubyBleGlzdGVcbiAgaWYgKCF3aW5kb3cuX193cGxhY2VCb3QpIHtcbiAgICB3aW5kb3cuX193cGxhY2VCb3QgPSB7fTtcbiAgfVxuICBcbiAgLy8gTWFyY2FyIHF1ZSBlbCBpbWFnZSBib3QgZXN0XHUwMEUxIGVqZWN1dFx1MDBFMW5kb3NlXG4gIHdpbmRvdy5fX3dwbGFjZUJvdC5pbWFnZVJ1bm5pbmcgPSB0cnVlO1xuICBcbiAgcnVuSW1hZ2UoKS5jYXRjaCgoZSkgPT4ge1xuICAgIGNvbnNvbGUuZXJyb3IoXCJbQk9UXSBFcnJvciBlbiBBdXRvLUltYWdlOlwiLCBlKTtcbiAgICBpZiAod2luZG93Ll9fd3BsYWNlQm90KSB7XG4gICAgICB3aW5kb3cuX193cGxhY2VCb3QuaW1hZ2VSdW5uaW5nID0gZmFsc2U7XG4gICAgfVxuICAgIGFsZXJ0KFwiQXV0by1JbWFnZTogZXJyb3IgaW5lc3BlcmFkby4gUmV2aXNhIGNvbnNvbGEuXCIpO1xuICB9KTtcbn0pKCk7XG4iXSwKICAibWFwcGluZ3MiOiAiOzs7QUFVTyxNQUFNLE1BQU0sSUFBSSxNQUFNLFFBQVEsSUFBSSxZQUFZLEdBQUcsQ0FBQzs7O0FDVmxELE1BQU0sS0FBSztBQUFBO0FBQUEsSUFFaEIsVUFBVTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsV0FBVztBQUFBLE1BQ1gsY0FBYztBQUFBLE1BQ2QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsSUFBSTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLElBQ1g7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1oscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2Ysa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIsVUFBVTtBQUFBLE1BQ1YsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osbUJBQW1CO0FBQUEsTUFDbkIsZUFBZTtBQUFBLE1BQ2YsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIscUJBQXFCO0FBQUEsTUFDckIsbUJBQW1CO0FBQUEsTUFDbkIsaUJBQWlCO0FBQUEsTUFDakIsUUFBUTtBQUFBLE1BQ1IsVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osT0FBTztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1YsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIseUJBQXlCO0FBQUEsTUFDekIsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsb0JBQW9CO0FBQUEsTUFDcEIsY0FBYztBQUFBLE1BQ2QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLElBQ2hCO0FBQUE7QUFBQSxJQUdBLE1BQU07QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLE9BQU87QUFBQSxNQUNQLGdCQUFnQjtBQUFBLE1BQ2hCLFlBQVk7QUFBQSxNQUNaLFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLFlBQVk7QUFBQSxNQUNaLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLHFCQUFxQjtBQUFBLE1BQ3JCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGNBQWM7QUFBQSxNQUNkLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLG9CQUFvQjtBQUFBLElBQ3RCO0FBQUE7QUFBQSxJQUdBLFFBQVE7QUFBQSxNQUNOLEtBQUs7QUFBQSxNQUNMLElBQUk7QUFBQSxNQUNKLElBQUk7QUFBQSxNQUNKLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE1BQU07QUFBQSxNQUNOLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGlCQUFpQjtBQUFBLElBQ25CO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLG9CQUFvQjtBQUFBLE1BQ3BCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLG9CQUFvQjtBQUFBLE1BQ3BCLGtCQUFrQjtBQUFBLE1BQ2xCLGdCQUFnQjtBQUFBLElBQ2xCO0FBQUEsRUFDRjs7O0FDM1BPLE1BQU0sS0FBSztBQUFBO0FBQUEsSUFFaEIsVUFBVTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsV0FBVztBQUFBLE1BQ1gsY0FBYztBQUFBLE1BQ2QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsSUFBSTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLElBQ1g7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1oscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2Ysa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIsVUFBVTtBQUFBLE1BQ1YsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osbUJBQW1CO0FBQUEsTUFDbkIsZUFBZTtBQUFBLE1BQ2YsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIscUJBQXFCO0FBQUEsTUFDckIsbUJBQW1CO0FBQUEsTUFDbkIsaUJBQWlCO0FBQUEsTUFDakIsUUFBUTtBQUFBLE1BQ1IsVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osT0FBTztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1YsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIseUJBQXlCO0FBQUEsTUFDekIsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsb0JBQW9CO0FBQUEsTUFDcEIsY0FBYztBQUFBLE1BQ2QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLElBQ2hCO0FBQUE7QUFBQSxJQUdBLE1BQU07QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLE9BQU87QUFBQSxNQUNQLGdCQUFnQjtBQUFBLE1BQ2hCLFlBQVk7QUFBQSxNQUNaLFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLFlBQVk7QUFBQSxNQUNaLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLHFCQUFxQjtBQUFBLE1BQ3JCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGNBQWM7QUFBQSxNQUNkLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLG9CQUFvQjtBQUFBLElBQ3RCO0FBQUE7QUFBQSxJQUdBLFFBQVE7QUFBQSxNQUNOLEtBQUs7QUFBQSxNQUNMLElBQUk7QUFBQSxNQUNKLElBQUk7QUFBQSxNQUNKLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE1BQU07QUFBQSxNQUNOLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGlCQUFpQjtBQUFBLElBQ25CO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLG9CQUFvQjtBQUFBLE1BQ3BCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLG9CQUFvQjtBQUFBLE1BQ3BCLGtCQUFrQjtBQUFBLE1BQ2xCLGdCQUFnQjtBQUFBLElBQ2xCO0FBQUEsRUFDRjs7O0FDM1BPLE1BQU0sS0FBSztBQUFBO0FBQUEsSUFFaEIsVUFBVTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsV0FBVztBQUFBLE1BQ1gsY0FBYztBQUFBLE1BQ2QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsSUFBSTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLElBQ1g7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1oscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2Ysa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIsVUFBVTtBQUFBLE1BQ1YsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osbUJBQW1CO0FBQUEsTUFDbkIsZUFBZTtBQUFBLE1BQ2YsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIscUJBQXFCO0FBQUEsTUFDckIsbUJBQW1CO0FBQUEsTUFDbkIsaUJBQWlCO0FBQUEsTUFDakIsUUFBUTtBQUFBLE1BQ1IsVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osT0FBTztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1YsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIseUJBQXlCO0FBQUEsTUFDekIsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsb0JBQW9CO0FBQUEsTUFDcEIsY0FBYztBQUFBLE1BQ2QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLElBQ2hCO0FBQUE7QUFBQSxJQUdBLE1BQU07QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLE9BQU87QUFBQSxNQUNQLGdCQUFnQjtBQUFBLE1BQ2hCLFlBQVk7QUFBQSxNQUNaLFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLFlBQVk7QUFBQSxNQUNaLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLHFCQUFxQjtBQUFBLE1BQ3JCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGNBQWM7QUFBQSxNQUNkLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLG9CQUFvQjtBQUFBLElBQ3RCO0FBQUE7QUFBQSxJQUdBLFFBQVE7QUFBQSxNQUNOLEtBQUs7QUFBQSxNQUNMLElBQUk7QUFBQSxNQUNKLElBQUk7QUFBQSxNQUNKLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE1BQU07QUFBQSxNQUNOLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGlCQUFpQjtBQUFBLElBQ25CO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLG9CQUFvQjtBQUFBLE1BQ3BCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLG9CQUFvQjtBQUFBLE1BQ3BCLGtCQUFrQjtBQUFBLE1BQ2xCLGdCQUFnQjtBQUFBLElBQ2xCO0FBQUEsRUFDRjs7O0FDM1BPLE1BQU0sS0FBSztBQUFBO0FBQUEsSUFFaEIsVUFBVTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsV0FBVztBQUFBLE1BQ1gsY0FBYztBQUFBLE1BQ2QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsSUFBSTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLElBQ1g7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1oscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2Ysa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIsVUFBVTtBQUFBLE1BQ1YsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osbUJBQW1CO0FBQUEsTUFDbkIsZUFBZTtBQUFBLE1BQ2YsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIscUJBQXFCO0FBQUEsTUFDckIsbUJBQW1CO0FBQUEsTUFDbkIsaUJBQWlCO0FBQUEsTUFDakIsUUFBUTtBQUFBLE1BQ1IsVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIseUJBQXlCO0FBQUEsTUFDekIsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsb0JBQW9CO0FBQUEsTUFDcEIsY0FBYztBQUFBLE1BQ2QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLElBQ2hCO0FBQUE7QUFBQSxJQUdBLE1BQU07QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLE9BQU87QUFBQSxNQUNQLGdCQUFnQjtBQUFBLE1BQ2hCLFlBQVk7QUFBQSxNQUNaLFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLFlBQVk7QUFBQSxNQUNaLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLHFCQUFxQjtBQUFBLE1BQ3JCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGNBQWM7QUFBQSxNQUNkLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLG9CQUFvQjtBQUFBLElBQ3RCO0FBQUE7QUFBQSxJQUdBLFFBQVE7QUFBQSxNQUNOLEtBQUs7QUFBQSxNQUNMLElBQUk7QUFBQSxNQUNKLElBQUk7QUFBQSxNQUNKLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE1BQU07QUFBQSxNQUNOLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGlCQUFpQjtBQUFBLElBQ25CO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLG9CQUFvQjtBQUFBLE1BQ3BCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLG9CQUFvQjtBQUFBLE1BQ3BCLGtCQUFrQjtBQUFBLE1BQ2xCLGdCQUFnQjtBQUFBLElBQ2xCO0FBQUEsRUFDRjs7O0FDelBPLE1BQU0sU0FBUztBQUFBO0FBQUEsSUFFcEIsVUFBVTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsV0FBVztBQUFBLE1BQ1gsY0FBYztBQUFBLE1BQ2QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsSUFBSTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLElBQ1g7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1oscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2Ysa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIsVUFBVTtBQUFBLE1BQ1YsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osbUJBQW1CO0FBQUEsTUFDbkIsZUFBZTtBQUFBLE1BQ2YsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIscUJBQXFCO0FBQUEsTUFDckIsbUJBQW1CO0FBQUEsTUFDbkIsaUJBQWlCO0FBQUEsTUFDakIsUUFBUTtBQUFBLE1BQ1IsVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osT0FBTztBQUFBLE1BQ1AsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIseUJBQXlCO0FBQUEsTUFDekIsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsb0JBQW9CO0FBQUEsTUFDcEIsY0FBYztBQUFBLE1BQ2QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLElBQ2hCO0FBQUE7QUFBQSxJQUdBLE1BQU07QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLE9BQU87QUFBQSxNQUNQLGdCQUFnQjtBQUFBLE1BQ2hCLFlBQVk7QUFBQSxNQUNaLFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLFlBQVk7QUFBQSxNQUNaLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLHFCQUFxQjtBQUFBLE1BQ3JCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGNBQWM7QUFBQSxNQUNkLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLG9CQUFvQjtBQUFBLElBQ3RCO0FBQUE7QUFBQSxJQUdBLFFBQVE7QUFBQSxNQUNOLEtBQUs7QUFBQSxNQUNMLElBQUk7QUFBQSxNQUNKLElBQUk7QUFBQSxNQUNKLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE1BQU07QUFBQSxNQUNOLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGlCQUFpQjtBQUFBLElBQ25CO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLG9CQUFvQjtBQUFBLE1BQ3BCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLG9CQUFvQjtBQUFBLE1BQ3BCLGtCQUFrQjtBQUFBLE1BQ2xCLGdCQUFnQjtBQUFBLElBQ2xCO0FBQUEsRUFDRjs7O0FDM1BPLE1BQU0sU0FBUztBQUFBO0FBQUEsSUFFcEIsVUFBVTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsV0FBVztBQUFBLE1BQ1gsY0FBYztBQUFBLE1BQ2QsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsSUFBSTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLElBQ1g7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1oscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2Ysa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIsVUFBVTtBQUFBLE1BQ1YsVUFBVTtBQUFBLE1BQ1YsUUFBUTtBQUFBLE1BQ1IsU0FBUztBQUFBLE1BQ1QsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osbUJBQW1CO0FBQUEsTUFDbkIsZUFBZTtBQUFBLE1BQ2YsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIscUJBQXFCO0FBQUEsTUFDckIsbUJBQW1CO0FBQUEsTUFDbkIsaUJBQWlCO0FBQUEsTUFDakIsUUFBUTtBQUFBLE1BQ1IsVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osT0FBTztBQUFBLE1BQ1AsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osZUFBZTtBQUFBLE1BQ2YscUJBQXFCO0FBQUEsTUFDckIseUJBQXlCO0FBQUEsTUFDekIsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsb0JBQW9CO0FBQUEsTUFDcEIsY0FBYztBQUFBLE1BQ2QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLElBQ2hCO0FBQUE7QUFBQSxJQUdBLE1BQU07QUFBQSxNQUNKLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLE9BQU87QUFBQSxNQUNQLGdCQUFnQjtBQUFBLE1BQ2hCLFlBQVk7QUFBQSxNQUNaLFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLFlBQVk7QUFBQSxNQUNaLFVBQVU7QUFBQSxNQUNWLE9BQU87QUFBQSxNQUNQLE9BQU87QUFBQSxNQUNQLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGFBQWE7QUFBQSxNQUNiLHFCQUFxQjtBQUFBLE1BQ3JCLGVBQWU7QUFBQSxNQUNmLGdCQUFnQjtBQUFBLE1BQ2hCLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGdCQUFnQjtBQUFBLE1BQ2hCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGNBQWM7QUFBQSxNQUNkLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLG9CQUFvQjtBQUFBLElBQ3RCO0FBQUE7QUFBQSxJQUdBLFFBQVE7QUFBQSxNQUNOLEtBQUs7QUFBQSxNQUNMLElBQUk7QUFBQSxNQUNKLElBQUk7QUFBQSxNQUNKLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE1BQU07QUFBQSxNQUNOLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFFBQVE7QUFBQSxNQUNSLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLE1BQU07QUFBQSxNQUNOLE9BQU87QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLGlCQUFpQjtBQUFBLElBQ25CO0FBQUE7QUFBQSxJQUdBLE9BQU87QUFBQSxNQUNMLE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxNQUNULFlBQVk7QUFBQSxNQUNaLGFBQWE7QUFBQSxNQUNiLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxNQUNaLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLFNBQVM7QUFBQSxNQUNULGFBQWE7QUFBQSxNQUNiLGdCQUFnQjtBQUFBLE1BQ2hCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLGNBQWM7QUFBQSxNQUNkLGVBQWU7QUFBQSxNQUNmLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLGNBQWM7QUFBQSxNQUNkLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLGlCQUFpQjtBQUFBLE1BQ2pCLGVBQWU7QUFBQSxNQUNmLGFBQWE7QUFBQSxNQUNiLFdBQVc7QUFBQSxNQUNYLFdBQVc7QUFBQSxNQUNYLGtCQUFrQjtBQUFBLE1BQ2xCLGlCQUFpQjtBQUFBLE1BQ2pCLGdCQUFnQjtBQUFBLE1BQ2hCLG9CQUFvQjtBQUFBLE1BQ3BCLGlCQUFpQjtBQUFBLE1BQ2pCLGlCQUFpQjtBQUFBLE1BQ2pCLHFCQUFxQjtBQUFBLE1BQ3JCLHFCQUFxQjtBQUFBLE1BQ3JCLGlCQUFpQjtBQUFBLE1BQ2pCLGtCQUFrQjtBQUFBLE1BQ2xCLGtCQUFrQjtBQUFBLE1BQ2xCLG1CQUFtQjtBQUFBLE1BQ25CLG1CQUFtQjtBQUFBLE1BQ25CLG9CQUFvQjtBQUFBLE1BQ3BCLGtCQUFrQjtBQUFBLE1BQ2xCLGdCQUFnQjtBQUFBLElBQ2xCO0FBQUEsRUFDRjs7O0FDek9BLE1BQU0sZUFBZTtBQUFBLElBQ25CO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxFQUNGO0FBR0EsTUFBSSxrQkFBa0I7QUFDdEIsTUFBSSxzQkFBc0IsYUFBYSxlQUFlO0FBTS9DLFdBQVMsd0JBQXdCO0FBQ3RDLFVBQU0sY0FBYyxPQUFPLFVBQVUsWUFBWSxPQUFPLFVBQVUsZ0JBQWdCO0FBR2xGLFVBQU0sV0FBVyxZQUFZLE1BQU0sR0FBRyxFQUFFLENBQUMsRUFBRSxZQUFZO0FBR3ZELFFBQUksYUFBYSxRQUFRLEdBQUc7QUFDMUIsYUFBTztBQUFBLElBQ1Q7QUFHQSxXQUFPO0FBQUEsRUFDVDtBQU1PLFdBQVMsbUJBQW1CO0FBRWpDLFdBQU87QUFBQSxFQUNUO0FBTU8sV0FBUyxhQUFhLFVBQVU7QUFFckM7QUFBQSxFQUNGO0FBTU8sV0FBUyxxQkFBcUI7QUFFbkMsVUFBTSxZQUFZLGlCQUFpQjtBQUNuQyxVQUFNLGNBQWMsc0JBQXNCO0FBRTFDLFFBQUksZUFBZTtBQUVuQixRQUFJLGFBQWEsYUFBYSxTQUFTLEdBQUc7QUFDeEMscUJBQWU7QUFBQSxJQUNqQixXQUFXLGVBQWUsYUFBYSxXQUFXLEdBQUc7QUFDbkQscUJBQWU7QUFBQSxJQUNqQjtBQUVBLGdCQUFZLFlBQVk7QUFDeEIsV0FBTztBQUFBLEVBQ1Q7QUFNTyxXQUFTLFlBQVksVUFBVTtBQUNwQyxRQUFJLENBQUMsYUFBYSxRQUFRLEdBQUc7QUFDM0IsY0FBUSxLQUFLLFdBQVcsUUFBUSw0QkFBNEIsZUFBZSxHQUFHO0FBQzlFO0FBQUEsSUFDRjtBQUVBLHNCQUFrQjtBQUNsQiwwQkFBc0IsYUFBYSxRQUFRO0FBQzNDLGlCQUFhLFFBQVE7QUFHckIsUUFBSSxPQUFPLFdBQVcsZUFBZSxPQUFPLGFBQWE7QUFDdkQsYUFBTyxjQUFjLElBQUksT0FBTyxZQUFZLG1CQUFtQjtBQUFBLFFBQzdELFFBQVEsRUFBRSxVQUFVLFVBQVUsY0FBYyxvQkFBb0I7QUFBQSxNQUNsRSxDQUFDLENBQUM7QUFBQSxJQUNKO0FBQUEsRUFDRjtBQU1PLFdBQVMscUJBQXFCO0FBQ25DLFdBQU87QUFBQSxFQUNUO0FBZ0JPLFdBQVMsRUFBRSxLQUFLLFNBQVMsQ0FBQyxHQUFHO0FBQ2xDLFVBQU0sT0FBTyxJQUFJLE1BQU0sR0FBRztBQUMxQixRQUFJLFFBQVE7QUFHWixlQUFXLEtBQUssTUFBTTtBQUNwQixVQUFJLFNBQVMsT0FBTyxVQUFVLFlBQVksS0FBSyxPQUFPO0FBQ3BELGdCQUFRLE1BQU0sQ0FBQztBQUFBLE1BQ2pCLE9BQU87QUFDTCxnQkFBUSxLQUFLLDBDQUF1QyxHQUFHLEdBQUc7QUFDMUQsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBRUEsUUFBSSxPQUFPLFVBQVUsVUFBVTtBQUM3QixjQUFRLEtBQUsseUNBQXNDLEdBQUcsR0FBRztBQUN6RCxhQUFPO0FBQUEsSUFDVDtBQUdBLFdBQU8sWUFBWSxPQUFPLE1BQU07QUFBQSxFQUNsQztBQVFBLFdBQVMsWUFBWSxNQUFNLFFBQVE7QUFDakMsUUFBSSxDQUFDLFVBQVUsT0FBTyxLQUFLLE1BQU0sRUFBRSxXQUFXLEdBQUc7QUFDL0MsYUFBTztBQUFBLElBQ1Q7QUFFQSxXQUFPLEtBQUssUUFBUSxjQUFjLENBQUMsT0FBTyxRQUFRO0FBQ2hELGFBQU8sT0FBTyxHQUFHLE1BQU0sU0FBWSxPQUFPLEdBQUcsSUFBSTtBQUFBLElBQ25ELENBQUM7QUFBQSxFQUNIO0FBT08sV0FBUyxXQUFXLFNBQVM7QUFDbEMsUUFBSSxvQkFBb0IsT0FBTyxHQUFHO0FBQ2hDLGFBQU8sb0JBQW9CLE9BQU87QUFBQSxJQUNwQztBQUVBLFlBQVEsS0FBSywrQ0FBeUMsT0FBTyxHQUFHO0FBQ2hFLFdBQU8sQ0FBQztBQUFBLEVBQ1Y7QUFZQSxxQkFBbUI7OztBQ2xNWixNQUFNLGlCQUFpQjtBQUFBLElBQzVCLFNBQVM7QUFBQSxJQUNULGtCQUFrQjtBQUFBLElBQ2xCLHdCQUF3QjtBQUFBLElBQ3hCLGlCQUFpQjtBQUFBLElBQ2pCLGNBQWM7QUFBQSxJQUNkLFdBQVc7QUFBQSxJQUNYLGtCQUFrQjtBQUFBLElBQ2xCLGlCQUFpQjtBQUFBLElBQ2pCLE9BQU87QUFBQSxNQUNMLFNBQVM7QUFBQSxNQUNULFdBQVc7QUFBQSxNQUNYLFFBQVE7QUFBQSxNQUNSLE1BQU07QUFBQSxNQUNOLFdBQVc7QUFBQSxNQUNYLFNBQVM7QUFBQSxNQUNULE9BQU87QUFBQSxNQUNQLFNBQVM7QUFBQSxJQUNYO0FBQUEsRUFDRjtBQThCTyxNQUFNLGFBQWE7QUFBQSxJQUN4QixTQUFTO0FBQUEsSUFDVCxhQUFhO0FBQUEsSUFDYixZQUFZO0FBQUEsSUFDWixhQUFhO0FBQUEsSUFDYixlQUFlO0FBQUEsSUFDZixpQkFBaUIsQ0FBQztBQUFBLElBQ2xCLGdCQUFnQjtBQUFBLElBQ2hCLFVBQVUsZUFBZTtBQUFBLElBQ3pCLFdBQVc7QUFBQSxJQUNYLFVBQVU7QUFBQSxJQUNWLGVBQWU7QUFBQSxJQUNmLGVBQWU7QUFBQSxJQUNmLG1CQUFtQjtBQUFBLElBQ25CLG1CQUFtQjtBQUFBO0FBQUEsSUFDbkIsaUJBQWlCO0FBQUE7QUFBQSxJQUNqQixRQUFRO0FBQUEsSUFDUixXQUFXO0FBQUEsSUFDWCxjQUFjLEVBQUUsR0FBRyxHQUFHLEdBQUcsRUFBRTtBQUFBLElBQzNCLGVBQWU7QUFBQSxJQUNmLFVBQVU7QUFBQSxJQUNWLE9BQU87QUFBQSxJQUNQLE9BQU87QUFBQSxJQUNQLGdCQUFnQixlQUFlO0FBQUEsSUFDL0Isb0JBQW9CO0FBQUE7QUFBQSxJQUNwQixjQUFjO0FBQUE7QUFBQSxJQUNkLFlBQVk7QUFBQTtBQUFBLElBQ1osbUJBQW1CO0FBQUE7QUFBQSxJQUNuQixZQUFZO0FBQUEsSUFDWixpQkFBaUI7QUFBQSxJQUNqQixpQkFBaUIsQ0FBQztBQUFBLElBQ2xCLGtCQUFrQjtBQUFBLElBQ2xCLG1CQUFtQjtBQUFBLElBQ25CLG1CQUFtQjtBQUFBLElBQ25CLFlBQVk7QUFBQTtBQUFBLEVBQ2Q7OztBQ3VHTyxXQUFTLHdCQUF3QjtBQUN0QyxRQUFJLDZDQUFzQztBQUcxQyxVQUFNLGdCQUFnQixTQUFTLGlCQUFpQixnQkFBZ0I7QUFDaEUsVUFBTSxTQUFTLENBQUM7QUFFaEIsZUFBVyxXQUFXLGVBQWU7QUFFbkMsVUFBSSxRQUFRLGNBQWMsS0FBSyxHQUFHO0FBQ2hDO0FBQUEsTUFDRjtBQUVBLFlBQU0sUUFBUSxRQUFRLEdBQUcsUUFBUSxVQUFVLEVBQUU7QUFDN0MsWUFBTSxLQUFLLFNBQVMsS0FBSztBQUd6QixVQUFJLE9BQU8sR0FBRztBQUNaO0FBQUEsTUFDRjtBQUdBLFlBQU0sa0JBQWtCLFFBQVEsTUFBTTtBQUN0QyxVQUFJLGlCQUFpQjtBQUNuQixjQUFNLFdBQVcsZ0JBQWdCLE1BQU0sTUFBTTtBQUM3QyxZQUFJLFlBQVksU0FBUyxVQUFVLEdBQUc7QUFDcEMsZ0JBQU0sTUFBTTtBQUFBLFlBQ1YsR0FBRyxTQUFTLFNBQVMsQ0FBQyxDQUFDO0FBQUEsWUFDdkIsR0FBRyxTQUFTLFNBQVMsQ0FBQyxDQUFDO0FBQUEsWUFDdkIsR0FBRyxTQUFTLFNBQVMsQ0FBQyxDQUFDO0FBQUEsVUFDekI7QUFFQSxpQkFBTyxLQUFLO0FBQUEsWUFDVjtBQUFBLFlBQ0E7QUFBQSxZQUNBLEdBQUc7QUFBQSxVQUNMLENBQUM7QUFFRCxjQUFJLHVCQUF1QixFQUFFLFNBQVMsSUFBSSxDQUFDLElBQUksSUFBSSxDQUFDLElBQUksSUFBSSxDQUFDLEdBQUc7QUFBQSxRQUNsRTtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBRUEsUUFBSSxVQUFLLE9BQU8sTUFBTSxpQ0FBaUM7QUFDdkQsV0FBTztBQUFBLEVBQ1Q7OztBQ25PTyxNQUFNLDRCQUFOLE1BQWdDO0FBQUEsSUFDckMsWUFBWSxVQUFVO0FBQ3BCLFdBQUssV0FBVztBQUNoQixXQUFLLE1BQU0sSUFBSSxPQUFPLE1BQU07QUFDNUIsV0FBSyxlQUFlO0FBR3BCLFdBQUssV0FBVztBQUNoQixXQUFLLFdBQVc7QUFDaEIsV0FBSyxhQUFhO0FBR2xCLFdBQUssU0FBUztBQUNkLFdBQUssYUFBYTtBQUNsQixXQUFLLGNBQWM7QUFDbkIsV0FBSyxjQUFjO0FBQ25CLFdBQUsscUJBQXFCO0FBQzFCLFdBQUssbUJBQW1CO0FBQ3hCLFdBQUssZUFBZSxDQUFDO0FBQ3JCLFdBQUssbUJBQW1CLG9CQUFJLElBQUk7QUFDaEMsV0FBSyxZQUFZLG9CQUFJLElBQUk7QUFDekIsV0FBSyxTQUFTLENBQUMsR0FBRyxHQUFHLEdBQUcsQ0FBQztBQUN6QixXQUFLLGdCQUFnQixDQUFDO0FBQ3RCLFdBQUssdUJBQXVCLENBQUM7QUFDN0IsV0FBSyxlQUFlLG9CQUFJLElBQUk7QUFBQSxJQUM5QjtBQUFBLElBRUEsTUFBTSxPQUFPO0FBQ1gsYUFBTyxJQUFJLFFBQVEsQ0FBQyxTQUFTLFdBQVc7QUFDdEMsYUFBSyxJQUFJLFNBQVMsWUFBWTtBQUM1QixjQUFJO0FBQ0YsaUJBQUssU0FBUyxNQUFNLGtCQUFrQixLQUFLLEdBQUc7QUFDOUMsaUJBQUssYUFBYSxLQUFLLE9BQU87QUFDOUIsaUJBQUssY0FBYyxLQUFLLE9BQU87QUFDL0IsaUJBQUssY0FBYyxLQUFLLGFBQWEsS0FBSztBQUUxQyxnQkFBSSxpQ0FBaUMsS0FBSyxVQUFVLE9BQUksS0FBSyxXQUFXLE1BQU0sS0FBSyxZQUFZLGVBQWUsQ0FBQyxhQUFVO0FBQ3pILG9CQUFRO0FBQUEsVUFDVixTQUFTLE9BQU87QUFDZCxtQkFBTyxLQUFLO0FBQUEsVUFDZDtBQUFBLFFBQ0Y7QUFDQSxhQUFLLElBQUksVUFBVTtBQUNuQixhQUFLLElBQUksTUFBTSxLQUFLO0FBQUEsTUFDdEIsQ0FBQztBQUFBLElBQ0g7QUFBQTtBQUFBO0FBQUE7QUFBQSxJQUtBLHlCQUF5QjtBQUN2QixVQUFJLGtEQUFrRDtBQUd0RCxZQUFNLGtCQUFrQixLQUFLLGlCQUFpQjtBQUs5QyxZQUFNLGlCQUFpQixnQkFDcEIsT0FBTyxPQUFLLEVBQUUsUUFBUSxFQUFFLEtBQUssWUFBWSxNQUFNLGlCQUFpQixNQUFNLFFBQVEsRUFBRSxHQUFHLENBQUM7QUFJdkYsV0FBSyxtQkFBbUIsSUFBSTtBQUFBLFFBQzFCLGVBQWUsSUFBSSxPQUFLLEdBQUcsRUFBRSxJQUFJLENBQUMsQ0FBQyxJQUFJLEVBQUUsSUFBSSxDQUFDLENBQUMsSUFBSSxFQUFFLElBQUksQ0FBQyxDQUFDLEVBQUU7QUFBQSxNQUMvRDtBQUtBLFlBQU0sWUFBWTtBQUNsQixXQUFLLGlCQUFpQixJQUFJLFNBQVM7QUFHbkMsV0FBSyxZQUFZLElBQUk7QUFBQSxRQUNuQixnQkFDRyxPQUFPLE9BQUssTUFBTSxRQUFRLEVBQUUsR0FBRyxDQUFDLEVBQ2hDLElBQUksT0FBSztBQUFBLFVBQ1IsR0FBRyxFQUFFLElBQUksQ0FBQyxDQUFDLElBQUksRUFBRSxJQUFJLENBQUMsQ0FBQyxJQUFJLEVBQUUsSUFBSSxDQUFDLENBQUM7QUFBQSxVQUNuQztBQUFBLFlBQ0UsSUFBSSxFQUFFO0FBQUEsWUFDTixTQUFTLENBQUMsQ0FBQyxFQUFFO0FBQUEsWUFDYixNQUFNLEVBQUUsUUFBUSxTQUFTLEVBQUUsRUFBRTtBQUFBLFVBQy9CO0FBQUEsUUFDRixDQUFDO0FBQUEsTUFDTDtBQUdBLFVBQUk7QUFDRixjQUFNLGNBQWMsZ0JBQWdCLEtBQUssT0FBSyxFQUFFLFFBQVEsRUFBRSxLQUFLLFlBQVksTUFBTSxhQUFhO0FBQzlGLFlBQUksZUFBZSxNQUFNLFFBQVEsWUFBWSxHQUFHLEdBQUc7QUFDakQsZUFBSyxVQUFVLElBQUksV0FBVztBQUFBLFlBQzVCLElBQUksWUFBWTtBQUFBLFlBQ2hCLFNBQVMsQ0FBQyxDQUFDLFlBQVk7QUFBQSxZQUN2QixNQUFNLFlBQVk7QUFBQSxVQUNwQixDQUFDO0FBQUEsUUFDSDtBQUFBLE1BQ0YsU0FBUyxRQUFRO0FBQUEsTUFFakI7QUFFQSxVQUFJLHNDQUFzQyxLQUFLLGlCQUFpQixJQUFJLHFCQUFxQjtBQUN6RixhQUFPLE1BQU0sS0FBSyxlQUFlO0FBQUEsSUFDbkM7QUFBQTtBQUFBO0FBQUE7QUFBQSxJQUtBLG1CQUFtQjtBQUNqQixZQUFNLGdCQUFnQixTQUFTLGlCQUFpQixnQkFBZ0I7QUFDaEUsWUFBTSxTQUFTLENBQUM7QUFFaEIsaUJBQVcsV0FBVyxlQUFlO0FBQ25DLGNBQU0sUUFBUSxRQUFRLEdBQUcsUUFBUSxVQUFVLEVBQUU7QUFDN0MsY0FBTSxLQUFLLFNBQVMsS0FBSztBQUd6QixZQUFJLFFBQVEsY0FBYyxLQUFLLEdBQUc7QUFDaEM7QUFBQSxRQUNGO0FBR0EsWUFBSSxPQUFPLEdBQUc7QUFDWjtBQUFBLFFBQ0Y7QUFHQSxjQUFNLGtCQUFrQixRQUFRLE1BQU07QUFDdEMsWUFBSSxpQkFBaUI7QUFDbkIsZ0JBQU0sV0FBVyxnQkFBZ0IsTUFBTSxNQUFNO0FBQzdDLGNBQUksWUFBWSxTQUFTLFVBQVUsR0FBRztBQUNwQyxrQkFBTSxNQUFNO0FBQUEsY0FDVixTQUFTLFNBQVMsQ0FBQyxDQUFDO0FBQUEsY0FDcEIsU0FBUyxTQUFTLENBQUMsQ0FBQztBQUFBLGNBQ3BCLFNBQVMsU0FBUyxDQUFDLENBQUM7QUFBQSxZQUN0QjtBQUVBLGtCQUFNLFlBQVk7QUFBQSxjQUNoQjtBQUFBLGNBQ0E7QUFBQSxjQUNBO0FBQUEsY0FDQSxNQUFNLFFBQVEsU0FBUyxRQUFRLGFBQWEsWUFBWSxLQUFLLFNBQVMsRUFBRTtBQUFBLGNBQ3hFLFNBQVMsUUFBUSxVQUFVLFNBQVMsU0FBUyxLQUFLLFFBQVEsY0FBYyxVQUFVO0FBQUEsWUFDcEY7QUFFQSxtQkFBTyxLQUFLLFNBQVM7QUFBQSxVQUN2QjtBQUFBLFFBQ0Y7QUFBQSxNQUNGO0FBRUEsVUFBSSxpQkFBaUIsT0FBTyxNQUFNLCtCQUErQjtBQUlqRSxhQUFPO0FBQUEsSUFDVDtBQUFBO0FBQUE7QUFBQTtBQUFBLElBS0EsVUFBVSxPQUFPLE9BQU8sUUFBUSxRQUFRO0FBQ3RDLFdBQUssU0FBUyxDQUFDLE9BQU8sT0FBTyxRQUFRLE1BQU07QUFDM0MsVUFBSSxnREFBZ0QsS0FBSyxJQUFJLEtBQUssV0FBVyxNQUFNLElBQUksTUFBTSxHQUFHO0FBQUEsSUFDbEc7QUFBQTtBQUFBO0FBQUE7QUFBQSxJQUtBLE1BQU0sZ0JBQWdCO0FBQ3BCLFVBQUksQ0FBQyxLQUFLLFFBQVE7QUFDaEIsY0FBTSxJQUFJLE1BQU0sNENBQTRDO0FBQUEsTUFDOUQ7QUFFQSxVQUFJLHFEQUFrRDtBQUV0RCxVQUFJO0FBRUYsY0FBTSxnQkFBZ0IsSUFBSSxnQkFBZ0IsS0FBSyxZQUFZLEtBQUssV0FBVztBQUMzRSxjQUFNLGFBQWEsY0FBYyxXQUFXLE1BQU0sRUFBRSxvQkFBb0IsS0FBSyxDQUFDO0FBQzlFLG1CQUFXLHdCQUF3QjtBQUNuQyxtQkFBVyxVQUFVLEdBQUcsR0FBRyxLQUFLLFlBQVksS0FBSyxXQUFXO0FBQzVELG1CQUFXLFVBQVUsS0FBSyxRQUFRLEdBQUcsQ0FBQztBQUN0QyxjQUFNLGNBQWMsV0FBVyxhQUFhLEdBQUcsR0FBRyxLQUFLLFlBQVksS0FBSyxXQUFXLEVBQUU7QUFFckYsWUFBSSxXQUFXO0FBQ2YsWUFBSSxTQUFTO0FBQ2IsY0FBTSxhQUFhLG9CQUFJLElBQUk7QUFJM0IsaUJBQVMsSUFBSSxHQUFHLElBQUksS0FBSyxhQUFhLEtBQUs7QUFDekMsbUJBQVMsSUFBSSxHQUFHLElBQUksS0FBSyxZQUFZLEtBQUs7QUFDeEMsa0JBQU0sT0FBTyxJQUFJLEtBQUssYUFBYSxLQUFLO0FBQ3hDLGtCQUFNLElBQUksWUFBWSxHQUFHO0FBQ3pCLGtCQUFNLElBQUksWUFBWSxNQUFNLENBQUM7QUFDN0Isa0JBQU0sSUFBSSxZQUFZLE1BQU0sQ0FBQztBQUM3QixrQkFBTSxJQUFJLFlBQVksTUFBTSxDQUFDO0FBRTdCLGdCQUFJLE1BQU0sRUFBRztBQUViLGtCQUFNLE1BQU0sR0FBRyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUM7QUFHMUIsZ0JBQUksTUFBTSxPQUFPLE1BQU0sT0FBTyxNQUFNLEtBQUs7QUFDdkM7QUFBQSxZQUNGO0FBR0EsZ0JBQUksYUFBYTtBQUNqQixnQkFBSSxlQUFlLEtBQUssaUJBQWlCLElBQUksR0FBRztBQUdoRCxnQkFBSSxDQUFDLGdCQUFnQixLQUFLLGlCQUFpQixJQUFJLGFBQWEsR0FBRztBQUU3RCxrQkFBSSxLQUFLLE9BQU8sS0FBSyxPQUFPLEtBQUssS0FBSztBQUNwQyw2QkFBYTtBQUNiLCtCQUFlO0FBQUEsY0FDakI7QUFBQSxZQUNGO0FBR0EsZ0JBQUksQ0FBQyxhQUFjO0FBRW5CO0FBQ0EsdUJBQVcsSUFBSSxhQUFhLFdBQVcsSUFBSSxVQUFVLEtBQUssS0FBSyxDQUFDO0FBQUEsVUFDbEU7QUFBQSxRQUNGO0FBRUEsYUFBSyxxQkFBcUI7QUFDMUIsYUFBSyxtQkFBbUI7QUFHeEIsY0FBTSxhQUFhLENBQUM7QUFDcEIsbUJBQVcsQ0FBQyxLQUFLLEtBQUssS0FBSyxXQUFXLFFBQVEsR0FBRztBQUMvQyxxQkFBVyxHQUFHLElBQUksRUFBRSxPQUFPLFNBQVMsS0FBSztBQUFBLFFBQzNDO0FBQ0EsYUFBSyxlQUFlO0FBRXBCLFlBQUksdUNBQW9DO0FBQ3hDLFlBQUksOEJBQTJCLFNBQVMsZUFBZSxDQUFDLEVBQUU7QUFDMUQsWUFBSSwyQkFBd0IsT0FBTyxlQUFlLENBQUMsRUFBRTtBQUNyRCxZQUFJLDBCQUF1QixXQUFXLElBQUksRUFBRTtBQUU1QyxlQUFPO0FBQUEsVUFDTCxhQUFhLEtBQUs7QUFBQSxVQUNsQixnQkFBZ0I7QUFBQSxVQUNoQixjQUFjO0FBQUEsVUFDZCxjQUFjLFdBQVc7QUFBQSxVQUN6QixjQUFjO0FBQUEsUUFDaEI7QUFBQSxNQUVGLFNBQVMsTUFBTTtBQUViLGFBQUsscUJBQXFCLEtBQUssSUFBSSxHQUFHLEtBQUssV0FBVztBQUN0RCxhQUFLLG1CQUFtQjtBQUN4QixZQUFJLG9FQUFpRTtBQUVyRSxlQUFPO0FBQUEsVUFDTCxhQUFhLEtBQUs7QUFBQSxVQUNsQixnQkFBZ0IsS0FBSztBQUFBLFVBQ3JCLGNBQWM7QUFBQSxVQUNkLGNBQWM7QUFBQSxVQUNkLGNBQWMsQ0FBQztBQUFBLFFBQ2pCO0FBQUEsTUFDRjtBQUFBLElBQ0Y7QUFBQTtBQUFBO0FBQUE7QUFBQSxJQUtBLE1BQU0sc0JBQXNCO0FBQzFCLFVBQUksQ0FBQyxLQUFLLFFBQVE7QUFDaEIsY0FBTSxJQUFJLE1BQU0sNENBQTRDO0FBQUEsTUFDOUQ7QUFFQSxVQUFJLDRDQUE0QztBQUVoRCxZQUFNLGdCQUFnQixDQUFDO0FBQ3ZCLFlBQU0sdUJBQXVCLENBQUM7QUFFOUIsWUFBTSxTQUFTLElBQUksZ0JBQWdCLEtBQUssVUFBVSxLQUFLLFFBQVE7QUFDL0QsWUFBTSxVQUFVLE9BQU8sV0FBVyxNQUFNLEVBQUUsb0JBQW9CLEtBQUssQ0FBQztBQUdwRSxlQUFTLFNBQVMsS0FBSyxPQUFPLENBQUMsR0FBRyxTQUFTLEtBQUssY0FBYyxLQUFLLE9BQU8sQ0FBQyxLQUFLO0FBRzlFLGNBQU0sWUFBWSxLQUFLO0FBQUEsVUFDckIsS0FBSyxXQUFZLFNBQVMsS0FBSztBQUFBLFVBQy9CLEtBQUssZUFBZSxTQUFTLEtBQUssT0FBTyxDQUFDO0FBQUEsUUFDNUM7QUFHQSxpQkFBUyxTQUFTLEtBQUssT0FBTyxDQUFDLEdBQUcsU0FBUyxLQUFLLGFBQWEsS0FBSyxPQUFPLENBQUMsS0FBSztBQUc3RSxnQkFBTSxZQUFZLEtBQUs7QUFBQSxZQUNyQixLQUFLLFdBQVksU0FBUyxLQUFLO0FBQUEsWUFDL0IsS0FBSyxjQUFjLFNBQVMsS0FBSyxPQUFPLENBQUM7QUFBQSxVQUMzQztBQUdBLGdCQUFNLGNBQWMsWUFBWSxLQUFLO0FBQ3JDLGdCQUFNLGVBQWUsWUFBWSxLQUFLO0FBQ3RDLGlCQUFPLFFBQVE7QUFDZixpQkFBTyxTQUFTO0FBRWhCLGtCQUFRLHdCQUF3QjtBQUdoQyxrQkFBUSxVQUFVLEdBQUcsR0FBRyxhQUFhLFlBQVk7QUFDakQsa0JBQVE7QUFBQSxZQUNOLEtBQUs7QUFBQTtBQUFBLFlBQ0wsU0FBUyxLQUFLLE9BQU8sQ0FBQztBQUFBO0FBQUEsWUFDdEIsU0FBUyxLQUFLLE9BQU8sQ0FBQztBQUFBO0FBQUEsWUFDdEI7QUFBQTtBQUFBLFlBQ0E7QUFBQTtBQUFBLFlBQ0E7QUFBQTtBQUFBLFlBQ0E7QUFBQTtBQUFBLFlBQ0EsWUFBWSxLQUFLO0FBQUE7QUFBQSxZQUNqQixZQUFZLEtBQUs7QUFBQTtBQUFBLFVBQ25CO0FBRUEsZ0JBQU0sWUFBWSxRQUFRLGFBQWEsR0FBRyxHQUFHLGFBQWEsWUFBWTtBQUd0RSxtQkFBUyxJQUFJLEdBQUcsSUFBSSxjQUFjLEtBQUs7QUFDckMscUJBQVMsSUFBSSxHQUFHLElBQUksYUFBYSxLQUFLO0FBQ3BDLG9CQUFNLGNBQWMsSUFBSSxjQUFjLEtBQUs7QUFHM0Msa0JBQ0UsVUFBVSxLQUFLLFVBQVUsTUFBTSxPQUMvQixVQUFVLEtBQUssYUFBYSxDQUFDLE1BQU0sT0FDbkMsVUFBVSxLQUFLLGFBQWEsQ0FBQyxNQUFNLEtBQ25DO0FBQ0EscUJBQUssSUFBSSxLQUFLLE1BQU0sR0FBRztBQUNyQiw0QkFBVSxLQUFLLFVBQVUsSUFBSTtBQUM3Qiw0QkFBVSxLQUFLLGFBQWEsQ0FBQyxJQUFJO0FBQ2pDLDRCQUFVLEtBQUssYUFBYSxDQUFDLElBQUk7QUFBQSxnQkFDbkMsT0FBTztBQUNMLDRCQUFVLEtBQUssVUFBVSxJQUFJO0FBQzdCLDRCQUFVLEtBQUssYUFBYSxDQUFDLElBQUk7QUFDakMsNEJBQVUsS0FBSyxhQUFhLENBQUMsSUFBSTtBQUFBLGdCQUNuQztBQUNBLDBCQUFVLEtBQUssYUFBYSxDQUFDLElBQUk7QUFBQSxjQUNuQyxXQUFXLElBQUksS0FBSyxlQUFlLEtBQUssSUFBSSxLQUFLLGVBQWUsR0FBRztBQUVqRSwwQkFBVSxLQUFLLGFBQWEsQ0FBQyxJQUFJO0FBQUEsY0FDbkMsT0FBTztBQUVMLHNCQUFNLElBQUksVUFBVSxLQUFLLFVBQVU7QUFDbkMsc0JBQU0sSUFBSSxVQUFVLEtBQUssYUFBYSxDQUFDO0FBQ3ZDLHNCQUFNLElBQUksVUFBVSxLQUFLLGFBQWEsQ0FBQztBQUN2QyxvQkFBSSxDQUFDLEtBQUssaUJBQWlCLElBQUksR0FBRyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsRUFBRSxHQUFHO0FBQ2hELDRCQUFVLEtBQUssYUFBYSxDQUFDLElBQUk7QUFBQSxnQkFDbkM7QUFBQSxjQUNGO0FBQUEsWUFDRjtBQUFBLFVBQ0Y7QUFFQSxrQkFBUSxhQUFhLFdBQVcsR0FBRyxDQUFDO0FBR3BDLGdCQUFNLG1CQUFtQixJQUFJLEtBQUssT0FBTyxDQUFDLElBQUksS0FBSyxNQUFNLFNBQVMsR0FBSSxHQUNuRSxTQUFTLEVBQ1QsU0FBUyxHQUFHLEdBQUcsQ0FBQyxLQUFLLEtBQUssT0FBTyxDQUFDLElBQUksS0FBSyxNQUFNLFNBQVMsR0FBSSxHQUM5RCxTQUFTLEVBQ1QsU0FBUyxHQUFHLEdBQUcsQ0FBQyxLQUFLLFNBQVMsS0FDOUIsU0FBUyxFQUNULFNBQVMsR0FBRyxHQUFHLENBQUMsS0FBSyxTQUFTLEtBQU0sU0FBUyxFQUFFLFNBQVMsR0FBRyxHQUFHLENBQUM7QUFFbEUsd0JBQWMsZ0JBQWdCLElBQUksTUFBTSxrQkFBa0IsTUFBTTtBQUdoRSxlQUFLLGFBQWEsSUFBSSxpQkFBaUIsTUFBTSxHQUFHLEVBQUUsTUFBTSxHQUFHLENBQUMsRUFBRSxLQUFLLEdBQUcsQ0FBQztBQUd2RSxnQkFBTSxhQUFhLE1BQU0sT0FBTyxjQUFjO0FBQzlDLGdCQUFNLGVBQWUsTUFBTSxXQUFXLFlBQVk7QUFDbEQsK0JBQXFCLGdCQUFnQixJQUFJO0FBRXpDLG9CQUFVO0FBQUEsUUFDWjtBQUVBLGtCQUFVO0FBQUEsTUFDWjtBQUVBLFdBQUssZ0JBQWdCO0FBQ3JCLFdBQUssdUJBQXVCO0FBRTVCLFVBQUksZ0NBQWdDLE9BQU8sS0FBSyxhQUFhLEVBQUUsTUFBTSxRQUFRO0FBQzdFLFVBQUksdUNBQXVDLEtBQUssYUFBYSxJQUFJLGtCQUFlO0FBRWhGLGFBQU8sRUFBRSxlQUFlLHFCQUFxQjtBQUFBLElBQy9DO0FBQUE7QUFBQTtBQUFBO0FBQUEsSUFLQSxxQkFBcUI7QUFDbkIsVUFBSSxDQUFDLEtBQUssUUFBUTtBQUNoQixjQUFNLElBQUksTUFBTSw0Q0FBNEM7QUFBQSxNQUM5RDtBQUVBLFVBQUksK0NBQTRDO0FBRWhELFlBQU0sUUFBUSxDQUFDO0FBQ2YsWUFBTSxRQUFRLEtBQUssT0FBTyxDQUFDLElBQUksT0FBUSxLQUFLLE9BQU8sQ0FBQyxLQUFLO0FBQ3pELFlBQU0sUUFBUSxLQUFLLE9BQU8sQ0FBQyxJQUFJLE9BQVEsS0FBSyxPQUFPLENBQUMsS0FBSztBQUd6RCxZQUFNLGFBQWEsSUFBSSxnQkFBZ0IsS0FBSyxZQUFZLEtBQUssV0FBVztBQUN4RSxZQUFNLFVBQVUsV0FBVyxXQUFXLE1BQU0sRUFBRSxvQkFBb0IsS0FBSyxDQUFDO0FBQ3hFLGNBQVEsd0JBQXdCO0FBQ2hDLGNBQVEsVUFBVSxLQUFLLFFBQVEsR0FBRyxDQUFDO0FBQ25DLFlBQU0sWUFBWSxRQUFRLGFBQWEsR0FBRyxHQUFHLEtBQUssWUFBWSxLQUFLLFdBQVcsRUFBRTtBQUVoRixlQUFTLElBQUksR0FBRyxJQUFJLEtBQUssYUFBYSxLQUFLO0FBQ3pDLGlCQUFTLElBQUksR0FBRyxJQUFJLEtBQUssWUFBWSxLQUFLO0FBQ3hDLGdCQUFNLE9BQU8sSUFBSSxLQUFLLGFBQWEsS0FBSztBQUN4QyxnQkFBTSxJQUFJLFVBQVUsR0FBRztBQUN2QixnQkFBTSxJQUFJLFVBQVUsTUFBTSxDQUFDO0FBQzNCLGdCQUFNLElBQUksVUFBVSxNQUFNLENBQUM7QUFDM0IsZ0JBQU0sUUFBUSxVQUFVLE1BQU0sQ0FBQztBQUcvQixjQUFJLFVBQVUsRUFBRztBQUdqQixjQUFJLE1BQU0sT0FBTyxNQUFNLE9BQU8sTUFBTSxJQUFLO0FBRXpDLGdCQUFNLFdBQVcsR0FBRyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUM7QUFHL0IsY0FBSSxDQUFDLEtBQUssaUJBQWlCLElBQUksUUFBUSxFQUFHO0FBRzFDLGdCQUFNLFVBQVUsUUFBUTtBQUN4QixnQkFBTSxVQUFVLFFBQVE7QUFHeEIsZ0JBQU0sUUFBUSxLQUFLLE1BQU0sVUFBVSxHQUFJO0FBQ3ZDLGdCQUFNLFFBQVEsS0FBSyxNQUFNLFVBQVUsR0FBSTtBQUN2QyxnQkFBTSxTQUFTLFVBQVU7QUFDekIsZ0JBQU0sU0FBUyxVQUFVO0FBR3pCLGdCQUFNLFlBQVksS0FBSyxVQUFVLElBQUksUUFBUSxLQUFLLEVBQUUsSUFBSSxHQUFHLE1BQU0sVUFBVTtBQUUzRSxnQkFBTSxLQUFLO0FBQUE7QUFBQSxZQUVULFFBQVE7QUFBQSxZQUNSLFFBQVE7QUFBQTtBQUFBLFlBRVI7QUFBQSxZQUNBO0FBQUE7QUFBQSxZQUVBO0FBQUEsWUFDQTtBQUFBLFlBQ0E7QUFBQSxZQUNBO0FBQUE7QUFBQSxZQUVBLE9BQU87QUFBQSxjQUNMO0FBQUEsY0FDQTtBQUFBLGNBQ0E7QUFBQSxjQUNBLElBQUksVUFBVTtBQUFBLGNBQ2QsTUFBTSxVQUFVO0FBQUEsWUFDbEI7QUFBQSxZQUNBLGVBQWUsRUFBRSxHQUFHLEdBQUcsR0FBRyxNQUFNO0FBQUEsVUFDbEMsQ0FBQztBQUFBLFFBQ0g7QUFBQSxNQUNGO0FBRUEsVUFBSSxnQ0FBZ0MsTUFBTSxNQUFNLHdCQUFrQjtBQUNsRSxhQUFPO0FBQUEsSUFDVDtBQUFBO0FBQUE7QUFBQTtBQUFBLElBS0EsTUFBTSxPQUFPLFVBQVUsV0FBVyxrQkFBa0IsTUFBTTtBQUN4RCxVQUFJLENBQUMsS0FBSyxLQUFLO0FBQ2IsY0FBTSxJQUFJLE1BQU0sNENBQTRDO0FBQUEsTUFDOUQ7QUFFQSxZQUFNLGdCQUFnQixLQUFLLElBQUk7QUFDL0IsWUFBTSxpQkFBaUIsS0FBSyxJQUFJO0FBRWhDLFVBQUksaUJBQWlCO0FBQ25CLGNBQU0sY0FBYyxnQkFBZ0I7QUFDcEMsWUFBSSxXQUFXLFlBQVksYUFBYTtBQUN0QyxxQkFBVyxZQUFZO0FBQUEsUUFDekIsT0FBTztBQUNMLHNCQUFZLFdBQVc7QUFBQSxRQUN6QjtBQUFBLE1BQ0Y7QUFHQSxZQUFNLGFBQWEsU0FBUyxjQUFjLFFBQVE7QUFDbEQsaUJBQVcsUUFBUTtBQUNuQixpQkFBVyxTQUFTO0FBQ3BCLFlBQU0sVUFBVSxXQUFXLFdBQVcsSUFBSTtBQUMxQyxjQUFRLHdCQUF3QjtBQUNoQyxjQUFRLFVBQVUsS0FBSyxLQUFLLEdBQUcsR0FBRyxVQUFVLFNBQVM7QUFHckQsWUFBTSxhQUFhLFdBQVcsVUFBVTtBQUN4QyxXQUFLLElBQUksTUFBTTtBQUNmLFdBQUssV0FBVztBQUVoQixZQUFNLElBQUksUUFBUSxhQUFXO0FBQzNCLGFBQUssSUFBSSxTQUFTLFlBQVk7QUFDNUIsZUFBSyxTQUFTLE1BQU0sa0JBQWtCLEtBQUssR0FBRztBQUM5QyxlQUFLLGFBQWEsS0FBSyxPQUFPO0FBQzlCLGVBQUssY0FBYyxLQUFLLE9BQU87QUFDL0IsZUFBSyxjQUFjLEtBQUssYUFBYSxLQUFLO0FBQzFDLGtCQUFRO0FBQUEsUUFDVjtBQUFBLE1BQ0YsQ0FBQztBQUVELFVBQUksd0NBQXdDLGFBQWEsT0FBSSxjQUFjLFdBQU0sS0FBSyxVQUFVLE9BQUksS0FBSyxXQUFXLEVBQUU7QUFFdEgsYUFBTztBQUFBLFFBQ0wsT0FBTyxLQUFLO0FBQUEsUUFDWixRQUFRLEtBQUs7QUFBQSxNQUNmO0FBQUEsSUFDRjtBQUFBO0FBQUE7QUFBQTtBQUFBLElBS0EsZUFBZTtBQUNiLGFBQU87QUFBQSxRQUNMLE9BQU8sS0FBSztBQUFBLFFBQ1osUUFBUSxLQUFLO0FBQUEsUUFDYixhQUFhLEtBQUs7QUFBQSxRQUNsQixnQkFBZ0IsS0FBSztBQUFBLFFBQ3JCLGNBQWMsS0FBSztBQUFBLFFBQ25CLGNBQWMsS0FBSztBQUFBLFFBQ25CLFFBQVEsQ0FBQyxHQUFHLEtBQUssTUFBTTtBQUFBLFFBQ3ZCLGNBQWMsS0FBSyxnQkFBZ0I7QUFBQTtBQUFBLFFBRW5DLFFBQVEsS0FBSyxtQkFBbUI7QUFBQSxNQUNsQztBQUFBLElBQ0Y7QUFBQTtBQUFBO0FBQUE7QUFBQSxJQUtBLGdCQUFnQixXQUFXLEtBQUssWUFBWSxLQUFLO0FBQy9DLFVBQUksQ0FBQyxLQUFLLElBQUssUUFBTztBQUV0QixZQUFNLFNBQVMsU0FBUyxjQUFjLFFBQVE7QUFDOUMsWUFBTSxNQUFNLE9BQU8sV0FBVyxJQUFJO0FBRWxDLFlBQU0sRUFBRSxPQUFPLFdBQVcsUUFBUSxXQUFXLElBQUksS0FBSztBQUN0RCxZQUFNLGNBQWMsWUFBWTtBQUVoQyxVQUFJLFVBQVU7QUFDZCxVQUFJLFdBQVcsWUFBWSxhQUFhO0FBQ3RDLG9CQUFZO0FBQ1osbUJBQVcsWUFBWTtBQUFBLE1BQ3pCLE9BQU87QUFDTCxtQkFBVztBQUNYLG9CQUFZLFdBQVc7QUFBQSxNQUN6QjtBQUVBLGFBQU8sUUFBUTtBQUNmLGFBQU8sU0FBUztBQUNoQixVQUFJLHdCQUF3QjtBQUM1QixVQUFJLFVBQVUsS0FBSyxLQUFLLEdBQUcsR0FBRyxVQUFVLFNBQVM7QUFFakQsYUFBTyxPQUFPLFVBQVU7QUFBQSxJQUMxQjtBQUFBLElBRUEsZ0JBQWdCO0FBQ2QsYUFBTztBQUFBLFFBQ0wsT0FBTyxLQUFLO0FBQUEsUUFDWixRQUFRLEtBQUs7QUFBQSxNQUNmO0FBQUEsSUFDRjtBQUFBLEVBQ0Y7OztBQy9rQk8sTUFBTSxRQUFRLENBQUMsT0FBTyxJQUFJLFFBQVEsT0FBSyxXQUFXLEdBQUcsRUFBRSxDQUFDOzs7QUNFL0QsTUFBTSxPQUFPO0FBRWIsaUJBQXNCLGFBQWE7QUFKbkM7QUFLRSxRQUFJO0FBQ0YsWUFBTSxLQUFLLE1BQU0sTUFBTSxHQUFHLElBQUksT0FBTyxFQUFFLGFBQWEsVUFBVSxDQUFDLEVBQUUsS0FBSyxPQUFLLEVBQUUsS0FBSyxDQUFDO0FBQ25GLFlBQU0sT0FBTyxNQUFNO0FBQ25CLFlBQU0sS0FBSSx5QkFBSSxZQUFXLENBQUM7QUFDMUIsWUFBTSxVQUFVO0FBQUEsUUFDZCxRQUFPLE9BQUUsVUFBRixZQUFXO0FBQUE7QUFBQSxRQUNsQixNQUFLLE9BQUUsUUFBRixZQUFTO0FBQUE7QUFBQSxRQUNkLGFBQVksT0FBRSxlQUFGLFlBQWdCO0FBQUEsTUFDOUI7QUFFQSxhQUFPO0FBQUEsUUFDTCxTQUFTO0FBQUEsUUFDVCxNQUFNO0FBQUEsVUFDSjtBQUFBLFVBQ0EsU0FBUyxRQUFRO0FBQUEsVUFDakIsWUFBWSxRQUFRO0FBQUEsVUFDcEIsYUFBYSxRQUFRO0FBQUEsUUFDdkI7QUFBQSxNQUNGO0FBQUEsSUFDRixTQUFTLE9BQU87QUFDZCxhQUFPO0FBQUEsUUFDTCxTQUFTO0FBQUEsUUFDVCxPQUFPLE1BQU07QUFBQSxRQUNiLE1BQU07QUFBQSxVQUNKLE1BQU07QUFBQSxVQUNOLFNBQVM7QUFBQSxVQUNULFlBQVk7QUFBQSxVQUNaLGFBQWE7QUFBQSxRQUNmO0FBQUEsTUFDRjtBQUFBLElBQ0Y7QUFBQSxFQUNGO0FBa0lBLGlCQUFzQixvQkFBb0IsT0FBTyxPQUFPLFFBQVEsUUFBUSxnQkFBZ0I7QUFDdEYsUUFBSTtBQUNGLFlBQU0sT0FBTyxLQUFLLFVBQVU7QUFBQSxRQUMxQjtBQUFBLFFBQ0E7QUFBQSxRQUNBLEdBQUc7QUFBQSxNQUNMLENBQUM7QUFFRCxZQUFNLFdBQVcsTUFBTSxNQUFNLEdBQUcsSUFBSSxhQUFhLEtBQUssSUFBSSxLQUFLLElBQUk7QUFBQSxRQUNqRSxRQUFRO0FBQUEsUUFDUixhQUFhO0FBQUEsUUFDYixTQUFTLEVBQUUsZ0JBQWdCLDJCQUEyQjtBQUFBLFFBQ3REO0FBQUEsTUFDRixDQUFDO0FBRUQsVUFBSSxlQUFlO0FBQ25CLFVBQUk7QUFDRix1QkFBZSxNQUFNLFNBQVMsS0FBSztBQUFBLE1BQ3JDLFFBQVE7QUFDTix1QkFBZSxDQUFDO0FBQUEsTUFDbEI7QUFFQSxhQUFPO0FBQUEsUUFDTCxRQUFRLFNBQVM7QUFBQSxRQUNqQixNQUFNO0FBQUEsUUFDTixTQUFTLFNBQVM7QUFBQSxRQUNsQixVQUFTLDZDQUFjLFlBQVc7QUFBQSxNQUNwQztBQUFBLElBQ0YsU0FBUyxPQUFPO0FBQ2QsYUFBTztBQUFBLFFBQ0wsUUFBUTtBQUFBLFFBQ1IsTUFBTSxFQUFFLE9BQU8sTUFBTSxRQUFRO0FBQUEsUUFDN0IsU0FBUztBQUFBLFFBQ1QsU0FBUztBQUFBLE1BQ1g7QUFBQSxJQUNGO0FBQUEsRUFDRjs7O0FDMU1BLE1BQUksU0FBUztBQUViLGlCQUFzQixnQkFBZ0I7QUFDcEMsUUFBSSxVQUFVLE9BQU8sVUFBVztBQUVoQyxXQUFPLElBQUksUUFBUSxDQUFDLFNBQVMsV0FBVztBQUN0QyxZQUFNLElBQUksU0FBUyxjQUFjLFFBQVE7QUFDekMsUUFBRSxNQUFNO0FBQ1IsUUFBRSxRQUFRO0FBQ1YsUUFBRSxRQUFRO0FBQ1YsUUFBRSxTQUFTLE1BQU07QUFDZixpQkFBUztBQUNULGdCQUFRO0FBQUEsTUFDVjtBQUNBLFFBQUUsVUFBVSxNQUFNLE9BQU8sSUFBSSxNQUFNLDZCQUE2QixDQUFDO0FBQ2pFLGVBQVMsS0FBSyxZQUFZLENBQUM7QUFBQSxJQUM3QixDQUFDO0FBQUEsRUFDSDtBQUVBLGlCQUFzQixpQkFBaUIsU0FBUyxTQUFTLFNBQVM7QUFuQmxFO0FBb0JFLFVBQU0sY0FBYztBQUVwQixRQUFJLFNBQU8sWUFBTyxjQUFQLG1CQUFrQixhQUFZLFlBQVk7QUFDbkQsVUFBSTtBQUNGLGNBQU0sUUFBUSxNQUFNLE9BQU8sVUFBVSxRQUFRLFNBQVMsRUFBRSxPQUFPLENBQUM7QUFDaEUsWUFBSSxTQUFTLE1BQU0sU0FBUyxHQUFJLFFBQU87QUFBQSxNQUN6QyxRQUFRO0FBQUEsTUFFUjtBQUFBLElBQ0Y7QUFHQSxXQUFPLE1BQU0sSUFBSSxRQUFRLENBQUMsWUFBWTtBQUNwQyxZQUFNLE9BQU8sU0FBUyxjQUFjLEtBQUs7QUFDekMsV0FBSyxNQUFNLFdBQVc7QUFDdEIsV0FBSyxNQUFNLE9BQU87QUFDbEIsZUFBUyxLQUFLLFlBQVksSUFBSTtBQUM5QixhQUFPLFVBQVUsT0FBTyxNQUFNO0FBQUEsUUFDNUIsU0FBUztBQUFBLFFBQ1QsVUFBVSxDQUFDQSxPQUFNO0FBQ2YsbUJBQVMsS0FBSyxZQUFZLElBQUk7QUFDOUIsa0JBQVFBLEVBQUM7QUFBQSxRQUNYO0FBQUEsTUFDRixDQUFDO0FBQUEsSUFDSCxDQUFDO0FBQUEsRUFDSDtBQUdBLGlCQUFzQixrQkFBa0IsU0FBUztBQUMvQyxXQUFPLGlCQUFpQixTQUFTLE9BQU87QUFBQSxFQUMxQztBQUlPLFdBQVMsY0FBYyxXQUFXLElBQUk7QUF0RDdDO0FBdURFLFFBQUk7QUFFRixZQUFNLEtBQUssU0FBUyxjQUFjLGdCQUFnQjtBQUNsRCxVQUFJLElBQUk7QUFDTixjQUFNLE1BQU0sR0FBRyxhQUFhLGNBQWM7QUFDMUMsWUFBSSxPQUFPLElBQUksU0FBUyxHQUFJLFFBQU87QUFBQSxNQUNyQztBQUVBLFlBQU0sS0FBSyxTQUFTLGNBQWMsZUFBZTtBQUNqRCxVQUFJLFFBQU0sUUFBRyxZQUFILG1CQUFZLFlBQVcsR0FBRyxRQUFRLFFBQVEsU0FBUyxJQUFJO0FBQy9ELGVBQU8sR0FBRyxRQUFRO0FBQUEsTUFDcEI7QUFFQSxVQUFJLE9BQU8sV0FBVyxlQUFlLE9BQU8sdUJBQXVCLE9BQU8sb0JBQW9CLFNBQVMsSUFBSTtBQUN6RyxlQUFPLE9BQU87QUFBQSxNQUNoQjtBQUFBLElBQ0YsUUFBUTtBQUFBLElBRVI7QUFDQSxXQUFPO0FBQUEsRUFDVDs7O0FDcEVBLGlCQUFzQixhQUFhLFdBQVcsZUFBZSxZQUFZLFlBQVksU0FBUztBQUM1RixVQUFNLEVBQUUsT0FBTyxPQUFPLElBQUk7QUFDMUIsVUFBTSxFQUFFLEdBQUcsYUFBYSxHQUFHLFlBQVksSUFBSTtBQUUzQyxRQUFJLDZCQUE2QixLQUFLLElBQUksTUFBTSxrQkFBa0IsV0FBVyxJQUFJLFdBQVcsVUFBVSxXQUFXLEtBQUssSUFBSSxXQUFXLEtBQUssR0FBRztBQUc3SSxRQUFJLENBQUMsV0FBVyxtQkFBbUIsV0FBVyxnQkFBZ0IsV0FBVyxLQUFNLFdBQVcsYUFBYSxNQUFNLEtBQUssV0FBVyxhQUFhLE1BQU0sR0FBSTtBQUNsSixVQUFJLGlDQUE4QjtBQUNsQyxpQkFBVyxrQkFBa0IsbUJBQW1CLFdBQVcsZUFBZSxXQUFXLE9BQU8sV0FBVyxLQUFLO0FBRzVHLFVBQUksV0FBVyxhQUFhLElBQUksS0FBSyxXQUFXLGFBQWEsSUFBSSxHQUFHO0FBQ2xFLG1CQUFXLGtCQUFrQixXQUFXLGdCQUFnQixPQUFPLFdBQVM7QUFDdEUsZ0JBQU0sYUFBYSxNQUFNLFNBQVMsUUFBUSxNQUFNO0FBQ2hELGdCQUFNLFlBQVksV0FBVyxhQUFhLElBQUksUUFBUSxXQUFXLGFBQWE7QUFDOUUsaUJBQU8sY0FBYztBQUFBLFFBQ3ZCLENBQUM7QUFBQSxNQUNIO0FBRUEsVUFBSSxrQkFBa0IsV0FBVyxnQkFBZ0IsTUFBTSx3QkFBcUI7QUFFNUUsVUFBSTtBQUNGLFlBQUksT0FBTyxzQkFBc0I7QUFDL0IsaUJBQU8scUJBQXFCLGFBQWE7QUFDekMsaUJBQU8scUJBQXFCLFdBQVcsSUFBSTtBQUczQyxjQUFJLFdBQVcsaUJBQWlCLFdBQVcsVUFBVSxVQUFhLFdBQVcsVUFBVSxRQUFXO0FBQ2hHLG1CQUFPLHFCQUFxQixVQUFVO0FBQUEsY0FDcEMsT0FBTyxXQUFXO0FBQUEsY0FDbEIsT0FBTyxXQUFXO0FBQUEsY0FDbEIsS0FBSyxXQUFXLGNBQWM7QUFBQSxjQUM5QixLQUFLLFdBQVcsY0FBYztBQUFBLFlBQ2hDLENBQUM7QUFBQSxVQUNIO0FBRUEsaUJBQU8scUJBQXFCLFFBQVEsV0FBVyxpQkFBaUI7QUFBQSxZQUM5RCxTQUFTO0FBQUEsWUFDVCxnQkFBZ0IsV0FBVztBQUFBLFVBQzdCLENBQUM7QUFFRCxjQUFJLHVDQUFrQyxXQUFXLGdCQUFnQixNQUFNLHFCQUFrQjtBQUFBLFFBQzNGO0FBQUEsTUFDRixTQUFTLEdBQUc7QUFDVixZQUFJLGlEQUF1QyxDQUFDO0FBQUEsTUFDOUM7QUFBQSxJQUNGO0FBRUEsUUFBSTtBQUNGLGFBQU8sV0FBVyxnQkFBZ0IsU0FBUyxLQUFLLENBQUMsV0FBVyxVQUFVO0FBRXBFLFlBQUksbUJBQW1CLEtBQUssTUFBTSxXQUFXLGNBQWM7QUFHM0QsWUFBSTtBQUNKLFlBQUksV0FBVyxnQkFBZ0IsV0FBVyxzQkFBc0IsbUJBQW1CLEdBQUc7QUFFcEYsMkJBQWlCLEtBQUssSUFBSSxrQkFBa0IsV0FBVyxnQkFBZ0IsTUFBTTtBQUM3RSxxQkFBVyxlQUFlO0FBQzFCLGNBQUksMEJBQTBCLGNBQWMsY0FBYyxnQkFBZ0IsY0FBYztBQUFBLFFBQzFGLE9BQU87QUFFTCwyQkFBaUIsS0FBSyxJQUFJLFdBQVcsZ0JBQWdCLFdBQVcsZ0JBQWdCLE1BQU07QUFBQSxRQUN4RjtBQUVBLFlBQUksbUJBQW1CLGdCQUFnQjtBQUNyQyxjQUFJLHlCQUF5QixnQkFBZ0IsSUFBSSxjQUFjLGFBQWE7QUFDNUUsZ0JBQU0sZ0JBQWdCLGlCQUFpQixrQkFBa0IsVUFBVTtBQUVuRSw2QkFBbUIsS0FBSyxNQUFNLFdBQVcsY0FBYztBQUV2RCxjQUFJLENBQUMsV0FBVyxjQUFjO0FBQzVCLDZCQUFpQixLQUFLLElBQUksV0FBVyxnQkFBZ0IsV0FBVyxnQkFBZ0IsUUFBUSxnQkFBZ0I7QUFBQSxVQUMxRztBQUNBO0FBQUEsUUFDRjtBQUdBLGNBQU0sUUFBUSxXQUFXLGdCQUFnQixPQUFPLEdBQUcsY0FBYztBQUVqRSxZQUFJLG9CQUFvQixNQUFNLE1BQU0sZ0JBQWE7QUFHakQsWUFBSTtBQUNGLGNBQUksT0FBTyxzQkFBc0I7QUFDL0IsbUJBQU8scUJBQXFCLFFBQVEsV0FBVyxpQkFBaUI7QUFBQSxjQUM5RCxTQUFTO0FBQUE7QUFBQSxjQUNULGdCQUFnQixXQUFXO0FBQUEsWUFDN0IsQ0FBQztBQUFBLFVBQ0g7QUFBQSxRQUNGLFNBQVMsR0FBRztBQUNWLGNBQUksaUVBQXVELENBQUM7QUFBQSxRQUM5RDtBQUdBLGNBQU0sU0FBUyxNQUFNLHlCQUF5QixPQUFPLFVBQVU7QUFFL0QsWUFBSSxPQUFPLFdBQVcsT0FBTyxVQUFVLEdBQUc7QUFDeEMscUJBQVcsaUJBQWlCLE9BQU87QUFHbkMscUJBQVcsaUJBQWlCLEtBQUssSUFBSSxHQUFHLFdBQVcsaUJBQWlCLE9BQU8sT0FBTztBQUNsRixjQUFJLCtCQUE0QixXQUFXLGVBQWUsUUFBUSxDQUFDLENBQUMsaUJBQWlCLE9BQU8sT0FBTyxHQUFHO0FBR3RHLGNBQUksTUFBTSxTQUFTLEdBQUc7QUFDcEIsa0JBQU0sWUFBWSxNQUFNLE1BQU0sU0FBUyxDQUFDO0FBQ3hDLHVCQUFXLGVBQWUsRUFBRSxHQUFHLFVBQVUsUUFBUSxHQUFHLFVBQVUsT0FBTztBQUFBLFVBQ3ZFO0FBRUEsY0FBSSxpQkFBaUIsT0FBTyxPQUFPLElBQUksTUFBTSxNQUFNLGdDQUE2QixXQUFXLGFBQWEsSUFBSSxXQUFXLFdBQVcsRUFBRTtBQUdwSSxnQkFBTSxnQkFBZ0IsdUJBQXVCO0FBRzdDLGdCQUFNLG1CQUFvQixXQUFXLGdCQUFnQixXQUFXLGNBQWUsS0FBSyxRQUFRLENBQUM7QUFDN0YsZ0JBQU0saUJBQWlCLEVBQUUsdUJBQXVCO0FBQUEsWUFDOUMsU0FBUyxPQUFPO0FBQUEsWUFDaEIsU0FBUztBQUFBLFlBQ1QsU0FBUyxXQUFXO0FBQUEsWUFDcEIsT0FBTyxXQUFXO0FBQUEsVUFDcEIsQ0FBQztBQUdELGNBQUksWUFBWTtBQUNkLHVCQUFXLFdBQVcsZUFBZSxXQUFXLGFBQWEsZ0JBQWdCLGFBQWE7QUFBQSxVQUM1RjtBQUdBLGdCQUFNLE1BQU0sR0FBSTtBQUFBLFFBQ2xCLFdBQVcsT0FBTyxnQkFBZ0I7QUFFaEMsY0FBSSxxRkFBK0U7QUFBQSxRQUNyRixPQUFPO0FBRUwscUJBQVcsZ0JBQWdCLFFBQVEsR0FBRyxLQUFLO0FBQzNDLGNBQUksOENBQTJDO0FBQy9DLGdCQUFNLE1BQU0sR0FBSTtBQUFBLFFBQ2xCO0FBR0EsY0FBTSxNQUFNLEdBQUc7QUFBQSxNQUNqQjtBQUVBLFVBQUksV0FBVyxVQUFVO0FBQ3ZCLFlBQUksc0NBQW1DLFdBQVcsYUFBYSxDQUFDLElBQUksV0FBVyxhQUFhLENBQUMsR0FBRztBQUNoRyxZQUFJLFlBQVk7QUFDZCxxQkFBVyxPQUFPLFdBQVcsYUFBYTtBQUFBLFFBQzVDO0FBQUEsTUFDRixPQUFPO0FBQ0wsWUFBSSx1QkFBdUIsV0FBVyxhQUFhLHNCQUFtQjtBQUN0RSxtQkFBVyxlQUFlLEVBQUUsR0FBRyxHQUFHLEdBQUcsRUFBRTtBQUN2QyxtQkFBVyxrQkFBa0IsQ0FBQztBQUU5QixZQUFJO0FBQ0YsY0FBSSxPQUFPLHNCQUFzQjtBQUMvQixtQkFBTyxxQkFBcUIsUUFBUSxDQUFDLEdBQUc7QUFBQSxjQUN0QyxTQUFTO0FBQUE7QUFBQSxjQUNULGdCQUFnQjtBQUFBLFlBQ2xCLENBQUM7QUFDRCxnQkFBSSxtREFBOEM7QUFBQSxVQUNwRDtBQUFBLFFBQ0YsU0FBUyxHQUFHO0FBQ1YsY0FBSSw4Q0FBb0MsQ0FBQztBQUFBLFFBQzNDO0FBQ0EsWUFBSSxZQUFZO0FBQ2QscUJBQVcsTUFBTSxXQUFXLGFBQWE7QUFBQSxRQUMzQztBQUFBLE1BQ0Y7QUFBQSxJQUNGLFNBQVMsT0FBTztBQUNkLFVBQUksZ0NBQWdDLEtBQUs7QUFDekMsVUFBSSxTQUFTO0FBQ1gsZ0JBQVEsS0FBSztBQUFBLE1BQ2Y7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUVBLGlCQUFzQixnQkFBZ0IsT0FBTztBQTFMN0M7QUEyTEUsUUFBSTtBQUNGLFVBQUksQ0FBQyxTQUFTLE1BQU0sV0FBVyxHQUFHO0FBQ2hDLGVBQU8sRUFBRSxTQUFTLE9BQU8sU0FBUyxHQUFHLE9BQU8sZ0JBQWE7QUFBQSxNQUMzRDtBQUdBLFlBQU0sU0FBUyxvQkFBSSxJQUFJO0FBQ3ZCLGlCQUFXLEtBQUssT0FBTztBQUNyQixjQUFNLE1BQU0sR0FBRyxFQUFFLEtBQUssSUFBSSxFQUFFLEtBQUs7QUFDakMsWUFBSSxDQUFDLE9BQU8sSUFBSSxHQUFHLEVBQUcsUUFBTyxJQUFJLEtBQUssRUFBRSxRQUFRLENBQUMsR0FBRyxRQUFRLENBQUMsR0FBRyxJQUFJLEVBQUUsT0FBTyxJQUFJLEVBQUUsTUFBTSxDQUFDO0FBQzFGLGNBQU0sU0FBUyxPQUFPLElBQUksR0FBRztBQUM3QixlQUFPLE9BQU8sS0FBSyxFQUFFLFFBQVEsRUFBRSxNQUFNO0FBQ3JDLGVBQU8sT0FBTyxLQUFLLEVBQUUsTUFBTSxNQUFNLEVBQUUsTUFBTSxTQUFTLENBQUM7QUFBQSxNQUNyRDtBQUdBLFlBQU0sVUFBVSxjQUFjLGVBQWUsT0FBTztBQUNwRCxZQUFNLFFBQVEsTUFBTSxrQkFBa0IsT0FBTztBQUU3QyxVQUFJLGVBQWU7QUFDbkIsaUJBQVcsRUFBRSxRQUFRLFFBQVEsSUFBSSxHQUFHLEtBQUssT0FBTyxPQUFPLEdBQUc7QUFDeEQsWUFBSSxPQUFPLFdBQVcsRUFBRztBQUV6QixjQUFNLFlBQVksQ0FBQztBQUNuQixpQkFBUyxJQUFJLEdBQUcsSUFBSSxPQUFPLFFBQVEsS0FBSyxHQUFHO0FBQ3pDLGdCQUFNLEtBQU0sT0FBTyxPQUFPLENBQUMsQ0FBQyxJQUFJLE1BQVEsT0FBUTtBQUNoRCxnQkFBTSxLQUFNLE9BQU8sT0FBTyxJQUFJLENBQUMsQ0FBQyxJQUFJLE1BQVEsT0FBUTtBQUVwRCxjQUFJLE9BQU8sU0FBUyxDQUFDLEtBQUssT0FBTyxTQUFTLENBQUMsR0FBRztBQUM1QyxzQkFBVSxLQUFLLEdBQUcsQ0FBQztBQUFBLFVBQ3JCO0FBQUEsUUFDRjtBQUVBLFlBQUk7QUFDRixjQUFJLE9BQU8sS0FBSyxPQUFPLEdBQUcsT0FBTyxLQUFLLE9BQU87QUFDN0MsbUJBQVMsSUFBSSxHQUFHLElBQUksVUFBVSxRQUFRLEtBQUssR0FBRztBQUM1QyxrQkFBTSxJQUFJLFVBQVUsQ0FBQyxHQUFHLElBQUksVUFBVSxJQUFJLENBQUM7QUFDM0MsZ0JBQUksSUFBSSxLQUFNLFFBQU87QUFBRyxnQkFBSSxJQUFJLEtBQU0sUUFBTztBQUM3QyxnQkFBSSxJQUFJLEtBQU0sUUFBTztBQUFHLGdCQUFJLElBQUksS0FBTSxRQUFPO0FBQUEsVUFDL0M7QUFDQSxjQUFJLHVCQUF1QixFQUFFLElBQUksRUFBRSxLQUFLLE9BQU8sTUFBTSxZQUFZLElBQUksSUFBSSxJQUFJLFFBQVEsSUFBSSxJQUFJLElBQUksR0FBRztBQUFBLFFBQ3RHLFNBQVMsR0FBRztBQUFBLFFBRVo7QUFFQSxjQUFNLE9BQU8sTUFBTSxvQkFBb0IsSUFBSSxJQUFJLFdBQVcsUUFBUSxLQUFLO0FBQ3ZFLFlBQUksS0FBSyxXQUFXLEtBQUs7QUFDdkIsaUJBQU87QUFBQSxZQUNMLFNBQVM7QUFBQSxZQUNULFNBQVM7QUFBQSxZQUNULFNBQU8sVUFBSyxTQUFMLG1CQUFXLFlBQVcsUUFBUSxLQUFLLE1BQU07QUFBQSxZQUNoRCxRQUFRLEtBQUs7QUFBQSxVQUNmO0FBQUEsUUFDRjtBQUNBLHdCQUFnQixLQUFLLFdBQVc7QUFBQSxNQUNsQztBQUVBLGFBQU8sRUFBRSxTQUFTLE1BQU0sU0FBUyxhQUFhO0FBQUEsSUFDaEQsU0FBUyxPQUFPO0FBQ2QsVUFBSSw2QkFBNkIsS0FBSztBQUN0QyxhQUFPO0FBQUEsUUFDTCxTQUFTO0FBQUEsUUFDVCxTQUFTO0FBQUEsUUFDVCxPQUFPLE1BQU07QUFBQSxNQUNmO0FBQUEsSUFDRjtBQUFBLEVBQ0Y7QUFHQSxpQkFBc0IseUJBQXlCLE9BQU8sWUFBWTtBQUNoRSxVQUFNLGNBQWM7QUFDcEIsVUFBTSxZQUFZO0FBRWxCLGFBQVMsVUFBVSxHQUFHLFdBQVcsYUFBYSxXQUFXO0FBQ3ZELFVBQUk7QUFDRixjQUFNLFNBQVMsTUFBTSxnQkFBZ0IsS0FBSztBQUUxQyxZQUFJLE9BQU8sU0FBUztBQUNsQixxQkFBVyxhQUFhO0FBQ3hCLGlCQUFPO0FBQUEsUUFDVDtBQUVBLG1CQUFXLGFBQWE7QUFFeEIsWUFBSSxVQUFVLGFBQWE7QUFDekIsZ0JBQU0sUUFBUSxZQUFZLEtBQUssSUFBSSxHQUFHLFVBQVUsQ0FBQztBQUNqRCxnQkFBTSxlQUFlLEtBQUssTUFBTSxRQUFRLEdBQUk7QUFHNUMsY0FBSTtBQUNKLGNBQUksT0FBTyxXQUFXLEtBQUssT0FBTyxXQUFXLGdCQUFnQjtBQUMzRCwyQkFBZSxFQUFFLG9CQUFvQjtBQUFBLFVBQ3ZDLFdBQVcsT0FBTyxVQUFVLEtBQUs7QUFDL0IsMkJBQWUsRUFBRSxtQkFBbUI7QUFBQSxVQUN0QyxXQUFXLE9BQU8sV0FBVyxLQUFLO0FBQ2hDLDJCQUFlLEVBQUUsb0JBQW9CO0FBQUEsVUFDdkMsT0FBTztBQUNMLDJCQUFlLEVBQUUsc0JBQXNCO0FBQUEsY0FDckM7QUFBQSxjQUNBO0FBQUEsY0FDQSxPQUFPO0FBQUEsWUFDVCxDQUFDO0FBQUEsVUFDSDtBQUVBLGNBQUksWUFBWTtBQUNkLHVCQUFXLFdBQVcsZUFBZSxXQUFXLGFBQWEsWUFBWTtBQUFBLFVBQzNFO0FBRUEsY0FBSSxhQUFhLE9BQU8sSUFBSSxXQUFXLGtCQUFlLFlBQVksYUFBYSxPQUFPLEtBQUssRUFBRTtBQUM3RixnQkFBTSxNQUFNLEtBQUs7QUFBQSxRQUNuQjtBQUFBLE1BRUYsU0FBUyxPQUFPO0FBQ2QsWUFBSSxvQkFBb0IsT0FBTyxLQUFLLEtBQUs7QUFDekMsbUJBQVcsYUFBYTtBQUV4QixZQUFJLFVBQVUsYUFBYTtBQUN6QixnQkFBTSxRQUFRLFlBQVksS0FBSyxJQUFJLEdBQUcsVUFBVSxDQUFDO0FBQ2pELGdCQUFNLGVBQWUsS0FBSyxNQUFNLFFBQVEsR0FBSTtBQUU1QyxnQkFBTSxlQUFlLEVBQUUsb0JBQW9CO0FBQUEsWUFDekM7QUFBQSxZQUNBO0FBQUEsWUFDQSxPQUFPO0FBQUEsVUFDVCxDQUFDO0FBRUQsY0FBSSxZQUFZO0FBQ2QsdUJBQVcsV0FBVyxlQUFlLFdBQVcsYUFBYSxZQUFZO0FBQUEsVUFDM0U7QUFFQSxnQkFBTSxNQUFNLEtBQUs7QUFBQSxRQUNuQjtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBRUEsZUFBVyxhQUFhO0FBQ3hCLFVBQU0sY0FBYyxFQUFFLHFCQUFxQixFQUFFLFlBQVksQ0FBQztBQUUxRCxRQUFJLFlBQVk7QUFDZCxpQkFBVyxXQUFXLGVBQWUsV0FBVyxhQUFhLFdBQVc7QUFBQSxJQUMxRTtBQUVBLFFBQUksMEJBQW9CLFdBQVcsMkNBQTJDO0FBRzlFLFdBQU87QUFBQSxNQUNMLFNBQVM7QUFBQSxNQUNULFNBQVM7QUFBQSxNQUNULE9BQU8sMEJBQW9CLFdBQVc7QUFBQSxNQUN0QyxnQkFBZ0I7QUFBQTtBQUFBLElBQ2xCO0FBQUEsRUFDRjtBQXVEQSxpQkFBZSxnQkFBZ0IsZUFBZSxZQUFZO0FBQ3hELFVBQU0sYUFBYSxlQUFlLGtCQUFrQjtBQUNwRCxVQUFNLFdBQVcsYUFBYTtBQUU5QixRQUFJLGFBQWEsS0FBSyxNQUFNLFdBQVMsR0FBSSxDQUFDLGtCQUFrQixhQUFhLFNBQVM7QUFHbEYsZUFBVyxhQUFhO0FBQ3hCLGVBQVcsa0JBQWtCLEtBQUssSUFBSSxJQUFJO0FBQzFDLGVBQVcsb0JBQW9CLEtBQUssTUFBTSxXQUFXLEdBQUk7QUFFekQsUUFBSSxZQUFZO0FBQ2QsWUFBTSxVQUFVLEtBQUssTUFBTSxXQUFXLEdBQUs7QUFDM0MsWUFBTSxVQUFVLEtBQUssTUFBTyxXQUFXLE1BQVMsR0FBSTtBQUNwRCxZQUFNLFdBQVcsVUFBVSxJQUFJLEdBQUcsT0FBTyxLQUFLLE9BQU8sTUFBTSxHQUFHLE9BQU87QUFDckUsWUFBTSxVQUFVLEVBQUUsNkJBQTZCO0FBQUEsUUFDN0MsU0FBUyxLQUFLLE1BQU0sV0FBVyxjQUFjO0FBQUEsUUFDN0MsUUFBUTtBQUFBLFFBQ1IsTUFBTTtBQUFBLE1BQ1IsQ0FBQztBQUNELGlCQUFXLFdBQVcsZUFBZSxXQUFXLGFBQWEsT0FBTztBQUFBLElBQ3RFO0FBR0EsYUFBUyxJQUFJLEtBQUssTUFBTSxXQUFTLEdBQUksR0FBRyxJQUFJLEdBQUcsS0FBSztBQUNsRCxVQUFJLFdBQVcsU0FBVTtBQUV6QixpQkFBVyxvQkFBb0I7QUFHL0IsVUFBSSxlQUFlLElBQUksTUFBTSxLQUFLLEtBQUssTUFBTSxNQUFNLEtBQUssTUFBTSxXQUFTLEdBQUksSUFBSTtBQUM3RSxjQUFNLFVBQVUsS0FBSyxNQUFNLElBQUksRUFBRTtBQUNqQyxjQUFNLFVBQVUsSUFBSTtBQUNwQixjQUFNLFdBQVcsVUFBVSxJQUFJLEdBQUcsT0FBTyxLQUFLLE9BQU8sTUFBTSxHQUFHLE9BQU87QUFDckUsY0FBTSxVQUFVLEVBQUUsaUNBQWlDO0FBQUEsVUFDakQsU0FBUyxLQUFLLE1BQU0sV0FBVyxjQUFjO0FBQUEsVUFDN0MsUUFBUTtBQUFBLFVBQ1IsTUFBTTtBQUFBLFFBQ1IsQ0FBQztBQUNELG1CQUFXLFdBQVcsZUFBZSxXQUFXLGFBQWEsT0FBTztBQUFBLE1BQ3RFO0FBRUEsWUFBTSxNQUFNLEdBQUk7QUFBQSxJQUNsQjtBQUVBLGVBQVcsYUFBYTtBQUN4QixlQUFXLG9CQUFvQjtBQUcvQixlQUFXLGlCQUFpQixLQUFLO0FBQUEsTUFDL0IsV0FBVyxjQUFjO0FBQUE7QUFBQSxNQUN6QixXQUFXLGlCQUFrQixXQUFXLGVBQWU7QUFBQSxJQUN6RDtBQUFBLEVBQ0Y7QUFFQSxXQUFTLG1CQUFtQixXQUFXLGVBQWUsV0FBVyxXQUFXO0FBQzFFLFVBQU0sRUFBRSxPQUFPLElBQUk7QUFDbkIsVUFBTSxFQUFFLEdBQUcsYUFBYSxHQUFHLFlBQVksSUFBSTtBQUMzQyxVQUFNLFFBQVEsQ0FBQztBQUdmLFFBQUksQ0FBQyxNQUFNLFFBQVEsTUFBTSxHQUFHO0FBQzFCLFVBQUksdURBQWtELE9BQU8sTUFBTSxJQUFJLE1BQU07QUFDN0UsYUFBTyxDQUFDO0FBQUEsSUFDVjtBQUVBLGVBQVcsYUFBYSxRQUFRO0FBQzlCLFVBQUksQ0FBQyxVQUFXO0FBS2hCLFlBQU0sU0FBUyxVQUFVLFdBQVcsU0FBWSxVQUFVLFNBQVMsVUFBVTtBQUM3RSxZQUFNLFNBQVMsVUFBVSxXQUFXLFNBQVksVUFBVSxTQUFTLFVBQVU7QUFDN0UsWUFBTSxhQUFhLFVBQVUsVUFBVSxTQUFZLFVBQVUsUUFBUSxVQUFVO0FBRS9FLFVBQUksV0FBVyxVQUFhLFdBQVcsUUFBVztBQUNoRCxZQUFJLHVEQUF1QyxTQUFTO0FBQ3BEO0FBQUEsTUFDRjtBQUdBLFlBQU0sVUFBVSxjQUFjO0FBQzlCLFlBQU0sVUFBVSxjQUFjO0FBQzlCLFlBQU0sY0FBYyxLQUFLLE1BQU0sVUFBVSxHQUFJO0FBQzdDLFlBQU0sY0FBYyxLQUFLLE1BQU0sVUFBVSxHQUFJO0FBQzdDLFlBQU0sS0FBSyxZQUFZO0FBQ3ZCLFlBQU0sS0FBSyxZQUFZO0FBQ3ZCLFlBQU0sVUFBVyxVQUFVLE1BQVEsT0FBUTtBQUMzQyxZQUFNLFVBQVcsVUFBVSxNQUFRLE9BQVE7QUFFM0MsWUFBTSxLQUFLO0FBQUEsUUFDVCxRQUFRO0FBQUEsUUFDUixRQUFRO0FBQUEsUUFDUjtBQUFBLFFBQ0E7QUFBQSxRQUNBLE9BQU87QUFBQSxRQUNQLE9BQU87QUFBQSxRQUNQLE9BQU87QUFBQSxRQUNQLGVBQWUsVUFBVTtBQUFBLE1BQzNCLENBQUM7QUFBQSxJQUNIO0FBRUEsUUFBSSxnQ0FBNkIsTUFBTSxNQUFNLHlCQUFzQjtBQUNuRSxXQUFPO0FBQUEsRUFDVDtBQUVBLFdBQVMseUJBQXlCO0FBQ2hDLFFBQUksQ0FBQyxXQUFXLG1CQUFtQixXQUFXLGdCQUFnQixXQUFXLEdBQUc7QUFDMUUsYUFBTztBQUFBLElBQ1Q7QUFFQSxVQUFNLGtCQUFrQixXQUFXLGdCQUFnQjtBQUNuRCxVQUFNLFlBQVksV0FBVztBQUM3QixVQUFNLGtCQUFrQixlQUFlLGtCQUFrQjtBQUd6RCxVQUFNLGdCQUFnQixLQUFLLEtBQUssa0JBQWtCLFNBQVM7QUFHM0QsVUFBTSx5QkFBeUIsWUFBWTtBQUczQyxVQUFNLGlCQUFpQixnQkFBZ0IsS0FBSztBQUM1QyxVQUFNLGdCQUFnQixnQkFBZ0I7QUFFdEMsV0FBTyxLQUFLLEtBQUssZ0JBQWdCLGFBQWE7QUFBQSxFQUNoRDtBQUlPLFdBQVMsZUFBZTtBQUM3QixlQUFXLFdBQVc7QUFDdEIsZUFBVyxVQUFVO0FBQ3JCLFFBQUksNENBQXFDO0FBQUEsRUFDM0M7OztBQzdnQk8sV0FBUyxhQUFhLFdBQVcsTUFBTTtBQUM1QyxRQUFJO0FBQ0YsVUFBSSxDQUFDLFdBQVcsYUFBYSxXQUFXLGtCQUFrQixHQUFHO0FBQzNELGNBQU0sSUFBSSxNQUFNLDhCQUE4QjtBQUFBLE1BQ2hEO0FBRUEsWUFBTSxlQUFlO0FBQUEsUUFDbkIsU0FBUztBQUFBLFFBQ1QsV0FBVyxLQUFLLElBQUk7QUFBQSxRQUNwQixXQUFXO0FBQUEsVUFDVCxPQUFPLFdBQVcsVUFBVTtBQUFBLFVBQzVCLFFBQVEsV0FBVyxVQUFVO0FBQUEsVUFDN0IsY0FBYyxXQUFXO0FBQUEsUUFDM0I7QUFBQSxRQUNBLFVBQVU7QUFBQSxVQUNSLGVBQWUsV0FBVztBQUFBLFVBQzFCLGFBQWEsV0FBVztBQUFBLFVBQ3hCLGNBQWMsRUFBRSxHQUFHLFdBQVcsYUFBYTtBQUFBLFFBQzdDO0FBQUEsUUFDQSxVQUFVO0FBQUEsVUFDUixlQUFlLEVBQUUsR0FBRyxXQUFXLGNBQWM7QUFBQSxVQUM3QyxPQUFPLFdBQVc7QUFBQSxVQUNsQixPQUFPLFdBQVc7QUFBQSxRQUNwQjtBQUFBLFFBQ0EsUUFBUTtBQUFBLFVBQ04sZ0JBQWdCLFdBQVc7QUFBQSxVQUMzQixvQkFBb0IsV0FBVztBQUFBLFVBQy9CLGNBQWMsV0FBVztBQUFBLFVBQ3pCLFlBQVksV0FBVztBQUFBLFFBQ3pCO0FBQUE7QUFBQSxRQUVBLFFBQVEsV0FBVyxnQkFBZ0IsSUFBSSxZQUFVO0FBQUEsVUFDL0MsSUFBSSxNQUFNO0FBQUEsVUFDVixHQUFHLE1BQU07QUFBQSxVQUNULEdBQUcsTUFBTTtBQUFBLFVBQ1QsR0FBRyxNQUFNO0FBQUEsUUFDWCxFQUFFO0FBQUEsUUFDRixpQkFBaUIsV0FBVyxtQkFBbUIsQ0FBQztBQUFBLE1BQ2xEO0FBSUEsWUFBTSxVQUFVLEtBQUssVUFBVSxjQUFjLE1BQU0sQ0FBQztBQUNwRCxZQUFNLE9BQU8sSUFBSSxPQUFPLEtBQUssQ0FBQyxPQUFPLEdBQUcsRUFBRSxNQUFNLG1CQUFtQixDQUFDO0FBRXBFLFlBQU0sZ0JBQWdCLFlBQVksbUJBQW1CLFdBQVcscUJBQXFCLE9BQU8sS0FBSSxvQkFBSSxLQUFLLEdBQUUsWUFBWSxFQUFFLE1BQU0sR0FBRyxFQUFFLEVBQUUsUUFBUSxNQUFNLEdBQUcsQ0FBQztBQUd4SixZQUFNLE1BQU0sT0FBTyxJQUFJLGdCQUFnQixJQUFJO0FBQzNDLFlBQU0sT0FBTyxTQUFTLGNBQWMsR0FBRztBQUN2QyxXQUFLLE9BQU87QUFDWixXQUFLLFdBQVc7QUFDaEIsZUFBUyxLQUFLLFlBQVksSUFBSTtBQUM5QixXQUFLLE1BQU07QUFDWCxlQUFTLEtBQUssWUFBWSxJQUFJO0FBQzlCLGFBQU8sSUFBSSxnQkFBZ0IsR0FBRztBQUU5QixVQUFJLDZCQUF3QixhQUFhLEVBQUU7QUFDM0MsYUFBTyxFQUFFLFNBQVMsTUFBTSxVQUFVLGNBQWM7QUFBQSxJQUVsRCxTQUFTLE9BQU87QUFDZCxVQUFJLG9DQUErQixLQUFLO0FBQ3hDLGFBQU8sRUFBRSxTQUFTLE9BQU8sT0FBTyxNQUFNLFFBQVE7QUFBQSxJQUNoRDtBQUFBLEVBQ0Y7QUFFQSxpQkFBc0IsYUFBYSxNQUFNO0FBQ3ZDLFdBQU8sSUFBSSxRQUFRLENBQUMsWUFBWTtBQUM5QixVQUFJO0FBQ0YsY0FBTSxTQUFTLElBQUksT0FBTyxXQUFXO0FBRXJDLGVBQU8sU0FBUyxDQUFDLE1BQU07QUFDckIsY0FBSTtBQUNGLGtCQUFNLGVBQWUsS0FBSyxNQUFNLEVBQUUsT0FBTyxNQUFNO0FBRy9DLGtCQUFNLGlCQUFpQixDQUFDLGFBQWEsWUFBWSxZQUFZLFFBQVE7QUFDckUsa0JBQU0sZ0JBQWdCLGVBQWUsT0FBTyxXQUFTLEVBQUUsU0FBUyxhQUFhO0FBRTdFLGdCQUFJLGNBQWMsU0FBUyxHQUFHO0FBQzVCLG9CQUFNLElBQUksTUFBTSxnQ0FBZ0MsY0FBYyxLQUFLLElBQUksQ0FBQyxFQUFFO0FBQUEsWUFDNUU7QUFHQSxnQkFBSSxXQUFXLGdCQUFnQixTQUFTLEdBQUc7QUFDekMsb0JBQU0sZ0JBQWdCLGFBQWEsT0FBTyxJQUFJLE9BQUssRUFBRSxFQUFFO0FBQ3ZELG9CQUFNLGtCQUFrQixXQUFXLGdCQUFnQixJQUFJLE9BQUssRUFBRSxFQUFFO0FBQ2hFLG9CQUFNLGVBQWUsY0FBYyxPQUFPLFFBQU0sZ0JBQWdCLFNBQVMsRUFBRSxDQUFDO0FBRTVFLGtCQUFJLGFBQWEsU0FBUyxjQUFjLFNBQVMsS0FBSztBQUNwRCxvQkFBSSxnRkFBc0U7QUFBQSxjQUM1RTtBQUFBLFlBQ0Y7QUFHQSx1QkFBVyxZQUFZO0FBQUEsY0FDckIsR0FBRyxhQUFhO0FBQUEsY0FDaEIsUUFBUSxDQUFDO0FBQUE7QUFBQSxZQUNYO0FBRUEsdUJBQVcsZ0JBQWdCLGFBQWEsU0FBUztBQUNqRCx1QkFBVyxjQUFjLGFBQWEsU0FBUztBQUcvQyxnQkFBSSxhQUFhLFNBQVMsY0FBYztBQUV0Qyx5QkFBVyxlQUFlLGFBQWEsU0FBUztBQUFBLFlBQ2xELFdBQVcsYUFBYSxTQUFTLFVBQVUsVUFBYSxhQUFhLFNBQVMsVUFBVSxRQUFXO0FBRWpHLHlCQUFXLGVBQWUsRUFBRSxHQUFHLGFBQWEsU0FBUyxPQUFPLEdBQUcsYUFBYSxTQUFTLE1BQU07QUFBQSxZQUM3RjtBQUdBLGdCQUFJLGFBQWEsU0FBUyxlQUFlO0FBRXZDLHlCQUFXLGdCQUFnQixhQUFhLFNBQVM7QUFBQSxZQUNuRCxXQUFXLGFBQWEsU0FBUyxXQUFXLFVBQWEsYUFBYSxTQUFTLFdBQVcsUUFBVztBQUVuRyx5QkFBVyxnQkFBZ0IsRUFBRSxHQUFHLGFBQWEsU0FBUyxRQUFRLEdBQUcsYUFBYSxTQUFTLE9BQU87QUFBQSxZQUNoRztBQUVBLHVCQUFXLFFBQVEsYUFBYSxTQUFTO0FBQ3pDLHVCQUFXLFFBQVEsYUFBYSxTQUFTO0FBQ3pDLHVCQUFXLG9CQUFvQixhQUFhLFVBQVU7QUFHdEQsdUJBQVcsa0JBQWtCLGFBQWEsbUJBQW1CLGFBQWEsU0FBUyxtQkFBbUIsQ0FBQztBQUd2RyxnQkFBSTtBQUNGLGtCQUFJLE9BQU8sc0JBQXNCO0FBQy9CLHVCQUFPLHFCQUFxQixhQUFhO0FBQ3pDLHVCQUFPLHFCQUFxQixXQUFXLElBQUk7QUFHM0Msb0JBQUksV0FBVyxpQkFBaUIsV0FBVyxVQUFVLFVBQWEsV0FBVyxVQUFVLFFBQVc7QUFDaEcseUJBQU8scUJBQXFCLFVBQVU7QUFBQSxvQkFDcEMsT0FBTyxXQUFXO0FBQUEsb0JBQ2xCLE9BQU8sV0FBVztBQUFBLG9CQUNsQixLQUFLLFdBQVcsY0FBYztBQUFBLG9CQUM5QixLQUFLLFdBQVcsY0FBYztBQUFBLGtCQUNoQyxDQUFDO0FBQ0Qsc0JBQUksNkRBQXFELFdBQVcsS0FBSyxJQUFJLFdBQVcsS0FBSyxXQUFXLFdBQVcsY0FBYyxDQUFDLElBQUksV0FBVyxjQUFjLENBQUMsR0FBRztBQUFBLGdCQUNySztBQUVBLHVCQUFPLHFCQUFxQixRQUFRLFdBQVcsaUJBQWlCO0FBQUEsa0JBQzlELFNBQVM7QUFBQSxrQkFDVCxnQkFBZ0IsV0FBVztBQUFBLGdCQUM3QixDQUFDO0FBRUQsb0JBQUksb0NBQStCLFdBQVcsZ0JBQWdCLE1BQU0sdUJBQW9CO0FBQUEsY0FDMUY7QUFBQSxZQUNGLFNBQVNDLElBQUc7QUFDVixrQkFBSSxpRUFBdURBLEVBQUM7QUFBQSxZQUM5RDtBQUVBLGdCQUFJLGFBQWEsUUFBUTtBQUN2Qix5QkFBVyxpQkFBaUIsYUFBYSxPQUFPLGtCQUFrQixXQUFXO0FBQzdFLHlCQUFXLHFCQUFxQixhQUFhLE9BQU8sdUJBQXVCLFNBQ3pFLGFBQWEsT0FBTyxxQkFBcUIsV0FBVztBQUN0RCx5QkFBVyxlQUFlLGFBQWEsT0FBTyxpQkFBaUIsU0FDN0QsYUFBYSxPQUFPLGVBQWU7QUFDckMseUJBQVcsYUFBYSxhQUFhLE9BQU8sY0FBYyxXQUFXO0FBQUEsWUFDdkU7QUFHQSx1QkFBVyxjQUFjO0FBQ3pCLHVCQUFXLGdCQUFnQjtBQUkzQixnQkFBSSw0QkFBdUIsV0FBVyxhQUFhLElBQUksV0FBVyxXQUFXLGFBQVU7QUFFdkYsb0JBQVE7QUFBQSxjQUNOLFNBQVM7QUFBQSxjQUNULE1BQU07QUFBQSxjQUNOLFNBQVMsV0FBVztBQUFBLGNBQ3BCLE9BQU8sV0FBVztBQUFBLGNBQ2xCLGFBQWEsV0FBVyxnQkFBZ0IsU0FBUztBQUFBLFlBQ25ELENBQUM7QUFBQSxVQUVILFNBQVMsWUFBWTtBQUNuQixnQkFBSSwrQ0FBMEMsVUFBVTtBQUN4RCxvQkFBUSxFQUFFLFNBQVMsT0FBTyxPQUFPLFdBQVcsUUFBUSxDQUFDO0FBQUEsVUFDdkQ7QUFBQSxRQUNGO0FBRUEsZUFBTyxVQUFVLE1BQU07QUFDckIsZ0JBQU0sUUFBUTtBQUNkLGNBQUksVUFBSyxLQUFLO0FBQ2Qsa0JBQVEsRUFBRSxTQUFTLE9BQU8sTUFBTSxDQUFDO0FBQUEsUUFDbkM7QUFFQSxlQUFPLFdBQVcsSUFBSTtBQUFBLE1BRXhCLFNBQVMsT0FBTztBQUNkLFlBQUksbUNBQThCLEtBQUs7QUFDdkMsZ0JBQVEsRUFBRSxTQUFTLE9BQU8sT0FBTyxNQUFNLFFBQVEsQ0FBQztBQUFBLE1BQ2xEO0FBQUEsSUFDRixDQUFDO0FBQUEsRUFDSDtBQUVPLFdBQVMsZ0JBQWdCO0FBQzlCLGVBQVcsZ0JBQWdCO0FBQzNCLGVBQVcsY0FBYztBQUN6QixlQUFXLGVBQWUsRUFBRSxHQUFHLEdBQUcsR0FBRyxFQUFFO0FBQ3ZDLGVBQVcsa0JBQWtCLENBQUM7QUFDOUIsZUFBVyxZQUFZO0FBQ3ZCLGVBQVcsZ0JBQWdCO0FBQzNCLGVBQVcsY0FBYztBQUN6QixlQUFXLG9CQUFvQjtBQUMvQixlQUFXLGVBQWU7QUFDMUIsZUFBVyxvQkFBb0I7QUFFL0IsUUFBSSw2QkFBc0I7QUFBQSxFQUM1QjtBQUVPLFdBQVMsY0FBYztBQUM1QixXQUFPLFdBQVcsZUFDWCxXQUFXLGdCQUFnQixLQUMzQixXQUFXLG1CQUNYLFdBQVcsZ0JBQWdCLFNBQVM7QUFBQSxFQUM3QztBQUVPLFdBQVMsa0JBQWtCO0FBQ2hDLFdBQU87QUFBQSxNQUNMLGFBQWEsWUFBWTtBQUFBLE1BQ3pCLFNBQVMsV0FBVztBQUFBLE1BQ3BCLE9BQU8sV0FBVztBQUFBLE1BQ2xCLFdBQVcsV0FBVyxrQkFBa0IsV0FBVyxnQkFBZ0IsU0FBUztBQUFBLE1BQzVFLFlBQVksV0FBVyxjQUFjLElBQUssV0FBVyxnQkFBZ0IsV0FBVyxjQUFjLE1BQU87QUFBQSxNQUNyRyxjQUFjLEVBQUUsR0FBRyxXQUFXLGFBQWE7QUFBQSxNQUMzQyxhQUFhLFlBQVk7QUFBQSxJQUMzQjtBQUFBLEVBQ0Y7OztBQzdPTyxXQUFTLGlCQUFpQixTQUFTLE1BQU07QUFDOUMsVUFBTSxPQUFPLFNBQVMsY0FBYyxLQUFLO0FBQ3pDLFFBQUksUUFBUTtBQUNWLFdBQUssS0FBSztBQUFBLElBQ1o7QUFDQSxTQUFLLE1BQU0sVUFBVTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQVFyQixVQUFNLE9BQU8sS0FBSyxhQUFhLEVBQUUsTUFBTSxPQUFPLENBQUM7QUFDL0MsYUFBUyxLQUFLLFlBQVksSUFBSTtBQUU5QixXQUFPLEVBQUUsTUFBTSxLQUFLO0FBQUEsRUFDdEI7QUFFTyxXQUFTLGNBQWMsWUFBWSxTQUFTO0FBQ2pELFFBQUksT0FBTyxHQUFHLE9BQU8sR0FBRyxPQUFPLEdBQUcsT0FBTztBQUV6QyxlQUFXLE1BQU0sU0FBUztBQUMxQixlQUFXLGlCQUFpQixhQUFhLGFBQWE7QUFFdEQsYUFBUyxjQUFjLEdBQUc7QUFFeEIsVUFBSSxFQUFFLE9BQU8sUUFBUSxpQ0FBaUMsRUFBRztBQUV6RCxRQUFFLGVBQWU7QUFDakIsYUFBTyxFQUFFO0FBQ1QsYUFBTyxFQUFFO0FBQ1QsZUFBUyxpQkFBaUIsV0FBVyxnQkFBZ0I7QUFDckQsZUFBUyxpQkFBaUIsYUFBYSxXQUFXO0FBQUEsSUFDcEQ7QUFFQSxhQUFTLFlBQVksR0FBRztBQUN0QixRQUFFLGVBQWU7QUFDakIsYUFBTyxPQUFPLEVBQUU7QUFDaEIsYUFBTyxPQUFPLEVBQUU7QUFDaEIsYUFBTyxFQUFFO0FBQ1QsYUFBTyxFQUFFO0FBQ1QsY0FBUSxNQUFNLE1BQU8sUUFBUSxZQUFZLE9BQVE7QUFDakQsY0FBUSxNQUFNLE9BQVEsUUFBUSxhQUFhLE9BQVE7QUFBQSxJQUNyRDtBQUVBLGFBQVMsbUJBQW1CO0FBQzFCLGVBQVMsb0JBQW9CLFdBQVcsZ0JBQWdCO0FBQ3hELGVBQVMsb0JBQW9CLGFBQWEsV0FBVztBQUFBLElBQ3ZEO0FBQUEsRUFDRjs7O0FDL0NBLGlCQUFzQixjQUFjLEVBQUUsT0FBTyxHQUFHLFNBQVMsR0FBRztBQUMxRCxRQUFJLDBDQUFtQztBQUd2QyxRQUFJLENBQUMsU0FBUyxjQUFjLDRCQUE0QixHQUFHO0FBQ3pELFlBQU0sY0FBYyxTQUFTLGNBQWMsTUFBTTtBQUNqRCxrQkFBWSxNQUFNO0FBQ2xCLGtCQUFZLE9BQU87QUFDbkIsZUFBUyxLQUFLLFlBQVksV0FBVztBQUNyQyxVQUFJLG1EQUF5QztBQUFBLElBQy9DO0FBR0EsVUFBTSxFQUFFLE1BQU0sS0FBSyxJQUFJLGlCQUFpQjtBQUd4QyxVQUFNLFFBQVEsU0FBUyxjQUFjLE9BQU87QUFDNUMsVUFBTSxjQUFjO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFvWnBCLFNBQUssWUFBWSxLQUFLO0FBR3RCLFVBQU0sWUFBWSxTQUFTLGNBQWMsS0FBSztBQUM5QyxjQUFVLFlBQVk7QUFDdEIsY0FBVSxZQUFZO0FBQUE7QUFBQTtBQUFBO0FBQUEsZ0JBSVIsTUFBTSxLQUFLO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLHlEQU04QixNQUFNLFFBQVE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLG1CQVFwRCxNQUFNLFNBQVM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsY0FNcEIsTUFBTSxhQUFhO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLGNBTW5CLE1BQU0sZUFBZSxpQkFBaUI7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsd0JBU25DLE1BQU0sU0FBUztBQUFBO0FBQUE7QUFBQTtBQUFBLDJCQUlmLE1BQU0sYUFBYTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxrQkFTbEIsTUFBTSxPQUFPO0FBQUE7QUFBQTtBQUFBO0FBQUEsa0JBSWIsTUFBTSxXQUFXO0FBQUE7QUFBQTtBQUFBO0FBQUEsa0JBSWpCLE1BQU0sWUFBWTtBQUFBO0FBQUE7QUFBQTtBQUFBLGtCQUlsQixNQUFNLFdBQVc7QUFBQTtBQUFBO0FBQUE7QUFBQSxrQkFJakIsTUFBTSxjQUFjO0FBQUE7QUFBQTtBQUFBO0FBQUEsa0JBSXBCLE1BQU0sYUFBYTtBQUFBO0FBQUE7QUFBQTtBQUFBLGtCQUluQixNQUFNLFlBQVk7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLG1EQVdLLE1BQU0sV0FBVztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxVQU1oRCxNQUFNLFdBQVc7QUFBQTtBQUFBO0FBQUE7QUFLekIsU0FBSyxZQUFZLFNBQVM7QUFHMUIsVUFBTSxZQUFZLFNBQVMsY0FBYyxPQUFPO0FBQ2hELGNBQVUsT0FBTztBQUNqQixjQUFVLFNBQVM7QUFDbkIsY0FBVSxNQUFNLFVBQVU7QUFDMUIsU0FBSyxZQUFZLFNBQVM7QUFFMUIsVUFBTSxvQkFBb0IsU0FBUyxjQUFjLE9BQU87QUFDeEQsc0JBQWtCLE9BQU87QUFDekIsc0JBQWtCLFNBQVM7QUFDM0Isc0JBQWtCLE1BQU0sVUFBVTtBQUNsQyxTQUFLLFlBQVksaUJBQWlCO0FBR2xDLFVBQU0sZ0JBQWdCLFNBQVMsY0FBYyxLQUFLO0FBQ2xELGtCQUFjLFlBQVk7QUFDMUIsU0FBSyxZQUFZLGFBQWE7QUFFOUIsVUFBTSxrQkFBa0IsU0FBUyxjQUFjLEtBQUs7QUFDcEQsb0JBQWdCLFlBQVk7QUFDNUIsb0JBQWdCLFlBQVk7QUFBQSxVQUNwQixNQUFNLFdBQVc7QUFBQTtBQUFBO0FBQUEsVUFHakIsTUFBTSxLQUFLO0FBQUE7QUFBQTtBQUFBO0FBQUEsVUFJWCxNQUFNLE1BQU07QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLFVBS1osTUFBTSxVQUFVO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLGtCQU1SLE1BQU0sS0FBSztBQUFBO0FBQUE7QUFBQTtBQUFBLGtCQUlYLE1BQU0sTUFBTTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBSzVCLFNBQUssWUFBWSxlQUFlO0FBR2hDLFVBQU0sV0FBVztBQUFBLE1BQ2YsUUFBUSxVQUFVLGNBQWMsU0FBUztBQUFBLE1BQ3pDLFdBQVcsVUFBVSxjQUFjLGFBQWE7QUFBQSxNQUNoRCxhQUFhLFVBQVUsY0FBYyxlQUFlO0FBQUEsTUFDcEQsYUFBYSxVQUFVLGNBQWMsZUFBZTtBQUFBLE1BQ3BELGdCQUFnQixVQUFVLGNBQWMsbUJBQW1CO0FBQUEsTUFDM0QsZUFBZSxVQUFVLGNBQWMsa0JBQWtCO0FBQUEsTUFDekQsYUFBYSxVQUFVLGNBQWMsZUFBZTtBQUFBLE1BQ3BELFlBQVksVUFBVSxjQUFjLGNBQWM7QUFBQSxNQUNsRCxlQUFlLFVBQVUsY0FBYyxpQkFBaUI7QUFBQSxNQUN4RCxTQUFTLFVBQVUsY0FBYyxXQUFXO0FBQUEsTUFDNUMsV0FBVyxVQUFVLGNBQWMsYUFBYTtBQUFBLE1BQ2hELGlCQUFpQixVQUFVLGNBQWMsb0JBQW9CO0FBQUEsTUFDN0QsV0FBVyxVQUFVLGNBQWMsYUFBYTtBQUFBLE1BQ2hELGNBQWMsVUFBVSxjQUFjLGlCQUFpQjtBQUFBLE1BQ3ZELFVBQVUsVUFBVSxjQUFjLFlBQVk7QUFBQSxNQUM5QyxTQUFTLFVBQVUsY0FBYyxXQUFXO0FBQUEsTUFDNUMsYUFBYSxVQUFVLGNBQWMsZUFBZTtBQUFBLE1BQ3BELFdBQVcsVUFBVSxjQUFjLGFBQWE7QUFBQSxNQUNoRCxRQUFRLFVBQVUsY0FBYyxTQUFTO0FBQUEsTUFDekMsU0FBUyxVQUFVLGNBQWMsVUFBVTtBQUFBLElBQzdDO0FBR0EsVUFBTSxpQkFBaUI7QUFBQSxNQUNyQixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhLGdCQUFnQixjQUFjLGVBQWU7QUFBQSxNQUMxRCxjQUFjLGdCQUFnQixjQUFjLGdCQUFnQjtBQUFBLE1BQzVELFlBQVksZ0JBQWdCLGNBQWMsY0FBYztBQUFBLE1BQ3hELGFBQWEsZ0JBQWdCLGNBQWMsZUFBZTtBQUFBLE1BQzFELFlBQVksZ0JBQWdCLGNBQWMsY0FBYztBQUFBLE1BQ3hELFNBQVMsZ0JBQWdCLGNBQWMsaUJBQWlCO0FBQUEsTUFDeEQsWUFBWSxnQkFBZ0IsY0FBYyxpQkFBaUI7QUFBQSxNQUMzRCxXQUFXLGdCQUFnQixjQUFjLGdCQUFnQjtBQUFBLElBQzNEO0FBR0EsUUFBSSxRQUFRO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsSUFDakI7QUFHQSxrQkFBYyxTQUFTLFFBQVEsU0FBUztBQUd4QyxhQUFTLFlBQVksaUJBQWlCLFNBQVMsTUFBTTtBQUNuRCxZQUFNLFlBQVksQ0FBQyxNQUFNO0FBQ3pCLFVBQUksTUFBTSxXQUFXO0FBQ25CLGtCQUFVLFVBQVUsSUFBSSxXQUFXO0FBQ25DLGlCQUFTLFlBQVksWUFBWTtBQUFBLE1BQ25DLE9BQU87QUFDTCxrQkFBVSxVQUFVLE9BQU8sV0FBVztBQUN0QyxpQkFBUyxZQUFZLFlBQVk7QUFBQSxNQUNuQztBQUFBLElBQ0YsQ0FBQztBQUVELGFBQVMsVUFBVSxpQkFBaUIsU0FBUyxNQUFNO0FBQ2pELFlBQU0sZ0JBQWdCLENBQUMsTUFBTTtBQUM3QixVQUFJLE1BQU0sZUFBZTtBQUN2QixpQkFBUyxZQUFZLFVBQVUsSUFBSSxTQUFTO0FBQzVDLGlCQUFTLFVBQVUsWUFBWTtBQUFBLE1BQ2pDLE9BQU87QUFDTCxpQkFBUyxZQUFZLFVBQVUsT0FBTyxTQUFTO0FBQy9DLGlCQUFTLFVBQVUsWUFBWTtBQUFBLE1BQ2pDO0FBQUEsSUFDRixDQUFDO0FBR0QsYUFBUyxlQUFlLGlCQUFpQixVQUFVLE1BQU07QUFDdkQsWUFBTSxRQUFRLFNBQVMsU0FBUyxlQUFlLEtBQUssS0FBSztBQUN6RCxlQUFTLFdBQVcsY0FBYztBQUdsQyxVQUFJLFNBQVMsZ0JBQWdCO0FBQzNCLGlCQUFTLGVBQWUsRUFBRSxnQkFBZ0IsTUFBTSxDQUFDO0FBQUEsTUFDbkQ7QUFBQSxJQUNGLENBQUM7QUFFRCxhQUFTLGNBQWMsaUJBQWlCLFVBQVUsTUFBTTtBQUN0RCxVQUFJLFNBQVMsZ0JBQWdCO0FBQzNCLGlCQUFTLGVBQWUsRUFBRSxlQUFlLFNBQVMsY0FBYyxRQUFRLENBQUM7QUFBQSxNQUMzRTtBQUFBLElBQ0YsQ0FBQztBQUdELGFBQVMseUJBQXlCO0FBQ2hDLGVBQVMsVUFBVSxXQUFXO0FBQzlCLGVBQVMsZ0JBQWdCLFdBQVc7QUFBQSxJQUN0QztBQUVBLGFBQVMsUUFBUSxpQkFBaUIsU0FBUyxZQUFZO0FBQ3JELGVBQVMsUUFBUSxXQUFXO0FBQzVCLFVBQUksU0FBUyxXQUFXO0FBQ3RCLGNBQU0sVUFBVSxNQUFNLFNBQVMsVUFBVTtBQUN6QyxZQUFJLFNBQVM7QUFDWCxpQ0FBdUI7QUFBQSxRQUN6QjtBQUFBLE1BQ0Y7QUFDQSxlQUFTLFFBQVEsV0FBVztBQUFBLElBQzlCLENBQUM7QUFFRCxhQUFTLFVBQVUsaUJBQWlCLFNBQVMsTUFBTTtBQUNqRCxnQkFBVSxNQUFNO0FBQUEsSUFDbEIsQ0FBQztBQUVELGNBQVUsaUJBQWlCLFVBQVUsWUFBWTtBQUMvQyxVQUFJLFVBQVUsTUFBTSxTQUFTLEtBQUssU0FBUyxlQUFlO0FBQ3hELGNBQU0sVUFBVSxNQUFNLFNBQVMsY0FBYyxVQUFVLE1BQU0sQ0FBQyxDQUFDO0FBQy9ELFlBQUksU0FBUztBQUNYLG1CQUFTLGFBQWEsV0FBVztBQUNqQyxtQkFBUyxVQUFVLFdBQVc7QUFBQSxRQUNoQztBQUFBLE1BQ0Y7QUFBQSxJQUNGLENBQUM7QUFFRCxhQUFTLGdCQUFnQixpQkFBaUIsU0FBUyxNQUFNO0FBQ3ZELHdCQUFrQixNQUFNO0FBQUEsSUFDMUIsQ0FBQztBQUVELHNCQUFrQixpQkFBaUIsVUFBVSxZQUFZO0FBQ3ZELFVBQUksa0JBQWtCLE1BQU0sU0FBUyxLQUFLLFNBQVMsZ0JBQWdCO0FBQ2pFLGNBQU0sVUFBVSxNQUFNLFNBQVMsZUFBZSxrQkFBa0IsTUFBTSxDQUFDLENBQUM7QUFDeEUsWUFBSSxTQUFTO0FBQ1gsbUJBQVMsYUFBYSxXQUFXO0FBQ2pDLG1CQUFTLFNBQVMsV0FBVztBQUM3QixtQkFBUyxVQUFVLFdBQVc7QUFBQSxRQUNoQztBQUFBLE1BQ0Y7QUFBQSxJQUNGLENBQUM7QUFFRCxhQUFTLFVBQVUsaUJBQWlCLFNBQVMsTUFBTTtBQUNqRCxVQUFJLFNBQVMsZUFBZTtBQUMxQixpQkFBUyxjQUFjO0FBQUEsTUFDekI7QUFBQSxJQUNGLENBQUM7QUFFRCxhQUFTLGFBQWEsaUJBQWlCLFNBQVMsWUFBWTtBQUMxRCxVQUFJLFNBQVMsa0JBQWtCO0FBQzdCLGlCQUFTLGFBQWEsV0FBVztBQUNqQyxjQUFNLFVBQVUsTUFBTSxTQUFTLGlCQUFpQjtBQUNoRCxZQUFJLFNBQVM7QUFDWCxtQkFBUyxTQUFTLFdBQVc7QUFBQSxRQUMvQjtBQUNBLGlCQUFTLGFBQWEsV0FBVztBQUFBLE1BQ25DO0FBQUEsSUFDRixDQUFDO0FBR0QsYUFBUyxZQUFZLGlCQUFpQixVQUFVLE1BQU07QUFDcEQsVUFBSSxDQUFDLE9BQU8scUJBQXNCO0FBQ2xDLGFBQU8scUJBQXFCLGFBQWE7QUFDekMsWUFBTSxZQUFZLFNBQVMsWUFBWTtBQUN2QyxhQUFPLHFCQUFxQixXQUFXLFNBQVM7QUFBQSxJQUNsRCxDQUFDO0FBRUQsYUFBUyxTQUFTLGlCQUFpQixTQUFTLFlBQVk7QUFDdEQsVUFBSSxTQUFTLGlCQUFpQjtBQUM1QixpQkFBUyxTQUFTLFdBQVc7QUFDN0IsaUJBQVMsUUFBUSxXQUFXO0FBQzVCLGNBQU0sVUFBVSxNQUFNLFNBQVMsZ0JBQWdCO0FBQy9DLFlBQUksQ0FBQyxTQUFTO0FBQ1osbUJBQVMsU0FBUyxXQUFXO0FBQzdCLG1CQUFTLFFBQVEsV0FBVztBQUFBLFFBQzlCO0FBQUEsTUFDRjtBQUFBLElBQ0YsQ0FBQztBQUVELGFBQVMsUUFBUSxpQkFBaUIsU0FBUyxZQUFZO0FBQ3JELFVBQUksU0FBUyxnQkFBZ0I7QUFDM0IsY0FBTSxhQUFhLE1BQU0sU0FBUyxlQUFlO0FBQ2pELFlBQUksWUFBWTtBQUNkLG1CQUFTLFNBQVMsV0FBVztBQUM3QixtQkFBUyxRQUFRLFdBQVc7QUFBQSxRQUM5QjtBQUFBLE1BQ0Y7QUFBQSxJQUNGLENBQUM7QUFHRCxhQUFTLFVBQVUsU0FBUyxPQUFPLFdBQVc7QUFDNUMsZUFBUyxPQUFPLGNBQWM7QUFDOUIsZUFBUyxPQUFPLFlBQVksaUJBQWlCLElBQUk7QUFDakQsZUFBUyxPQUFPLE1BQU0sWUFBWTtBQUNsQyxXQUFLLFNBQVMsT0FBTztBQUNyQixlQUFTLE9BQU8sTUFBTSxZQUFZO0FBQUEsSUFDcEM7QUFFQSxhQUFTLGlCQUFpQixXQUFXO0FBQ25DLFlBQU0sRUFBRSxPQUFPLE9BQU8sSUFBSSxVQUFVLGNBQWM7QUFDbEQsWUFBTSxjQUFjLFFBQVE7QUFHNUIscUJBQWUsWUFBWSxRQUFRO0FBQ25DLHFCQUFlLGFBQWEsUUFBUTtBQUNwQyxxQkFBZSxXQUFXLGNBQWM7QUFDeEMscUJBQWUsWUFBWSxjQUFjO0FBQ3pDLHFCQUFlLFFBQVEsTUFBTSxVQUFVLElBQUk7QUFHM0MscUJBQWUsUUFBUSxNQUFNLFVBQVU7QUFDdkMscUJBQWUsVUFBVSxNQUFNLFVBQVU7QUFFekMsWUFBTSxnQkFBZ0IsTUFBTTtBQUMxQixjQUFNLFdBQVcsU0FBUyxlQUFlLFlBQVksS0FBSztBQUMxRCxjQUFNLFlBQVksU0FBUyxlQUFlLGFBQWEsS0FBSztBQUU1RCx1QkFBZSxXQUFXLGNBQWM7QUFDeEMsdUJBQWUsWUFBWSxjQUFjO0FBRXpDLHVCQUFlLFFBQVEsTUFBTSxVQUFVLGdCQUFnQixVQUFVLFNBQVM7QUFBQSxNQUM1RTtBQUdBLFlBQU0sZ0JBQWdCLE1BQU07QUFDMUIsWUFBSSxlQUFlLFdBQVcsU0FBUztBQUNyQyxnQkFBTSxXQUFXLFNBQVMsZUFBZSxZQUFZLEtBQUs7QUFDMUQsZ0JBQU0sWUFBWSxLQUFLLE1BQU0sV0FBVyxXQUFXO0FBQ25ELHlCQUFlLGFBQWEsUUFBUTtBQUFBLFFBQ3RDO0FBQ0Esc0JBQWM7QUFBQSxNQUNoQjtBQUVBLFlBQU0saUJBQWlCLE1BQU07QUFDM0IsWUFBSSxlQUFlLFdBQVcsU0FBUztBQUNyQyxnQkFBTSxZQUFZLFNBQVMsZUFBZSxhQUFhLEtBQUs7QUFDNUQsZ0JBQU0sV0FBVyxLQUFLLE1BQU0sWUFBWSxXQUFXO0FBQ25ELHlCQUFlLFlBQVksUUFBUTtBQUFBLFFBQ3JDO0FBQ0Esc0JBQWM7QUFBQSxNQUNoQjtBQUdBLHFCQUFlLFlBQVksaUJBQWlCLFNBQVMsYUFBYTtBQUNsRSxxQkFBZSxhQUFhLGlCQUFpQixTQUFTLGNBQWM7QUFHcEUsWUFBTSxZQUFZLE1BQU07QUFDdEIsY0FBTSxXQUFXLFNBQVMsZUFBZSxZQUFZLEtBQUs7QUFDMUQsY0FBTSxZQUFZLFNBQVMsZUFBZSxhQUFhLEtBQUs7QUFFNUQsWUFBSSxTQUFTLGlCQUFpQjtBQUM1QixtQkFBUyxnQkFBZ0IsV0FBVyxVQUFVLFNBQVM7QUFBQSxRQUN6RDtBQUVBLDBCQUFrQjtBQUFBLE1BQ3BCO0FBR0EsWUFBTSxXQUFXLE1BQU07QUFDckIsMEJBQWtCO0FBQUEsTUFDcEI7QUFFQSxxQkFBZSxXQUFXLGlCQUFpQixTQUFTLFNBQVM7QUFDN0QscUJBQWUsVUFBVSxpQkFBaUIsU0FBUyxRQUFRO0FBQzNELHFCQUFlLFFBQVEsaUJBQWlCLFNBQVMsUUFBUTtBQUd6RCxhQUFPLHNCQUFzQixNQUFNO0FBQ2pDLHVCQUFlLFlBQVksb0JBQW9CLFNBQVMsYUFBYTtBQUNyRSx1QkFBZSxhQUFhLG9CQUFvQixTQUFTLGNBQWM7QUFDdkUsdUJBQWUsV0FBVyxvQkFBb0IsU0FBUyxTQUFTO0FBQ2hFLHVCQUFlLFVBQVUsb0JBQW9CLFNBQVMsUUFBUTtBQUM5RCx1QkFBZSxRQUFRLG9CQUFvQixTQUFTLFFBQVE7QUFBQSxNQUM5RDtBQUdBLG9CQUFjO0FBQUEsSUFDaEI7QUFFQSxhQUFTLG9CQUFvQjtBQUMzQixxQkFBZSxRQUFRLE1BQU0sVUFBVTtBQUN2QyxxQkFBZSxVQUFVLE1BQU0sVUFBVTtBQUd6QyxVQUFJLE9BQU8scUJBQXFCO0FBQzlCLGVBQU8sb0JBQW9CO0FBQzNCLGVBQU8sT0FBTztBQUFBLE1BQ2hCO0FBQUEsSUFDRjtBQUVBLGFBQVMsZUFBZSxTQUFTLE9BQU8sV0FBVyxNQUFNO0FBQ3ZELFlBQU0sYUFBYSxRQUFRLElBQUssVUFBVSxRQUFTLE1BQU07QUFDekQsZUFBUyxZQUFZLE1BQU0sUUFBUSxHQUFHLFVBQVU7QUFHaEQsVUFBSSxZQUFZO0FBQUE7QUFBQSw0Q0FFaUIsTUFBTSxRQUFRO0FBQUEsZUFDcEMsT0FBTyxJQUFJLEtBQUssS0FBSyxXQUFXLFFBQVEsQ0FBQyxDQUFDO0FBQUE7QUFBQTtBQUtyRCxVQUFJLFVBQVU7QUFFWixZQUFJLFNBQVMsVUFBVTtBQUNyQix1QkFBYTtBQUFBO0FBQUEsZ0RBRW9CLE1BQU0sUUFBUTtBQUFBLG1CQUNwQyxTQUFTLFFBQVE7QUFBQTtBQUFBO0FBQUEsUUFHOUI7QUFHQSxZQUFJLFNBQVMsWUFBWSxRQUFXO0FBQ2xDLHVCQUFhO0FBQUE7QUFBQSw2Q0FFbUIsTUFBTSxPQUFPO0FBQUEsbUJBQ2xDLEtBQUssTUFBTSxTQUFTLE9BQU8sQ0FBQztBQUFBO0FBQUE7QUFBQSxRQUd6QztBQUdBLFlBQUksU0FBUyxXQUFXLFFBQVc7QUFDakMsdUJBQWE7QUFBQTtBQUFBLGdEQUVvQixNQUFNLE1BQU07QUFBQSxtQkFDbEMsU0FBUyxPQUFPLGVBQWUsQ0FBQztBQUFBO0FBQUE7QUFBQSxRQUc3QztBQUdBLFlBQUksU0FBUyxrQkFBa0IsVUFBYSxTQUFTLGdCQUFnQixHQUFHO0FBQ3RFLGdCQUFNLFFBQVEsS0FBSyxNQUFNLFNBQVMsZ0JBQWdCLElBQUk7QUFDdEQsZ0JBQU0sVUFBVSxLQUFLLE1BQU8sU0FBUyxnQkFBZ0IsT0FBUSxFQUFFO0FBQy9ELGdCQUFNLFVBQVUsUUFBUSxJQUFJLEdBQUcsS0FBSyxLQUFLLE9BQU8sTUFBTSxHQUFHLE9BQU87QUFFaEUsdUJBQWE7QUFBQTtBQUFBLDZDQUVtQixNQUFNLGFBQWE7QUFBQSxtQkFDeEMsT0FBTztBQUFBO0FBQUE7QUFBQSxRQUdwQjtBQUFBLE1BQ0Y7QUFFQSxlQUFTLFVBQVUsWUFBWTtBQUFBLElBQ2pDO0FBRUEsYUFBUyxzQkFBc0IsU0FBUztBQUN0QyxVQUFJLFVBQVUsR0FBRztBQUNmLGNBQU0sVUFBVSxLQUFLLE1BQU0sVUFBVSxFQUFFO0FBQ3ZDLGNBQU0sT0FBTyxVQUFVO0FBQ3ZCLGNBQU0sVUFBVSxVQUFVLElBQUksR0FBRyxPQUFPLEtBQUssSUFBSSxNQUFNLEdBQUcsSUFBSTtBQUM5RCxpQkFBUyxjQUFjLGNBQWM7QUFBQSxNQUN2QyxPQUFPO0FBQ0wsaUJBQVMsY0FBYyxjQUFjO0FBQUEsTUFDdkM7QUFBQSxJQUNGO0FBR0EsYUFBUyxzQkFBc0IsU0FBUztBQUN0QyxVQUFJLFdBQVcsUUFBUSxTQUFTLFFBQUcsR0FBRztBQUVwQyxpQkFBUyxPQUFPLGNBQWM7QUFDOUIsaUJBQVMsT0FBTyxZQUFZO0FBQUEsTUFFOUIsV0FBVyxTQUFTO0FBRWxCLGtCQUFVLFNBQVMsTUFBTTtBQUFBLE1BQzNCO0FBQUEsSUFDRjtBQUdBLGFBQVMsZUFBZSxlQUFlO0FBQ3JDLFVBQUksZUFBZTtBQUNqQixpQkFBUyxRQUFRLFdBQVc7QUFDNUIsaUJBQVMsUUFBUSxNQUFNLFVBQVU7QUFDakMsaUJBQVMsUUFBUSxZQUFZLGdCQUFXLE1BQU0sT0FBTztBQUFBLE1BQ3ZELE9BQU87QUFDTCxpQkFBUyxRQUFRLFdBQVc7QUFDNUIsaUJBQVMsUUFBUSxNQUFNLFVBQVU7QUFDakMsaUJBQVMsUUFBUSxZQUFZLG1CQUFZLE1BQU0sT0FBTztBQUFBLE1BQ3hEO0FBQUEsSUFDRjtBQUdBLGFBQVMscUJBQXFCLFNBQVM7QUFDckMsZUFBUyxRQUFRLE1BQU0sVUFBVSxVQUFVLFNBQVM7QUFBQSxJQUN0RDtBQUVBLGFBQVMsVUFBVTtBQUNqQixXQUFLLE9BQU87QUFBQSxJQUNkO0FBRUEsUUFBSSxzQ0FBaUM7QUFFckMsV0FBTztBQUFBLE1BQ0w7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUVPLFdBQVMsa0JBQWtCLFNBQVMsT0FBTyxVQUFVLENBQUMsR0FBRztBQUM5RCxXQUFPLElBQUksUUFBUSxDQUFDLFlBQVk7QUFDOUIsWUFBTSxVQUFVLFNBQVMsY0FBYyxLQUFLO0FBQzVDLGNBQVEsWUFBWTtBQUNwQixjQUFRLE1BQU0sV0FBVztBQUN6QixjQUFRLE1BQU0sTUFBTTtBQUNwQixjQUFRLE1BQU0sT0FBTztBQUNyQixjQUFRLE1BQU0sUUFBUTtBQUN0QixjQUFRLE1BQU0sU0FBUztBQUN2QixjQUFRLE1BQU0sYUFBYTtBQUMzQixjQUFRLE1BQU0sU0FBUztBQUN2QixjQUFRLE1BQU0sVUFBVTtBQUN4QixjQUFRLE1BQU0sYUFBYTtBQUMzQixjQUFRLE1BQU0saUJBQWlCO0FBRS9CLFlBQU0sUUFBUSxTQUFTLGNBQWMsS0FBSztBQUMxQyxZQUFNLE1BQU0sYUFBYTtBQUN6QixZQUFNLE1BQU0sU0FBUztBQUNyQixZQUFNLE1BQU0sZUFBZTtBQUMzQixZQUFNLE1BQU0sVUFBVTtBQUN0QixZQUFNLE1BQU0sUUFBUTtBQUNwQixZQUFNLE1BQU0sV0FBVztBQUN2QixZQUFNLE1BQU0sV0FBVztBQUN2QixZQUFNLE1BQU0sWUFBWTtBQUN4QixZQUFNLE1BQU0sYUFBYTtBQUV6QixZQUFNLFlBQVk7QUFBQSw2RUFDdUQsS0FBSztBQUFBLDZFQUNMLE9BQU87QUFBQTtBQUFBLFVBRTFFLFFBQVEsT0FBTyxvTUFBb00sUUFBUSxJQUFJLGNBQWMsRUFBRTtBQUFBLFVBQy9PLFFBQVEsVUFBVSx1TUFBdU0sUUFBUSxPQUFPLGNBQWMsRUFBRTtBQUFBLFVBQ3hQLFFBQVEsU0FBUyxzTUFBc00sUUFBUSxNQUFNLGNBQWMsRUFBRTtBQUFBO0FBQUE7QUFJM1AsY0FBUSxZQUFZLEtBQUs7QUFDekIsZUFBUyxLQUFLLFlBQVksT0FBTztBQUdqQyxZQUFNLFVBQVUsTUFBTSxjQUFjLFdBQVc7QUFDL0MsWUFBTSxhQUFhLE1BQU0sY0FBYyxjQUFjO0FBQ3JELFlBQU0sWUFBWSxNQUFNLGNBQWMsYUFBYTtBQUVuRCxZQUFNLFVBQVUsTUFBTTtBQUNwQixpQkFBUyxLQUFLLFlBQVksT0FBTztBQUFBLE1BQ25DO0FBRUEsVUFBSSxTQUFTO0FBQ1gsZ0JBQVEsaUJBQWlCLFNBQVMsTUFBTTtBQUN0QyxrQkFBUTtBQUNSLGtCQUFRLE1BQU07QUFBQSxRQUNoQixDQUFDO0FBQUEsTUFDSDtBQUVBLFVBQUksWUFBWTtBQUNkLG1CQUFXLGlCQUFpQixTQUFTLE1BQU07QUFDekMsa0JBQVE7QUFDUixrQkFBUSxTQUFTO0FBQUEsUUFDbkIsQ0FBQztBQUFBLE1BQ0g7QUFFQSxVQUFJLFdBQVc7QUFDYixrQkFBVSxpQkFBaUIsU0FBUyxNQUFNO0FBQ3hDLGtCQUFRO0FBQ1Isa0JBQVEsUUFBUTtBQUFBLFFBQ2xCLENBQUM7QUFBQSxNQUNIO0FBR0EsY0FBUSxpQkFBaUIsU0FBUyxDQUFDLE1BQU07QUFDdkMsWUFBSSxFQUFFLFdBQVcsU0FBUztBQUN4QixrQkFBUTtBQUNSLGtCQUFRLFFBQVE7QUFBQSxRQUNsQjtBQUFBLE1BQ0YsQ0FBQztBQUFBLElBQ0gsQ0FBQztBQUFBLEVBQ0g7OztBQ3RoQ08sV0FBUyxjQUFjLFFBQVEsT0FBTztBQUUzQyxVQUFNLG1CQUFtQjtBQUFBLE1BQ3ZCO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLElBQ0Y7QUFFQSxlQUFXLFlBQVksa0JBQWtCO0FBQ3ZDLFlBQU0sVUFBVSxTQUFTLGNBQWMsUUFBUTtBQUMvQyxVQUFJLFdBQVcsUUFBUSxpQkFBaUIsTUFBTTtBQUM1QyxZQUFJLE1BQU8sU0FBUSxJQUFJLHFEQUE4QyxRQUFRLEVBQUU7QUFDL0UsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBR0EsVUFBTSxnQkFBZ0IsU0FBUyxpQkFBaUIsK0VBQStFO0FBQy9ILFFBQUksZ0JBQWdCO0FBQ3BCLGVBQVcsTUFBTSxlQUFlO0FBQzlCLFVBQUksR0FBRyxpQkFBaUIsUUFBUSxHQUFHLGNBQWMsTUFBTSxHQUFHLGVBQWUsSUFBSTtBQUMzRTtBQUNBLFlBQUksaUJBQWlCLEdBQUc7QUFDdEIsY0FBSSxNQUFPLFNBQVEsSUFBSSw2REFBc0QsYUFBYSxFQUFFO0FBQzVGLGlCQUFPO0FBQUEsUUFDVDtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBRUEsUUFBSSxNQUFPLFNBQVEsSUFBSSw2REFBc0QsYUFBYSxFQUFFO0FBQzVGLFdBQU87QUFBQSxFQUNUO0FBR08sV0FBUyx3QkFBd0IsUUFBUSxPQUFPLGNBQWMsT0FBTztBQUUxRSxVQUFNLGlCQUFpQixTQUFTLGNBQWMsbUVBQW1FO0FBRWpILFFBQUksZ0JBQWdCO0FBQ2xCLFlBQU0sYUFBYSxlQUFlLFlBQVksWUFBWTtBQUMxRCxZQUFNLGVBQWUsV0FBVyxTQUFTLE9BQU8sS0FBSyxXQUFXLFNBQVMsUUFBUTtBQUNqRixZQUFNLGVBQWUsZUFBZSxjQUFjLHdCQUF3QixLQUN0RCxlQUFlLGNBQWMsb0JBQW9CO0FBRXJFLFVBQUksZ0JBQWdCLGNBQWM7QUFDaEMsWUFBSSxNQUFPLFNBQVEsSUFBSSw2RUFBZ0UsVUFBVSxHQUFHO0FBQ3BHLHVCQUFlLE1BQU07QUFHckIsWUFBSSxhQUFhO0FBQ2YscUJBQVcsTUFBTTtBQUNmLGdCQUFJLE1BQU8sU0FBUSxJQUFJLG1EQUF5QztBQUNoRSwyQkFBZSxNQUFNO0FBQUEsVUFDdkIsR0FBRyxHQUFHO0FBQUEsUUFDUjtBQUNBLGVBQU87QUFBQSxNQUNUO0FBQUEsSUFDRjtBQUdBLFVBQU0sVUFBVSxTQUFTLGlCQUFpQixRQUFRO0FBQ2xELGVBQVcsVUFBVSxTQUFTO0FBQzVCLFlBQU0sYUFBYSxPQUFPLFlBQVksWUFBWTtBQUNsRCxXQUFLLFdBQVcsU0FBUyxPQUFPLEtBQUssV0FBVyxTQUFTLFFBQVEsTUFDN0QsT0FBTyxpQkFBaUIsUUFDeEIsQ0FBQyxPQUFPLFVBQVU7QUFDcEIsWUFBSSxNQUFPLFNBQVEsSUFBSSw0REFBa0QsT0FBTyxZQUFZLEtBQUssQ0FBQyxHQUFHO0FBQ3JHLGVBQU8sTUFBTTtBQUdiLFlBQUksYUFBYTtBQUNmLHFCQUFXLE1BQU07QUFDZixnQkFBSSxNQUFPLFNBQVEsSUFBSSxtREFBeUM7QUFDaEUsbUJBQU8sTUFBTTtBQUFBLFVBQ2YsR0FBRyxHQUFHO0FBQUEsUUFDUjtBQUNBLGVBQU87QUFBQSxNQUNUO0FBQUEsSUFDRjtBQUVBLFFBQUksTUFBTyxTQUFRLElBQUksOENBQXNDO0FBQzdELFdBQU87QUFBQSxFQUNUO0FBR0EsaUJBQXNCLHFCQUFxQixjQUFjLEdBQUcsUUFBUSxNQUFNO0FBQ3hFLFFBQUksTUFBTyxTQUFRLElBQUkseUVBQTRELFdBQVcsWUFBWTtBQUUxRyxhQUFTLFVBQVUsR0FBRyxXQUFXLGFBQWEsV0FBVztBQUN2RCxVQUFJLE1BQU8sU0FBUSxJQUFJLDhCQUF1QixPQUFPLElBQUksV0FBVywrQkFBNEI7QUFHaEcsVUFBSSxjQUFjLEdBQUc7QUFDbkIsWUFBSSxNQUFPLFNBQVEsSUFBSSxrRUFBMEQ7QUFDakYsZUFBTztBQUFBLE1BQ1Q7QUFHQSxVQUFJLHdCQUF3QixPQUFPLEtBQUssR0FBRztBQUN6QyxZQUFJLE1BQU8sU0FBUSxJQUFJLHdFQUE4RDtBQUdyRixjQUFNLElBQUksUUFBUSxhQUFXLFdBQVcsU0FBUyxJQUFJLENBQUM7QUFHdEQsWUFBSSxjQUFjLEdBQUc7QUFDbkIsY0FBSSxNQUFPLFNBQVEsSUFBSSxzRUFBOEQsT0FBTyxFQUFFO0FBQzlGLGlCQUFPO0FBQUEsUUFDVCxPQUFPO0FBQ0wsY0FBSSxNQUFPLFNBQVEsSUFBSSxxRUFBMkQsT0FBTyxtQkFBZ0I7QUFBQSxRQUMzRztBQUFBLE1BQ0YsT0FBTztBQUNMLFlBQUksTUFBTyxTQUFRLElBQUkscUVBQTZELE9BQU8sRUFBRTtBQUFBLE1BQy9GO0FBR0EsVUFBSSxVQUFVLGFBQWE7QUFDekIsY0FBTSxJQUFJLFFBQVEsYUFBVyxXQUFXLFNBQVMsR0FBSSxDQUFDO0FBQUEsTUFDeEQ7QUFBQSxJQUNGO0FBRUEsUUFBSSxNQUFPLFNBQVEsSUFBSSxxREFBMEMsV0FBVyxXQUFXO0FBQ3ZGLFdBQU87QUFBQSxFQUNUOzs7QUM1SUEsR0FBQyxNQUFNO0FBQ0wsVUFBTSxZQUFZO0FBRWxCLFVBQU0sUUFBUTtBQUFBLE1BQ1osU0FBUztBQUFBLE1BQ1QsV0FBVyxDQUFDO0FBQUE7QUFBQSxNQUNaLHdCQUF3QjtBQUFBLE1BQ3hCLFVBQVU7QUFBQTtBQUFBLE1BQ1YsVUFBVTtBQUFBO0FBQUE7QUFBQSxNQUVWLFdBQVc7QUFBQSxNQUNYLGdCQUFnQjtBQUFBLE1BQ2hCLFFBQVE7QUFBQTtBQUFBLE1BQ1IsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBO0FBQUEsTUFFYixlQUFlO0FBQUEsTUFDZixrQkFBa0Isb0JBQUksSUFBSTtBQUFBLE1BQzFCLGdCQUFnQjtBQUFBLElBQ2xCO0FBRUEsYUFBUyxlQUFlO0FBRXRCLGNBQVEsSUFBSSxvREFBb0Q7QUFBQSxJQUNsRTtBQUdBLGFBQVMseUJBQXlCO0FBQ2hDLFVBQUksTUFBTSxlQUFnQjtBQUUxQixZQUFNLGdCQUFnQixPQUFPO0FBQzdCLFlBQU0saUJBQWlCO0FBRXZCLGFBQU8sUUFBUSxrQkFBa0IsTUFBTTtBQWxDM0M7QUFtQ00sY0FBTSxXQUFXLE1BQU0sTUFBTSxjQUFjLE1BQU0sTUFBTSxJQUFJO0FBQzNELGNBQU0sU0FBUyxTQUFTLE1BQU07QUFFOUIsY0FBTSxnQkFBaUIsS0FBSyxDQUFDLGFBQWEsV0FBVyxVQUFLLENBQUMsTUFBTixtQkFBUyxNQUFNLEtBQUssQ0FBQyxNQUFNO0FBQ2hGLGNBQU0sY0FBYyxPQUFPLFFBQVEsSUFBSSxjQUFjLEtBQUs7QUFHMUQsWUFBSSxZQUFZLFNBQVMsUUFBUSxLQUM3QixhQUFhLFNBQVMsU0FBUyxLQUMvQixDQUFDLGFBQWEsU0FBUyxhQUFhLEtBQ3BDLENBQUMsYUFBYSxTQUFTLE1BQU0sR0FBRztBQUVsQyxrQkFBUSxJQUFJLDZDQUE2QyxZQUFZO0FBRXJFLGNBQUk7QUFDRixrQkFBTSxPQUFPLE1BQU0sT0FBTyxLQUFLO0FBQy9CLGtCQUFNLGdCQUFnQixNQUFNLGVBQWUsTUFBTSxZQUFZO0FBRTdELG1CQUFPLElBQUksU0FBUyxlQUFlO0FBQUEsY0FDakMsU0FBUyxPQUFPO0FBQUEsY0FDaEIsUUFBUSxPQUFPO0FBQUEsY0FDZixZQUFZLE9BQU87QUFBQSxZQUNyQixDQUFDO0FBQUEsVUFDSCxTQUFTLE9BQU87QUFDZCxvQkFBUSxNQUFNLHlDQUF5QyxLQUFLO0FBQzVELG1CQUFPO0FBQUEsVUFDVDtBQUFBLFFBQ0Y7QUFFQSxlQUFPO0FBQUEsTUFDVDtBQUVBLGNBQVEsSUFBSSwyQ0FBMkM7QUFBQSxJQUN6RDtBQUVBLGFBQVMsd0JBQXdCO0FBQy9CLFVBQUksQ0FBQyxNQUFNLGtCQUFrQixDQUFDLE1BQU0sY0FBZTtBQUVuRCxhQUFPLFFBQVEsTUFBTTtBQUNyQixZQUFNLGlCQUFpQjtBQUV2QixjQUFRLElBQUksMkNBQTJDO0FBQUEsSUFDekQ7QUFHQSxtQkFBZSxlQUFlLFVBQVUsYUFBYTtBQUNuRCxVQUFJLENBQUMsTUFBTSxXQUFXLENBQUMsTUFBTSwwQkFBMEIsQ0FBQyxNQUFNLFdBQVc7QUFDdkUsZUFBTztBQUFBLE1BQ1Q7QUFJQSxZQUFNLFdBQVcsWUFBWSxNQUFNLEdBQUc7QUFDdEMsWUFBTSxRQUFRLFNBQVMsU0FBUyxTQUFTLFNBQVMsQ0FBQyxFQUFFLFFBQVEsUUFBUSxFQUFFLENBQUM7QUFDeEUsWUFBTSxRQUFRLFNBQVMsU0FBUyxTQUFTLFNBQVMsQ0FBQyxDQUFDO0FBRXBELFVBQUksTUFBTSxLQUFLLEtBQUssTUFBTSxLQUFLLEdBQUc7QUFDaEMsZ0JBQVEsS0FBSywrREFBK0QsV0FBVztBQUN2RixlQUFPO0FBQUEsTUFDVDtBQUVBLGNBQVEsSUFBSSxtQ0FBbUMsS0FBSyxJQUFJLEtBQUssRUFBRTtBQUcvRCxZQUFNLGFBQWEsaUJBQWlCLE9BQU8sS0FBSztBQUNoRCxVQUFJLFdBQVcsV0FBVyxHQUFHO0FBQzNCLGVBQU87QUFBQSxNQUNUO0FBRUEsY0FBUSxJQUFJLHdCQUF3QixXQUFXLE1BQU0sb0JBQW9CLEtBQUssSUFBSSxLQUFLLEVBQUU7QUFHekYsWUFBTSxXQUFXLE1BQU0sV0FBVyxNQUFNO0FBQ3hDLFlBQU0sYUFBYSxNQUFNLGtCQUFrQixRQUFRO0FBRW5ELFlBQU0sU0FBUyxJQUFJLGdCQUFnQixVQUFVLFFBQVE7QUFDckQsWUFBTSxVQUFVLE9BQU8sV0FBVyxJQUFJO0FBRXRDLGNBQVEsd0JBQXdCO0FBQ2hDLGNBQVEsVUFBVSxHQUFHLEdBQUcsVUFBVSxRQUFRO0FBQzFDLGNBQVEsVUFBVSxZQUFZLEdBQUcsR0FBRyxVQUFVLFFBQVE7QUFHdEQsdUJBQWlCLFNBQVMsWUFBWSxPQUFPLEtBQUs7QUFFbEQsYUFBTyxNQUFNLE9BQU8sY0FBYyxFQUFFLE1BQU0sWUFBWSxDQUFDO0FBQUEsSUFDekQ7QUFFQSxhQUFTLGlCQUFpQixPQUFPLE9BQU87QUFDdEMsVUFBSSxDQUFDLE1BQU0sYUFBYSxDQUFDLE1BQU0sVUFBVSxPQUFRLFFBQU8sQ0FBQztBQUV6RCxhQUFPLE1BQU0sVUFBVSxPQUFPLE9BQU8sV0FBUztBQUU1QyxjQUFNLGFBQWEsS0FBSyxNQUFNLE1BQU0sVUFBVSxTQUFTO0FBQ3ZELGNBQU0sYUFBYSxLQUFLLE1BQU0sTUFBTSxVQUFVLFNBQVM7QUFDdkQsZUFBTyxlQUFlLFNBQVMsZUFBZTtBQUFBLE1BQ2hELENBQUM7QUFBQSxJQUNIO0FBRUEsYUFBUyxpQkFBaUIsU0FBUyxRQUFRLE9BQU8sT0FBTztBQUN2RCxZQUFNLGFBQWEsUUFBUTtBQUMzQixZQUFNLGFBQWEsUUFBUTtBQUczQixjQUFRLGNBQWM7QUFFdEIsaUJBQVcsU0FBUyxRQUFRO0FBRTFCLGNBQU0sVUFBVSxNQUFNLFVBQVUsY0FBYyxNQUFNLFdBQVc7QUFDL0QsY0FBTSxVQUFVLE1BQU0sVUFBVSxjQUFjLE1BQU0sV0FBVztBQUcvRCxZQUFJLFVBQVUsS0FBSyxTQUFTLE1BQU0sV0FBVyxNQUFNLFlBQy9DLFVBQVUsS0FBSyxTQUFTLE1BQU0sV0FBVyxNQUFNLFVBQVU7QUFFM0Qsa0JBQVEsWUFBWSxPQUFPLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQztBQUN4RCxrQkFBUSxTQUFTLFFBQVEsUUFBUSxHQUFHLENBQUM7QUFBQSxRQUN2QztBQUFBLE1BQ0Y7QUFHQSxVQUFJLE1BQU0saUJBQWlCLEdBQUc7QUFDNUIsZ0JBQVEsY0FBYztBQUN0QixjQUFNLGNBQWMsT0FBTyxNQUFNLEdBQUcsTUFBTSxjQUFjO0FBRXhELG1CQUFXLFNBQVMsYUFBYTtBQUMvQixnQkFBTSxVQUFVLE1BQU0sVUFBVSxjQUFjLE1BQU0sV0FBVztBQUMvRCxnQkFBTSxVQUFVLE1BQU0sVUFBVSxjQUFjLE1BQU0sV0FBVztBQUUvRCxjQUFJLFVBQVUsS0FBSyxTQUFTLE1BQU0sV0FBVyxNQUFNLFlBQy9DLFVBQVUsS0FBSyxTQUFTLE1BQU0sV0FBVyxNQUFNLFVBQVU7QUFFM0Qsb0JBQVEsWUFBWSxPQUFPLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQztBQUN4RCxvQkFBUSxTQUFTLFFBQVEsUUFBUSxHQUFHLENBQUM7QUFBQSxVQUN2QztBQUFBLFFBQ0Y7QUFBQSxNQUNGO0FBQUEsSUFDRjtBQUdBLGFBQVMsV0FBVyxTQUFTO0FBQzNCLFlBQU0sVUFBVSxDQUFDLENBQUM7QUFFbEIsVUFBSSxNQUFNLFNBQVM7QUFDakIsK0JBQXVCO0FBQUEsTUFDekIsT0FBTztBQUNMLDhCQUFzQjtBQUFBLE1BQ3hCO0FBRUEsY0FBUSxJQUFJLDhCQUE4QixNQUFNLE9BQU8sRUFBRTtBQUFBLElBQzNEO0FBRUEsYUFBUyxRQUFRLFdBQVcsT0FBTyxDQUFDLEdBQUc7QUEzTHpDO0FBNExJLFVBQUksQ0FBQyxhQUFhLFVBQVUsV0FBVyxHQUFHO0FBQ3hDLGNBQU0sWUFBWTtBQUNsQixnQkFBUSxJQUFJLDZCQUE2QjtBQUN6QztBQUFBLE1BQ0Y7QUFHQSxZQUFNLFNBQVMsQ0FBQztBQUNoQixpQkFBVyxRQUFRLFdBQVc7QUFDNUIsWUFBSSxTQUFTO0FBRWIsWUFBSSxPQUFPLEtBQUssVUFBVSxZQUFZLE9BQU8sS0FBSyxXQUFXLFVBQVU7QUFFckUsb0JBQVUsS0FBSyxRQUFRLFlBQVksS0FBSztBQUN4QyxvQkFBVSxLQUFLLFFBQVEsWUFBWSxLQUFLO0FBQUEsUUFDMUMsV0FBVyxLQUFLLFVBQVUsT0FBTyxLQUFLLFdBQVcsVUFBVTtBQUV6RCxnQkFBTSxRQUFRLEtBQUssT0FBTyxRQUFRLGFBQWEsS0FBSyxPQUFPLE9BQU87QUFDbEUsZ0JBQU0sUUFBUSxLQUFLLE9BQU8sUUFBUSxhQUFhLEtBQUssT0FBTyxPQUFPO0FBQ2xFLG9CQUFVLFFBQVEsS0FBSztBQUN2QixvQkFBVSxRQUFRLEtBQUs7QUFBQSxRQUN6QixPQUFPO0FBQ0w7QUFBQSxRQUNGO0FBRUEsZUFBTyxLQUFLO0FBQUEsVUFDVjtBQUFBLFVBQ0E7QUFBQSxVQUNBLEtBQUcsVUFBSyxVQUFMLG1CQUFZLE1BQUs7QUFBQSxVQUNwQixLQUFHLFVBQUssVUFBTCxtQkFBWSxNQUFLO0FBQUEsVUFDcEIsS0FBRyxVQUFLLFVBQUwsbUJBQVksTUFBSztBQUFBLFFBQ3RCLENBQUM7QUFBQSxNQUNIO0FBRUEsWUFBTSxZQUFZLEVBQUUsT0FBTztBQUMzQixZQUFNLGlCQUFpQixLQUFLLGtCQUFrQjtBQUM5QyxZQUFNLFNBQVMsS0FBSyxVQUFVO0FBQzlCLFlBQU0sYUFBYSxLQUFLLGNBQWM7QUFDdEMsWUFBTSxjQUFjLEtBQUssZUFBZTtBQUV4QyxjQUFRLElBQUksNEJBQTRCLE9BQU8sTUFBTSxTQUFTO0FBRTlELFVBQUksT0FBTyxLQUFLLFlBQVksV0FBVztBQUNyQyxtQkFBVyxLQUFLLE9BQU87QUFBQSxNQUN6QjtBQUFBLElBQ0Y7QUFFQSxhQUFTLGtCQUFrQixPQUFPO0FBQ2hDLFlBQU0saUJBQWlCLEtBQUssSUFBSSxHQUFHLE9BQU8sU0FBUyxDQUFDLENBQUM7QUFDckQsY0FBUSxJQUFJLG9DQUFvQyxNQUFNLGNBQWMsRUFBRTtBQUFBLElBQ3hFO0FBRUEsYUFBUyxVQUFVLFFBQVE7QUFDekIsWUFBTSxTQUFTO0FBQ2YsY0FBUSxJQUFJLDhCQUE4QixNQUFNO0FBQUEsSUFDbEQ7QUFFQSxhQUFTLGFBQWEsR0FBRyxHQUFHO0FBRTFCLGNBQVEsSUFBSSwyREFBMkQsRUFBRSxHQUFHLEVBQUUsQ0FBQztBQUFBLElBQ2pGO0FBRUEsYUFBUyxtQkFBbUI7QUFFMUIsY0FBUSxJQUFJLDhEQUE4RDtBQUFBLElBQzVFO0FBRUEsYUFBUyxVQUFVO0FBQ2pCLDRCQUFzQjtBQUN0QixZQUFNLFlBQVk7QUFDbEIsWUFBTSxpQkFBaUIsTUFBTTtBQUM3QixjQUFRLElBQUksa0NBQWtDO0FBQUEsSUFDaEQ7QUFHQSxXQUFPLHVCQUF1QjtBQUFBLE1BQzVCO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBLDBCQUEwQjtBQUFBO0FBQUEsTUFDMUI7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBLFFBQVEsTUFBTTtBQUFBLE1BQUM7QUFBQTtBQUFBLE1BQ2Y7QUFBQSxNQUNBLElBQUksUUFBUTtBQUFFLGVBQU87QUFBQSxNQUFPO0FBQUEsSUFDOUI7QUFFQSxZQUFRLElBQUksOENBQThDO0FBQUEsRUFDNUQsR0FBRzs7O0FDM1FILGlCQUFzQixXQUFXO0FBQy9CLFFBQUksNERBQWtEO0FBR3RELHVCQUFtQjtBQUduQixXQUFPLGNBQWMsRUFBRSxHQUFHLE9BQU8sYUFBYSxjQUFjLEtBQUs7QUFFakUsUUFBSSxrQkFBa0I7QUFDdEIsUUFBSSxnQkFBZ0IsT0FBTztBQUczQixVQUFNLGVBQWUsTUFBTTtBQUN6QixVQUFJLE9BQU8sVUFBVSxlQUFlO0FBQ2xDLGVBQU8sUUFBUTtBQUNmLFlBQUkscUNBQThCO0FBQUEsTUFDcEM7QUFDQSxVQUFJLFdBQVcsbUJBQW1CO0FBQ2hDLHFCQUFhLFdBQVcsaUJBQWlCO0FBQ3pDLG1CQUFXLG9CQUFvQjtBQUFBLE1BQ2pDO0FBQ0EsVUFBSSxXQUFXLGlCQUFpQjtBQUM5QixtQkFBVyxnQkFBZ0I7QUFDM0IsbUJBQVcsa0JBQWtCO0FBQUEsTUFDL0I7QUFDQSxpQkFBVyxvQkFBb0I7QUFBQSxJQUNqQztBQUVBLFFBQUk7QUFFRixZQUFNLFNBQVMsRUFBRSxHQUFHLGVBQWU7QUFHbkMsWUFBTSxRQUFRLFdBQVcsT0FBTztBQUdoQyxpQkFBVyxXQUFXLG1CQUFtQjtBQUd6QyxVQUFJLENBQUMsT0FBTyxTQUFTO0FBQ25CLGNBQU0saUJBQWlCLFNBQVMsY0FBYyxpQkFBaUI7QUFDL0QsWUFBSSxnQkFBZ0I7QUFDbEIsaUJBQU8sVUFBVSxlQUFlLGFBQWEsY0FBYztBQUMzRCxjQUFJLG9EQUEwQyxPQUFPLFFBQVEsVUFBVSxHQUFHLEVBQUUsQ0FBQyxLQUFLO0FBQUEsUUFDcEYsT0FBTztBQUNMLGNBQUksaUVBQW9EO0FBQUEsUUFDMUQ7QUFBQSxNQUNGO0FBR0EscUJBQWUsY0FBYztBQUMzQixZQUFJLHFDQUE4QjtBQUdsQyxZQUFJLGNBQWMsR0FBRztBQUNuQixjQUFJLGdEQUFzQztBQUMxQyxpQkFBTztBQUFBLFFBQ1Q7QUFFQSxZQUFJLDRFQUFrRTtBQUd0RSxjQUFNLFVBQVUsTUFBTSxxQkFBcUIsR0FBRyxJQUFJO0FBRWxELFlBQUksU0FBUztBQUNYLGNBQUksMkNBQXNDO0FBQzFDLGlCQUFPO0FBQUEsUUFDVCxPQUFPO0FBQ0wsY0FBSSx3REFBNkM7QUFDakQsaUJBQU87QUFBQSxRQUNUO0FBQUEsTUFDRjtBQUdBLHFCQUFlLGNBQWMsYUFBYSxPQUFPO0FBQy9DLFlBQUksdUNBQWdDO0FBR3BDLFdBQUcsVUFBVSxFQUFFLHNCQUFzQixHQUFHLE1BQU07QUFDOUMsY0FBTSxTQUFTLHNCQUFzQjtBQUVyQyxZQUFJLE9BQU8sV0FBVyxHQUFHO0FBQ3ZCLGFBQUcsVUFBVSxFQUFFLHFCQUFxQixHQUFHLE9BQU87QUFDOUMsaUJBQU87QUFBQSxRQUNUO0FBR0EsY0FBTSxjQUFjLE1BQU0sV0FBVztBQUNyQyxZQUFJLFdBQVc7QUFDZixZQUFJLFlBQVksV0FBVyxZQUFZLEtBQUssTUFBTTtBQUNoRCxxQkFBVztBQUFBLFlBQ1QsVUFBVSxZQUFZLEtBQUssS0FBSyxRQUFRO0FBQUEsWUFDeEMsU0FBUyxZQUFZLEtBQUs7QUFBQSxZQUMxQixZQUFZLFlBQVksS0FBSztBQUFBLFlBQzdCLFFBQVEsWUFBWSxLQUFLLEtBQUssaUJBQWlCO0FBQUE7QUFBQSxVQUNqRDtBQUNBLDRCQUFrQjtBQUNsQixxQkFBVyxpQkFBaUIsWUFBWSxLQUFLO0FBQzdDLHFCQUFXLGFBQWEsWUFBWSxLQUFLLGNBQWM7QUFDdkQsY0FBSSxnQ0FBeUIsWUFBWSxLQUFLLEtBQUssUUFBUSxZQUFTLGNBQWMsU0FBUyxPQUFPLElBQUksU0FBUyxVQUFVLGtCQUFlLFNBQVMsTUFBTSxFQUFFO0FBQUEsUUFDM0osT0FBTztBQUNMLGNBQUksNERBQStDO0FBQUEsUUFDckQ7QUFFQSxtQkFBVyxrQkFBa0I7QUFDN0IsbUJBQVcsZ0JBQWdCO0FBRTNCLFdBQUcsVUFBVSxFQUFFLHFCQUFxQixFQUFFLE9BQU8sT0FBTyxPQUFPLENBQUMsR0FBRyxTQUFTO0FBQ3hFLFdBQUcsZUFBZSxHQUFHLEdBQUcsUUFBUTtBQUdoQyxZQUFJLENBQUMsWUFBWTtBQUNmLGNBQUksVUFBSyxPQUFPLE1BQU0saUNBQWlDO0FBQUEsUUFDekQ7QUFHQSxXQUFHLGVBQWUsSUFBSTtBQUd0QixXQUFHLHVCQUF1QjtBQUcxQixZQUFJO0FBQUEsUUFFSixRQUFRO0FBQUEsUUFFUjtBQUVBLGVBQU87QUFBQSxNQUNUO0FBR0EsWUFBTSxLQUFLLE1BQU0sY0FBYztBQUFBLFFBQzdCO0FBQUEsUUFFQSxnQkFBZ0IsQ0FBQ0MsWUFBVztBQUUxQixjQUFJQSxRQUFPLG1CQUFtQixRQUFXO0FBQ3ZDLHVCQUFXLGlCQUFpQkEsUUFBTztBQUFBLFVBQ3JDO0FBQ0EsY0FBSUEsUUFBTyxrQkFBa0IsUUFBVztBQUN0Qyx1QkFBVyxxQkFBcUJBLFFBQU87QUFBQSxVQUN6QztBQUNBLGNBQUksaUNBQThCQSxPQUFNO0FBQUEsUUFDMUM7QUFBQSxRQUVBLFdBQVc7QUFBQSxRQUVYLGVBQWUsT0FBTyxTQUFTO0FBQzdCLGNBQUk7QUFDRixlQUFHLFVBQVUsRUFBRSxvQkFBb0IsR0FBRyxNQUFNO0FBRTVDLGtCQUFNLFdBQVcsT0FBTyxJQUFJLGdCQUFnQixJQUFJO0FBQ2hELGtCQUFNLFlBQVksSUFBSSwwQkFBMEIsUUFBUTtBQUN4RCxzQkFBVSxlQUFlLEtBQUs7QUFFOUIsa0JBQU0sVUFBVSxLQUFLO0FBR3JCLGtCQUFNLGtCQUFrQixVQUFVLHVCQUF1QjtBQUN6RCx1QkFBVyxrQkFBa0I7QUFHN0Isa0JBQU0saUJBQWlCLE1BQU0sVUFBVSxjQUFjO0FBR3JELHNCQUFVLFVBQVUsR0FBRyxHQUFHLEdBQUcsQ0FBQztBQUc5QixrQkFBTSxnQkFBZ0IsVUFBVSxhQUFhO0FBRTdDLHVCQUFXLFlBQVk7QUFDdkIsdUJBQVcsVUFBVSxZQUFZO0FBQ2pDLHVCQUFXLGNBQWMsZUFBZTtBQUN4Qyx1QkFBVyxnQkFBZ0I7QUFDM0IsdUJBQVcsb0JBQW9CLEtBQUs7QUFDcEMsdUJBQVcsY0FBYztBQUV6QixlQUFHLFVBQVUsRUFBRSxxQkFBcUIsRUFBRSxPQUFPLGVBQWUsZUFBZSxDQUFDLEdBQUcsU0FBUztBQUN4RixlQUFHLGVBQWUsR0FBRyxlQUFlLGdCQUFnQixlQUFlO0FBRW5FLGdCQUFJLHdDQUFtQyxjQUFjLEtBQUssSUFBSSxjQUFjLE1BQU0sS0FBSyxlQUFlLGNBQWMsd0JBQWtCO0FBQ3RJLGdCQUFJLHFDQUE2QixlQUFlLFlBQVksdUJBQW9CLGVBQWUsWUFBWSxxQkFBa0I7QUFHN0gsbUJBQU8sSUFBSSxnQkFBZ0IsUUFBUTtBQUduQyxnQkFBSTtBQUNGLGtCQUFJLE9BQU8sc0JBQXNCO0FBQy9CLHVCQUFPLHFCQUFxQixhQUFhO0FBQ3pDLHVCQUFPLHFCQUFxQixXQUFXLElBQUk7QUFFM0MsdUJBQU8scUJBQXFCLFFBQVEsQ0FBQyxHQUFHO0FBQUEsa0JBQ3RDLFNBQVM7QUFBQSxrQkFDVCxnQkFBZ0I7QUFBQSxnQkFDbEIsQ0FBQztBQUNELG9CQUFJLGtFQUEwRDtBQUFBLGNBQ2hFO0FBQUEsWUFDRixTQUFTLEdBQUc7QUFDVixrQkFBSSw4Q0FBb0MsQ0FBQztBQUFBLFlBQzNDO0FBRUEsbUJBQU87QUFBQSxVQUNULFNBQVMsT0FBTztBQUNkLGVBQUcsVUFBVSxFQUFFLGtCQUFrQixHQUFHLE9BQU87QUFDM0MsZ0JBQUksaUNBQTRCLEtBQUs7QUFDckMsbUJBQU87QUFBQSxVQUNUO0FBQUEsUUFDRjtBQUFBLFFBRUEsa0JBQWtCLFlBQVk7QUFDNUIsaUJBQU8sSUFBSSxRQUFRLENBQUMsWUFBWTtBQUM5QixlQUFHLFVBQVUsRUFBRSwyQkFBMkIsR0FBRyxNQUFNO0FBQ25ELGVBQUcsVUFBVSxFQUFFLHVCQUF1QixHQUFHLE1BQU07QUFFL0MsdUJBQVcsb0JBQW9CO0FBQy9CLGdCQUFJLG1CQUFtQjtBQUd2QixrQkFBTSx5QkFBeUIsTUFBTTtBQUNuQyxxQkFBTyxRQUFRLE9BQU8sS0FBSyxZQUFZO0FBRXJDLG9CQUFJLFdBQVcscUJBQ1gsQ0FBQyxvQkFDRCxPQUFPLFFBQVEsWUFDZixJQUFJLFNBQVMsWUFBWSxLQUN6QixXQUNBLFFBQVEsV0FBVyxRQUFRO0FBRTdCLHNCQUFJO0FBQ0Ysd0JBQUksK0NBQXdDLEdBQUcsRUFBRTtBQUVqRCwwQkFBTSxXQUFXLE1BQU0sY0FBYyxLQUFLLE9BQU87QUFFakQsd0JBQUksU0FBUyxNQUFNLFFBQVEsTUFBTTtBQUMvQiwwQkFBSTtBQUNKLDBCQUFJO0FBQ0YsbUNBQVcsS0FBSyxNQUFNLFFBQVEsSUFBSTtBQUFBLHNCQUNwQyxTQUFTLFlBQVk7QUFDbkIsNEJBQUkscUNBQXFDLFVBQVU7QUFDbkQsK0JBQU87QUFBQSxzQkFDVDtBQUVBLDBCQUFJLFNBQVMsVUFBVSxNQUFNLFFBQVEsU0FBUyxNQUFNLEtBQUssU0FBUyxPQUFPLFVBQVUsR0FBRztBQUNwRiw4QkFBTSxTQUFTLFNBQVMsT0FBTyxDQUFDO0FBQ2hDLDhCQUFNLFNBQVMsU0FBUyxPQUFPLENBQUM7QUFHaEMsOEJBQU0sWUFBWSxJQUFJLE1BQU0sK0JBQStCO0FBQzNELDRCQUFJLGFBQWEsQ0FBQyxrQkFBa0I7QUFDbEMsNkNBQW1CO0FBQ25CLGdDQUFNLFFBQVEsU0FBUyxVQUFVLENBQUMsQ0FBQztBQUNuQyxnQ0FBTSxRQUFRLFNBQVMsVUFBVSxDQUFDLENBQUM7QUFHbkMscUNBQVcsUUFBUTtBQUNuQixxQ0FBVyxRQUFRO0FBQ25CLHFDQUFXLGdCQUFnQixFQUFFLEdBQUcsUUFBUSxHQUFHLE9BQU87QUFDbEQscUNBQVcsb0JBQW9CO0FBRy9CLDhCQUFJLFdBQVcsYUFBYSxXQUFXLFVBQVUsV0FBVztBQUMxRCxrQ0FBTSxZQUFZLFdBQVcsVUFBVTtBQUN2QyxzQ0FBVSxVQUFVLE9BQU8sT0FBTyxRQUFRLE1BQU07QUFHaEQsZ0NBQUk7QUFDRixvQ0FBTSxVQUFVLG9CQUFvQjtBQUNwQyxrQ0FBSSxxRUFBNkQsS0FBSyxJQUFJLEtBQUssV0FBVyxNQUFNLElBQUksTUFBTSxHQUFHO0FBQUEsNEJBQy9HLFNBQVMsT0FBTztBQUNkLGtDQUFJLHNEQUFpRCxNQUFNLE9BQU8sRUFBRTtBQUFBLDRCQUN0RTtBQUdBLGtDQUFNLGFBQWEsVUFBVSxtQkFBbUI7QUFDaEQsdUNBQVcsa0JBQWtCO0FBQzdCLHVDQUFXLGNBQWMsV0FBVztBQUVwQyxnQ0FBSSx1Q0FBK0IsV0FBVyxNQUFNLDBCQUF1QjtBQUFBLDBCQUM3RTtBQUdBLDhCQUFJO0FBQ0YsZ0NBQUksT0FBTyxzQkFBc0I7QUFDL0IscUNBQU8scUJBQXFCLGFBQWE7QUFDekMscUNBQU8scUJBQXFCLFdBQVcsSUFBSTtBQUczQyxxQ0FBTyxxQkFBcUIsVUFBVTtBQUFBLGdDQUNwQztBQUFBLGdDQUNBO0FBQUEsZ0NBQ0EsS0FBSztBQUFBLGdDQUNMLEtBQUs7QUFBQSw4QkFDUCxDQUFDO0FBR0Qsa0NBQUksV0FBVyxtQkFBbUIsV0FBVyxnQkFBZ0IsU0FBUyxHQUFHO0FBQ3ZFLHVDQUFPLHFCQUFxQixRQUFRLFdBQVcsaUJBQWlCO0FBQUEsa0NBQzlELFFBQVEsRUFBRSxPQUFjLE9BQWMsS0FBSyxRQUFRLEtBQUssT0FBTztBQUFBLGtDQUMvRCxZQUFZLFdBQVcsVUFBVTtBQUFBLGtDQUNqQyxhQUFhLFdBQVcsVUFBVTtBQUFBLGtDQUNsQyxTQUFTO0FBQUEsZ0NBQ1gsQ0FBQztBQUVELG9DQUFJLHVDQUFrQyxLQUFLLElBQUksS0FBSyxXQUFXLE1BQU0sSUFBSSxNQUFNLEdBQUc7QUFBQSw4QkFDcEYsT0FBTztBQUNMLG9DQUFJLHdEQUEyQztBQUFBLDhCQUNqRDtBQUFBLDRCQUNGO0FBQUEsMEJBQ0YsU0FBUyxPQUFPO0FBQ2QsZ0NBQUksc0NBQWlDLE1BQU0sT0FBTyxFQUFFO0FBQUEsMEJBQ3REO0FBR0EsdUNBQWE7QUFFYiw2QkFBRyxVQUFVLEVBQUUsbUJBQW1CLEdBQUcsU0FBUztBQUM5Qyw4QkFBSSx3Q0FBZ0MsV0FBVyxLQUFLLElBQUksV0FBVyxLQUFLLFdBQVcsTUFBTSxJQUFJLE1BQU0sR0FBRztBQUV0RyxrQ0FBUSxJQUFJO0FBQUEsd0JBQ2QsT0FBTztBQUNMLDhCQUFJLG1EQUF5QyxHQUFHO0FBQUEsd0JBQ2xEO0FBQUEsc0JBQ0Y7QUFBQSxvQkFDRjtBQUVBLDJCQUFPO0FBQUEsa0JBQ1QsU0FBUyxPQUFPO0FBQ2Qsd0JBQUkscUNBQWdDLEtBQUs7QUFFekMsd0JBQUksQ0FBQyxrQkFBa0I7QUFDckIsbUNBQWE7QUFDYiw2QkFBTyxjQUFjLEtBQUssT0FBTztBQUFBLG9CQUNuQztBQUFBLGtCQUNGO0FBQUEsZ0JBQ0Y7QUFHQSx1QkFBTyxjQUFjLEtBQUssT0FBTztBQUFBLGNBQ25DO0FBQUEsWUFDRjtBQUdBLGtCQUFNLHNCQUFzQixNQUFNO0FBQ2hDLG9CQUFNLGlCQUFpQixTQUFTLGlCQUFpQixRQUFRO0FBQ3pELGtCQUFJLGVBQWUsV0FBVyxHQUFHO0FBQy9CLG9CQUFJLGlEQUF1QztBQUMzQztBQUFBLGNBQ0Y7QUFFQSxrQkFBSSx3Q0FBaUMsZUFBZSxNQUFNLFNBQVM7QUFHbkUsb0JBQU0sZUFBZSxDQUFDLFVBQVU7QUE5VzVDO0FBK1djLG9CQUFJLENBQUMsV0FBVyxxQkFBcUIsaUJBQWtCO0FBR3ZELHNCQUFNLFNBQVMsTUFBTTtBQUNyQixvQkFBSSxVQUFVLE9BQU8sWUFBWSxVQUFVO0FBQ3pDLHNCQUFJLGdFQUFpRDtBQUVyRCxzQkFBSTtBQUNGLDBCQUFNLFVBQVEsY0FBUyxjQUFjLFFBQVEsTUFBL0IsbUJBQWtDLGtCQUFpQixTQUFTO0FBQzFFLDBCQUFNLE9BQU8sTUFBTSxzQkFBc0I7QUFDekMsMEJBQU0sT0FBTyxNQUFNLFVBQVUsS0FBSztBQUNsQywwQkFBTSxPQUFPLE1BQU0sVUFBVSxLQUFLO0FBQ2xDLHdCQUFJLE9BQU8sc0JBQXNCO0FBQy9CLDZCQUFPLHFCQUFxQixhQUFhLE1BQU0sSUFBSTtBQUNuRCwwQkFBSSwyQ0FBMkMsSUFBSSxLQUFLLElBQUksR0FBRztBQUFBLG9CQUNqRTtBQUFBLGtCQUNGLFNBQVMsR0FBRztBQUNWLHdCQUFJLDRDQUE0QyxDQUFDO0FBQUEsa0JBQ25EO0FBR0EsNkJBQVcsTUFBTTtBQUNmLHdCQUFJLENBQUMsb0JBQW9CLFdBQVcsbUJBQW1CO0FBQ3JELDBCQUFJLHFEQUE4QztBQUFBLG9CQUVwRDtBQUFBLGtCQUNGLEdBQUcsR0FBRztBQUFBLGdCQUNSO0FBQUEsY0FDRjtBQUVBLHVCQUFTLGlCQUFpQixTQUFTLFlBQVk7QUFHL0MseUJBQVcsa0JBQWtCLE1BQU07QUFDakMseUJBQVMsb0JBQW9CLFNBQVMsWUFBWTtBQUFBLGNBQ3BEO0FBQUEsWUFDRjtBQUdBLG1DQUF1QjtBQUN2QixnQ0FBb0I7QUFHcEIsa0JBQU0sWUFBWSxXQUFXLE1BQU07QUFDakMsa0JBQUksV0FBVyxxQkFBcUIsQ0FBQyxrQkFBa0I7QUFDckQsNkJBQWE7QUFDYixvQkFBSSxXQUFXLGlCQUFpQjtBQUM5Qiw2QkFBVyxnQkFBZ0I7QUFBQSxnQkFDN0I7QUFDQSxtQkFBRyxVQUFVLEVBQUUsdUJBQXVCLEdBQUcsT0FBTztBQUNoRCxvQkFBSSwrQ0FBb0M7QUFDeEMsd0JBQVEsS0FBSztBQUFBLGNBQ2Y7QUFBQSxZQUNGLEdBQUcsSUFBTTtBQUdULHVCQUFXLG9CQUFvQjtBQUFBLFVBQ2pDLENBQUM7QUFBQSxRQUNIO0FBQUEsUUFFQSxpQkFBaUIsWUFBWTtBQTNhbkM7QUE2YVEsY0FBSSwwQ0FBbUM7QUFBQSxZQUNyQyxhQUFhLFdBQVc7QUFBQSxZQUN4QixlQUFlLFdBQVc7QUFBQSxZQUMxQixPQUFPLFdBQVc7QUFBQSxZQUNsQixPQUFPLFdBQVc7QUFBQSxZQUNsQixhQUFhLFdBQVc7QUFBQSxZQUN4QixtQkFBaUIsZ0JBQVcsb0JBQVgsbUJBQTRCLFdBQVU7QUFBQSxVQUN6RCxDQUFDO0FBRUQsY0FBSSxDQUFDLFdBQVcsZUFBZSxDQUFDLFdBQVcsZUFBZTtBQUN4RCxlQUFHLFVBQVUsRUFBRSwyQkFBMkIsR0FBRyxPQUFPO0FBQ3BELGdCQUFJLDZDQUFxQyxXQUFXLFdBQVcsbUJBQW1CLENBQUMsQ0FBQyxXQUFXLGFBQWEsRUFBRTtBQUM5RyxtQkFBTztBQUFBLFVBQ1Q7QUFFQSxxQkFBVyxVQUFVO0FBQ3JCLHFCQUFXLFdBQVc7QUFDdEIscUJBQVcsZUFBZTtBQUUxQixhQUFHLFVBQVUsRUFBRSx3QkFBd0IsR0FBRyxTQUFTO0FBRW5ELGNBQUk7QUFDRixrQkFBTTtBQUFBLGNBQ0osV0FBVztBQUFBLGNBQ1gsV0FBVztBQUFBO0FBQUEsY0FFWCxDQUFDLFNBQVMsT0FBTyxTQUFTLGtCQUFrQjtBQUUxQyxvQkFBSSxpQkFBaUI7QUFDbkIsa0NBQWdCLFVBQVUsS0FBSyxNQUFNLFdBQVcsY0FBYztBQUM5RCxzQkFBSSxrQkFBa0IsUUFBVztBQUMvQixvQ0FBZ0IsZ0JBQWdCO0FBQUEsa0JBQ2xDO0FBQUEsZ0JBQ0Y7QUFFQSxtQkFBRyxlQUFlLFNBQVMsT0FBTyxlQUFlO0FBR2pELG9CQUFJLFdBQVcsY0FBYyxXQUFXLG9CQUFvQixHQUFHO0FBQzdELHFCQUFHLHNCQUFzQixXQUFXLGlCQUFpQjtBQUFBLGdCQUN2RCxPQUFPO0FBQ0wscUJBQUcsc0JBQXNCLENBQUM7QUFBQSxnQkFDNUI7QUFFQSxvQkFBSSxTQUFTO0FBRVgsc0JBQUksUUFBUSxTQUFTLFFBQUcsS0FBSyxXQUFXLFlBQVk7QUFDbEQsdUJBQUcsc0JBQXNCLE9BQU87QUFBQSxrQkFDbEMsT0FBTztBQUNMLHVCQUFHLFVBQVUsU0FBUyxNQUFNO0FBQUEsa0JBQzlCO0FBQUEsZ0JBQ0YsT0FBTztBQUNMLHFCQUFHLFVBQVUsRUFBRSwwQkFBMEIsRUFBRSxTQUFTLE1BQU0sQ0FBQyxHQUFHLE1BQU07QUFBQSxnQkFDdEU7QUFBQSxjQUNGO0FBQUE7QUFBQSxjQUVBLENBQUMsV0FBVyxrQkFBa0I7QUFDNUIsb0JBQUksV0FBVztBQUNiLHFCQUFHLFVBQVUsRUFBRSwwQkFBMEIsRUFBRSxPQUFPLGNBQWMsQ0FBQyxHQUFHLFNBQVM7QUFDN0UsZ0NBQWM7QUFBQSxnQkFDaEIsT0FBTztBQUNMLHFCQUFHLFVBQVUsRUFBRSx1QkFBdUIsR0FBRyxTQUFTO0FBQUEsZ0JBQ3BEO0FBQ0EsMkJBQVcsVUFBVTtBQUFBLGNBQ3ZCO0FBQUE7QUFBQSxjQUVBLENBQUMsVUFBVTtBQUNULG1CQUFHLFVBQVUsRUFBRSxxQkFBcUIsR0FBRyxPQUFPO0FBQzlDLG9CQUFJLHVDQUFrQyxLQUFLO0FBQzNDLDJCQUFXLFVBQVU7QUFBQSxjQUN2QjtBQUFBLFlBQ0Y7QUFFQSxtQkFBTztBQUFBLFVBQ1QsU0FBUyxPQUFPO0FBQ2QsZUFBRyxVQUFVLEVBQUUscUJBQXFCLEdBQUcsT0FBTztBQUM5QyxnQkFBSSxtQ0FBOEIsS0FBSztBQUN2Qyx1QkFBVyxVQUFVO0FBQ3JCLG1CQUFPO0FBQUEsVUFDVDtBQUFBLFFBQ0Y7QUFBQSxRQUVBLGdCQUFnQixZQUFZO0FBQzFCLGdCQUFNLGVBQWUsZ0JBQWdCO0FBRXJDLGNBQUksYUFBYSxhQUFhO0FBQzVCLGtCQUFNLGFBQWEsTUFBTTtBQUFBLGNBQ3ZCLEVBQUUsMkJBQTJCO0FBQUEsY0FDN0IsRUFBRSx5QkFBeUI7QUFBQSxjQUMzQjtBQUFBLGdCQUNFLE1BQU0sRUFBRSxvQkFBb0I7QUFBQSxnQkFDNUIsU0FBUyxFQUFFLHVCQUF1QjtBQUFBLGdCQUNsQyxRQUFRLEVBQUUsY0FBYztBQUFBLGNBQzFCO0FBQUEsWUFDRjtBQUVBLGdCQUFJLGVBQWUsUUFBUTtBQUN6QixvQkFBTSxTQUFTLGFBQWE7QUFDNUIsa0JBQUksT0FBTyxTQUFTO0FBQ2xCLG1CQUFHLFVBQVUsRUFBRSx1QkFBdUIsRUFBRSxVQUFVLE9BQU8sU0FBUyxDQUFDLEdBQUcsU0FBUztBQUFBLGNBQ2pGLE9BQU87QUFDTCxtQkFBRyxVQUFVLEVBQUUsMkJBQTJCLEVBQUUsT0FBTyxPQUFPLE1BQU0sQ0FBQyxHQUFHLE9BQU87QUFBQSxjQUM3RTtBQUFBLFlBQ0YsV0FBVyxlQUFlLFVBQVU7QUFDbEMscUJBQU87QUFBQSxZQUNUO0FBQUEsVUFDRjtBQUVBLHVCQUFhO0FBQ2IsYUFBRyxVQUFVLEVBQUUsdUJBQXVCLEdBQUcsU0FBUztBQUNsRCxpQkFBTztBQUFBLFFBQ1Q7QUFBQSxRQUVBLGdCQUFnQixZQUFZO0FBQzFCLGdCQUFNLFNBQVMsYUFBYTtBQUM1QixjQUFJLE9BQU8sU0FBUztBQUNsQixlQUFHLFVBQVUsRUFBRSx1QkFBdUIsRUFBRSxVQUFVLE9BQU8sU0FBUyxDQUFDLEdBQUcsU0FBUztBQUFBLFVBQ2pGLE9BQU87QUFDTCxlQUFHLFVBQVUsRUFBRSwyQkFBMkIsRUFBRSxPQUFPLE9BQU8sTUFBTSxDQUFDLEdBQUcsT0FBTztBQUFBLFVBQzdFO0FBQ0EsaUJBQU8sT0FBTztBQUFBLFFBQ2hCO0FBQUEsUUFFQSxnQkFBZ0IsT0FBTyxTQUFTO0FBQzlCLGNBQUk7QUFDRixrQkFBTSxTQUFTLE1BQU0sYUFBYSxJQUFJO0FBQ3RDLGdCQUFJLE9BQU8sU0FBUztBQUNsQixpQkFBRyxVQUFVLEVBQUUsd0JBQXdCLEVBQUUsU0FBUyxPQUFPLFNBQVMsT0FBTyxPQUFPLE1BQU0sQ0FBQyxHQUFHLFNBQVM7QUFDbkcsaUJBQUcsZUFBZSxPQUFPLFNBQVMsT0FBTyxPQUFPLGVBQWU7QUFJL0Qsa0JBQUkseURBQW9EO0FBRXhELHFCQUFPO0FBQUEsWUFDVCxPQUFPO0FBQ0wsaUJBQUcsVUFBVSxFQUFFLDJCQUEyQixFQUFFLE9BQU8sT0FBTyxNQUFNLENBQUMsR0FBRyxPQUFPO0FBQzNFLHFCQUFPO0FBQUEsWUFDVDtBQUFBLFVBQ0YsU0FBUyxPQUFPO0FBQ2QsZUFBRyxVQUFVLEVBQUUsMkJBQTJCLEVBQUUsT0FBTyxNQUFNLFFBQVEsQ0FBQyxHQUFHLE9BQU87QUFDNUUsbUJBQU87QUFBQSxVQUNUO0FBQUEsUUFDRjtBQUFBLFFBRUEsZUFBZSxNQUFNO0FBQ25CLGNBQUksV0FBVyxlQUFlLFdBQVcsYUFBYSxXQUFXLFVBQVUsV0FBVztBQUNwRixlQUFHLGlCQUFpQixXQUFXLFVBQVUsU0FBUztBQUFBLFVBQ3BEO0FBQUEsUUFDRjtBQUFBLFFBRUEsaUJBQWlCLE9BQU8sV0FBVyxVQUFVLGNBQWM7QUFDekQsY0FBSSx1Q0FBZ0MsVUFBVSxjQUFjLEVBQUUsS0FBSyxJQUFJLFVBQVUsY0FBYyxFQUFFLE1BQU0sTUFBTSxRQUFRLElBQUksU0FBUyxFQUFFO0FBRXBJLGNBQUk7QUFFRixrQkFBTSxVQUFVLE9BQU8sVUFBVSxTQUFTO0FBRzFDLGtCQUFNLGlCQUFpQixNQUFNLFVBQVUsY0FBYztBQUdyRCx1QkFBVyxZQUFZO0FBQUEsY0FDckI7QUFBQSxjQUNBLE9BQU87QUFBQSxjQUNQLFFBQVE7QUFBQSxjQUNSLGlCQUFpQixlQUFlO0FBQUEsY0FDaEMsYUFBYSxlQUFlO0FBQUEsY0FDNUIsZUFBZSxlQUFlO0FBQUEsWUFDaEM7QUFFQSx1QkFBVyxjQUFjLGVBQWU7QUFDeEMsdUJBQVcsZ0JBQWdCO0FBQzNCLHVCQUFXLGtCQUFrQixDQUFDO0FBQzlCLHVCQUFXLGVBQWUsRUFBRSxHQUFHLEdBQUcsR0FBRyxFQUFFO0FBR3ZDLGVBQUcsZUFBZSxHQUFHLGVBQWUsaUJBQWlCLGVBQWU7QUFDcEUsZUFBRyxVQUFVLEVBQUUsdUJBQXVCLEVBQUUsT0FBTyxVQUFVLFFBQVEsVUFBVSxDQUFDLEdBQUcsU0FBUztBQUV4RixnQkFBSSxpQ0FBNEIsZUFBZSxlQUFlLDZCQUF1QixlQUFlLFdBQVcsVUFBVTtBQUd6SCxnQkFBSTtBQUNGLGtCQUFJLE9BQU8sd0JBQXdCLFdBQVcsaUJBQWlCLFdBQVcsU0FBUyxRQUFRLFdBQVcsU0FBUyxNQUFNO0FBRW5ILHNCQUFNLFVBQVUsb0JBQW9CO0FBR3BDLHNCQUFNLGFBQWEsVUFBVSxtQkFBbUI7QUFDaEQsMkJBQVcsa0JBQWtCO0FBQzdCLDJCQUFXLGNBQWMsV0FBVztBQUdwQyx1QkFBTyxxQkFBcUIsUUFBUSxZQUFZO0FBQUEsa0JBQzlDLFFBQVE7QUFBQSxvQkFDTixPQUFPLFdBQVc7QUFBQSxvQkFDbEIsT0FBTyxXQUFXO0FBQUEsb0JBQ2xCLEtBQUssV0FBVyxjQUFjO0FBQUEsb0JBQzlCLEtBQUssV0FBVyxjQUFjO0FBQUEsa0JBQ2hDO0FBQUEsa0JBQ0EsWUFBWTtBQUFBLGtCQUNaLGFBQWE7QUFBQSxrQkFDYixTQUFTO0FBQUEsZ0JBQ1gsQ0FBQztBQUVELG9CQUFJLGtDQUE2QixXQUFXLE1BQU0sbUNBQTZCO0FBQUEsY0FDakY7QUFBQSxZQUNGLFNBQVMsY0FBYztBQUNyQixrQkFBSSxrRUFBcUQsYUFBYSxPQUFPLEVBQUU7QUFBQSxZQUNqRjtBQUFBLFVBQ0YsU0FBUyxPQUFPO0FBQ2QsZ0JBQUksd0NBQW1DLE1BQU0sT0FBTyxFQUFFO0FBQ3RELGVBQUcsVUFBVSxFQUFFLGtCQUFrQixHQUFHLE9BQU87QUFBQSxVQUM3QztBQUFBLFFBQ0Y7QUFBQSxNQUNGLENBQUM7QUFHRCxZQUFNLCtCQUErQixDQUFDLFVBQVU7QUFDOUMsY0FBTSxFQUFFLFNBQVMsSUFBSSxNQUFNO0FBQzNCLFlBQUksZ0VBQXlELFFBQVEsRUFBRTtBQUd2RSxtQkFBVyxXQUFXO0FBQUEsTUFJeEI7QUFFQSxhQUFPLGlCQUFpQiwyQkFBMkIsNEJBQTRCO0FBQy9FLGFBQU8saUJBQWlCLG1CQUFtQiw0QkFBNEI7QUFHdkUsYUFBTyxpQkFBaUIsZ0JBQWdCLE1BQU07QUFFNUMscUJBQWE7QUFFYixxQkFBYTtBQUNiLFdBQUcsUUFBUTtBQUNYLGVBQU8sb0JBQW9CLDJCQUEyQiw0QkFBNEI7QUFDbEYsZUFBTyxvQkFBb0IsbUJBQW1CLDRCQUE0QjtBQUMxRSxZQUFJLE9BQU8sYUFBYTtBQUN0QixpQkFBTyxZQUFZLGVBQWU7QUFBQSxRQUNwQztBQUFBLE1BQ0YsQ0FBQztBQUVELFVBQUksOENBQXlDO0FBRzdDLGlCQUFXLFlBQVk7QUFDckIsWUFBSTtBQUNGLGFBQUcsVUFBVSxFQUFFLHdCQUF3QixHQUFHLE1BQU07QUFDaEQsY0FBSSxxQ0FBOEI7QUFFbEMsZ0JBQU0sa0JBQWtCLE1BQU0sWUFBWTtBQUUxQyxjQUFJLGlCQUFpQjtBQUNuQixlQUFHLFVBQVUsRUFBRSx1QkFBdUIsR0FBRyxTQUFTO0FBQ2xELGdCQUFJLDRCQUF1QjtBQUczQixlQUFHLHFCQUFxQixLQUFLO0FBRzdCLGtCQUFNLGFBQWEsTUFBTSxjQUFjLElBQUk7QUFDM0MsZ0JBQUksWUFBWTtBQUNkLGtCQUFJLDJDQUFvQztBQUFBLFlBQzFDO0FBQUEsVUFDRixPQUFPO0FBQ0wsZUFBRyxVQUFVLEVBQUUsc0JBQXNCLEdBQUcsU0FBUztBQUNqRCxnQkFBSSw4REFBaUQ7QUFBQSxVQUV2RDtBQUFBLFFBQ0YsU0FBUyxPQUFPO0FBQ2QsY0FBSSxnQ0FBMkIsS0FBSztBQUNwQyxhQUFHLFVBQVUsRUFBRSwwQkFBMEIsR0FBRyxTQUFTO0FBQUEsUUFDdkQ7QUFBQSxNQUNGLEdBQUcsR0FBSTtBQUFBLElBRVQsU0FBUyxPQUFPO0FBQ2QsVUFBSSwwQ0FBcUMsS0FBSztBQUM5QyxVQUFJLE9BQU8sYUFBYTtBQUN0QixlQUFPLFlBQVksZUFBZTtBQUFBLE1BQ3BDO0FBQ0EsWUFBTTtBQUFBLElBQ1I7QUFBQSxFQUNGOzs7QUN6c0JBLEdBQUMsWUFBWTtBQUNYO0FBSkY7QUFPRSxRQUFJO0FBQ0YsY0FBUSxJQUFJLGtFQUF3RDtBQUNwRSxZQUFNLHFCQUFxQixHQUFHLElBQUk7QUFBQSxJQUNwQyxTQUFTLE9BQU87QUFDZCxjQUFRLElBQUksb0VBQXVELEtBQUs7QUFBQSxJQUMxRTtBQUdBLFNBQUksWUFBTyxnQkFBUCxtQkFBb0IsY0FBYztBQUNwQyxZQUFNLGtDQUErQjtBQUNyQztBQUFBLElBQ0Y7QUFHQSxTQUFJLFlBQU8sZ0JBQVAsbUJBQW9CLGFBQWE7QUFDbkMsWUFBTSw2RUFBb0U7QUFDMUU7QUFBQSxJQUNGO0FBR0EsUUFBSSxDQUFDLE9BQU8sYUFBYTtBQUN2QixhQUFPLGNBQWMsQ0FBQztBQUFBLElBQ3hCO0FBR0EsV0FBTyxZQUFZLGVBQWU7QUFFbEMsYUFBUyxFQUFFLE1BQU0sQ0FBQyxNQUFNO0FBQ3RCLGNBQVEsTUFBTSw4QkFBOEIsQ0FBQztBQUM3QyxVQUFJLE9BQU8sYUFBYTtBQUN0QixlQUFPLFlBQVksZUFBZTtBQUFBLE1BQ3BDO0FBQ0EsWUFBTSwrQ0FBK0M7QUFBQSxJQUN2RCxDQUFDO0FBQUEsRUFDSCxHQUFHOyIsCiAgIm5hbWVzIjogWyJ0IiwgImUiLCAiY29uZmlnIl0KfQo=

--- a/Auto-Launcher.js
+++ b/Auto-Launcher.js
@@ -1,11 +1,1689 @@
-/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-20T06:47:15.364Z */
-(()=>{var i=(...n)=>console.log("[WPA-UI]",...n);function $(n=null){let a=document.createElement("div");n&&(a.id=n),a.style.cssText=`
+/* WPlace AutoBOT — uso bajo tu responsabilidad. Compilado 2025-08-21T06:28:30.591Z */
+(() => {
+  // src/core/logger.js
+  var log = (...a) => console.log("[WPA-UI]", ...a);
+
+  // src/core/ui-utils.js
+  function createShadowRoot(hostId = null) {
+    const host = document.createElement("div");
+    if (hostId) {
+      host.id = hostId;
+    }
+    host.style.cssText = `
     position: fixed;
     top: 10px;
     right: 10px;
     z-index: 2147483647;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  `;let o=a.attachShadow({mode:"open"});return document.body.appendChild(a),{host:a,root:o}}function M(n,a){let o=0,u=0,l=0,c=0;n.style.cursor="move",n.addEventListener("mousedown",r);function r(h){h.target.closest(".header-btn, .wplace-header-btn")||(h.preventDefault(),l=h.clientX,c=h.clientY,document.addEventListener("mouseup",x),document.addEventListener("mousemove",d))}function d(h){h.preventDefault(),o=l-h.clientX,u=c-h.clientY,l=h.clientX,c=h.clientY,a.style.top=a.offsetTop-u+"px",a.style.left=a.offsetLeft-o+"px"}function x(){document.removeEventListener("mouseup",x),document.removeEventListener("mousemove",d)}}var G={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selecci\xF3n",user:"Usuario",charges:"Cargas",backend:"Backend",database:"Database",uptime:"Uptime",close:"Cerrar",launch:"Lanzar",loading:"Cargando\u2026",executing:"Ejecutando\u2026",downloading:"Descargando script\u2026",chooseBot:"Elige un bot y presiona Lanzar",readyToLaunch:"Listo para lanzar",loadError:"Error al cargar",loadErrorMsg:"No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",checking:"\u{1F504} Verificando...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Iniciar Auto-BOT",uploadImage:"Subir Imagen",resizeImage:"Redimensionar Imagen",selectPosition:"Seleccionar Posici\xF3n",startPainting:"Iniciar Pintura",stopPainting:"Detener Pintura",saveProgress:"Guardar Progreso",loadProgress:"Cargar Progreso",checkingColors:"\u{1F50D} Verificando colores disponibles...",noColorsFound:"\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",colorsFound:"\u2705 {count} colores disponibles encontrados",loadingImage:"\u{1F5BC}\uFE0F Cargando imagen...",imageLoaded:"\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",imageError:"\u274C Error al cargar la imagen",selectPositionAlert:"\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Posici\xF3n establecida con \xE9xito!",positionTimeout:"\u274C Tiempo agotado para seleccionar posici\xF3n",positionDetected:"\u{1F3AF} Posici\xF3n detectada, procesando...",positionError:"\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",startPaintingMsg:"\u{1F3A8} Iniciando pintura...",paintingProgress:"\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",noCharges:"\u231B Sin cargas. Esperando {time}...",paintingStopped:"\u23F9\uFE0F Pintura detenida por el usuario",paintingComplete:"\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",paintingError:"\u274C Error durante la pintura",missingRequirements:"\u274C Carga una imagen y selecciona una posici\xF3n primero",progress:"Progreso",userName:"Usuario",pixels:"P\xEDxeles",charges:"Cargas",estimatedTime:"Tiempo estimado",initMessage:"Haz clic en 'Iniciar Auto-BOT' para comenzar",waitingInit:"Esperando inicializaci\xF3n...",resizeSuccess:"\u2705 Imagen redimensionada a {width}x{height}",paintingPaused:"\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",pixelsPerBatch:"P\xEDxeles por lote",batchSize:"Tama\xF1o del lote",nextBatchTime:"Siguiente lote en",useAllCharges:"Usar todas las cargas disponibles",showOverlay:"Mostrar overlay",maxCharges:"Cargas m\xE1ximas por lote",waitingForCharges:"\u23F3 Esperando cargas: {current}/{needed}",timeRemaining:"Tiempo restante",cooldownWaiting:"\u23F3 Esperando {time} para continuar...",progressSaved:"\u2705 Progreso guardado como {filename}",progressLoaded:"\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",progressLoadError:"\u274C Error al cargar progreso: {error}",progressSaveError:"\u274C Error al guardar progreso: {error}",confirmSaveProgress:"\xBFDeseas guardar el progreso actual antes de detener?",saveProgressTitle:"Guardar Progreso",discardProgress:"Descartar",cancel:"Cancelar",minimize:"Minimizar",width:"Ancho",height:"Alto",keepAspect:"Mantener proporci\xF3n",apply:"Aplicar",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",waitingChargesCountdown:"\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Bot iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",manualInitRequired:"\u{1F527} Inicio manual requerido",retryAttempt:"\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",retryError:"\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",retryFailed:"\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",networkError:"\u{1F310} Error de red. Reintentando...",serverError:"\u{1F525} Error del servidor. Reintentando...",timeoutError:"\u23F0 Timeout del servidor. Reintentando..."},farm:{title:"WPlace Farm Bot",start:"Iniciar",stop:"Detener",stopped:"Bot detenido",calibrate:"Calibrar",paintOnce:"Una vez",checkingStatus:"Verificando estado...",configuration:"Configuraci\xF3n",delay:"Delay (ms)",pixelsPerBatch:"P\xEDxeles/lote",minCharges:"Cargas m\xEDn",colorMode:"Modo color",random:"Aleatorio",fixed:"Fijo",range:"Rango",fixedColor:"Color fijo",advanced:"Avanzado",tileX:"Tile X",tileY:"Tile Y",customPalette:"Paleta personalizada",paletteExample:"ej: #FF0000,#00FF00,#0000FF",capture:"Capturar",painted:"Pintados",charges:"Cargas",retries:"Fallos",tile:"Tile",configSaved:"Configuraci\xF3n guardada",configLoaded:"Configuraci\xF3n cargada",configReset:"Configuraci\xF3n reiniciada",captureInstructions:"Pinta un p\xEDxel manualmente para capturar coordenadas...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Iniciando bot...",stoppingBot:"Deteniendo bot...",calibrating:"Calibrando...",alreadyRunning:"Auto-Farm ya est\xE1 corriendo.",imageRunningWarning:"Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",selectPosition:"Seleccionar Zona",selectPositionAlert:"\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",waitingPosition:"\u{1F446} Esperando que pintes el p\xEDxel de referencia...",positionSet:"\u2705 \xA1Zona establecida! Radio: 500px",positionTimeout:"\u274C Tiempo agotado para seleccionar zona",missingPosition:"\u274C Selecciona una zona primero usando 'Seleccionar Zona'",farmRadius:"Radio farm",positionInfo:"Zona actual",farmingInRadius:"\u{1F33E} Farming en radio {radius}px desde ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",noPosition:"Sin zona",currentZone:"Zona: ({x},{y})",autoSelectPosition:"\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"},common:{yes:"S\xED",no:"No",ok:"Aceptar",cancel:"Cancelar",close:"Cerrar",save:"Guardar",load:"Cargar",delete:"Eliminar",edit:"Editar",start:"Iniciar",stop:"Detener",pause:"Pausar",resume:"Reanudar",reset:"Reiniciar",settings:"Configuraci\xF3n",help:"Ayuda",about:"Acerca de",language:"Idioma",loading:"Cargando...",error:"Error",success:"\xC9xito",warning:"Advertencia",info:"Informaci\xF3n",languageChanged:"Idioma cambiado a {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Inicializar Guard-BOT",selectArea:"Seleccionar \xC1rea",captureArea:"Capturar \xC1rea",startProtection:"Iniciar Protecci\xF3n",stopProtection:"Detener Protecci\xF3n",upperLeft:"Esquina Superior Izquierda",lowerRight:"Esquina Inferior Derecha",protectedPixels:"P\xEDxeles Protegidos",detectedChanges:"Cambios Detectados",repairedPixels:"P\xEDxeles Reparados",charges:"Cargas",waitingInit:"Esperando inicializaci\xF3n...",checkingColors:"\u{1F3A8} Verificando colores disponibles...",noColorsFound:"\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",colorsFound:"\u2705 {count} colores disponibles encontrados",initSuccess:"\u2705 Guard-BOT inicializado correctamente",initError:"\u274C Error inicializando Guard-BOT",invalidCoords:"\u274C Coordenadas inv\xE1lidas",invalidArea:"\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",areaTooLarge:"\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",capturingArea:"\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",areaCaptured:"\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",captureError:"\u274C Error capturando \xE1rea: {error}",captureFirst:"\u274C Primero captura un \xE1rea de protecci\xF3n",protectionStarted:"\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",protectionStopped:"\u23F9\uFE0F Protecci\xF3n detenida",noChanges:"\u2705 \xC1rea protegida - sin cambios detectados",changesDetected:"\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",repairing:"\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",repairedSuccess:"\u2705 Reparados {count} p\xEDxeles correctamente",repairError:"\u274C Error reparando p\xEDxeles: {error}",noCharges:"\u26A0\uFE0F Sin cargas suficientes para reparar cambios",checkingChanges:"\u{1F50D} Verificando cambios en \xE1rea protegida...",errorChecking:"\u274C Error verificando cambios: {error}",guardActive:"\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",lastCheck:"\xDAltima verificaci\xF3n: {time}",nextCheck:"Pr\xF3xima verificaci\xF3n en: {time}s",autoInitializing:"\u{1F916} Inicializando autom\xE1ticamente...",autoInitSuccess:"\u2705 Guard-BOT iniciado autom\xE1ticamente",autoInitFailed:"\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",manualInitRequired:"\u{1F527} Inicio manual requerido",paletteDetected:"\u{1F3A8} Paleta de colores detectada",paletteNotFound:"\u{1F50D} Buscando paleta de colores...",clickingPaintButton:"\u{1F446} Haciendo clic en el bot\xF3n Paint...",paintButtonNotFound:"\u274C Bot\xF3n Paint no encontrado",selectUpperLeft:"\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",selectLowerRight:"\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",waitingUpperLeft:"\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",waitingLowerRight:"\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",upperLeftCaptured:"\u2705 Esquina superior izquierda capturada: ({x}, {y})",lowerRightCaptured:"\u2705 Esquina inferior derecha capturada: ({x}, {y})",selectionTimeout:"\u274C Tiempo agotado para selecci\xF3n",selectionError:"\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"}};var H={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"Selection",user:"User",charges:"Charges",backend:"Backend",database:"Database",uptime:"Uptime",close:"Close",launch:"Launch",loading:"Loading\u2026",executing:"Executing\u2026",downloading:"Downloading script\u2026",chooseBot:"Choose a bot and press Launch",readyToLaunch:"Ready to launch",loadError:"Load error",loadErrorMsg:"Could not load the selected bot. Check your connection or try again.",checking:"\u{1F504} Checking...",online:"\u{1F7E2} Online",offline:"\u{1F534} Offline",ok:"\u{1F7E2} OK",error:"\u{1F534} Error",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialize Auto-BOT",uploadImage:"Upload Image",resizeImage:"Resize Image",selectPosition:"Select Position",startPainting:"Start Painting",stopPainting:"Stop Painting",saveProgress:"Save Progress",loadProgress:"Load Progress",checkingColors:"\u{1F50D} Checking available colors...",noColorsFound:"\u274C Open the color palette on the site and try again!",colorsFound:"\u2705 Found {count} available colors",loadingImage:"\u{1F5BC}\uFE0F Loading image...",imageLoaded:"\u2705 Image loaded with {count} valid pixels",imageError:"\u274C Error loading image",selectPositionAlert:"Paint the first pixel at the location where you want the art to start!",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Position set successfully!",positionTimeout:"\u274C Timeout for position selection",positionDetected:"\u{1F3AF} Position detected, processing...",positionError:"\u274C Error detecting position, please try again",startPaintingMsg:"\u{1F3A8} Starting painting...",paintingProgress:"\u{1F9F1} Progress: {painted}/{total} pixels...",noCharges:"\u231B No charges. Waiting {time}...",paintingStopped:"\u23F9\uFE0F Painting stopped by user",paintingComplete:"\u2705 Painting completed! {count} pixels painted.",paintingError:"\u274C Error during painting",missingRequirements:"\u274C Load an image and select a position first",progress:"Progress",userName:"User",pixels:"Pixels",charges:"Charges",estimatedTime:"Estimated time",initMessage:"Click 'Initialize Auto-BOT' to begin",waitingInit:"Waiting for initialization...",resizeSuccess:"\u2705 Image resized to {width}x{height}",paintingPaused:"\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",pixelsPerBatch:"Pixels per batch",batchSize:"Batch size",nextBatchTime:"Next batch in",useAllCharges:"Use all available charges",showOverlay:"Show overlay",maxCharges:"Max charges per batch",waitingForCharges:"\u23F3 Waiting for charges: {current}/{needed}",timeRemaining:"Time remaining",cooldownWaiting:"\u23F3 Waiting {time} to continue...",progressSaved:"\u2705 Progress saved as {filename}",progressLoaded:"\u2705 Progress loaded: {painted}/{total} pixels painted",progressLoadError:"\u274C Error loading progress: {error}",progressSaveError:"\u274C Error saving progress: {error}",confirmSaveProgress:"Do you want to save the current progress before stopping?",saveProgressTitle:"Save Progress",discardProgress:"Discard",cancel:"Cancel",minimize:"Minimize",width:"Width",height:"Height",keepAspect:"Keep aspect ratio",apply:"Apply",overlayOn:"Overlay: ON",overlayOff:"Overlay: OFF",passCompleted:"\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",waitingChargesCountdown:"\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Bot auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",manualInitRequired:"\u{1F527} Manual initialization required",retryAttempt:"\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",retryError:"\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",retryFailed:"\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",networkError:"\u{1F310} Network error. Retrying...",serverError:"\u{1F525} Server error. Retrying...",timeoutError:"\u23F0 Server timeout. Retrying..."},farm:{title:"WPlace Farm Bot",start:"Start",stop:"Stop",stopped:"Bot stopped",calibrate:"Calibrate",paintOnce:"Once",checkingStatus:"Checking status...",configuration:"Configuration",delay:"Delay (ms)",pixelsPerBatch:"Pixels/batch",minCharges:"Min charges",colorMode:"Color mode",random:"Random",fixed:"Fixed",range:"Range",fixedColor:"Fixed color",advanced:"Advanced",tileX:"Tile X",tileY:"Tile Y",customPalette:"Custom palette",paletteExample:"e.g: #FF0000,#00FF00,#0000FF",capture:"Capture",painted:"Painted",charges:"Charges",retries:"Retries",tile:"Tile",configSaved:"Configuration saved",configLoaded:"Configuration loaded",configReset:"Configuration reset",captureInstructions:"Paint a pixel manually to capture coordinates...",backendOnline:"Backend Online",backendOffline:"Backend Offline",startingBot:"Starting bot...",stoppingBot:"Stopping bot...",calibrating:"Calibrating...",alreadyRunning:"Auto-Farm is already running.",imageRunningWarning:"Auto-Image is running. Close it before starting Auto-Farm.",selectPosition:"Select Area",selectPositionAlert:"\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",waitingPosition:"\u{1F446} Waiting for you to paint the reference pixel...",positionSet:"\u2705 Area set! Radius: 500px",positionTimeout:"\u274C Timeout for area selection",missingPosition:"\u274C Select an area first using 'Select Area'",farmRadius:"Farm radius",positionInfo:"Current area",farmingInRadius:"\u{1F33E} Farming in {radius}px radius from ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",noPosition:"No area",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"},common:{yes:"Yes",no:"No",ok:"OK",cancel:"Cancel",close:"Close",save:"Save",load:"Load",delete:"Delete",edit:"Edit",start:"Start",stop:"Stop",pause:"Pause",resume:"Resume",reset:"Reset",settings:"Settings",help:"Help",about:"About",language:"Language",loading:"Loading...",error:"Error",success:"Success",warning:"Warning",info:"Information",languageChanged:"Language changed to {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialize Guard-BOT",selectArea:"Select Area",captureArea:"Capture Area",startProtection:"Start Protection",stopProtection:"Stop Protection",upperLeft:"Upper Left Corner",lowerRight:"Lower Right Corner",protectedPixels:"Protected Pixels",detectedChanges:"Detected Changes",repairedPixels:"Repaired Pixels",charges:"Charges",waitingInit:"Waiting for initialization...",checkingColors:"\u{1F3A8} Checking available colors...",noColorsFound:"\u274C No colors found. Open the color palette on the site.",colorsFound:"\u2705 Found {count} available colors",initSuccess:"\u2705 Guard-BOT initialized successfully",initError:"\u274C Error initializing Guard-BOT",invalidCoords:"\u274C Invalid coordinates",invalidArea:"\u274C Area must have upper left corner less than lower right corner",areaTooLarge:"\u274C Area too large: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capturing protection area...",areaCaptured:"\u2705 Area captured: {count} pixels under protection",captureError:"\u274C Error capturing area: {error}",captureFirst:"\u274C First capture a protection area",protectionStarted:"\u{1F6E1}\uFE0F Protection started - monitoring area",protectionStopped:"\u23F9\uFE0F Protection stopped",noChanges:"\u2705 Protected area - no changes detected",changesDetected:"\u{1F6A8} {count} changes detected in protected area",repairing:"\u{1F6E0}\uFE0F Repairing {count} altered pixels...",repairedSuccess:"\u2705 Successfully repaired {count} pixels",repairError:"\u274C Error repairing pixels: {error}",noCharges:"\u26A0\uFE0F Insufficient charges to repair changes",checkingChanges:"\u{1F50D} Checking changes in protected area...",errorChecking:"\u274C Error checking changes: {error}",guardActive:"\u{1F6E1}\uFE0F Guardian active - area under protection",lastCheck:"Last check: {time}",nextCheck:"Next check in: {time}s",autoInitializing:"\u{1F916} Auto-initializing...",autoInitSuccess:"\u2705 Guard-BOT auto-started successfully",autoInitFailed:"\u26A0\uFE0F Could not auto-start. Use manual button.",manualInitRequired:"\u{1F527} Manual initialization required",paletteDetected:"\u{1F3A8} Color palette detected",paletteNotFound:"\u{1F50D} Searching for color palette...",clickingPaintButton:"\u{1F446} Clicking Paint button...",paintButtonNotFound:"\u274C Paint button not found",selectUpperLeft:"\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",selectLowerRight:"\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",waitingUpperLeft:"\u{1F446} Waiting for upper left corner selection...",waitingLowerRight:"\u{1F446} Waiting for lower right corner selection...",upperLeftCaptured:"\u2705 Upper left corner captured: ({x}, {y})",lowerRightCaptured:"\u2705 Lower right corner captured: ({x}, {y})",selectionTimeout:"\u274C Selection timeout",selectionError:"\u274C Selection error, please try again"}};var W={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} Auto-Farm",autoImage:"\u{1F3A8} Auto-Image",autoGuard:"\u{1F6E1}\uFE0F Auto-Guard",selection:"S\xE9lection",user:"Utilisateur",charges:"Charges",backend:"Backend",database:"Base de donn\xE9es",uptime:"Temps actif",close:"Fermer",launch:"Lancer",loading:"Chargement\u2026",executing:"Ex\xE9cution\u2026",downloading:"T\xE9l\xE9chargement du script\u2026",chooseBot:"Choisissez un bot et appuyez sur Lancer",readyToLaunch:"Pr\xEAt \xE0 lancer",loadError:"Erreur de chargement",loadErrorMsg:"Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",checking:"\u{1F504} V\xE9rification...",online:"\u{1F7E2} En ligne",offline:"\u{1F534} Hors ligne",ok:"\u{1F7E2} OK",error:"\u{1F534} Erreur",unknown:"-"},image:{title:"WPlace Auto-Image",initBot:"Initialiser Auto-BOT",uploadImage:"T\xE9l\xE9charger Image",resizeImage:"Redimensionner Image",selectPosition:"S\xE9lectionner Position",startPainting:"Commencer Peinture",stopPainting:"Arr\xEAter Peinture",saveProgress:"Sauvegarder Progr\xE8s",loadProgress:"Charger Progr\xE8s",checkingColors:"\u{1F50D} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",loadingImage:"\u{1F5BC}\uFE0F Chargement de l'image...",imageLoaded:"\u2705 Image charg\xE9e avec {count} pixels valides",imageError:"\u274C Erreur lors du chargement de l'image",selectPositionAlert:"Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Position d\xE9finie avec succ\xE8s!",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",positionDetected:"\u{1F3AF} Position d\xE9tect\xE9e, traitement...",positionError:"\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",startPaintingMsg:"\u{1F3A8} D\xE9but de la peinture...",paintingProgress:"\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",noCharges:"\u231B Aucune charge. Attendre {time}...",paintingStopped:"\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",paintingComplete:"\u2705 Peinture termin\xE9e! {count} pixels peints.",paintingError:"\u274C Erreur pendant la peinture",missingRequirements:"\u274C Chargez une image et s\xE9lectionnez une position d'abord",progress:"Progr\xE8s",userName:"Usager",pixels:"Pixels",charges:"Charges",estimatedTime:"Temps estim\xE9",initMessage:"Cliquez sur 'Initialiser Auto-BOT' pour commencer",waitingInit:"En attente d'initialisation...",resizeSuccess:"\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",paintingPaused:"\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",pixelsPerBatch:"Pixels par lot",batchSize:"Taille du lot",nextBatchTime:"Prochain lot dans",useAllCharges:"Utiliser toutes les charges disponibles",showOverlay:"Afficher l'overlay",maxCharges:"Charges max par lot",waitingForCharges:"\u23F3 En attente de charges: {current}/{needed}",timeRemaining:"Temps restant",cooldownWaiting:"\u23F3 Attendre {time} pour continuer...",progressSaved:"\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",progressLoaded:"\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",progressLoadError:"\u274C Erreur lors du chargement du progr\xE8s: {error}",progressSaveError:"\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",confirmSaveProgress:"Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",saveProgressTitle:"Sauvegarder Progr\xE8s",discardProgress:"Abandonner",cancel:"Annuler",minimize:"Minimiser",width:"Largeur",height:"Hauteur",keepAspect:"Garder les proportions",apply:"Appliquer",overlayOn:"Overlay : ON",overlayOff:"Overlay : OFF",passCompleted:"\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",waitingChargesRegen:"\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",waitingChargesCountdown:"\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Bot d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",manualInitRequired:"\u{1F527} Initialisation manuelle requise",retryAttempt:"\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",retryError:"\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",retryFailed:"\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",networkError:"\u{1F310} Erreur r\xE9seau. Nouvel essai...",serverError:"\u{1F525} Erreur serveur. Nouvel essai...",timeoutError:"\u23F0 Timeout serveur. Nouvel essai..."},farm:{title:"WPlace Farm Bot",start:"D\xE9marrer",stop:"Arr\xEAter",stopped:"Bot arr\xEAt\xE9",calibrate:"Calibrer",paintOnce:"Une fois",checkingStatus:"V\xE9rification du statut...",configuration:"Configuration",delay:"D\xE9lai (ms)",pixelsPerBatch:"Pixels/lot",minCharges:"Charges min",colorMode:"Mode couleur",random:"Al\xE9atoire",fixed:"Fixe",range:"Plage",fixedColor:"Couleur fixe",advanced:"Avanc\xE9",tileX:"Tuile X",tileY:"Tuile Y",customPalette:"Palette personnalis\xE9e",paletteExample:"ex: #FF0000,#00FF00,#0000FF",capture:"Capturer",painted:"Peints",charges:"Charges",retries:"\xC9checs",tile:"Tuile",configSaved:"Configuration sauvegard\xE9e",configLoaded:"Configuration charg\xE9e",configReset:"Configuration r\xE9initialis\xE9e",captureInstructions:"Peindre un pixel manuellement pour capturer les coordonn\xE9es...",backendOnline:"Backend En ligne",backendOffline:"Backend Hors ligne",startingBot:"D\xE9marrage du bot...",stoppingBot:"Arr\xEAt du bot...",calibrating:"Calibrage...",alreadyRunning:"Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",imageRunningWarning:"Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",selectPosition:"S\xE9lectionner Zone",selectPositionAlert:"\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",waitingPosition:"\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",positionSet:"\u2705 Zone d\xE9finie! Rayon: 500px",positionTimeout:"\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",missingPosition:"\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",farmRadius:"Rayon farm",positionInfo:"Zone actuelle",farmingInRadius:"\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",selectEmptyArea:"\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",noPosition:"Aucune zone",currentZone:"Zone: ({x},{y})",autoSelectPosition:"\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"},common:{yes:"Oui",no:"Non",ok:"OK",cancel:"Annuler",close:"Fermer",save:"Sauvegarder",load:"Charger",delete:"Supprimer",edit:"Modifier",start:"D\xE9marrer",stop:"Arr\xEAter",pause:"Pause",resume:"Reprendre",reset:"R\xE9initialiser",settings:"Param\xE8tres",help:"Aide",about:"\xC0 propos",language:"Langue",loading:"Chargement...",error:"Erreur",success:"Succ\xE8s",warning:"Avertissement",info:"Information",languageChanged:"Langue chang\xE9e en {language}"},guard:{title:"WPlace Auto-Guard",initBot:"Initialiser Guard-BOT",selectArea:"S\xE9lectionner Zone",captureArea:"Capturer Zone",startProtection:"D\xE9marrer Protection",stopProtection:"Arr\xEAter Protection",upperLeft:"Coin Sup\xE9rieur Gauche",lowerRight:"Coin Inf\xE9rieur Droit",protectedPixels:"Pixels Prot\xE9g\xE9s",detectedChanges:"Changements D\xE9tect\xE9s",repairedPixels:"Pixels R\xE9par\xE9s",charges:"Charges",waitingInit:"En attente d'initialisation...",checkingColors:"\u{1F3A8} V\xE9rification des couleurs disponibles...",noColorsFound:"\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",colorsFound:"\u2705 {count} couleurs disponibles trouv\xE9es",initSuccess:"\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",initError:"\u274C Erreur lors de l'initialisation de Guard-BOT",invalidCoords:"\u274C Coordonn\xE9es invalides",invalidArea:"\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",areaTooLarge:"\u274C Zone trop grande: {size} pixels (maximum: {max})",capturingArea:"\u{1F4F8} Capture de la zone de protection...",areaCaptured:"\u2705 Zone captur\xE9e: {count} pixels sous protection",captureError:"\u274C Erreur lors de la capture de zone: {error}",captureFirst:"\u274C Capturez d'abord une zone de protection",protectionStarted:"\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",protectionStopped:"\u23F9\uFE0F Protection arr\xEAt\xE9e",noChanges:"\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",changesDetected:"\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",repairing:"\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",repairedSuccess:"\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",repairError:"\u274C Erreur lors de la r\xE9paration des pixels: {error}",noCharges:"\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",checkingChanges:"\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",errorChecking:"\u274C Erreur lors de la v\xE9rification des changements: {error}",guardActive:"\u{1F6E1}\uFE0F Gardien actif - zone sous protection",lastCheck:"Derni\xE8re v\xE9rification: {time}",nextCheck:"Prochaine v\xE9rification dans: {time}s",autoInitializing:"\u{1F916} Initialisation automatique...",autoInitSuccess:"\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",autoInitFailed:"\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",manualInitRequired:"\u{1F527} Initialisation manuelle requise",paletteDetected:"\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",paletteNotFound:"\u{1F50D} Recherche de la palette de couleurs...",clickingPaintButton:"\u{1F446} Clic sur le bouton Paint...",paintButtonNotFound:"\u274C Bouton Paint introuvable",selectUpperLeft:"\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",selectLowerRight:"\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",waitingUpperLeft:"\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",waitingLowerRight:"\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",upperLeftCaptured:"\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",lowerRightCaptured:"\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",selectionTimeout:"\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",selectionError:"\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"}};var _={launcher:{title:"WPlace AutoBOT",autoFarm:"\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",autoImage:"\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",autoGuard:"\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",selection:"\u0412\u044B\u0431\u0440\u0430\u043D\u043E",user:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",charges:"\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",backend:"\u0411\u044D\u043A\u0435\u043D\u0434",database:"\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",uptime:"\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",launch:"\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",executing:"\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",downloading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",chooseBot:"\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",readyToLaunch:"\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",loadError:"\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",loadErrorMsg:"\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",checking:"\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",online:"\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",offline:"\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",ok:"\u{1F7E2} \u041E\u041A",error:"\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",unknown:"-"},image:{title:"WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",uploadImage:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",resizeImage:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",startPainting:"\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",stopPainting:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",saveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",loadProgress:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",checkingColors:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",loadingImage:"\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",imageLoaded:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",imageError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",selectPositionAlert:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",positionDetected:"\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",positionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",startPaintingMsg:"\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",paintingProgress:"\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",noCharges:"\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",paintingStopped:"\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",paintingComplete:"\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",paintingError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",missingRequirements:"\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",progress:"\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",userName:"\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",pixels:"\u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",estimatedTime:"\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",initMessage:"\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",resizeSuccess:"\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",paintingPaused:"\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",batchSize:"\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",nextBatchTime:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",useAllCharges:"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",showOverlay:"\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",maxCharges:"\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",waitingForCharges:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",timeRemaining:"\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",cooldownWaiting:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",progressSaved:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",progressLoaded:"\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",progressLoadError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",progressSaveError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",confirmSaveProgress:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",saveProgressTitle:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",discardProgress:"\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",minimize:"\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",width:"\u0428\u0438\u0440\u0438\u043D\u0430",height:"\u0412\u044B\u0441\u043E\u0442\u0430",keepAspect:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",apply:"\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",passCompleted:"\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",waitingChargesRegen:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",waitingChargesCountdown:"\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",retryAttempt:"\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryError:"\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",retryFailed:"\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",networkError:"\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",serverError:"\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",timeoutError:"\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."},farm:{title:"WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",stopped:"\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",calibrate:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",paintOnce:"\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",checkingStatus:"\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",configuration:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",delay:"\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",pixelsPerBatch:"\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",minCharges:"\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",colorMode:"\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",random:"\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",fixed:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",range:"\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",fixedColor:"\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",advanced:"\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",tileX:"\u041F\u043B\u0438\u0442\u043A\u0430 X",tileY:"\u041F\u043B\u0438\u0442\u043A\u0430 Y",customPalette:"\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",paletteExample:"\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",capture:"\u0417\u0430\u0445\u0432\u0430\u0442",painted:"\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",retries:"\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",tile:"\u041F\u043B\u0438\u0442\u043A\u0430",configSaved:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",configLoaded:"\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",configReset:"\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",captureInstructions:"\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",backendOnline:"\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",backendOffline:"\u0411\u044D\u043A\u044D\u043D\u0434",startingBot:"\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",stoppingBot:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",calibrating:"\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",alreadyRunning:"\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",imageRunningWarning:"\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",selectPosition:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C",selectPositionAlert:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",waitingPosition:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",positionSet:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",positionTimeout:"\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",missingPosition:"\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",farmRadius:"\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",positionInfo:"\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",farmingInRadius:"\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",selectEmptyArea:"\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",noPosition:"\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",currentZone:"\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",autoSelectPosition:"\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."},common:{yes:"\u0414\u0430",no:"\u041D\u0435\u0442",ok:"\u041E\u041A",cancel:"\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",close:"\u0417\u0430\u043A\u0440\u044B\u0442\u044C",save:"\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",load:"\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",delete:"\u0423\u0434\u0430\u043B\u0438\u0442\u044C",edit:"\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",start:"\u041D\u0430\u0447\u0430\u0442\u044C",stop:"\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",pause:"\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",resume:"\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",reset:"\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",settings:"\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",help:"\u041F\u043E\u043C\u043E\u0449\u044C",about:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",language:"\u042F\u0437\u044B\u043A",loading:"\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",error:"\u041E\u0448\u0438\u0431\u043A\u0430",success:"\u0423\u0441\u043F\u0435\u0445",warning:"\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",info:"\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",languageChanged:"\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"},guard:{title:"WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",initBot:"\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",selectArea:"\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",captureArea:"\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",startProtection:"\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",stopProtection:"\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",upperLeft:"\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",lowerRight:"\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",protectedPixels:"\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",detectedChanges:"\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",repairedPixels:"\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",charges:"\u0417\u0430\u0440\u044F\u0434\u044B",waitingInit:"\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",checkingColors:"\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",noColorsFound:"\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",colorsFound:"\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",initSuccess:"\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",initError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",invalidCoords:"\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",invalidArea:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",areaTooLarge:"\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",capturingArea:"\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",areaCaptured:"\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",captureError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",captureFirst:"\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",protectionStarted:"\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",protectionStopped:"\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",noChanges:"\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",changesDetected:"\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",repairing:"\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",repairedSuccess:"\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",repairError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",noCharges:"\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",checkingChanges:"\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",errorChecking:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",guardActive:"\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",lastCheck:"\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",nextCheck:"\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",autoInitializing:"\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",autoInitSuccess:"\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",autoInitFailed:"\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",manualInitRequired:"\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",paletteDetected:"\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",paletteNotFound:"\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",clickingPaintButton:"\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",paintButtonNotFound:"\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",selectUpperLeft:"\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",selectLowerRight:"\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",waitingUpperLeft:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",waitingLowerRight:"\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",upperLeftCaptured:"\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",lowerRightCaptured:"\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",selectionTimeout:"\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",selectionError:"\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"}};var k={es:{name:"Espa\xF1ol",flag:"\u{1F1EA}\u{1F1F8}",code:"es"},en:{name:"English",flag:"\u{1F1FA}\u{1F1F8}",code:"en"},fr:{name:"Fran\xE7ais",flag:"\u{1F1EB}\u{1F1F7}",code:"fr"},ru:{name:"\u0420\u0443\u0441\u0441\u043A\u0438\u0439",flag:"\u{1F1F7}\u{1F1FA}",code:"ru"}},S={es:G,en:H,fr:W,ru:_},I="es",A=S[I];function ee(){let a=(window.navigator.language||window.navigator.userLanguage||"es").split("-")[0].toLowerCase();return S[a]?a:"es"}function te(){return null}function T(){let n=te(),a=ee(),o="es";return n&&S[n]?o=n:a&&S[a]&&(o=a),R(o),o}function R(n){if(!S[n]){console.warn(`Idioma '${n}' no disponible. Usando '${I}'`);return}I=n,A=S[n],typeof window!="undefined"&&window.CustomEvent&&window.dispatchEvent(new window.CustomEvent("languageChanged",{detail:{language:n,translations:A}}))}function L(){return I}function f(n,a={}){let o=n.split("."),u=A;for(let l of o)if(u&&typeof u=="object"&&l in u)u=u[l];else return console.warn(`Clave de traducci\xF3n no encontrada: '${n}'`),n;return typeof u!="string"?(console.warn(`Clave de traducci\xF3n no es string: '${n}'`),n):ae(u,a)}function ae(n,a){return!a||Object.keys(a).length===0?n:n.replace(/\{(\w+)\}/g,(o,u)=>a[u]!==void 0?a[u]:o)}function j(n){return A[n]?A[n]:(console.warn(`Secci\xF3n de traducci\xF3n no encontrada: '${n}'`),{})}T();var m={RAW_BASE:"https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main",REFRESH_INTERVAL:6e4,THEME:{primary:"#000000",secondary:"#111111",accent:"#222222",text:"#ffffff",highlight:"#775ce3",success:"#00ff00",error:"#ff0000"}};function z(){return j("launcher")}var p={me:null,health:null,refreshTimer:null,selectedBot:null};function Y({onSelectBot:n,onLaunch:a,onClose:o,updateUserInfo:u,updateHealthInfo:l}){i("\u{1F39B}\uFE0F Creando interfaz del Launcher");let c=document.getElementById("wpl-panel");c&&(c.remove(),i("\u{1F5D1}\uFE0F Panel existente removido"));let r=z(),{host:d,root:x}=$("wpl-panel"),h=document.createElement("style");h.textContent=`
+  `;
+    const root = host.attachShadow({ mode: "open" });
+    document.body.appendChild(host);
+    return { host, root };
+  }
+  function makeDraggable(dragHandle, element) {
+    let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    dragHandle.style.cursor = "move";
+    dragHandle.addEventListener("mousedown", dragMouseDown);
+    function dragMouseDown(e) {
+      if (e.target.closest(".header-btn, .wplace-header-btn")) return;
+      e.preventDefault();
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      document.addEventListener("mouseup", closeDragElement);
+      document.addEventListener("mousemove", elementDrag);
+    }
+    function elementDrag(e) {
+      e.preventDefault();
+      pos1 = pos3 - e.clientX;
+      pos2 = pos4 - e.clientY;
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      element.style.top = element.offsetTop - pos2 + "px";
+      element.style.left = element.offsetLeft - pos1 + "px";
+    }
+    function closeDragElement() {
+      document.removeEventListener("mouseup", closeDragElement);
+      document.removeEventListener("mousemove", elementDrag);
+    }
+  }
+
+  // src/locales/es.js
+  var es = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selecci\xF3n",
+      user: "Usuario",
+      charges: "Cargas",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Cerrar",
+      launch: "Lanzar",
+      loading: "Cargando\u2026",
+      executing: "Ejecutando\u2026",
+      downloading: "Descargando script\u2026",
+      chooseBot: "Elige un bot y presiona Lanzar",
+      readyToLaunch: "Listo para lanzar",
+      loadError: "Error al cargar",
+      loadErrorMsg: "No se pudo cargar el bot seleccionado. Revisa tu conexi\xF3n o int\xE9ntalo de nuevo.",
+      checking: "\u{1F504} Verificando...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Iniciar Auto-BOT",
+      uploadImage: "Subir Imagen",
+      resizeImage: "Redimensionar Imagen",
+      selectPosition: "Seleccionar Posici\xF3n",
+      startPainting: "Iniciar Pintura",
+      stopPainting: "Detener Pintura",
+      saveProgress: "Guardar Progreso",
+      loadProgress: "Cargar Progreso",
+      checkingColors: "\u{1F50D} Verificando colores disponibles...",
+      noColorsFound: "\u274C \xA1Abre la paleta de colores en el sitio e int\xE9ntalo de nuevo!",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      loadingImage: "\u{1F5BC}\uFE0F Cargando imagen...",
+      imageLoaded: "\u2705 Imagen cargada con {count} p\xEDxeles v\xE1lidos",
+      imageError: "\u274C Error al cargar la imagen",
+      selectPositionAlert: "\xA1Pinta el primer p\xEDxel en la ubicaci\xF3n donde quieres que comience el arte!",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Posici\xF3n establecida con \xE9xito!",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar posici\xF3n",
+      positionDetected: "\u{1F3AF} Posici\xF3n detectada, procesando...",
+      positionError: "\u274C Error detectando posici\xF3n, int\xE9ntalo de nuevo",
+      startPaintingMsg: "\u{1F3A8} Iniciando pintura...",
+      paintingProgress: "\u{1F9F1} Progreso: {painted}/{total} p\xEDxeles...",
+      noCharges: "\u231B Sin cargas. Esperando {time}...",
+      paintingStopped: "\u23F9\uFE0F Pintura detenida por el usuario",
+      paintingComplete: "\u2705 \xA1Pintura completada! {count} p\xEDxeles pintados.",
+      paintingError: "\u274C Error durante la pintura",
+      missingRequirements: "\u274C Carga una imagen y selecciona una posici\xF3n primero",
+      progress: "Progreso",
+      userName: "Usuario",
+      pixels: "P\xEDxeles",
+      charges: "Cargas",
+      estimatedTime: "Tiempo estimado",
+      initMessage: "Haz clic en 'Iniciar Auto-BOT' para comenzar",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      resizeSuccess: "\u2705 Imagen redimensionada a {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Pintura pausada en la posici\xF3n X: {x}, Y: {y}",
+      pixelsPerBatch: "P\xEDxeles por lote",
+      batchSize: "Tama\xF1o del lote",
+      nextBatchTime: "Siguiente lote en",
+      useAllCharges: "Usar todas las cargas disponibles",
+      showOverlay: "Mostrar overlay",
+      maxCharges: "Cargas m\xE1ximas por lote",
+      waitingForCharges: "\u23F3 Esperando cargas: {current}/{needed}",
+      timeRemaining: "Tiempo restante",
+      cooldownWaiting: "\u23F3 Esperando {time} para continuar...",
+      progressSaved: "\u2705 Progreso guardado como {filename}",
+      progressLoaded: "\u2705 Progreso cargado: {painted}/{total} p\xEDxeles pintados",
+      progressLoadError: "\u274C Error al cargar progreso: {error}",
+      progressSaveError: "\u274C Error al guardar progreso: {error}",
+      confirmSaveProgress: "\xBFDeseas guardar el progreso actual antes de detener?",
+      saveProgressTitle: "Guardar Progreso",
+      discardProgress: "Descartar",
+      cancel: "Cancelar",
+      minimize: "Minimizar",
+      width: "Ancho",
+      height: "Alto",
+      keepAspect: "Mantener proporci\xF3n",
+      apply: "Aplicar",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pasada completada: {painted} p\xEDxeles pintados | Progreso: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Esperando regeneraci\xF3n de cargas: {current}/{needed} - Tiempo: {time}",
+      waitingChargesCountdown: "\u23F3 Esperando cargas: {current}/{needed} - Quedan: {time}",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Bot iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      retryAttempt: "\u{1F504} Reintento {attempt}/{maxAttempts} en {delay}s...",
+      retryError: "\u{1F4A5} Error en intento {attempt}/{maxAttempts}, reintentando en {delay}s...",
+      retryFailed: "\u274C Fall\xF3 despu\xE9s de {maxAttempts} intentos. Continuando con siguiente lote...",
+      networkError: "\u{1F310} Error de red. Reintentando...",
+      serverError: "\u{1F525} Error del servidor. Reintentando...",
+      timeoutError: "\u23F0 Timeout del servidor. Reintentando..."
+    },
+    // Farm Module (por implementar)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Iniciar",
+      stop: "Detener",
+      stopped: "Bot detenido",
+      calibrate: "Calibrar",
+      paintOnce: "Una vez",
+      checkingStatus: "Verificando estado...",
+      configuration: "Configuraci\xF3n",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "P\xEDxeles/lote",
+      minCharges: "Cargas m\xEDn",
+      colorMode: "Modo color",
+      random: "Aleatorio",
+      fixed: "Fijo",
+      range: "Rango",
+      fixedColor: "Color fijo",
+      advanced: "Avanzado",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Paleta personalizada",
+      paletteExample: "ej: #FF0000,#00FF00,#0000FF",
+      capture: "Capturar",
+      painted: "Pintados",
+      charges: "Cargas",
+      retries: "Fallos",
+      tile: "Tile",
+      configSaved: "Configuraci\xF3n guardada",
+      configLoaded: "Configuraci\xF3n cargada",
+      configReset: "Configuraci\xF3n reiniciada",
+      captureInstructions: "Pinta un p\xEDxel manualmente para capturar coordenadas...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Iniciando bot...",
+      stoppingBot: "Deteniendo bot...",
+      calibrating: "Calibrando...",
+      alreadyRunning: "Auto-Farm ya est\xE1 corriendo.",
+      imageRunningWarning: "Auto-Image est\xE1 ejecut\xE1ndose. Ci\xE9rralo antes de iniciar Auto-Farm.",
+      selectPosition: "Seleccionar Zona",
+      selectPositionAlert: "\u{1F3AF} Pinta un p\xEDxel en una zona DESPOBLADA del mapa para establecer el \xE1rea de farming",
+      waitingPosition: "\u{1F446} Esperando que pintes el p\xEDxel de referencia...",
+      positionSet: "\u2705 \xA1Zona establecida! Radio: 500px",
+      positionTimeout: "\u274C Tiempo agotado para seleccionar zona",
+      missingPosition: "\u274C Selecciona una zona primero usando 'Seleccionar Zona'",
+      farmRadius: "Radio farm",
+      positionInfo: "Zona actual",
+      farmingInRadius: "\u{1F33E} Farming en radio {radius}px desde ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANTE: Selecciona una zona DESPOBLADA para evitar conflictos",
+      noPosition: "Sin zona",
+      currentZone: "Zona: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Selecciona una zona primero. Pinta un p\xEDxel en el mapa para establecer la zona de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "S\xED",
+      no: "No",
+      ok: "Aceptar",
+      cancel: "Cancelar",
+      close: "Cerrar",
+      save: "Guardar",
+      load: "Cargar",
+      delete: "Eliminar",
+      edit: "Editar",
+      start: "Iniciar",
+      stop: "Detener",
+      pause: "Pausar",
+      resume: "Reanudar",
+      reset: "Reiniciar",
+      settings: "Configuraci\xF3n",
+      help: "Ayuda",
+      about: "Acerca de",
+      language: "Idioma",
+      loading: "Cargando...",
+      error: "Error",
+      success: "\xC9xito",
+      warning: "Advertencia",
+      info: "Informaci\xF3n",
+      languageChanged: "Idioma cambiado a {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Inicializar Guard-BOT",
+      selectArea: "Seleccionar \xC1rea",
+      captureArea: "Capturar \xC1rea",
+      startProtection: "Iniciar Protecci\xF3n",
+      stopProtection: "Detener Protecci\xF3n",
+      upperLeft: "Esquina Superior Izquierda",
+      lowerRight: "Esquina Inferior Derecha",
+      protectedPixels: "P\xEDxeles Protegidos",
+      detectedChanges: "Cambios Detectados",
+      repairedPixels: "P\xEDxeles Reparados",
+      charges: "Cargas",
+      waitingInit: "Esperando inicializaci\xF3n...",
+      checkingColors: "\u{1F3A8} Verificando colores disponibles...",
+      noColorsFound: "\u274C No se encontraron colores. Abre la paleta de colores en el sitio.",
+      colorsFound: "\u2705 {count} colores disponibles encontrados",
+      initSuccess: "\u2705 Guard-BOT inicializado correctamente",
+      initError: "\u274C Error inicializando Guard-BOT",
+      invalidCoords: "\u274C Coordenadas inv\xE1lidas",
+      invalidArea: "\u274C El \xE1rea debe tener esquina superior izquierda menor que inferior derecha",
+      areaTooLarge: "\u274C \xC1rea demasiado grande: {size} p\xEDxeles (m\xE1ximo: {max})",
+      capturingArea: "\u{1F4F8} Capturando \xE1rea de protecci\xF3n...",
+      areaCaptured: "\u2705 \xC1rea capturada: {count} p\xEDxeles bajo protecci\xF3n",
+      captureError: "\u274C Error capturando \xE1rea: {error}",
+      captureFirst: "\u274C Primero captura un \xE1rea de protecci\xF3n",
+      protectionStarted: "\u{1F6E1}\uFE0F Protecci\xF3n iniciada - monitoreando \xE1rea",
+      protectionStopped: "\u23F9\uFE0F Protecci\xF3n detenida",
+      noChanges: "\u2705 \xC1rea protegida - sin cambios detectados",
+      changesDetected: "\u{1F6A8} {count} cambios detectados en el \xE1rea protegida",
+      repairing: "\u{1F6E0}\uFE0F Reparando {count} p\xEDxeles alterados...",
+      repairedSuccess: "\u2705 Reparados {count} p\xEDxeles correctamente",
+      repairError: "\u274C Error reparando p\xEDxeles: {error}",
+      noCharges: "\u26A0\uFE0F Sin cargas suficientes para reparar cambios",
+      checkingChanges: "\u{1F50D} Verificando cambios en \xE1rea protegida...",
+      errorChecking: "\u274C Error verificando cambios: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardi\xE1n activo - \xE1rea bajo protecci\xF3n",
+      lastCheck: "\xDAltima verificaci\xF3n: {time}",
+      nextCheck: "Pr\xF3xima verificaci\xF3n en: {time}s",
+      autoInitializing: "\u{1F916} Inicializando autom\xE1ticamente...",
+      autoInitSuccess: "\u2705 Guard-BOT iniciado autom\xE1ticamente",
+      autoInitFailed: "\u26A0\uFE0F No se pudo iniciar autom\xE1ticamente. Usa el bot\xF3n manual.",
+      manualInitRequired: "\u{1F527} Inicio manual requerido",
+      paletteDetected: "\u{1F3A8} Paleta de colores detectada",
+      paletteNotFound: "\u{1F50D} Buscando paleta de colores...",
+      clickingPaintButton: "\u{1F446} Haciendo clic en el bot\xF3n Paint...",
+      paintButtonNotFound: "\u274C Bot\xF3n Paint no encontrado",
+      selectUpperLeft: "\u{1F3AF} Pinta un p\xEDxel en la esquina SUPERIOR IZQUIERDA del \xE1rea a proteger",
+      selectLowerRight: "\u{1F3AF} Ahora pinta un p\xEDxel en la esquina INFERIOR DERECHA del \xE1rea",
+      waitingUpperLeft: "\u{1F446} Esperando selecci\xF3n de esquina superior izquierda...",
+      waitingLowerRight: "\u{1F446} Esperando selecci\xF3n de esquina inferior derecha...",
+      upperLeftCaptured: "\u2705 Esquina superior izquierda capturada: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Esquina inferior derecha capturada: ({x}, {y})",
+      selectionTimeout: "\u274C Tiempo agotado para selecci\xF3n",
+      selectionError: "\u274C Error en selecci\xF3n, int\xE9ntalo de nuevo"
+    }
+  };
+
+  // src/locales/en.js
+  var en = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "Selection",
+      user: "User",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Database",
+      uptime: "Uptime",
+      close: "Close",
+      launch: "Launch",
+      loading: "Loading\u2026",
+      executing: "Executing\u2026",
+      downloading: "Downloading script\u2026",
+      chooseBot: "Choose a bot and press Launch",
+      readyToLaunch: "Ready to launch",
+      loadError: "Load error",
+      loadErrorMsg: "Could not load the selected bot. Check your connection or try again.",
+      checking: "\u{1F504} Checking...",
+      online: "\u{1F7E2} Online",
+      offline: "\u{1F534} Offline",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Error",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialize Auto-BOT",
+      uploadImage: "Upload Image",
+      resizeImage: "Resize Image",
+      selectPosition: "Select Position",
+      startPainting: "Start Painting",
+      stopPainting: "Stop Painting",
+      saveProgress: "Save Progress",
+      loadProgress: "Load Progress",
+      checkingColors: "\u{1F50D} Checking available colors...",
+      noColorsFound: "\u274C Open the color palette on the site and try again!",
+      colorsFound: "\u2705 Found {count} available colors",
+      loadingImage: "\u{1F5BC}\uFE0F Loading image...",
+      imageLoaded: "\u2705 Image loaded with {count} valid pixels",
+      imageError: "\u274C Error loading image",
+      selectPositionAlert: "Paint the first pixel at the location where you want the art to start!",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Position set successfully!",
+      positionTimeout: "\u274C Timeout for position selection",
+      positionDetected: "\u{1F3AF} Position detected, processing...",
+      positionError: "\u274C Error detecting position, please try again",
+      startPaintingMsg: "\u{1F3A8} Starting painting...",
+      paintingProgress: "\u{1F9F1} Progress: {painted}/{total} pixels...",
+      noCharges: "\u231B No charges. Waiting {time}...",
+      paintingStopped: "\u23F9\uFE0F Painting stopped by user",
+      paintingComplete: "\u2705 Painting completed! {count} pixels painted.",
+      paintingError: "\u274C Error during painting",
+      missingRequirements: "\u274C Load an image and select a position first",
+      progress: "Progress",
+      userName: "User",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Estimated time",
+      initMessage: "Click 'Initialize Auto-BOT' to begin",
+      waitingInit: "Waiting for initialization...",
+      resizeSuccess: "\u2705 Image resized to {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Painting paused at position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels per batch",
+      batchSize: "Batch size",
+      nextBatchTime: "Next batch in",
+      useAllCharges: "Use all available charges",
+      showOverlay: "Show overlay",
+      maxCharges: "Max charges per batch",
+      waitingForCharges: "\u23F3 Waiting for charges: {current}/{needed}",
+      timeRemaining: "Time remaining",
+      cooldownWaiting: "\u23F3 Waiting {time} to continue...",
+      progressSaved: "\u2705 Progress saved as {filename}",
+      progressLoaded: "\u2705 Progress loaded: {painted}/{total} pixels painted",
+      progressLoadError: "\u274C Error loading progress: {error}",
+      progressSaveError: "\u274C Error saving progress: {error}",
+      confirmSaveProgress: "Do you want to save the current progress before stopping?",
+      saveProgressTitle: "Save Progress",
+      discardProgress: "Discard",
+      cancel: "Cancel",
+      minimize: "Minimize",
+      width: "Width",
+      height: "Height",
+      keepAspect: "Keep aspect ratio",
+      apply: "Apply",
+      overlayOn: "Overlay: ON",
+      overlayOff: "Overlay: OFF",
+      passCompleted: "\u2705 Pass completed: {painted} pixels painted | Progress: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Waiting for charge regeneration: {current}/{needed} - Time: {time}",
+      waitingChargesCountdown: "\u23F3 Waiting for charges: {current}/{needed} - Remaining: {time}",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Bot auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      retryAttempt: "\u{1F504} Retry {attempt}/{maxAttempts} in {delay}s...",
+      retryError: "\u{1F4A5} Error in attempt {attempt}/{maxAttempts}, retrying in {delay}s...",
+      retryFailed: "\u274C Failed after {maxAttempts} attempts. Continuing with next batch...",
+      networkError: "\u{1F310} Network error. Retrying...",
+      serverError: "\u{1F525} Server error. Retrying...",
+      timeoutError: "\u23F0 Server timeout. Retrying..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "Start",
+      stop: "Stop",
+      stopped: "Bot stopped",
+      calibrate: "Calibrate",
+      paintOnce: "Once",
+      checkingStatus: "Checking status...",
+      configuration: "Configuration",
+      delay: "Delay (ms)",
+      pixelsPerBatch: "Pixels/batch",
+      minCharges: "Min charges",
+      colorMode: "Color mode",
+      random: "Random",
+      fixed: "Fixed",
+      range: "Range",
+      fixedColor: "Fixed color",
+      advanced: "Advanced",
+      tileX: "Tile X",
+      tileY: "Tile Y",
+      customPalette: "Custom palette",
+      paletteExample: "e.g: #FF0000,#00FF00,#0000FF",
+      capture: "Capture",
+      painted: "Painted",
+      charges: "Charges",
+      retries: "Retries",
+      tile: "Tile",
+      configSaved: "Configuration saved",
+      configLoaded: "Configuration loaded",
+      configReset: "Configuration reset",
+      captureInstructions: "Paint a pixel manually to capture coordinates...",
+      backendOnline: "Backend Online",
+      backendOffline: "Backend Offline",
+      startingBot: "Starting bot...",
+      stoppingBot: "Stopping bot...",
+      calibrating: "Calibrating...",
+      alreadyRunning: "Auto-Farm is already running.",
+      imageRunningWarning: "Auto-Image is running. Close it before starting Auto-Farm.",
+      selectPosition: "Select Area",
+      selectPositionAlert: "\u{1F3AF} Paint a pixel in an EMPTY area of the map to set the farming zone",
+      waitingPosition: "\u{1F446} Waiting for you to paint the reference pixel...",
+      positionSet: "\u2705 Area set! Radius: 500px",
+      positionTimeout: "\u274C Timeout for area selection",
+      missingPosition: "\u274C Select an area first using 'Select Area'",
+      farmRadius: "Farm radius",
+      positionInfo: "Current area",
+      farmingInRadius: "\u{1F33E} Farming in {radius}px radius from ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: Select an EMPTY area to avoid conflicts",
+      noPosition: "No area",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} Select an area first. Paint a pixel on the map to set the farming zone"
+    },
+    // Common/Shared
+    common: {
+      yes: "Yes",
+      no: "No",
+      ok: "OK",
+      cancel: "Cancel",
+      close: "Close",
+      save: "Save",
+      load: "Load",
+      delete: "Delete",
+      edit: "Edit",
+      start: "Start",
+      stop: "Stop",
+      pause: "Pause",
+      resume: "Resume",
+      reset: "Reset",
+      settings: "Settings",
+      help: "Help",
+      about: "About",
+      language: "Language",
+      loading: "Loading...",
+      error: "Error",
+      success: "Success",
+      warning: "Warning",
+      info: "Information",
+      languageChanged: "Language changed to {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialize Guard-BOT",
+      selectArea: "Select Area",
+      captureArea: "Capture Area",
+      startProtection: "Start Protection",
+      stopProtection: "Stop Protection",
+      upperLeft: "Upper Left Corner",
+      lowerRight: "Lower Right Corner",
+      protectedPixels: "Protected Pixels",
+      detectedChanges: "Detected Changes",
+      repairedPixels: "Repaired Pixels",
+      charges: "Charges",
+      waitingInit: "Waiting for initialization...",
+      checkingColors: "\u{1F3A8} Checking available colors...",
+      noColorsFound: "\u274C No colors found. Open the color palette on the site.",
+      colorsFound: "\u2705 Found {count} available colors",
+      initSuccess: "\u2705 Guard-BOT initialized successfully",
+      initError: "\u274C Error initializing Guard-BOT",
+      invalidCoords: "\u274C Invalid coordinates",
+      invalidArea: "\u274C Area must have upper left corner less than lower right corner",
+      areaTooLarge: "\u274C Area too large: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capturing protection area...",
+      areaCaptured: "\u2705 Area captured: {count} pixels under protection",
+      captureError: "\u274C Error capturing area: {error}",
+      captureFirst: "\u274C First capture a protection area",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection started - monitoring area",
+      protectionStopped: "\u23F9\uFE0F Protection stopped",
+      noChanges: "\u2705 Protected area - no changes detected",
+      changesDetected: "\u{1F6A8} {count} changes detected in protected area",
+      repairing: "\u{1F6E0}\uFE0F Repairing {count} altered pixels...",
+      repairedSuccess: "\u2705 Successfully repaired {count} pixels",
+      repairError: "\u274C Error repairing pixels: {error}",
+      noCharges: "\u26A0\uFE0F Insufficient charges to repair changes",
+      checkingChanges: "\u{1F50D} Checking changes in protected area...",
+      errorChecking: "\u274C Error checking changes: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Guardian active - area under protection",
+      lastCheck: "Last check: {time}",
+      nextCheck: "Next check in: {time}s",
+      autoInitializing: "\u{1F916} Auto-initializing...",
+      autoInitSuccess: "\u2705 Guard-BOT auto-started successfully",
+      autoInitFailed: "\u26A0\uFE0F Could not auto-start. Use manual button.",
+      manualInitRequired: "\u{1F527} Manual initialization required",
+      paletteDetected: "\u{1F3A8} Color palette detected",
+      paletteNotFound: "\u{1F50D} Searching for color palette...",
+      clickingPaintButton: "\u{1F446} Clicking Paint button...",
+      paintButtonNotFound: "\u274C Paint button not found",
+      selectUpperLeft: "\u{1F3AF} Paint a pixel at the UPPER LEFT corner of the area to protect",
+      selectLowerRight: "\u{1F3AF} Now paint a pixel at the LOWER RIGHT corner of the area",
+      waitingUpperLeft: "\u{1F446} Waiting for upper left corner selection...",
+      waitingLowerRight: "\u{1F446} Waiting for lower right corner selection...",
+      upperLeftCaptured: "\u2705 Upper left corner captured: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Lower right corner captured: ({x}, {y})",
+      selectionTimeout: "\u274C Selection timeout",
+      selectionError: "\u274C Selection error, please try again"
+    }
+  };
+
+  // src/locales/fr.js
+  var fr = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} Auto-Farm",
+      autoImage: "\u{1F3A8} Auto-Image",
+      autoGuard: "\u{1F6E1}\uFE0F Auto-Guard",
+      selection: "S\xE9lection",
+      user: "Utilisateur",
+      charges: "Charges",
+      backend: "Backend",
+      database: "Base de donn\xE9es",
+      uptime: "Temps actif",
+      close: "Fermer",
+      launch: "Lancer",
+      loading: "Chargement\u2026",
+      executing: "Ex\xE9cution\u2026",
+      downloading: "T\xE9l\xE9chargement du script\u2026",
+      chooseBot: "Choisissez un bot et appuyez sur Lancer",
+      readyToLaunch: "Pr\xEAt \xE0 lancer",
+      loadError: "Erreur de chargement",
+      loadErrorMsg: "Impossible de charger le bot s\xE9lectionn\xE9. V\xE9rifiez votre connexion ou r\xE9essayez.",
+      checking: "\u{1F504} V\xE9rification...",
+      online: "\u{1F7E2} En ligne",
+      offline: "\u{1F534} Hors ligne",
+      ok: "\u{1F7E2} OK",
+      error: "\u{1F534} Erreur",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace Auto-Image",
+      initBot: "Initialiser Auto-BOT",
+      uploadImage: "T\xE9l\xE9charger Image",
+      resizeImage: "Redimensionner Image",
+      selectPosition: "S\xE9lectionner Position",
+      startPainting: "Commencer Peinture",
+      stopPainting: "Arr\xEAter Peinture",
+      saveProgress: "Sauvegarder Progr\xE8s",
+      loadProgress: "Charger Progr\xE8s",
+      checkingColors: "\u{1F50D} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Ouvrez la palette de couleurs sur le site et r\xE9essayez!",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      loadingImage: "\u{1F5BC}\uFE0F Chargement de l'image...",
+      imageLoaded: "\u2705 Image charg\xE9e avec {count} pixels valides",
+      imageError: "\u274C Erreur lors du chargement de l'image",
+      selectPositionAlert: "Peignez le premier pixel \xE0 l'emplacement o\xF9 vous voulez que l'art commence!",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Position d\xE9finie avec succ\xE8s!",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de position",
+      positionDetected: "\u{1F3AF} Position d\xE9tect\xE9e, traitement...",
+      positionError: "\u274C Erreur d\xE9tectant la position, essayez \xE0 nouveau",
+      startPaintingMsg: "\u{1F3A8} D\xE9but de la peinture...",
+      paintingProgress: "\u{1F9F1} Progr\xE8s: {painted}/{total} pixels...",
+      noCharges: "\u231B Aucune charge. Attendre {time}...",
+      paintingStopped: "\u23F9\uFE0F Peinture arr\xEAt\xE9e par l'utilisateur",
+      paintingComplete: "\u2705 Peinture termin\xE9e! {count} pixels peints.",
+      paintingError: "\u274C Erreur pendant la peinture",
+      missingRequirements: "\u274C Chargez une image et s\xE9lectionnez une position d'abord",
+      progress: "Progr\xE8s",
+      userName: "Usager",
+      pixels: "Pixels",
+      charges: "Charges",
+      estimatedTime: "Temps estim\xE9",
+      initMessage: "Cliquez sur 'Initialiser Auto-BOT' pour commencer",
+      waitingInit: "En attente d'initialisation...",
+      resizeSuccess: "\u2705 Image redimensionn\xE9e \xE0 {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F Peinture mise en pause \xE0 la position X: {x}, Y: {y}",
+      pixelsPerBatch: "Pixels par lot",
+      batchSize: "Taille du lot",
+      nextBatchTime: "Prochain lot dans",
+      useAllCharges: "Utiliser toutes les charges disponibles",
+      showOverlay: "Afficher l'overlay",
+      maxCharges: "Charges max par lot",
+      waitingForCharges: "\u23F3 En attente de charges: {current}/{needed}",
+      timeRemaining: "Temps restant",
+      cooldownWaiting: "\u23F3 Attendre {time} pour continuer...",
+      progressSaved: "\u2705 Progr\xE8s sauvegard\xE9 sous {filename}",
+      progressLoaded: "\u2705 Progr\xE8s charg\xE9: {painted}/{total} pixels peints",
+      progressLoadError: "\u274C Erreur lors du chargement du progr\xE8s: {error}",
+      progressSaveError: "\u274C Erreur lors de la sauvegarde du progr\xE8s: {error}",
+      confirmSaveProgress: "Voulez-vous sauvegarder le progr\xE8s actuel avant d'arr\xEAter?",
+      saveProgressTitle: "Sauvegarder Progr\xE8s",
+      discardProgress: "Abandonner",
+      cancel: "Annuler",
+      minimize: "Minimiser",
+      width: "Largeur",
+      height: "Hauteur",
+      keepAspect: "Garder les proportions",
+      apply: "Appliquer",
+      overlayOn: "Overlay : ON",
+      overlayOff: "Overlay : OFF",
+      passCompleted: "\u2705 Passage termin\xE9: {painted} pixels peints | Progr\xE8s: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 Attente de r\xE9g\xE9n\xE9ration des charges: {current}/{needed} - Temps: {time}",
+      waitingChargesCountdown: "\u23F3 Attente des charges: {current}/{needed} - Restant: {time}",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Bot d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      retryAttempt: "\u{1F504} Tentative {attempt}/{maxAttempts} dans {delay}s...",
+      retryError: "\u{1F4A5} Erreur dans tentative {attempt}/{maxAttempts}, nouvel essai dans {delay}s...",
+      retryFailed: "\u274C \xC9chec apr\xE8s {maxAttempts} tentatives. Continuant avec le lot suivant...",
+      networkError: "\u{1F310} Erreur r\xE9seau. Nouvel essai...",
+      serverError: "\u{1F525} Erreur serveur. Nouvel essai...",
+      timeoutError: "\u23F0 Timeout serveur. Nouvel essai..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace Farm Bot",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      stopped: "Bot arr\xEAt\xE9",
+      calibrate: "Calibrer",
+      paintOnce: "Une fois",
+      checkingStatus: "V\xE9rification du statut...",
+      configuration: "Configuration",
+      delay: "D\xE9lai (ms)",
+      pixelsPerBatch: "Pixels/lot",
+      minCharges: "Charges min",
+      colorMode: "Mode couleur",
+      random: "Al\xE9atoire",
+      fixed: "Fixe",
+      range: "Plage",
+      fixedColor: "Couleur fixe",
+      advanced: "Avanc\xE9",
+      tileX: "Tuile X",
+      tileY: "Tuile Y",
+      customPalette: "Palette personnalis\xE9e",
+      paletteExample: "ex: #FF0000,#00FF00,#0000FF",
+      capture: "Capturer",
+      painted: "Peints",
+      charges: "Charges",
+      retries: "\xC9checs",
+      tile: "Tuile",
+      configSaved: "Configuration sauvegard\xE9e",
+      configLoaded: "Configuration charg\xE9e",
+      configReset: "Configuration r\xE9initialis\xE9e",
+      captureInstructions: "Peindre un pixel manuellement pour capturer les coordonn\xE9es...",
+      backendOnline: "Backend En ligne",
+      backendOffline: "Backend Hors ligne",
+      startingBot: "D\xE9marrage du bot...",
+      stoppingBot: "Arr\xEAt du bot...",
+      calibrating: "Calibrage...",
+      alreadyRunning: "Auto-Farm est d\xE9j\xE0 en cours d'ex\xE9cution.",
+      imageRunningWarning: "Auto-Image est en cours d'ex\xE9cution. Fermez-le avant de d\xE9marrer Auto-Farm.",
+      selectPosition: "S\xE9lectionner Zone",
+      selectPositionAlert: "\u{1F3AF} Peignez un pixel dans une zone VIDE de la carte pour d\xE9finir la zone de farming",
+      waitingPosition: "\u{1F446} En attente que vous peigniez le pixel de r\xE9f\xE9rence...",
+      positionSet: "\u2705 Zone d\xE9finie! Rayon: 500px",
+      positionTimeout: "\u274C D\xE9lai d\xE9pass\xE9 pour la s\xE9lection de zone",
+      missingPosition: "\u274C S\xE9lectionnez une zone d'abord en utilisant 'S\xE9lectionner Zone'",
+      farmRadius: "Rayon farm",
+      positionInfo: "Zone actuelle",
+      farmingInRadius: "\u{1F33E} Farming dans un rayon de {radius}px depuis ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F IMPORTANT: S\xE9lectionnez une zone VIDE pour \xE9viter les conflits",
+      noPosition: "Aucune zone",
+      currentZone: "Zone: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} S\xE9lectionnez une zone d'abord. Peignez un pixel sur la carte pour d\xE9finir la zone de farming"
+    },
+    // Common/Shared
+    common: {
+      yes: "Oui",
+      no: "Non",
+      ok: "OK",
+      cancel: "Annuler",
+      close: "Fermer",
+      save: "Sauvegarder",
+      load: "Charger",
+      delete: "Supprimer",
+      edit: "Modifier",
+      start: "D\xE9marrer",
+      stop: "Arr\xEAter",
+      pause: "Pause",
+      resume: "Reprendre",
+      reset: "R\xE9initialiser",
+      settings: "Param\xE8tres",
+      help: "Aide",
+      about: "\xC0 propos",
+      language: "Langue",
+      loading: "Chargement...",
+      error: "Erreur",
+      success: "Succ\xE8s",
+      warning: "Avertissement",
+      info: "Information",
+      languageChanged: "Langue chang\xE9e en {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace Auto-Guard",
+      initBot: "Initialiser Guard-BOT",
+      selectArea: "S\xE9lectionner Zone",
+      captureArea: "Capturer Zone",
+      startProtection: "D\xE9marrer Protection",
+      stopProtection: "Arr\xEAter Protection",
+      upperLeft: "Coin Sup\xE9rieur Gauche",
+      lowerRight: "Coin Inf\xE9rieur Droit",
+      protectedPixels: "Pixels Prot\xE9g\xE9s",
+      detectedChanges: "Changements D\xE9tect\xE9s",
+      repairedPixels: "Pixels R\xE9par\xE9s",
+      charges: "Charges",
+      waitingInit: "En attente d'initialisation...",
+      checkingColors: "\u{1F3A8} V\xE9rification des couleurs disponibles...",
+      noColorsFound: "\u274C Aucune couleur trouv\xE9e. Ouvrez la palette de couleurs sur le site.",
+      colorsFound: "\u2705 {count} couleurs disponibles trouv\xE9es",
+      initSuccess: "\u2705 Guard-BOT initialis\xE9 avec succ\xE8s",
+      initError: "\u274C Erreur lors de l'initialisation de Guard-BOT",
+      invalidCoords: "\u274C Coordonn\xE9es invalides",
+      invalidArea: "\u274C La zone doit avoir le coin sup\xE9rieur gauche inf\xE9rieur au coin inf\xE9rieur droit",
+      areaTooLarge: "\u274C Zone trop grande: {size} pixels (maximum: {max})",
+      capturingArea: "\u{1F4F8} Capture de la zone de protection...",
+      areaCaptured: "\u2705 Zone captur\xE9e: {count} pixels sous protection",
+      captureError: "\u274C Erreur lors de la capture de zone: {error}",
+      captureFirst: "\u274C Capturez d'abord une zone de protection",
+      protectionStarted: "\u{1F6E1}\uFE0F Protection d\xE9marr\xE9e - surveillance de la zone",
+      protectionStopped: "\u23F9\uFE0F Protection arr\xEAt\xE9e",
+      noChanges: "\u2705 Zone prot\xE9g\xE9e - aucun changement d\xE9tect\xE9",
+      changesDetected: "\u{1F6A8} {count} changements d\xE9tect\xE9s dans la zone prot\xE9g\xE9e",
+      repairing: "\u{1F6E0}\uFE0F R\xE9paration de {count} pixels alt\xE9r\xE9s...",
+      repairedSuccess: "\u2705 {count} pixels r\xE9par\xE9s avec succ\xE8s",
+      repairError: "\u274C Erreur lors de la r\xE9paration des pixels: {error}",
+      noCharges: "\u26A0\uFE0F Charges insuffisantes pour r\xE9parer les changements",
+      checkingChanges: "\u{1F50D} V\xE9rification des changements dans la zone prot\xE9g\xE9e...",
+      errorChecking: "\u274C Erreur lors de la v\xE9rification des changements: {error}",
+      guardActive: "\u{1F6E1}\uFE0F Gardien actif - zone sous protection",
+      lastCheck: "Derni\xE8re v\xE9rification: {time}",
+      nextCheck: "Prochaine v\xE9rification dans: {time}s",
+      autoInitializing: "\u{1F916} Initialisation automatique...",
+      autoInitSuccess: "\u2705 Guard-BOT d\xE9marr\xE9 automatiquement",
+      autoInitFailed: "\u26A0\uFE0F Impossible de d\xE9marrer automatiquement. Utilisez le bouton manuel.",
+      manualInitRequired: "\u{1F527} Initialisation manuelle requise",
+      paletteDetected: "\u{1F3A8} Palette de couleurs d\xE9tect\xE9e",
+      paletteNotFound: "\u{1F50D} Recherche de la palette de couleurs...",
+      clickingPaintButton: "\u{1F446} Clic sur le bouton Paint...",
+      paintButtonNotFound: "\u274C Bouton Paint introuvable",
+      selectUpperLeft: "\u{1F3AF} Peignez un pixel au coin SUP\xC9RIEUR GAUCHE de la zone \xE0 prot\xE9ger",
+      selectLowerRight: "\u{1F3AF} Maintenant peignez un pixel au coin INF\xC9RIEUR DROIT de la zone",
+      waitingUpperLeft: "\u{1F446} En attente de la s\xE9lection du coin sup\xE9rieur gauche...",
+      waitingLowerRight: "\u{1F446} En attente de la s\xE9lection du coin inf\xE9rieur droit...",
+      upperLeftCaptured: "\u2705 Coin sup\xE9rieur gauche captur\xE9: ({x}, {y})",
+      lowerRightCaptured: "\u2705 Coin inf\xE9rieur droit captur\xE9: ({x}, {y})",
+      selectionTimeout: "\u274C D\xE9lai de s\xE9lection d\xE9pass\xE9",
+      selectionError: "\u274C Erreur de s\xE9lection, veuillez r\xE9essayer"
+    }
+  };
+
+  // src/locales/ru.js
+  var ru = {
+    // Launcher
+    launcher: {
+      title: "WPlace AutoBOT",
+      autoFarm: "\u{1F33E} \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      autoImage: "\u{1F3A8} \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      autoGuard: "\u{1F6E1}\uFE0F \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      selection: "\u0412\u044B\u0431\u0440\u0430\u043D\u043E",
+      user: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      charges: "\u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      backend: "\u0411\u044D\u043A\u0435\u043D\u0434",
+      database: "\u0411\u0430\u0437\u0430 \u0434\u0430\u043D\u043D\u044B\u0445",
+      uptime: "\u0412\u0440\u0435\u043C\u044F \u0440\u0430\u0431\u043E\u0442\u044B",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      launch: "\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430",
+      executing: "\u0412\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u0435",
+      downloading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0441\u043A\u0440\u0438\u043F\u0442\u0430...",
+      chooseBot: "\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0431\u043E\u0442\u0430 \u0438 \u043D\u0430\u0436\u043C\u0438\u0442\u0435 \u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C",
+      readyToLaunch: "\u0413\u043E\u0442\u043E\u0432\u043E \u043A \u0437\u0430\u043F\u0443\u0441\u043A\u0443",
+      loadError: "\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438",
+      loadErrorMsg: "\u041D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\u043E \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u0433\u043E \u0431\u043E\u0442\u0430. \u041F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u0435 \u0438\u043B\u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437.",
+      checking: "\u{1F504} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430...",
+      online: "\u{1F7E2} \u041E\u043D\u043B\u0430\u0439\u043D",
+      offline: "\u{1F534} \u041E\u0444\u043B\u0430\u0439\u043D",
+      ok: "\u{1F7E2} \u041E\u041A",
+      error: "\u{1F534} \u041E\u0448\u0438\u0431\u043A\u0430",
+      unknown: "-"
+    },
+    // Image Module
+    image: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Auto-BOT",
+      uploadImage: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435",
+      resizeImage: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C \u0440\u0430\u0437\u043C\u0435\u0440 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      startPainting: "\u041D\u0430\u0447\u0430\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u0442\u044C",
+      stopPainting: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435",
+      saveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      loadProgress: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      checkingColors: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435 \u0438 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430!",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      loadingImage: "\u{1F5BC}\uFE0F \u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F...",
+      imageLoaded: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u043E \u0441 {count} \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u043C\u0438 \u043F\u0438\u043A\u0441\u0435\u043B\u044F\u043C\u0438",
+      imageError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u044F",
+      selectPositionAlert: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u044B\u0439 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0442\u043E\u043C \u043C\u0435\u0441\u0442\u0435, \u0433\u0434\u0435 \u0432\u044B \u0445\u043E\u0442\u0438\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u0440\u0438\u0441\u0443\u043D\u043E\u043A \u043D\u0430\u0447\u0438\u043D\u0430\u043B\u0441\u044F!",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E!",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438",
+      positionDetected: "\u{1F3AF} \u041F\u043E\u0437\u0438\u0446\u0438\u044F \u0432\u044B\u0431\u0440\u0430\u043D\u0430, \u043E\u0431\u0440\u0430\u0431\u043E\u0442\u043A\u0430...",
+      positionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0435\u0449\u0435 \u0440\u0430\u0437",
+      startPaintingMsg: "\u{1F3A8} \u041D\u0430\u0447\u0430\u043B\u043E \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F...",
+      paintingProgress: "\u{1F9F1} \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      noCharges: "\u231B \u041D\u0435\u0442 \u0437\u0430\u0440\u044F\u0434\u043E\u0432. \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0435\u043C",
+      paintingComplete: "\u2705 \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D\u043E! {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E.",
+      paintingError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u0440\u043E\u0446\u0435\u0441\u0441\u0435 \u0440\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u044F",
+      missingRequirements: "\u274C \u0421\u043F\u0435\u0440\u0432\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u0435 \u0438\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043C\u0435\u0441\u0442\u043E \u043D\u0430\u0447\u0430\u043B\u0430",
+      progress: "\u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      userName: "\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C",
+      pixels: "\u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      estimatedTime: "\u041F\u0440\u0435\u0434\u043F\u043E\u043B\u043E\u0436\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0435 \u0432\u0440\u0435\u043C\u044F",
+      initMessage: "\u041D\u0430\u0436\u043C\u0438\u0442\u0435 \xAB\u0417\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C Auto-BOT\xBB, \u0447\u0442\u043E\u0431\u044B \u043D\u0430\u0447\u0430\u0442\u044C",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      resizeSuccess: "\u2705 \u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043E \u0434\u043E {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u0420\u0438\u0441\u043E\u0432\u0430\u043D\u0438\u0435 \u043F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E \u043D\u0430 \u043F\u043E\u0437\u0438\u0446\u0438\u0438 X: {x}, Y: {y}",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0432 \u043F\u0440\u043E\u0445\u043E\u0434\u0435",
+      batchSize: "\u0420\u0430\u0437\u043C\u0435\u0440 \u043F\u0440\u043E\u0445\u043E\u0434\u0430",
+      nextBatchTime: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0438\u0439 \u043F\u0440\u043E\u0445\u043E\u0434 \u0447\u0435\u0440\u0435\u0437",
+      useAllCharges: "\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C \u0432\u0441\u0435 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0437\u0430\u0440\u044F\u0434\u044B",
+      showOverlay: "\u041F\u043E\u043A\u0430\u0437\u0430\u0442\u044C \u043D\u0430\u043B\u043E\u0436\u0435\u043D\u0438\u0435",
+      maxCharges: "\u041C\u0430\u043A\u0441\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      waitingForCharges: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed}",
+      timeRemaining: "\u0412\u0440\u0435\u043C\u0435\u043D\u0438 \u043E\u0441\u0442\u0430\u043B\u043E\u0441\u044C",
+      cooldownWaiting: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 {time} \u0434\u043B\u044F \u043F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u044F...",
+      progressSaved: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D \u043A\u0430\u043A {filename}",
+      progressLoaded: "\u2705 \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D: {painted} \u0438\u0437 {total} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E",
+      progressLoadError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      progressSaveError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441\u0430: {error}",
+      confirmSaveProgress: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0442\u0435\u043A\u0443\u0449\u0438\u0439 \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441 \u043F\u0435\u0440\u0435\u0434 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u043E\u0439?",
+      saveProgressTitle: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      discardProgress: "\u041D\u0435 \u0441\u043E\u0445\u0440\u0430\u043D\u044F\u0442\u044C \u043F\u0440\u043E\u0433\u0440\u0435\u0441\u0441",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      minimize: "\u0421\u0432\u0435\u0440\u043D\u0443\u0442\u044C",
+      width: "\u0428\u0438\u0440\u0438\u043D\u0430",
+      height: "\u0412\u044B\u0441\u043E\u0442\u0430",
+      keepAspect: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u0441\u043E\u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0435 \u0441\u0442\u043E\u0440\u043E\u043D",
+      apply: "\u041F\u0440\u0438\u043C\u0435\u043D\u0438\u0442\u044C",
+      passCompleted: "\u2705 \u041F\u0440\u043E\u0446\u0435\u0441\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043D: {painted} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043D\u0430\u0440\u0438\u0441\u043E\u0432\u0430\u043D\u043E | \u041F\u0440\u043E\u0433\u0440\u0435\u0441\u0441: {percent}% ({current} \u0438\u0437 {total})",
+      waitingChargesRegen: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u043E\u0441\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F \u0437\u0430\u0440\u044F\u0434\u0430: {current} \u0438\u0437 {needed} - \u0412\u0440\u0435\u043C\u044F: {time}",
+      waitingChargesCountdown: "\u23F3 \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0437\u0430\u0440\u044F\u0434\u043E\u0432: {current} \u0438\u0437 {needed} - \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F: {time}",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 \u0411\u043E\u0442 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u043B\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0432\u044B\u043F\u043E\u043B\u043D\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u0437\u0430\u043F\u0443\u0441\u043A. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      retryAttempt: "\u{1F504} \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt} \u0438\u0437 {maxAttempts} \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryError: "\u{1F4A5} \u041E\u0448\u0438\u0431\u043A\u0430 \u0432 \u043F\u043E\u043F\u044B\u0442\u043A\u0435 {attempt} \u0438\u0437 {maxAttempts}, \u043F\u043E\u0432\u0442\u043E\u0440\u0435\u043D\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 {delay}s...",
+      retryFailed: "\u274C \u041F\u0440\u043E\u0432\u0430\u043B\u0435\u043D\u043E \u0441\u043F\u0443\u0441\u0442\u044F {maxAttempts} \u043F\u043E\u043F\u044B\u0442\u043E\u043A. \u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0435\u043D\u0438\u0435 \u0432 \u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u043C \u043F\u0440\u043E\u0445\u043E\u0434\u0435...",
+      networkError: "\u{1F310} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0442\u0438. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      serverError: "\u{1F525} \u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430...",
+      timeoutError: "\u23F0 \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430. \u041F\u043E\u0432\u0442\u043E\u0440\u043D\u0430\u044F \u043F\u043E\u043F\u044B\u0442\u043A\u0430..."
+    },
+    // Farm Module (to be implemented)
+    farm: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      stopped: "\u0411\u043E\u0442 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D",
+      calibrate: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u0430\u0442\u044C",
+      paintOnce: "\u0415\u0434\u0438\u043D\u043E\u0440\u0430\u0437\u043E\u0432\u043E",
+      checkingStatus: "\u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0441\u0442\u0430\u0442\u0443\u0441\u0430...",
+      configuration: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F",
+      delay: "\u0417\u0430\u0434\u0435\u0440\u0436\u043A\u0430 (\u043C\u0441)",
+      pixelsPerBatch: "\u041F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u0437\u0430 \u043F\u0440\u043E\u0445\u043E\u0434",
+      minCharges: "\u041C\u0438\u043D\u0438\u043C\u0430\u043B\u044C\u043D\u043E\u0435 \u043A\u043E\u043B-\u0432\u043E",
+      colorMode: "\u0420\u0435\u0436\u0438\u043C \u0446\u0432\u0435\u0442\u043E\u0432",
+      random: "\u0421\u043B\u0443\u0447\u0430\u0439\u043D\u044B\u0439",
+      fixed: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439",
+      range: "\u0414\u0438\u0430\u043F\u0430\u0437\u043E\u043D",
+      fixedColor: "\u0424\u0438\u043A\u0441\u0438\u0440\u043E\u0432\u0430\u043D\u043D\u044B\u0439 \u0446\u0432\u0435\u0442",
+      advanced: "\u0420\u0430\u0441\u0448\u0438\u0440\u0435\u043D\u043D\u044B\u0435",
+      tileX: "\u041F\u043B\u0438\u0442\u043A\u0430 X",
+      tileY: "\u041F\u043B\u0438\u0442\u043A\u0430 Y",
+      customPalette: "\u0421\u0432\u043E\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430",
+      paletteExample: "\u043F\u0440\u0438\u043C\u0435\u0440: #FF0000,#00FF00,#0000FF",
+      capture: "\u0417\u0430\u0445\u0432\u0430\u0442",
+      painted: "\u0417\u0430\u043A\u0440\u0430\u0448\u0435\u043D\u043E",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      retries: "\u041F\u043E\u0432\u0442\u043E\u0440\u043D\u044B\u0435 \u043F\u043E\u043F\u044B\u0442\u043A\u0438",
+      tile: "\u041F\u043B\u0438\u0442\u043A\u0430",
+      configSaved: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0430",
+      configLoaded: "\u041A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044F \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043D\u0430",
+      configReset: "\u0421\u0431\u0440\u043E\u0441 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",
+      captureInstructions: "\u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432\u0440\u0443\u0447\u043D\u0443\u044E \u0434\u043B\u044F \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442...",
+      backendOnline: "\u0411\u044D\u043A\u044D\u043D\u0434 \u041E\u043D\u043B\u0430\u0439\u043D",
+      backendOffline: "\u0411\u044D\u043A\u044D\u043D\u0434",
+      startingBot: "\u0417\u0430\u043F\u0443\u0441\u043A \u0431\u043E\u0442\u0430...",
+      stoppingBot: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430 \u0431\u043E\u0442\u0430...",
+      calibrating: "\u041A\u0430\u043B\u0438\u0431\u0440\u043E\u0432\u043A\u0430...",
+      alreadyRunning: "\u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C \u0443\u0436\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D",
+      imageRunningWarning: "\u0410\u0432\u0442\u043E-\u0418\u0437\u043E\u0431\u0440\u0430\u0436\u0435\u043D\u0438\u0435 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u043E. \u0417\u0430\u043A\u0440\u043E\u0439\u0442\u0435 \u0435\u0433\u043E \u043F\u0435\u0440\u0435\u0434 \u0437\u0430\u043F\u0443\u0441\u043A\u043E\u043C \u0410\u0432\u0442\u043E-\u0424\u0430\u0440\u043C\u0430.",
+      selectPosition: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C",
+      selectPositionAlert: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041F\u0423\u0421\u0422\u041E\u0419 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u043A\u0430\u0440\u0442\u044B, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430.",
+      waitingPosition: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0441\u0442\u0430\u0440\u0442\u043E\u0432\u043E\u0433\u043E \u043F\u0438\u043A\u0441\u0435\u043B\u044F....",
+      positionSet: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0443\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430! \u0420\u0430\u0434\u0438\u0443\u0441: 500px",
+      positionTimeout: "\u274C \u0422\u0430\u0439\u043C\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      missingPosition: "\u274C \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0441 \u043F\u043E\u043C\u043E\u0449\u044C\u044E \xAB\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C\xBB",
+      farmRadius: "\u0420\u0430\u0434\u0438\u0443\u0441 \u0444\u0430\u0440\u043C\u0430",
+      positionInfo: "\u0422\u0435\u043A\u0443\u0449\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C",
+      farmingInRadius: "\u{1F33E} \u0424\u0430\u0440\u043C \u0432 \u0440\u0430\u0434\u0438\u0443\u0441\u0435 {radius}px \u043E\u0442 ({x},{y})",
+      selectEmptyArea: "\u26A0\uFE0F \u0412\u0410\u0416\u041D\u041E: \u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u041F\u0423\u0421\u0422\u0423\u042E \u043E\u0431\u043B\u0430\u0441\u0442\u044C, \u0447\u0442\u043E\u0431\u044B \u0438\u0437\u0431\u0435\u0436\u0430\u0442\u044C \u043A\u043E\u043D\u0444\u043B\u0438\u043A\u0442\u043E\u0432.",
+      noPosition: "\u041D\u0435\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      currentZone: "\u041E\u0431\u043B\u0430\u0441\u0442\u044C: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0432\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C. \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u043D\u0430 \u043A\u0430\u0440\u0442\u0435, \u0447\u0442\u043E\u0431\u044B \u043E\u0431\u043E\u0437\u043D\u0430\u0447\u0438\u0442\u044C \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0444\u0430\u0440\u043C\u0430."
+    },
+    // Common/Shared
+    common: {
+      yes: "\u0414\u0430",
+      no: "\u041D\u0435\u0442",
+      ok: "\u041E\u041A",
+      cancel: "\u041E\u0442\u043C\u0435\u043D\u0438\u0442\u044C",
+      close: "\u0417\u0430\u043A\u0440\u044B\u0442\u044C",
+      save: "\u0421\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C",
+      load: "\u0417\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C",
+      delete: "\u0423\u0434\u0430\u043B\u0438\u0442\u044C",
+      edit: "\u0418\u0437\u043C\u0435\u043D\u0438\u0442\u044C",
+      start: "\u041D\u0430\u0447\u0430\u0442\u044C",
+      stop: "\u0417\u0430\u043A\u043E\u043D\u0447\u0438\u0442\u044C",
+      pause: "\u041F\u0440\u0438\u043E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C",
+      resume: "\u041F\u0440\u043E\u0434\u043E\u043B\u0436\u0438\u0442\u044C",
+      reset: "\u0421\u0431\u0440\u043E\u0441\u0438\u0442\u044C",
+      settings: "\u041D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",
+      help: "\u041F\u043E\u043C\u043E\u0449\u044C",
+      about: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      language: "\u042F\u0437\u044B\u043A",
+      loading: "\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...",
+      error: "\u041E\u0448\u0438\u0431\u043A\u0430",
+      success: "\u0423\u0441\u043F\u0435\u0445",
+      warning: "\u041F\u0440\u0435\u0434\u0443\u043F\u0440\u0435\u0436\u0434\u0435\u043D\u0438\u0435",
+      info: "\u0418\u043D\u0444\u043E\u0440\u043C\u0430\u0446\u0438\u044F",
+      languageChanged: "\u042F\u0437\u044B\u043A \u0438\u0437\u043C\u0435\u043D\u0435\u043D \u043D\u0430 {language}"
+    },
+    // Guard Module
+    guard: {
+      title: "WPlace \u0410\u0432\u0442\u043E-\u0417\u0430\u0449\u0438\u0442\u0430",
+      initBot: "\u0418\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u0442\u044C Guard-BOT",
+      selectArea: "\u0412\u044B\u0431\u0440\u0430\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      captureArea: "\u0417\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u044C \u041E\u0431\u043B\u0430\u0441\u0442\u044C",
+      startProtection: "\u041D\u0430\u0447\u0430\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      stopProtection: "\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u0438\u0442\u044C \u0417\u0430\u0449\u0438\u0442\u0443",
+      upperLeft: "\u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u041B\u0435\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      lowerRight: "\u041D\u0438\u0436\u043D\u0438\u0439 \u041F\u0440\u0430\u0432\u044B\u0439 \u0423\u0433\u043E\u043B",
+      protectedPixels: "\u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      detectedChanges: "\u041E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043D\u044B\u0435 \u0418\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u044F",
+      repairedPixels: "\u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u044B\u0435 \u041F\u0438\u043A\u0441\u0435\u043B\u0438",
+      charges: "\u0417\u0430\u0440\u044F\u0434\u044B",
+      waitingInit: "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438...",
+      checkingColors: "\u{1F3A8} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432...",
+      noColorsFound: "\u274C \u0426\u0432\u0435\u0442\u0430 \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u044B. \u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u043F\u0430\u043B\u0438\u0442\u0440\u0443 \u0446\u0432\u0435\u0442\u043E\u0432 \u043D\u0430 \u0441\u0430\u0439\u0442\u0435.",
+      colorsFound: "\u2705 \u041D\u0430\u0439\u0434\u0435\u043D\u043E {count} \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0446\u0432\u0435\u0442\u043E\u0432",
+      initSuccess: "\u2705 Guard-BOT \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0438\u0440\u043E\u0432\u0430\u043D",
+      initError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 Guard-BOT",
+      invalidCoords: "\u274C \u041D\u0435\u0434\u0435\u0439\u0441\u0442\u0432\u0438\u0442\u0435\u043B\u044C\u043D\u044B\u0435 \u043A\u043E\u043E\u0440\u0434\u0438\u043D\u0430\u0442\u044B",
+      invalidArea: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0434\u043E\u043B\u0436\u043D\u0430 \u0438\u043C\u0435\u0442\u044C \u0432\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u043C\u0435\u043D\u044C\u0448\u0435 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430",
+      areaTooLarge: "\u274C \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0441\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u0430\u044F: {size} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 (\u043C\u0430\u043A\u0441\u0438\u043C\u0443\u043C: {max})",
+      capturingArea: "\u{1F4F8} \u0417\u0430\u0445\u0432\u0430\u0442 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0437\u0430\u0449\u0438\u0442\u044B...",
+      areaCaptured: "\u2705 \u041E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D\u0430: {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439 \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      captureError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0430 \u043E\u0431\u043B\u0430\u0441\u0442\u0438: {error}",
+      captureFirst: "\u274C \u0421\u043D\u0430\u0447\u0430\u043B\u0430 \u0437\u0430\u0445\u0432\u0430\u0442\u0438\u0442\u0435 \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u0437\u0430\u0449\u0438\u0442\u044B",
+      protectionStarted: "\u{1F6E1}\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u0437\u0430\u043F\u0443\u0449\u0435\u043D\u0430 - \u043C\u043E\u043D\u0438\u0442\u043E\u0440\u0438\u043D\u0433 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      protectionStopped: "\u23F9\uFE0F \u0417\u0430\u0449\u0438\u0442\u0430 \u043E\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0430",
+      noChanges: "\u2705 \u0417\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u0430\u044F \u043E\u0431\u043B\u0430\u0441\u0442\u044C - \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043D\u0435 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E",
+      changesDetected: "\u{1F6A8} {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u043E \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      repairing: "\u{1F6E0}\uFE0F \u0412\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u0435 {count} \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u043D\u044B\u0445 \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439...",
+      repairedSuccess: "\u2705 \u0423\u0441\u043F\u0435\u0448\u043D\u043E \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u043E {count} \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439",
+      repairError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u043F\u0438\u043A\u0441\u0435\u043B\u0435\u0439: {error}",
+      noCharges: "\u26A0\uFE0F \u041D\u0435\u0434\u043E\u0441\u0442\u0430\u0442\u043E\u0447\u043D\u043E \u0437\u0430\u0440\u044F\u0434\u043E\u0432 \u0434\u043B\u044F \u0432\u043E\u0441\u0441\u0442\u0430\u043D\u043E\u0432\u043B\u0435\u043D\u0438\u044F \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439",
+      checkingChanges: "\u{1F50D} \u041F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439 \u0432 \u0437\u0430\u0449\u0438\u0449\u0435\u043D\u043D\u043E\u0439 \u043E\u0431\u043B\u0430\u0441\u0442\u0438...",
+      errorChecking: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0438 \u0438\u0437\u043C\u0435\u043D\u0435\u043D\u0438\u0439: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u0421\u0442\u0440\u0430\u0436 \u0430\u043A\u0442\u0438\u0432\u0435\u043D - \u043E\u0431\u043B\u0430\u0441\u0442\u044C \u043F\u043E\u0434 \u0437\u0430\u0449\u0438\u0442\u043E\u0439",
+      lastCheck: "\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u044F\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430: {time}",
+      nextCheck: "\u0421\u043B\u0435\u0434\u0443\u044E\u0449\u0430\u044F \u043F\u0440\u043E\u0432\u0435\u0440\u043A\u0430 \u0447\u0435\u0440\u0435\u0437: {time}\u0441",
+      autoInitializing: "\u{1F916} \u0410\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F...",
+      autoInitSuccess: "\u2705 Guard-BOT \u0437\u0430\u043F\u0443\u0449\u0435\u043D \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438",
+      autoInitFailed: "\u26A0\uFE0F \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u044C \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u0435\u0441\u043A\u0438. \u0418\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u0439\u0442\u0435 \u043A\u043D\u043E\u043F\u043A\u0443 \u0440\u0443\u0447\u043D\u043E\u0433\u043E \u0437\u0430\u043F\u0443\u0441\u043A\u0430.",
+      manualInitRequired: "\u{1F527} \u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u0440\u0443\u0447\u043D\u0430\u044F \u0438\u043D\u0438\u0446\u0438\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F",
+      paletteDetected: "\u{1F3A8} \u0426\u0432\u0435\u0442\u043E\u0432\u0430\u044F \u043F\u0430\u043B\u0438\u0442\u0440\u0430 \u043E\u0431\u043D\u0430\u0440\u0443\u0436\u0435\u043D\u0430",
+      paletteNotFound: "\u{1F50D} \u041F\u043E\u0438\u0441\u043A \u0446\u0432\u0435\u0442\u043E\u0432\u043E\u0439 \u043F\u0430\u043B\u0438\u0442\u0440\u044B...",
+      clickingPaintButton: "\u{1F446} \u041D\u0430\u0436\u0430\u0442\u0438\u0435 \u043A\u043D\u043E\u043F\u043A\u0438 \xABPaint\xBB...",
+      paintButtonNotFound: "\u274C \u041A\u043D\u043E\u043F\u043A\u0430 \xABPaint\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D\u0430",
+      selectUpperLeft: "\u{1F3AF} \u041D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u0412\u0415\u0420\u0425\u041D\u0415\u041C \u041B\u0415\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438 \u0434\u043B\u044F \u0437\u0430\u0449\u0438\u0442\u044B",
+      selectLowerRight: "\u{1F3AF} \u0422\u0435\u043F\u0435\u0440\u044C \u043D\u0430\u0440\u0438\u0441\u0443\u0439\u0442\u0435 \u043F\u0438\u043A\u0441\u0435\u043B\u044C \u0432 \u041D\u0418\u0416\u041D\u0415\u041C \u041F\u0420\u0410\u0412\u041E\u041C \u0443\u0433\u043B\u0443 \u043E\u0431\u043B\u0430\u0441\u0442\u0438",
+      waitingUpperLeft: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u0432\u0435\u0440\u0445\u043D\u0435\u0433\u043E \u043B\u0435\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      waitingLowerRight: "\u{1F446} \u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0432\u044B\u0431\u043E\u0440\u0430 \u043D\u0438\u0436\u043D\u0435\u0433\u043E \u043F\u0440\u0430\u0432\u043E\u0433\u043E \u0443\u0433\u043B\u0430...",
+      upperLeftCaptured: "\u2705 \u0412\u0435\u0440\u0445\u043D\u0438\u0439 \u043B\u0435\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u041D\u0438\u0436\u043D\u0438\u0439 \u043F\u0440\u0430\u0432\u044B\u0439 \u0443\u0433\u043E\u043B \u0437\u0430\u0445\u0432\u0430\u0447\u0435\u043D: ({x}, {y})",
+      selectionTimeout: "\u274C \u0422\u0430\u0439\u043C-\u0430\u0443\u0442 \u0432\u044B\u0431\u043E\u0440\u0430",
+      selectionError: "\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0432\u044B\u0431\u043E\u0440\u0430, \u043F\u043E\u0436\u0430\u043B\u0443\u0439\u0441\u0442\u0430, \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430"
+    }
+  };
+
+  // src/locales/zh-Hans.js
+  var zhHans = {
+    // 启动器
+    launcher: {
+      title: "WPlace \u81EA\u52A8\u673A\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52A8\u519C\u573A",
+      autoImage: "\u{1F3A8} \u81EA\u52A8\u7ED8\u56FE",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52A8\u5B88\u62A4",
+      selection: "\u9009\u62E9",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6570",
+      backend: "\u540E\u7AEF",
+      database: "\u6570\u636E\u5E93",
+      uptime: "\u8FD0\u884C\u65F6\u95F4",
+      close: "\u5173\u95ED",
+      launch: "\u542F\u52A8",
+      loading: "\u52A0\u8F7D\u4E2D\u2026",
+      executing: "\u6267\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F7D\u811A\u672C\u2026",
+      chooseBot: "\u9009\u62E9\u4E00\u4E2A\u673A\u5668\u4EBA\u5E76\u70B9\u51FB\u542F\u52A8",
+      readyToLaunch: "\u51C6\u5907\u542F\u52A8",
+      loadError: "\u52A0\u8F7D\u9519\u8BEF",
+      loadErrorMsg: "\u65E0\u6CD5\u52A0\u8F7D\u6240\u9009\u673A\u5668\u4EBA\u3002\u8BF7\u68C0\u67E5\u7F51\u7EDC\u8FDE\u63A5\u6216\u91CD\u8BD5\u3002",
+      checking: "\u{1F504} \u68C0\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7EBF",
+      offline: "\u{1F534} \u79BB\u7EBF",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u9519\u8BEF",
+      unknown: "-"
+    },
+    // 绘图模块
+    image: {
+      title: "WPlace \u81EA\u52A8\u7ED8\u56FE",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA",
+      uploadImage: "\u4E0A\u4F20\u56FE\u7247",
+      resizeImage: "\u8C03\u6574\u56FE\u7247\u5927\u5C0F",
+      selectPosition: "\u9009\u62E9\u4F4D\u7F6E",
+      startPainting: "\u5F00\u59CB\u7ED8\u5236",
+      stopPainting: "\u505C\u6B62\u7ED8\u5236",
+      saveProgress: "\u4FDD\u5B58\u8FDB\u5EA6",
+      loadProgress: "\u52A0\u8F7D\u8FDB\u5EA6",
+      checkingColors: "\u{1F50D} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u540E\u91CD\u8BD5\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F7D\u56FE\u7247...",
+      imageLoaded: "\u2705 \u56FE\u7247\u5DF2\u52A0\u8F7D\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u4E2A",
+      imageError: "\u274C \u56FE\u7247\u52A0\u8F7D\u5931\u8D25",
+      selectPositionAlert: "\u8BF7\u5728\u4F60\u60F3\u5F00\u59CB\u7ED8\u5236\u7684\u5730\u65B9\u6D82\u7B2C\u4E00\u4E2A\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8BBE\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9009\u62E9\u8D85\u65F6",
+      positionDetected: "\u{1F3AF} \u5DF2\u68C0\u6D4B\u5230\u4F4D\u7F6E\uFF0C\u5904\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u68C0\u6D4B\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5",
+      startPaintingMsg: "\u{1F3A8} \u5F00\u59CB\u7ED8\u5236...",
+      paintingProgress: "\u{1F9F1} \u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6CA1\u6709\u6B21\u6570\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7ED8\u5236",
+      paintingComplete: "\u2705 \u7ED8\u5236\u5B8C\u6210\uFF01\u5171\u7ED8\u5236 {count} \u4E2A\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7ED8\u5236\u8FC7\u7A0B\u4E2D\u51FA\u9519",
+      missingRequirements: "\u274C \u8BF7\u5148\u52A0\u8F7D\u56FE\u7247\u5E76\u9009\u62E9\u4F4D\u7F6E",
+      progress: "\u8FDB\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      estimatedTime: "\u9884\u8BA1\u65F6\u95F4",
+      initMessage: "\u70B9\u51FB\u201C\u521D\u59CB\u5316\u81EA\u52A8\u673A\u5668\u4EBA\u201D\u5F00\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u56FE\u7247\u5DF2\u8C03\u6574\u4E3A {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7ED8\u5236\u6682\u505C\u4E8E\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6570",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u65F6\u95F4",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6570",
+      showOverlay: "\u663E\u793A\u8986\u76D6\u5C42",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6570",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed}",
+      timeRemaining: "\u5269\u4F59\u65F6\u95F4",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u540E\u7EE7\u7EED...",
+      progressSaved: "\u2705 \u8FDB\u5EA6\u5DF2\u4FDD\u5B58\u4E3A {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F7D\u8FDB\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7ED8\u5236",
+      progressLoadError: "\u274C \u52A0\u8F7D\u8FDB\u5EA6\u5931\u8D25: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u8FDB\u5EA6\u5931\u8D25: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u5F53\u524D\u8FDB\u5EA6\u5417\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u8FDB\u5EA6",
+      discardProgress: "\u653E\u5F03",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BBD\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7EB5\u6A2A\u6BD4",
+      apply: "\u5E94\u7528",
+      overlayOn: "\u8986\u76D6\u5C42: \u5F00\u542F",
+      overlayOff: "\u8986\u76D6\u5C42: \u5173\u95ED",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7ED8\u5236 {painted} \u50CF\u7D20 | \u8FDB\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6570\u6062\u590D: {current}/{needed} - \u65F6\u95F4: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6570: {current}/{needed} - \u5269\u4F59: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8BD5 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5C1D\u8BD5\u51FA\u9519\uFF0C\u5C06\u5728 {delay} \u79D2\u540E\u91CD\u8BD5...",
+      retryFailed: "\u274C \u8D85\u8FC7 {maxAttempts} \u6B21\u5C1D\u8BD5\u5931\u8D25\u3002\u7EE7\u7EED\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7F51\u7EDC\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      serverError: "\u{1F525} \u670D\u52A1\u5668\u9519\u8BEF\uFF0C\u6B63\u5728\u91CD\u8BD5...",
+      timeoutError: "\u23F0 \u670D\u52A1\u5668\u8D85\u65F6\uFF0C\u6B63\u5728\u91CD\u8BD5..."
+    },
+    // 农场模块（待实现）
+    farm: {
+      title: "WPlace \u519C\u573A\u673A\u5668\u4EBA",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u673A\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u51C6",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u68C0\u67E5\u72B6\u6001\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u8FDF (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6570",
+      colorMode: "\u989C\u8272\u6A21\u5F0F",
+      random: "\u968F\u673A",
+      fixed: "\u56FA\u5B9A",
+      range: "\u8303\u56F4",
+      fixedColor: "\u56FA\u5B9A\u989C\u8272",
+      advanced: "\u9AD8\u7EA7",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u4E49\u8C03\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u83B7",
+      painted: "\u5DF2\u7ED8\u5236",
+      charges: "\u6B21\u6570",
+      retries: "\u91CD\u8BD5",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F7D",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8BF7\u624B\u52A8\u7ED8\u5236\u4E00\u4E2A\u50CF\u7D20\u4EE5\u6355\u83B7\u5750\u6807...",
+      backendOnline: "\u540E\u7AEF\u5728\u7EBF",
+      backendOffline: "\u540E\u7AEF\u79BB\u7EBF",
+      startingBot: "\u6B63\u5728\u542F\u52A8\u673A\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u673A\u5668\u4EBA...",
+      calibrating: "\u6821\u51C6\u4E2D...",
+      alreadyRunning: "\u81EA\u52A8\u519C\u573A\u5DF2\u5728\u8FD0\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52A8\u7ED8\u56FE\u6B63\u5728\u8FD0\u884C\uFF0C\u8BF7\u5148\u5173\u95ED\u518D\u542F\u52A8\u81EA\u52A8\u519C\u573A\u3002",
+      selectPosition: "\u9009\u62E9\u533A\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u56FE\u7684\u7A7A\u767D\u533A\u57DF\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u6D82\u53C2\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u533A\u57DF\u8BBE\u7F6E\u6210\u529F\uFF01\u534A\u5F84: 500px",
+      positionTimeout: "\u274C \u533A\u57DF\u9009\u62E9\u8D85\u65F6",
+      missingPosition: "\u274C \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF08\u4F7F\u7528\u201C\u9009\u62E9\u533A\u57DF\u201D\u6309\u94AE\uFF09",
+      farmRadius: "\u519C\u573A\u534A\u5F84",
+      positionInfo: "\u5F53\u524D\u533A\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F84 {radius}px \u5728 ({x},{y}) \u519C\u573A",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8BF7\u9009\u62E9\u7A7A\u767D\u533A\u57DF\u4EE5\u907F\u514D\u51B2\u7A81",
+      noPosition: "\u672A\u9009\u62E9\u533A\u57DF",
+      currentZone: "\u533A\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8BF7\u5148\u9009\u62E9\u533A\u57DF\uFF0C\u5728\u5730\u56FE\u4E0A\u6D82\u4E00\u4E2A\u50CF\u7D20\u4EE5\u8BBE\u7F6E\u519C\u573A\u533A\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u786E\u8BA4",
+      cancel: "\u53D6\u6D88",
+      close: "\u5173\u95ED",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F7D",
+      delete: "\u5220\u9664",
+      edit: "\u7F16\u8F91",
+      start: "\u5F00\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u6682\u505C",
+      resume: "\u7EE7\u7EED",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8BBE\u7F6E",
+      help: "\u5E2E\u52A9",
+      about: "\u5173\u4E8E",
+      language: "\u8BED\u8A00",
+      loading: "\u52A0\u8F7D\u4E2D...",
+      error: "\u9519\u8BEF",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8BED\u8A00\u5DF2\u5207\u6362\u4E3A {language}"
+    },
+    // 守护模块
+    guard: {
+      title: "WPlace \u81EA\u52A8\u5B88\u62A4",
+      initBot: "\u521D\u59CB\u5316\u5B88\u62A4\u673A\u5668\u4EBA",
+      selectArea: "\u9009\u62E9\u533A\u57DF",
+      captureArea: "\u6355\u83B7\u533A\u57DF",
+      startProtection: "\u5F00\u59CB\u5B88\u62A4",
+      stopProtection: "\u505C\u6B62\u5B88\u62A4",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u62A4\u50CF\u7D20",
+      detectedChanges: "\u68C0\u6D4B\u5230\u7684\u53D8\u5316",
+      repairedPixels: "\u4FEE\u590D\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6570",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u68C0\u67E5\u53EF\u7528\u989C\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u989C\u8272\uFF0C\u8BF7\u5728\u7F51\u7AD9\u4E0A\u6253\u5F00\u8C03\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u79CD\u53EF\u7528\u989C\u8272",
+      initSuccess: "\u2705 \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u62A4\u673A\u5668\u4EBA\u521D\u59CB\u5316\u5931\u8D25",
+      invalidCoords: "\u274C \u5750\u6807\u65E0\u6548",
+      invalidArea: "\u274C \u533A\u57DF\u65E0\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u987B\u5C0F\u4E8E\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u533A\u57DF\u8FC7\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u83B7\u5B88\u62A4\u533A\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u533A\u57DF\u6355\u83B7\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u62A4",
+      captureError: "\u274C \u6355\u83B7\u533A\u57DF\u51FA\u9519: {error}",
+      captureFirst: "\u274C \u8BF7\u5148\u6355\u83B7\u4E00\u4E2A\u5B88\u62A4\u533A\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u62A4\u5DF2\u542F\u52A8 - \u533A\u57DF\u76D1\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u62A4\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u533A\u57DF\u5B89\u5168 - \u672A\u68C0\u6D4B\u5230\u53D8\u5316",
+      changesDetected: "\u{1F6A8} \u68C0\u6D4B\u5230 {count} \u4E2A\u53D8\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u590D {count} \u4E2A\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u590D {count} \u4E2A\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u590D\u51FA\u9519: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6570\u4E0D\u8DB3\uFF0C\u65E0\u6CD5\u4FEE\u590D",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u68C0\u67E5\u533A\u57DF\u53D8\u5316...",
+      errorChecking: "\u274C \u68C0\u67E5\u51FA\u9519: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u62A4\u4E2D - \u533A\u57DF\u53D7\u4FDD\u62A4",
+      lastCheck: "\u4E0A\u6B21\u68C0\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u68C0\u67E5: {time} \u79D2\u540E",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52A8\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52A8\u542F\u52A8\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u65E0\u6CD5\u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u624B\u52A8\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52A8\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u68C0\u6D4B\u5230\u8C03\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8C03\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u70B9\u51FB\u7ED8\u5236\u6309\u94AE...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7ED8\u5236\u6309\u94AE",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u62A4\u533A\u57DF\u7684\u5DE6\u4E0A\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73B0\u5728\u5728\u53F3\u4E0B\u89D2\u6D82\u4E00\u4E2A\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9009\u62E9\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u83B7\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u83B7\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9009\u62E9\u8D85\u65F6",
+      selectionError: "\u274C \u9009\u62E9\u51FA\u9519\uFF0C\u8BF7\u91CD\u8BD5"
+    }
+  };
+
+  // src/locales/zh-Hant.js
+  var zhHant = {
+    // 啓動器
+    launcher: {
+      title: "WPlace \u81EA\u52D5\u6A5F\u5668\u4EBA",
+      autoFarm: "\u{1F33E} \u81EA\u52D5\u8FB2\u5834",
+      autoImage: "\u{1F3A8} \u81EA\u52D5\u7E6A\u5716",
+      autoGuard: "\u{1F6E1}\uFE0F \u81EA\u52D5\u5B88\u8B77",
+      selection: "\u9078\u64C7",
+      user: "\u7528\u6237",
+      charges: "\u6B21\u6578",
+      backend: "\u5F8C\u7AEF",
+      database: "\u6578\u64DA\u5EAB",
+      uptime: "\u904B\u884C\u6642\u9593",
+      close: "\u95DC\u9589",
+      launch: "\u5553\u52D5",
+      loading: "\u52A0\u8F09\u4E2D\u2026",
+      executing: "\u57F7\u884C\u4E2D\u2026",
+      downloading: "\u6B63\u5728\u4E0B\u8F09\u8173\u672C\u2026",
+      chooseBot: "\u9078\u64C7\u4E00\u500B\u6A5F\u5668\u4EBA\u4E26\u9EDE\u64CA\u5553\u52D5",
+      readyToLaunch: "\u6E96\u5099\u5553\u52D5",
+      loadError: "\u52A0\u8F09\u932F\u8AA4",
+      loadErrorMsg: "\u7121\u6CD5\u52A0\u8F09\u6240\u9078\u6A5F\u5668\u4EBA\u3002\u8ACB\u6AA2\u67E5\u7DB2\u7D61\u9023\u63A5\u6216\u91CD\u8A66\u3002",
+      checking: "\u{1F504} \u6AA2\u67E5\u4E2D...",
+      online: "\u{1F7E2} \u5728\u7DDA",
+      offline: "\u{1F534} \u96E2\u7DDA",
+      ok: "\u{1F7E2} \u6B63\u5E38",
+      error: "\u{1F534} \u932F\u8AA4",
+      unknown: "-"
+    },
+    // 繪圖模塊
+    image: {
+      title: "WPlace \u81EA\u52D5\u7E6A\u5716",
+      initBot: "\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA",
+      uploadImage: "\u4E0A\u50B3\u5716\u7247",
+      resizeImage: "\u8ABF\u6574\u5716\u7247\u5927\u5C0F",
+      selectPosition: "\u9078\u64C7\u4F4D\u7F6E",
+      startPainting: "\u958B\u59CB\u7E6A\u88FD",
+      stopPainting: "\u505C\u6B62\u7E6A\u88FD",
+      saveProgress: "\u4FDD\u5B58\u9032\u5EA6",
+      loadProgress: "\u52A0\u8F09\u9032\u5EA6",
+      checkingColors: "\u{1F50D} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u5F8C\u91CD\u8A66\uFF01",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      loadingImage: "\u{1F5BC}\uFE0F \u6B63\u5728\u52A0\u8F09\u5716\u7247...",
+      imageLoaded: "\u2705 \u5716\u7247\u5DF2\u52A0\u8F09\uFF0C\u6709\u6548\u50CF\u7D20 {count} \u500B",
+      imageError: "\u274C \u5716\u7247\u52A0\u8F09\u5931\u6557",
+      selectPositionAlert: "\u8ACB\u5728\u4F60\u60F3\u958B\u59CB\u7E6A\u88FD\u7684\u5730\u65B9\u5857\u7B2C\u4E00\u500B\u50CF\u7D20\uFF01",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u4F4D\u7F6E\u8A2D\u7F6E\u6210\u529F\uFF01",
+      positionTimeout: "\u274C \u4F4D\u7F6E\u9078\u64C7\u8D85\u6642",
+      positionDetected: "\u{1F3AF} \u5DF2\u6AA2\u6E2C\u5230\u4F4D\u7F6E\uFF0C\u8655\u7406\u4E2D...",
+      positionError: "\u274C \u4F4D\u7F6E\u6AA2\u6E2C\u5931\u6557\uFF0C\u8ACB\u91CD\u8A66",
+      startPaintingMsg: "\u{1F3A8} \u958B\u59CB\u7E6A\u88FD...",
+      paintingProgress: "\u{1F9F1} \u9032\u5EA6: {painted}/{total} \u50CF\u7D20...",
+      noCharges: "\u231B \u6C92\u6709\u6B21\u6578\u3002\u7B49\u5F85 {time}...",
+      paintingStopped: "\u23F9\uFE0F \u7528\u6237\u5DF2\u505C\u6B62\u7E6A\u88FD",
+      paintingComplete: "\u2705 \u7E6A\u88FD\u5B8C\u6210\uFF01\u5171\u7E6A\u88FD {count} \u500B\u50CF\u7D20\u3002",
+      paintingError: "\u274C \u7E6A\u88FD\u904E\u7A0B\u4E2D\u51FA\u932F",
+      missingRequirements: "\u274C \u8ACB\u5148\u52A0\u8F09\u5716\u7247\u4E26\u9078\u64C7\u4F4D\u7F6E",
+      progress: "\u9032\u5EA6",
+      userName: "\u7528\u6237",
+      pixels: "\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      estimatedTime: "\u9810\u8A08\u6642\u9593",
+      initMessage: "\u9EDE\u64CA\u201C\u521D\u59CB\u5316\u81EA\u52D5\u6A5F\u5668\u4EBA\u201D\u958B\u59CB",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      resizeSuccess: "\u2705 \u5716\u7247\u5DF2\u8ABF\u6574\u70BA {width}x{height}",
+      paintingPaused: "\u23F8\uFE0F \u7E6A\u88FD\u66AB\u505C\u65BC\u4F4D\u7F6E X: {x}, Y: {y}",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20\u6578",
+      batchSize: "\u6279\u6B21\u5927\u5C0F",
+      nextBatchTime: "\u4E0B\u6B21\u6279\u6B21\u6642\u9593",
+      useAllCharges: "\u4F7F\u7528\u6240\u6709\u53EF\u7528\u6B21\u6578",
+      showOverlay: "\u986F\u793A\u8986\u84CB\u5C64",
+      maxCharges: "\u6BCF\u6279\u6700\u5927\u6B21\u6578",
+      waitingForCharges: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed}",
+      timeRemaining: "\u5269\u9918\u6642\u9593",
+      cooldownWaiting: "\u23F3 \u7B49\u5F85 {time} \u5F8C\u7E7C\u7E8C...",
+      progressSaved: "\u2705 \u9032\u5EA6\u5DF2\u4FDD\u5B58\u70BA {filename}",
+      progressLoaded: "\u2705 \u5DF2\u52A0\u8F09\u9032\u5EA6: {painted}/{total} \u50CF\u7D20\u5DF2\u7E6A\u88FD",
+      progressLoadError: "\u274C \u52A0\u8F09\u9032\u5EA6\u5931\u6557: {error}",
+      progressSaveError: "\u274C \u4FDD\u5B58\u9032\u5EA6\u5931\u6557: {error}",
+      confirmSaveProgress: "\u5728\u505C\u6B62\u4E4B\u524D\u8981\u4FDD\u5B58\u7576\u524D\u9032\u5EA6\u55CE\uFF1F",
+      saveProgressTitle: "\u4FDD\u5B58\u9032\u5EA6",
+      discardProgress: "\u653E\u68C4",
+      cancel: "\u53D6\u6D88",
+      minimize: "\u6700\u5C0F\u5316",
+      width: "\u5BEC\u5EA6",
+      height: "\u9AD8\u5EA6",
+      keepAspect: "\u4FDD\u6301\u7E31\u6A6B\u6BD4",
+      apply: "\u61C9\u7528",
+      overlayOn: "\u8986\u84CB\u5C64: \u958B\u5553",
+      overlayOff: "\u8986\u84CB\u5C64: \u95DC\u9589",
+      passCompleted: "\u2705 \u6279\u6B21\u5B8C\u6210: \u5DF2\u7E6A\u88FD {painted} \u50CF\u7D20 | \u9032\u5EA6: {percent}% ({current}/{total})",
+      waitingChargesRegen: "\u23F3 \u7B49\u5F85\u6B21\u6578\u6062\u5FA9: {current}/{needed} - \u6642\u9593: {time}",
+      waitingChargesCountdown: "\u23F3 \u7B49\u5F85\u6B21\u6578: {current}/{needed} - \u5269\u9918: {time}",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      retryAttempt: "\u{1F504} \u91CD\u8A66 {attempt}/{maxAttempts}\uFF0C\u7B49\u5F85 {delay} \u79D2...",
+      retryError: "\u{1F4A5} \u7B2C {attempt}/{maxAttempts} \u6B21\u5617\u8A66\u51FA\u932F\uFF0C\u5C07\u5728 {delay} \u79D2\u5F8C\u91CD\u8A66...",
+      retryFailed: "\u274C \u8D85\u904E {maxAttempts} \u6B21\u5617\u8A66\u5931\u6557\u3002\u7E7C\u7E8C\u4E0B\u4E00\u6279...",
+      networkError: "\u{1F310} \u7DB2\u7D61\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      serverError: "\u{1F525} \u670D\u52D9\u5668\u932F\u8AA4\uFF0C\u6B63\u5728\u91CD\u8A66...",
+      timeoutError: "\u23F0 \u670D\u52D9\u5668\u8D85\u6642\uFF0C\u6B63\u5728\u91CD\u8A66..."
+    },
+    // 農場模塊（待實現）
+    farm: {
+      title: "WPlace \u8FB2\u5834\u6A5F\u5668\u4EBA",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      stopped: "\u6A5F\u5668\u4EBA\u5DF2\u505C\u6B62",
+      calibrate: "\u6821\u6E96",
+      paintOnce: "\u4E00\u6B21",
+      checkingStatus: "\u6AA2\u67E5\u72C0\u614B\u4E2D...",
+      configuration: "\u914D\u7F6E",
+      delay: "\u5EF6\u9072 (\u6BEB\u79D2)",
+      pixelsPerBatch: "\u6BCF\u6279\u50CF\u7D20",
+      minCharges: "\u6700\u5C11\u6B21\u6578",
+      colorMode: "\u984F\u8272\u6A21\u5F0F",
+      random: "\u96A8\u6A5F",
+      fixed: "\u56FA\u5B9A",
+      range: "\u7BC4\u570D",
+      fixedColor: "\u56FA\u5B9A\u984F\u8272",
+      advanced: "\u9AD8\u7D1A",
+      tileX: "\u74E6\u7247 X",
+      tileY: "\u74E6\u7247 Y",
+      customPalette: "\u81EA\u5B9A\u7FA9\u8ABF\u8272\u677F",
+      paletteExample: "\u4F8B\u5982: #FF0000,#00FF00,#0000FF",
+      capture: "\u6355\u7372",
+      painted: "\u5DF2\u7E6A\u88FD",
+      charges: "\u6B21\u6578",
+      retries: "\u91CD\u8A66",
+      tile: "\u74E6\u7247",
+      configSaved: "\u914D\u7F6E\u5DF2\u4FDD\u5B58",
+      configLoaded: "\u914D\u7F6E\u5DF2\u52A0\u8F09",
+      configReset: "\u914D\u7F6E\u5DF2\u91CD\u7F6E",
+      captureInstructions: "\u8ACB\u624B\u52D5\u7E6A\u88FD\u4E00\u500B\u50CF\u7D20\u4EE5\u6355\u7372\u5EA7\u6A19...",
+      backendOnline: "\u5F8C\u7AEF\u5728\u7DDA",
+      backendOffline: "\u5F8C\u7AEF\u96E2\u7DDA",
+      startingBot: "\u6B63\u5728\u5553\u52D5\u6A5F\u5668\u4EBA...",
+      stoppingBot: "\u6B63\u5728\u505C\u6B62\u6A5F\u5668\u4EBA...",
+      calibrating: "\u6821\u6E96\u4E2D...",
+      alreadyRunning: "\u81EA\u52D5\u8FB2\u5834\u5DF2\u5728\u904B\u884C\u3002",
+      imageRunningWarning: "\u81EA\u52D5\u7E6A\u5716\u6B63\u5728\u904B\u884C\uFF0C\u8ACB\u5148\u95DC\u9589\u518D\u5553\u52D5\u81EA\u52D5\u8FB2\u5834\u3002",
+      selectPosition: "\u9078\u64C7\u5340\u57DF",
+      selectPositionAlert: "\u{1F3AF} \u5728\u5730\u5716\u7684\u7A7A\u767D\u5340\u57DF\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF",
+      waitingPosition: "\u{1F446} \u7B49\u5F85\u4F60\u5857\u53C3\u8003\u50CF\u7D20...",
+      positionSet: "\u2705 \u5340\u57DF\u8A2D\u7F6E\u6210\u529F\uFF01\u534A\u5F91: 500px",
+      positionTimeout: "\u274C \u5340\u57DF\u9078\u64C7\u8D85\u6642",
+      missingPosition: "\u274C \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF08\u4F7F\u7528\u201C\u9078\u64C7\u5340\u57DF\u201D\u6309\u9215\uFF09",
+      farmRadius: "\u8FB2\u5834\u534A\u5F91",
+      positionInfo: "\u7576\u524D\u5340\u57DF",
+      farmingInRadius: "\u{1F33E} \u6B63\u5728\u4EE5\u534A\u5F91 {radius}px \u5728 ({x},{y}) \u8FB2\u5834",
+      selectEmptyArea: "\u26A0\uFE0F \u91CD\u8981: \u8ACB\u9078\u64C7\u7A7A\u767D\u5340\u57DF\u4EE5\u907F\u514D\u885D\u7A81",
+      noPosition: "\u672A\u9078\u64C7\u5340\u57DF",
+      currentZone: "\u5340\u57DF: ({x},{y})",
+      autoSelectPosition: "\u{1F3AF} \u8ACB\u5148\u9078\u64C7\u5340\u57DF\uFF0C\u5728\u5730\u5716\u4E0A\u5857\u4E00\u500B\u50CF\u7D20\u4EE5\u8A2D\u7F6E\u8FB2\u5834\u5340\u57DF"
+    },
+    // 公共
+    common: {
+      yes: "\u662F",
+      no: "\u5426",
+      ok: "\u78BA\u8A8D",
+      cancel: "\u53D6\u6D88",
+      close: "\u95DC\u9589",
+      save: "\u4FDD\u5B58",
+      load: "\u52A0\u8F09",
+      delete: "\u522A\u9664",
+      edit: "\u7DE8\u8F2F",
+      start: "\u958B\u59CB",
+      stop: "\u505C\u6B62",
+      pause: "\u66AB\u505C",
+      resume: "\u7E7C\u7E8C",
+      reset: "\u91CD\u7F6E",
+      settings: "\u8A2D\u7F6E",
+      help: "\u5E6B\u52A9",
+      about: "\u95DC\u65BC",
+      language: "\u8A9E\u8A00",
+      loading: "\u52A0\u8F09\u4E2D...",
+      error: "\u932F\u8AA4",
+      success: "\u6210\u529F",
+      warning: "\u8B66\u544A",
+      info: "\u4FE1\u606F",
+      languageChanged: "\u8A9E\u8A00\u5DF2\u5207\u63DB\u70BA {language}"
+    },
+    // 守護模塊
+    guard: {
+      title: "WPlace \u81EA\u52D5\u5B88\u8B77",
+      initBot: "\u521D\u59CB\u5316\u5B88\u8B77\u6A5F\u5668\u4EBA",
+      selectArea: "\u9078\u64C7\u5340\u57DF",
+      captureArea: "\u6355\u7372\u5340\u57DF",
+      startProtection: "\u958B\u59CB\u5B88\u8B77",
+      stopProtection: "\u505C\u6B62\u5B88\u8B77",
+      upperLeft: "\u5DE6\u4E0A\u89D2",
+      lowerRight: "\u53F3\u4E0B\u89D2",
+      protectedPixels: "\u53D7\u4FDD\u8B77\u50CF\u7D20",
+      detectedChanges: "\u6AA2\u6E2C\u5230\u7684\u8B8A\u5316",
+      repairedPixels: "\u4FEE\u5FA9\u7684\u50CF\u7D20",
+      charges: "\u6B21\u6578",
+      waitingInit: "\u7B49\u5F85\u521D\u59CB\u5316...",
+      checkingColors: "\u{1F3A8} \u6AA2\u67E5\u53EF\u7528\u984F\u8272...",
+      noColorsFound: "\u274C \u672A\u627E\u5230\u984F\u8272\uFF0C\u8ACB\u5728\u7DB2\u7AD9\u4E0A\u6253\u958B\u8ABF\u8272\u677F\u3002",
+      colorsFound: "\u2705 \u627E\u5230 {count} \u7A2E\u53EF\u7528\u984F\u8272",
+      initSuccess: "\u2705 \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u6210\u529F",
+      initError: "\u274C \u5B88\u8B77\u6A5F\u5668\u4EBA\u521D\u59CB\u5316\u5931\u6557",
+      invalidCoords: "\u274C \u5EA7\u6A19\u7121\u6548",
+      invalidArea: "\u274C \u5340\u57DF\u7121\u6548\uFF0C\u5DE6\u4E0A\u89D2\u5FC5\u9808\u5C0F\u65BC\u53F3\u4E0B\u89D2",
+      areaTooLarge: "\u274C \u5340\u57DF\u904E\u5927: {size} \u50CF\u7D20 (\u6700\u5927: {max})",
+      capturingArea: "\u{1F4F8} \u6355\u7372\u5B88\u8B77\u5340\u57DF\u4E2D...",
+      areaCaptured: "\u2705 \u5340\u57DF\u6355\u7372\u6210\u529F: {count} \u50CF\u7D20\u53D7\u4FDD\u8B77",
+      captureError: "\u274C \u6355\u7372\u5340\u57DF\u51FA\u932F: {error}",
+      captureFirst: "\u274C \u8ACB\u5148\u6355\u7372\u4E00\u500B\u5B88\u8B77\u5340\u57DF",
+      protectionStarted: "\u{1F6E1}\uFE0F \u5B88\u8B77\u5DF2\u5553\u52D5 - \u5340\u57DF\u76E3\u63A7\u4E2D",
+      protectionStopped: "\u23F9\uFE0F \u5B88\u8B77\u5DF2\u505C\u6B62",
+      noChanges: "\u2705 \u5340\u57DF\u5B89\u5168 - \u672A\u6AA2\u6E2C\u5230\u8B8A\u5316",
+      changesDetected: "\u{1F6A8} \u6AA2\u6E2C\u5230 {count} \u500B\u8B8A\u5316",
+      repairing: "\u{1F6E0}\uFE0F \u6B63\u5728\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20...",
+      repairedSuccess: "\u2705 \u5DF2\u6210\u529F\u4FEE\u5FA9 {count} \u500B\u50CF\u7D20",
+      repairError: "\u274C \u4FEE\u5FA9\u51FA\u932F: {error}",
+      noCharges: "\u26A0\uFE0F \u6B21\u6578\u4E0D\u8DB3\uFF0C\u7121\u6CD5\u4FEE\u5FA9",
+      checkingChanges: "\u{1F50D} \u6B63\u5728\u6AA2\u67E5\u5340\u57DF\u8B8A\u5316...",
+      errorChecking: "\u274C \u6AA2\u67E5\u51FA\u932F: {error}",
+      guardActive: "\u{1F6E1}\uFE0F \u5B88\u8B77\u4E2D - \u5340\u57DF\u53D7\u4FDD\u8B77",
+      lastCheck: "\u4E0A\u6B21\u6AA2\u67E5: {time}",
+      nextCheck: "\u4E0B\u6B21\u6AA2\u67E5: {time} \u79D2\u5F8C",
+      autoInitializing: "\u{1F916} \u6B63\u5728\u81EA\u52D5\u521D\u59CB\u5316...",
+      autoInitSuccess: "\u2705 \u81EA\u52D5\u5553\u52D5\u6210\u529F",
+      autoInitFailed: "\u26A0\uFE0F \u7121\u6CD5\u81EA\u52D5\u5553\u52D5\uFF0C\u8ACB\u624B\u52D5\u64CD\u4F5C\u3002",
+      manualInitRequired: "\u{1F527} \u9700\u8981\u624B\u52D5\u521D\u59CB\u5316",
+      paletteDetected: "\u{1F3A8} \u5DF2\u6AA2\u6E2C\u5230\u8ABF\u8272\u677F",
+      paletteNotFound: "\u{1F50D} \u6B63\u5728\u641C\u7D22\u8ABF\u8272\u677F...",
+      clickingPaintButton: "\u{1F446} \u6B63\u5728\u9EDE\u64CA\u7E6A\u88FD\u6309\u9215...",
+      paintButtonNotFound: "\u274C \u672A\u627E\u5230\u7E6A\u88FD\u6309\u9215",
+      selectUpperLeft: "\u{1F3AF} \u5728\u9700\u8981\u4FDD\u8B77\u5340\u57DF\u7684\u5DE6\u4E0A\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      selectLowerRight: "\u{1F3AF} \u73FE\u5728\u5728\u53F3\u4E0B\u89D2\u5857\u4E00\u500B\u50CF\u7D20",
+      waitingUpperLeft: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u5DE6\u4E0A\u89D2...",
+      waitingLowerRight: "\u{1F446} \u7B49\u5F85\u9078\u64C7\u53F3\u4E0B\u89D2...",
+      upperLeftCaptured: "\u2705 \u5DF2\u6355\u7372\u5DE6\u4E0A\u89D2: ({x}, {y})",
+      lowerRightCaptured: "\u2705 \u5DF2\u6355\u7372\u53F3\u4E0B\u89D2: ({x}, {y})",
+      selectionTimeout: "\u274C \u9078\u64C7\u8D85\u6642",
+      selectionError: "\u274C \u9078\u64C7\u51FA\u932F\uFF0C\u8ACB\u91CD\u8A66"
+    }
+  };
+
+  // src/locales/index.js
+  var AVAILABLE_LANGUAGES = {
+    es: { name: "Espa\xF1ol", flag: "\u{1F1EA}\u{1F1F8}", code: "es" },
+    en: { name: "English", flag: "\u{1F1FA}\u{1F1F8}", code: "en" },
+    fr: { name: "Fran\xE7ais", flag: "\u{1F1EB}\u{1F1F7}", code: "fr" },
+    ru: { name: "\u0420\u0443\u0441\u0441\u043A\u0438\u0439", flag: "\u{1F1F7}\u{1F1FA}", code: "ru" },
+    zhHans: { name: "\u7B80\u4F53\u4E2D\u6587", flag: "\u{1F1E8}\u{1F1F3}", code: "zh-Hans" },
+    zhHant: { name: "\u7E41\u9AD4\u4E2D\u6587", flag: "\u{1F1E8}\u{1F1F3}", code: "zh-Hant" }
+  };
+  var translations = {
+    es,
+    en,
+    fr,
+    ru,
+    zhHans,
+    zhHant
+  };
+  var currentLanguage = "es";
+  var currentTranslations = translations[currentLanguage];
+  function detectBrowserLanguage() {
+    const browserLang = window.navigator.language || window.navigator.userLanguage || "es";
+    const langCode = browserLang.split("-")[0].toLowerCase();
+    if (translations[langCode]) {
+      return langCode;
+    }
+    return "es";
+  }
+  function getSavedLanguage() {
+    return null;
+  }
+  function saveLanguage(langCode) {
+    return;
+  }
+  function initializeLanguage() {
+    const savedLang = getSavedLanguage();
+    const browserLang = detectBrowserLanguage();
+    let selectedLang = "es";
+    if (savedLang && translations[savedLang]) {
+      selectedLang = savedLang;
+    } else if (browserLang && translations[browserLang]) {
+      selectedLang = browserLang;
+    }
+    setLanguage(selectedLang);
+    return selectedLang;
+  }
+  function setLanguage(langCode) {
+    if (!translations[langCode]) {
+      console.warn(`Idioma '${langCode}' no disponible. Usando '${currentLanguage}'`);
+      return;
+    }
+    currentLanguage = langCode;
+    currentTranslations = translations[langCode];
+    saveLanguage(langCode);
+    if (typeof window !== "undefined" && window.CustomEvent) {
+      window.dispatchEvent(new window.CustomEvent("languageChanged", {
+        detail: { language: langCode, translations: currentTranslations }
+      }));
+    }
+  }
+  function getCurrentLanguage() {
+    return currentLanguage;
+  }
+  function t(key, params = {}) {
+    const keys = key.split(".");
+    let value = currentTranslations;
+    for (const k of keys) {
+      if (value && typeof value === "object" && k in value) {
+        value = value[k];
+      } else {
+        console.warn(`Clave de traducci\xF3n no encontrada: '${key}'`);
+        return key;
+      }
+    }
+    if (typeof value !== "string") {
+      console.warn(`Clave de traducci\xF3n no es string: '${key}'`);
+      return key;
+    }
+    return interpolate(value, params);
+  }
+  function interpolate(text, params) {
+    if (!params || Object.keys(params).length === 0) {
+      return text;
+    }
+    return text.replace(/\{(\w+)\}/g, (match, key) => {
+      return params[key] !== void 0 ? params[key] : match;
+    });
+  }
+  function getSection(section) {
+    if (currentTranslations[section]) {
+      return currentTranslations[section];
+    }
+    console.warn(`Secci\xF3n de traducci\xF3n no encontrada: '${section}'`);
+    return {};
+  }
+  initializeLanguage();
+
+  // src/launcher/config.js
+  var LAUNCHER_CONFIG = {
+    RAW_BASE: "https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main",
+    REFRESH_INTERVAL: 6e4,
+    // 1 minuto
+    THEME: {
+      primary: "#000000",
+      secondary: "#111111",
+      accent: "#222222",
+      text: "#ffffff",
+      highlight: "#775ce3",
+      success: "#00ff00",
+      error: "#ff0000"
+    }
+  };
+  function getLauncherTexts() {
+    return getSection("launcher");
+  }
+  var launcherState = {
+    me: null,
+    health: null,
+    refreshTimer: null,
+    selectedBot: null
+  };
+
+  // src/launcher/ui.js
+  function createLauncherUI({
+    onSelectBot,
+    onLaunch,
+    onClose,
+    updateUserInfo,
+    updateHealthInfo
+  }) {
+    log("\u{1F39B}\uFE0F Creando interfaz del Launcher");
+    const existing = document.getElementById("wpl-panel");
+    if (existing) {
+      existing.remove();
+      log("\u{1F5D1}\uFE0F Panel existente removido");
+    }
+    const texts = getLauncherTexts();
+    const { host, root } = createShadowRoot("wpl-panel");
+    const style = document.createElement("style");
+    style.textContent = `
     @keyframes slideIn {
       from { transform: translateY(20px); opacity: 0; }
       to { transform: translateY(0); opacity: 1; }
@@ -16,10 +1694,10 @@
       top: 20px;
       right: 20px;
       width: 300px;
-      background: ${m.THEME.primary};
-      border: 1px solid ${m.THEME.accent};
+      background: ${LAUNCHER_CONFIG.THEME.primary};
+      border: 1px solid ${LAUNCHER_CONFIG.THEME.accent};
       border-radius: 10px;
-      color: ${m.THEME.text};
+      color: ${LAUNCHER_CONFIG.THEME.text};
       font-family: system-ui, 'Segoe UI', Roboto, Helvetica, Arial;
       z-index: 999999;
       box-shadow: 0 8px 24px rgba(0,0,0,0.5);
@@ -31,9 +1709,9 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      background: ${m.THEME.secondary};
+      background: ${LAUNCHER_CONFIG.THEME.secondary};
       padding: 10px 12px;
-      color: ${m.THEME.highlight};
+      color: ${LAUNCHER_CONFIG.THEME.highlight};
       font-weight: 600;
       cursor: move;
       user-select: none;
@@ -66,22 +1744,22 @@
     }
     
     .btn.primary {
-      background: ${m.THEME.accent};
+      background: ${LAUNCHER_CONFIG.THEME.accent};
       color: white;
     }
     
     .btn.primary:hover:not(:disabled) {
-      background: ${m.THEME.highlight};
+      background: ${LAUNCHER_CONFIG.THEME.highlight};
     }
     
     .btn.ghost {
       background: transparent;
-      border: 1px solid ${m.THEME.accent};
-      color: ${m.THEME.text};
+      border: 1px solid ${LAUNCHER_CONFIG.THEME.accent};
+      color: ${LAUNCHER_CONFIG.THEME.text};
     }
     
     .btn.ghost:hover:not(:disabled) {
-      background: ${m.THEME.accent}22;
+      background: ${LAUNCHER_CONFIG.THEME.accent}22;
     }
     
     .btn.close {
@@ -90,7 +1768,7 @@
     }
     
     .card {
-      background: ${m.THEME.secondary};
+      background: ${LAUNCHER_CONFIG.THEME.secondary};
       padding: 10px;
       border-radius: 8px;
       margin-top: 10px;
@@ -114,61 +1792,373 @@
     }
     
     .selected {
-      outline: 2px solid ${m.THEME.highlight};
+      outline: 2px solid ${LAUNCHER_CONFIG.THEME.highlight};
     }
-  `,x.appendChild(h);let s=document.createElement("div");s.className="panel",s.innerHTML=`
+  `;
+    root.appendChild(style);
+    const panel = document.createElement("div");
+    panel.className = "panel";
+    panel.innerHTML = `
     <div class="header">
-      <div>${r.title}</div>
+      <div>${texts.title}</div>
       <button class="btn ghost close close-btn">\u2715</button>
     </div>
     <div class="body">
       <div class="row">
-        <button class="btn primary farm-btn">${r.autoFarm}</button>
-        <button class="btn ghost image-btn">${r.autoImage}</button>
+        <button class="btn primary farm-btn">${texts.autoFarm}</button>
+        <button class="btn ghost image-btn">${texts.autoImage}</button>
       </div>
       <div class="row">
-        <button class="btn ghost guard-btn">${r.autoGuard}</button>
+        <button class="btn ghost guard-btn">${texts.autoGuard}</button>
       </div>
       <div class="card">
         <div class="stat">
-          <span>${r.selection}</span>
+          <span>${texts.selection}</span>
           <span class="choice">\u2014</span>
         </div>
       </div>
       <div class="card user-card">
         <div class="stat">
-          <span>${r.user}</span>
+          <span>${texts.user}</span>
           <span class="user-name">-</span>
         </div>
         <div class="stat">
-          <span>${r.charges}</span>
+          <span>${texts.charges}</span>
           <span class="user-charges">-</span>
         </div>
       </div>
       <div class="card health-card">
         <div class="stat">
-          <span>${r.backend}</span>
-          <span class="backend-status">${r.checking}</span>
+          <span>${texts.backend}</span>
+          <span class="backend-status">${texts.checking}</span>
         </div>
         <div class="stat">
-          <span>${r.database}</span>
+          <span>${texts.database}</span>
           <span class="database-status">-</span>
         </div>
         <div class="stat">
-          <span>${r.uptime}</span>
+          <span>${texts.uptime}</span>
           <span class="uptime">-</span>
         </div>
       </div>
-      <div class="status status-text">${r.chooseBot}</div>
+      <div class="status status-text">${texts.chooseBot}</div>
       <div class="row" style="margin-top: 12px;">
-        <button class="btn primary launch-btn" disabled>${r.launch}</button>
-        <button class="btn ghost cancel-btn">${r.close}</button>
+        <button class="btn primary launch-btn" disabled>${texts.launch}</button>
+        <button class="btn ghost cancel-btn">${texts.close}</button>
       </div>
     </div>
-  `,x.appendChild(s);let e={header:s.querySelector(".header"),farmBtn:s.querySelector(".farm-btn"),imageBtn:s.querySelector(".image-btn"),guardBtn:s.querySelector(".guard-btn"),launchBtn:s.querySelector(".launch-btn"),cancelBtn:s.querySelector(".cancel-btn"),closeBtn:s.querySelector(".close-btn"),statusText:s.querySelector(".status-text"),choice:s.querySelector(".choice"),userName:s.querySelector(".user-name"),userCharges:s.querySelector(".user-charges"),backendStatus:s.querySelector(".backend-status"),databaseStatus:s.querySelector(".database-status"),uptime:s.querySelector(".uptime")};M(e.header,s);let b=null;function C(t){b=t,p.selectedBot=t,e.choice.textContent=t==="farm"?f("launcher.autoFarm"):t==="image"?f("launcher.autoImage"):f("launcher.autoGuard"),e.launchBtn.disabled=!1,e.farmBtn.classList.remove("primary"),e.farmBtn.classList.add("ghost"),e.imageBtn.classList.remove("primary"),e.imageBtn.classList.add("ghost"),e.guardBtn.classList.remove("primary"),e.guardBtn.classList.add("ghost"),t==="farm"?(e.farmBtn.classList.add("primary"),e.farmBtn.classList.remove("ghost")):t==="image"?(e.imageBtn.classList.add("primary"),e.imageBtn.classList.remove("ghost")):t==="guard"&&(e.guardBtn.classList.add("primary"),e.guardBtn.classList.remove("ghost")),e.statusText.textContent=f("launcher.readyToLaunch"),n&&n(t)}e.farmBtn.addEventListener("click",()=>C("farm")),e.imageBtn.addEventListener("click",()=>C("image")),e.guardBtn.addEventListener("click",()=>C("guard")),e.launchBtn.addEventListener("click",async()=>{if(b){e.launchBtn.disabled=!0,e.launchBtn.textContent=f("launcher.loading"),e.statusText.textContent=f("launcher.downloading");try{a&&(await a(b),v())}catch(t){i("\u274C Error en launch:",t),alert(f("launcher.loadErrorMsg")),e.launchBtn.disabled=!1,e.launchBtn.textContent=f("launcher.launch"),e.statusText.textContent=f("launcher.loadError")}}});function v(){window.removeEventListener("languageChanged",w),p.refreshTimer&&(window.clearInterval(p.refreshTimer),p.refreshTimer=null),d.remove(),i("\u{1F9F9} Launcher UI eliminado")}e.cancelBtn.addEventListener("click",v),e.closeBtn.addEventListener("click",v),document.addEventListener("keydown",t=>{t.key==="Escape"&&v()},{once:!0});let w=()=>{q()};window.addEventListener("languageChanged",w);function Q(t){var E,B;if(!t){e.userName.textContent="-",e.userCharges.textContent="-";return}let y=t.name||t.username||"-",P=Math.floor(Number((B=(E=t.charges)==null?void 0:E.count)!=null?B:NaN));e.userName.textContent=y,e.userCharges.textContent=Number.isFinite(P)?String(P):"-"}function J(t){if(!t){e.backendStatus.textContent=f("launcher.offline"),e.databaseStatus.textContent="-",e.uptime.textContent="-";return}let y=!!t.up,P=t.database,E=t.uptime||"-";e.backendStatus.textContent=y?f("launcher.online"):f("launcher.offline"),P==null?e.databaseStatus.textContent="-":e.databaseStatus.textContent=P?f("launcher.ok"):f("launcher.error"),e.uptime.textContent=typeof E=="number"?`${E}s`:E||"-"}function q(){let t=z(),y=s.querySelector(".header div:first-child");y&&(y.textContent=t.title),e.farmBtn&&(e.farmBtn.textContent=t.autoFarm),e.imageBtn&&(e.imageBtn.textContent=t.autoImage),e.guardBtn&&(e.guardBtn.textContent=t.autoGuard),e.launchBtn&&(e.launchBtn.textContent=t.launch),e.closeBtn&&(e.closeBtn.textContent=t.close);let P=s.querySelector(".card:first-of-type .stat span:first-child");P&&(P.textContent=t.selection);let E=s.querySelector(".user-card .stat:first-child span:first-child");E&&(E.textContent=t.user);let B=s.querySelector(".user-card .stat:last-child span:first-child");B&&(B.textContent=t.charges);let N=s.querySelector(".health-card .stat:first-child span:first-child");N&&(N.textContent=t.backend);let D=s.querySelector(".health-card .stat:nth-child(2) span:first-child");D&&(D.textContent=t.database);let U=s.querySelector(".health-card .stat:last-child span:first-child");if(U&&(U.textContent=t.uptime),e.statusText){let g=e.statusText.textContent;g===r.chooseBot||g===t.chooseBot?e.statusText.textContent=t.chooseBot:g===r.loading||g===t.loading?e.statusText.textContent=t.loading:g===r.downloading||g===t.downloading?e.statusText.textContent=t.downloading:g===r.readyToLaunch||g===t.readyToLaunch?e.statusText.textContent=t.readyToLaunch:(g===r.loadError||g===t.loadError)&&(e.statusText.textContent=t.loadError)}if(e.backendStatus){let g=e.backendStatus.textContent;g===r.online||g===t.online?e.backendStatus.textContent=t.online:g===r.offline||g===t.offline?e.backendStatus.textContent=t.offline:(g===r.checking||g===t.checking)&&(e.backendStatus.textContent=t.checking)}if(e.databaseStatus){let g=e.databaseStatus.textContent;g===r.ok||g===t.ok?e.databaseStatus.textContent=t.ok:(g===r.error||g===t.error)&&(e.databaseStatus.textContent=t.error)}b&&e.choice&&(e.choice.textContent=b==="farm"?t.autoFarm:b==="image"?t.autoImage:t.autoGuard),Object.assign(r,t),i(`\u{1F30D} Textos del launcher actualizados al idioma: ${L()}`)}return i("\u2705 Launcher UI creado exitosamente"),{setUserInfo:Q,setHealthInfo:J,cleanup:v,selectBot:C,updateTexts:q,getSelectedBot:()=>b}}async function F(){var n,a;i("\u{1F4E1} Obteniendo informaci\xF3n de sesi\xF3n...");try{let o=await fetch("https://backend.wplace.live/me",{credentials:"include"});if(!o.ok)throw new Error(`HTTP ${o.status}`);return p.me=await o.json(),i("\u2705 Informaci\xF3n de sesi\xF3n obtenida:",((n=p.me)==null?void 0:n.name)||((a=p.me)==null?void 0:a.username)||"Usuario"),p.me}catch(o){return i("\u274C Error obteniendo sesi\xF3n:",o.message),p.me=null,null}}async function O(){var n,a,o,u,l,c;i("\u{1F3E5} Verificando estado del backend...");try{let r=await fetch("https://backend.wplace.live/health",{method:"GET",credentials:"include"}),d=null;try{d=await r.json()}catch{d=null}r.ok&&d?(p.health={up:!!((n=d.up)==null||n),database:(u=(o=(a=d.database)==null?void 0:a.ok)!=null?o:d.database)!=null?u:void 0,uptime:(c=(l=d.uptime)!=null?l:d.uptimeHuman)!=null?c:typeof d.uptimeSeconds=="number"?`${d.uptimeSeconds}s`:void 0},i("\u2705 Estado del backend obtenido:",p.health)):(p.health={up:!1,database:!1,uptime:void 0},i("\u26A0\uFE0F Backend no responde correctamente"))}catch(r){i("\u274C Error verificando backend:",r.message),p.health={up:!1,database:!1,uptime:void 0}}return p.health}async function Z(n,a){i(`\u{1F4E5} Descargando bot: ${n}`);try{let u={farm:"Auto-Farm.js",image:"Auto-Image.js",guard:"Auto-Guard.js"}[n];if(!u)throw new Error(`Tipo de bot desconocido: ${n}`);let l=`${a}/${u}`;i(`\u{1F310} URL: ${l}`);let c=await fetch(l);if(!c.ok)throw new Error(`HTTP ${c.status}`);let r=await c.text();return i(`\u2705 Bot descargado (${r.length} chars), ejecutando...`),(0,eval)(r),i("\u{1F680} Bot ejecutado exitosamente"),!0}catch(o){throw i("\u274C Error descargando/ejecutando bot:",o.message),o}}function X(n={}){let{onLanguageChange:a=null,position:o="top-right",showFlags:u=!0}=n,l=document.createElement("div");l.className="language-selector";let c=`
+  `;
+    root.appendChild(panel);
+    const elements = {
+      header: panel.querySelector(".header"),
+      farmBtn: panel.querySelector(".farm-btn"),
+      imageBtn: panel.querySelector(".image-btn"),
+      guardBtn: panel.querySelector(".guard-btn"),
+      launchBtn: panel.querySelector(".launch-btn"),
+      cancelBtn: panel.querySelector(".cancel-btn"),
+      closeBtn: panel.querySelector(".close-btn"),
+      statusText: panel.querySelector(".status-text"),
+      choice: panel.querySelector(".choice"),
+      userName: panel.querySelector(".user-name"),
+      userCharges: panel.querySelector(".user-charges"),
+      backendStatus: panel.querySelector(".backend-status"),
+      databaseStatus: panel.querySelector(".database-status"),
+      uptime: panel.querySelector(".uptime")
+    };
+    makeDraggable(elements.header, panel);
+    let selectedBot = null;
+    function selectBot(botType) {
+      selectedBot = botType;
+      launcherState.selectedBot = botType;
+      elements.choice.textContent = botType === "farm" ? t("launcher.autoFarm") : botType === "image" ? t("launcher.autoImage") : t("launcher.autoGuard");
+      elements.launchBtn.disabled = false;
+      elements.farmBtn.classList.remove("primary");
+      elements.farmBtn.classList.add("ghost");
+      elements.imageBtn.classList.remove("primary");
+      elements.imageBtn.classList.add("ghost");
+      elements.guardBtn.classList.remove("primary");
+      elements.guardBtn.classList.add("ghost");
+      if (botType === "farm") {
+        elements.farmBtn.classList.add("primary");
+        elements.farmBtn.classList.remove("ghost");
+      } else if (botType === "image") {
+        elements.imageBtn.classList.add("primary");
+        elements.imageBtn.classList.remove("ghost");
+      } else if (botType === "guard") {
+        elements.guardBtn.classList.add("primary");
+        elements.guardBtn.classList.remove("ghost");
+      }
+      elements.statusText.textContent = t("launcher.readyToLaunch");
+      if (onSelectBot) {
+        onSelectBot(botType);
+      }
+    }
+    elements.farmBtn.addEventListener("click", () => selectBot("farm"));
+    elements.imageBtn.addEventListener("click", () => selectBot("image"));
+    elements.guardBtn.addEventListener("click", () => selectBot("guard"));
+    elements.launchBtn.addEventListener("click", async () => {
+      if (!selectedBot) return;
+      elements.launchBtn.disabled = true;
+      elements.launchBtn.textContent = t("launcher.loading");
+      elements.statusText.textContent = t("launcher.downloading");
+      try {
+        if (onLaunch) {
+          await onLaunch(selectedBot);
+          cleanup();
+        }
+      } catch (error) {
+        log("\u274C Error en launch:", error);
+        alert(t("launcher.loadErrorMsg"));
+        elements.launchBtn.disabled = false;
+        elements.launchBtn.textContent = t("launcher.launch");
+        elements.statusText.textContent = t("launcher.loadError");
+      }
+    });
+    function cleanup() {
+      window.removeEventListener("languageChanged", handleLanguageChange);
+      if (launcherState.refreshTimer) {
+        window.clearInterval(launcherState.refreshTimer);
+        launcherState.refreshTimer = null;
+      }
+      host.remove();
+      log("\u{1F9F9} Launcher UI eliminado");
+    }
+    elements.cancelBtn.addEventListener("click", cleanup);
+    elements.closeBtn.addEventListener("click", cleanup);
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        cleanup();
+      }
+    }, { once: true });
+    const handleLanguageChange = () => {
+      updateTexts();
+    };
+    window.addEventListener("languageChanged", handleLanguageChange);
+    function setUserInfo(userInfo) {
+      var _a, _b;
+      if (!userInfo) {
+        elements.userName.textContent = "-";
+        elements.userCharges.textContent = "-";
+        return;
+      }
+      const name = userInfo.name || userInfo.username || "-";
+      const charges = Math.floor(Number((_b = (_a = userInfo.charges) == null ? void 0 : _a.count) != null ? _b : NaN));
+      elements.userName.textContent = name;
+      elements.userCharges.textContent = Number.isFinite(charges) ? String(charges) : "-";
+    }
+    function setHealthInfo(healthInfo) {
+      if (!healthInfo) {
+        elements.backendStatus.textContent = t("launcher.offline");
+        elements.databaseStatus.textContent = "-";
+        elements.uptime.textContent = "-";
+        return;
+      }
+      const up = Boolean(healthInfo.up);
+      const db = healthInfo.database;
+      const uptime = healthInfo.uptime || "-";
+      elements.backendStatus.textContent = up ? t("launcher.online") : t("launcher.offline");
+      if (db === void 0 || db === null) {
+        elements.databaseStatus.textContent = "-";
+      } else {
+        elements.databaseStatus.textContent = db ? t("launcher.ok") : t("launcher.error");
+      }
+      elements.uptime.textContent = typeof uptime === "number" ? `${uptime}s` : uptime || "-";
+    }
+    function updateTexts() {
+      const newTexts = getLauncherTexts();
+      const titleElement = panel.querySelector(".header div:first-child");
+      if (titleElement) {
+        titleElement.textContent = newTexts.title;
+      }
+      if (elements.farmBtn) {
+        elements.farmBtn.textContent = newTexts.autoFarm;
+      }
+      if (elements.imageBtn) {
+        elements.imageBtn.textContent = newTexts.autoImage;
+      }
+      if (elements.guardBtn) {
+        elements.guardBtn.textContent = newTexts.autoGuard;
+      }
+      if (elements.launchBtn) {
+        elements.launchBtn.textContent = newTexts.launch;
+      }
+      if (elements.closeBtn) {
+        elements.closeBtn.textContent = newTexts.close;
+      }
+      const selectionSpan = panel.querySelector(".card:first-of-type .stat span:first-child");
+      if (selectionSpan) {
+        selectionSpan.textContent = newTexts.selection;
+      }
+      const userSpan = panel.querySelector(".user-card .stat:first-child span:first-child");
+      if (userSpan) {
+        userSpan.textContent = newTexts.user;
+      }
+      const chargesSpan = panel.querySelector(".user-card .stat:last-child span:first-child");
+      if (chargesSpan) {
+        chargesSpan.textContent = newTexts.charges;
+      }
+      const backendSpan = panel.querySelector(".health-card .stat:first-child span:first-child");
+      if (backendSpan) {
+        backendSpan.textContent = newTexts.backend;
+      }
+      const databaseSpan = panel.querySelector(".health-card .stat:nth-child(2) span:first-child");
+      if (databaseSpan) {
+        databaseSpan.textContent = newTexts.database;
+      }
+      const uptimeSpan = panel.querySelector(".health-card .stat:last-child span:first-child");
+      if (uptimeSpan) {
+        uptimeSpan.textContent = newTexts.uptime;
+      }
+      if (elements.statusText) {
+        const currentStatus = elements.statusText.textContent;
+        if (currentStatus === texts.chooseBot || currentStatus === newTexts.chooseBot) {
+          elements.statusText.textContent = newTexts.chooseBot;
+        } else if (currentStatus === texts.loading || currentStatus === newTexts.loading) {
+          elements.statusText.textContent = newTexts.loading;
+        } else if (currentStatus === texts.downloading || currentStatus === newTexts.downloading) {
+          elements.statusText.textContent = newTexts.downloading;
+        } else if (currentStatus === texts.readyToLaunch || currentStatus === newTexts.readyToLaunch) {
+          elements.statusText.textContent = newTexts.readyToLaunch;
+        } else if (currentStatus === texts.loadError || currentStatus === newTexts.loadError) {
+          elements.statusText.textContent = newTexts.loadError;
+        }
+      }
+      if (elements.backendStatus) {
+        const currentBackend = elements.backendStatus.textContent;
+        if (currentBackend === texts.online || currentBackend === newTexts.online) {
+          elements.backendStatus.textContent = newTexts.online;
+        } else if (currentBackend === texts.offline || currentBackend === newTexts.offline) {
+          elements.backendStatus.textContent = newTexts.offline;
+        } else if (currentBackend === texts.checking || currentBackend === newTexts.checking) {
+          elements.backendStatus.textContent = newTexts.checking;
+        }
+      }
+      if (elements.databaseStatus) {
+        const currentDb = elements.databaseStatus.textContent;
+        if (currentDb === texts.ok || currentDb === newTexts.ok) {
+          elements.databaseStatus.textContent = newTexts.ok;
+        } else if (currentDb === texts.error || currentDb === newTexts.error) {
+          elements.databaseStatus.textContent = newTexts.error;
+        }
+      }
+      if (selectedBot && elements.choice) {
+        elements.choice.textContent = selectedBot === "farm" ? newTexts.autoFarm : selectedBot === "image" ? newTexts.autoImage : newTexts.autoGuard;
+      }
+      Object.assign(texts, newTexts);
+      log(`\u{1F30D} Textos del launcher actualizados al idioma: ${getCurrentLanguage()}`);
+    }
+    log("\u2705 Launcher UI creado exitosamente");
+    return {
+      setUserInfo,
+      setHealthInfo,
+      cleanup,
+      selectBot,
+      updateTexts,
+      getSelectedBot: () => selectedBot
+    };
+  }
+
+  // src/launcher/api.js
+  async function getSession() {
+    var _a, _b;
+    log("\u{1F4E1} Obteniendo informaci\xF3n de sesi\xF3n...");
+    try {
+      const res = await fetch("https://backend.wplace.live/me", {
+        credentials: "include"
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      launcherState.me = await res.json();
+      log("\u2705 Informaci\xF3n de sesi\xF3n obtenida:", ((_a = launcherState.me) == null ? void 0 : _a.name) || ((_b = launcherState.me) == null ? void 0 : _b.username) || "Usuario");
+      return launcherState.me;
+    } catch (error) {
+      log("\u274C Error obteniendo sesi\xF3n:", error.message);
+      launcherState.me = null;
+      return null;
+    }
+  }
+  async function checkBackendHealth() {
+    var _a, _b, _c, _d, _e, _f;
+    log("\u{1F3E5} Verificando estado del backend...");
+    try {
+      const res = await fetch("https://backend.wplace.live/health", {
+        method: "GET",
+        credentials: "include"
+      });
+      let json = null;
+      try {
+        json = await res.json();
+      } catch {
+        json = null;
+      }
+      if (res.ok && json) {
+        launcherState.health = {
+          up: Boolean((_a = json.up) != null ? _a : true),
+          database: (_d = (_c = (_b = json.database) == null ? void 0 : _b.ok) != null ? _c : json.database) != null ? _d : void 0,
+          uptime: (_f = (_e = json.uptime) != null ? _e : json.uptimeHuman) != null ? _f : typeof json.uptimeSeconds === "number" ? `${json.uptimeSeconds}s` : void 0
+        };
+        log("\u2705 Estado del backend obtenido:", launcherState.health);
+      } else {
+        launcherState.health = {
+          up: false,
+          database: false,
+          uptime: void 0
+        };
+        log("\u26A0\uFE0F Backend no responde correctamente");
+      }
+    } catch (error) {
+      log("\u274C Error verificando backend:", error.message);
+      launcherState.health = {
+        up: false,
+        database: false,
+        uptime: void 0
+      };
+    }
+    return launcherState.health;
+  }
+  async function downloadAndExecuteBot(botType, rawBase) {
+    log(`\u{1F4E5} Descargando bot: ${botType}`);
+    try {
+      const botFiles = {
+        "farm": "Auto-Farm.js",
+        "image": "Auto-Image.js",
+        "guard": "Auto-Guard.js"
+      };
+      const fileName = botFiles[botType];
+      if (!fileName) {
+        throw new Error(`Tipo de bot desconocido: ${botType}`);
+      }
+      const url = `${rawBase}/${fileName}`;
+      log(`\u{1F310} URL: ${url}`);
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const code = await response.text();
+      log(`\u2705 Bot descargado (${code.length} chars), ejecutando...`);
+      (0, eval)(code);
+      log("\u{1F680} Bot ejecutado exitosamente");
+      return true;
+    } catch (error) {
+      log("\u274C Error descargando/ejecutando bot:", error.message);
+      throw error;
+    }
+  }
+
+  // src/core/language-selector.js
+  function createLanguageSelector(options = {}) {
+    const {
+      onLanguageChange = null,
+      position = "top-right",
+      showFlags = true
+    } = options;
+    const container = document.createElement("div");
+    container.className = "language-selector";
+    const styles = `
     .language-selector {
       position: fixed;
-      ${V(o)}
+      ${getPositionStyles(position)}
       z-index: 999998;
       background: #1a1a1a;
       border: 1px solid #333;
@@ -263,18 +2253,223 @@
         right: 10px;
       }
     }
-  `;if(!document.querySelector("#language-selector-styles")){let e=document.createElement("style");e.id="language-selector-styles",e.textContent=c,document.head.appendChild(e)}let r=!1,d=L();function x(){let e=k[d];l.innerHTML=`
+  `;
+    if (!document.querySelector("#language-selector-styles")) {
+      const styleSheet = document.createElement("style");
+      styleSheet.id = "language-selector-styles";
+      styleSheet.textContent = styles;
+      document.head.appendChild(styleSheet);
+    }
+    let isOpen = false;
+    let currentLang = getCurrentLanguage();
+    function render() {
+      const langInfo = AVAILABLE_LANGUAGES[currentLang];
+      container.innerHTML = `
       <button class="language-selector-button">
-        ${u?`<span class="language-flag">${e.flag}</span>`:""}
-        <span class="language-name">${e.name}</span>
-        <span style="margin-left: auto; transform: ${r?"rotate(180deg)":"rotate(0deg)"}; transition: transform 0.2s;">\u25BC</span>
+        ${showFlags ? `<span class="language-flag">${langInfo.flag}</span>` : ""}
+        <span class="language-name">${langInfo.name}</span>
+        <span style="margin-left: auto; transform: ${isOpen ? "rotate(180deg)" : "rotate(0deg)"}; transition: transform 0.2s;">\u25BC</span>
       </button>
-      <div class="language-selector-dropdown ${r?"visible":""}">
-        ${Object.entries(k).map(([b,C])=>`
-          <button class="language-option ${b===d?"active":""}" data-lang="${b}">
-            ${u?`<span class="language-flag">${C.flag}</span>`:""}
-            <span class="language-name">${C.name}</span>
+      <div class="language-selector-dropdown ${isOpen ? "visible" : ""}">
+        ${Object.entries(AVAILABLE_LANGUAGES).map(([code, info]) => `
+          <button class="language-option ${code === currentLang ? "active" : ""}" data-lang="${code}">
+            ${showFlags ? `<span class="language-flag">${info.flag}</span>` : ""}
+            <span class="language-name">${info.name}</span>
           </button>
         `).join("")}
       </div>
-    `,h()}function h(){let e=l.querySelector(".language-selector-button"),b=l.querySelectorAll(".language-option");e.addEventListener("click",C=>{C.stopPropagation(),r=!r,x()}),b.forEach(C=>{C.addEventListener("click",v=>{v.stopPropagation();let w=C.dataset.lang;w!==d&&(d=w,R(w),a&&a(w)),r=!1,x()})}),document.addEventListener("click",()=>{r&&(r=!1,x())})}function s(e){e.detail.language!==d&&(d=e.detail.language,x())}return window.addEventListener("languageChanged",s),x(),{mount(e=document.body){e.appendChild(l)},unmount(){window.removeEventListener("languageChanged",s),l.parentNode&&l.parentNode.removeChild(l)},setPosition(e){l.style.cssText=V(e)},getElement(){return l},update(){d=L(),x()}}}function V(n){let a={"top-right":"top: 15px; right: 15px;","top-left":"top: 15px; left: 15px;","bottom-right":"bottom: 15px; right: 15px;","bottom-left":"bottom: 15px; left: 15px;","top-center":"top: 15px; left: 50%; transform: translateX(-50%);","bottom-center":"bottom: 15px; left: 50%; transform: translateX(-50%);"};return a[n]||a["top-right"]}async function K(){var n;if(i("\u{1F680} Iniciando WPlace Auto-Launcher (versi\xF3n modular)"),T(),(n=window.__wplaceBot)!=null&&n.launcherRunning){alert("Auto-Launcher ya est\xE1 ejecut\xE1ndose.");return}window.__wplaceBot={...window.__wplaceBot,launcherRunning:!0};try{let a=null,o=Y({onSelectBot:c=>{i(`\u{1F3AF} Bot seleccionado: ${c}`),a&&(a.unmount(),a=null)},onLaunch:async c=>{i(`\u{1F680} Lanzando bot: ${c}`),await Z(c,m.RAW_BASE)},onClose:()=>{i("\u{1F44B} Cerrando launcher"),a&&(a.unmount(),a=null),window.__wplaceBot.launcherRunning=!1}});a=X({position:"top-left",showFlags:!0,onLanguageChange:c=>{i(`\u{1F30D} Idioma cambiado a: ${c} desde el launcher`),o.updateTexts(),typeof window!="undefined"&&window.CustomEvent&&window.dispatchEvent(new window.CustomEvent("launcherLanguageChanged",{detail:{language:c}}))}}),a.mount(),i("\u{1F4CA} Cargando informaci\xF3n inicial...");let u=await O();o.setHealthInfo(u);let l=await F();o.setUserInfo(l),p.refreshTimer=window.setInterval(async()=>{i("\u{1F504} Actualizando informaci\xF3n...");try{let[c,r]=await Promise.all([O(),F()]);o.setHealthInfo(c),o.setUserInfo(r)}catch(c){i("\u274C Error en actualizaci\xF3n peri\xF3dica:",c)}},m.REFRESH_INTERVAL),window.addEventListener("beforeunload",()=>{o.cleanup(),a&&a.unmount(),window.__wplaceBot.launcherRunning=!1}),i("\u2705 Auto-Launcher inicializado correctamente")}catch(a){throw i("\u274C Error inicializando Auto-Launcher:",a),window.__wplaceBot.launcherRunning=!1,a}}(()=>{"use strict";var n,a;if((n=window.__wplaceBot)!=null&&n.farmRunning||(a=window.__wplaceBot)!=null&&a.imageRunning){alert("Ya hay un bot ejecut\xE1ndose. Ci\xE9rralo antes de usar el launcher.");return}window.__wplaceBot||(window.__wplaceBot={}),K().catch(o=>{console.error("[BOT] Error en Auto-Launcher:",o),window.__wplaceBot&&(window.__wplaceBot.launcherRunning=!1),alert("Auto-Launcher: error inesperado. Revisa consola.")})})();})();
+    `;
+      setupEventListeners();
+    }
+    function setupEventListeners() {
+      const button = container.querySelector(".language-selector-button");
+      const options2 = container.querySelectorAll(".language-option");
+      button.addEventListener("click", (e) => {
+        e.stopPropagation();
+        isOpen = !isOpen;
+        render();
+      });
+      options2.forEach((option) => {
+        option.addEventListener("click", (e) => {
+          e.stopPropagation();
+          const selectedLang = option.dataset.lang;
+          if (selectedLang !== currentLang) {
+            currentLang = selectedLang;
+            setLanguage(selectedLang);
+            if (onLanguageChange) {
+              onLanguageChange(selectedLang);
+            }
+          }
+          isOpen = false;
+          render();
+        });
+      });
+      document.addEventListener("click", () => {
+        if (isOpen) {
+          isOpen = false;
+          render();
+        }
+      });
+    }
+    function handleLanguageChange(event) {
+      if (event.detail.language !== currentLang) {
+        currentLang = event.detail.language;
+        render();
+      }
+    }
+    window.addEventListener("languageChanged", handleLanguageChange);
+    render();
+    return {
+      /**
+       * Añade el selector al DOM
+       * @param {HTMLElement} parent - Elemento padre (opcional, por defecto document.body)
+       */
+      mount(parent = document.body) {
+        parent.appendChild(container);
+      },
+      /**
+       * Remueve el selector del DOM
+       */
+      unmount() {
+        window.removeEventListener("languageChanged", handleLanguageChange);
+        if (container.parentNode) {
+          container.parentNode.removeChild(container);
+        }
+      },
+      /**
+       * Actualiza la posición del selector
+       * @param {string} newPosition - Nueva posición
+       */
+      setPosition(newPosition) {
+        container.style.cssText = getPositionStyles(newPosition);
+      },
+      /**
+       * Obtiene el elemento DOM del selector
+       * @returns {HTMLElement} Elemento DOM
+       */
+      getElement() {
+        return container;
+      },
+      /**
+       * Fuerza una actualización del componente
+       */
+      update() {
+        currentLang = getCurrentLanguage();
+        render();
+      }
+    };
+  }
+  function getPositionStyles(position) {
+    const positions = {
+      "top-right": "top: 15px; right: 15px;",
+      "top-left": "top: 15px; left: 15px;",
+      "bottom-right": "bottom: 15px; right: 15px;",
+      "bottom-left": "bottom: 15px; left: 15px;",
+      "top-center": "top: 15px; left: 50%; transform: translateX(-50%);",
+      "bottom-center": "bottom: 15px; left: 50%; transform: translateX(-50%);"
+    };
+    return positions[position] || positions["top-right"];
+  }
+
+  // src/launcher/index.js
+  async function runLauncher() {
+    var _a;
+    log("\u{1F680} Iniciando WPlace Auto-Launcher (versi\xF3n modular)");
+    initializeLanguage();
+    if ((_a = window.__wplaceBot) == null ? void 0 : _a.launcherRunning) {
+      alert("Auto-Launcher ya est\xE1 ejecut\xE1ndose.");
+      return;
+    }
+    window.__wplaceBot = { ...window.__wplaceBot, launcherRunning: true };
+    try {
+      let languageSelector = null;
+      const ui = createLauncherUI({
+        onSelectBot: (botType) => {
+          log(`\u{1F3AF} Bot seleccionado: ${botType}`);
+          if (languageSelector) {
+            languageSelector.unmount();
+            languageSelector = null;
+          }
+        },
+        onLaunch: async (botType) => {
+          log(`\u{1F680} Lanzando bot: ${botType}`);
+          await downloadAndExecuteBot(botType, LAUNCHER_CONFIG.RAW_BASE);
+        },
+        onClose: () => {
+          log("\u{1F44B} Cerrando launcher");
+          if (languageSelector) {
+            languageSelector.unmount();
+            languageSelector = null;
+          }
+          window.__wplaceBot.launcherRunning = false;
+        }
+      });
+      languageSelector = createLanguageSelector({
+        position: "top-left",
+        // Esquina opuesta al launcher
+        showFlags: true,
+        onLanguageChange: (newLanguage) => {
+          log(`\u{1F30D} Idioma cambiado a: ${newLanguage} desde el launcher`);
+          ui.updateTexts();
+          if (typeof window !== "undefined" && window.CustomEvent) {
+            window.dispatchEvent(new window.CustomEvent("launcherLanguageChanged", {
+              detail: { language: newLanguage }
+            }));
+          }
+        }
+      });
+      languageSelector.mount();
+      log("\u{1F4CA} Cargando informaci\xF3n inicial...");
+      const health = await checkBackendHealth();
+      ui.setHealthInfo(health);
+      const user = await getSession();
+      ui.setUserInfo(user);
+      launcherState.refreshTimer = window.setInterval(async () => {
+        log("\u{1F504} Actualizando informaci\xF3n...");
+        try {
+          const [newHealth, newUser] = await Promise.all([
+            checkBackendHealth(),
+            getSession()
+          ]);
+          ui.setHealthInfo(newHealth);
+          ui.setUserInfo(newUser);
+        } catch (error) {
+          log("\u274C Error en actualizaci\xF3n peri\xF3dica:", error);
+        }
+      }, LAUNCHER_CONFIG.REFRESH_INTERVAL);
+      window.addEventListener("beforeunload", () => {
+        ui.cleanup();
+        if (languageSelector) {
+          languageSelector.unmount();
+        }
+        window.__wplaceBot.launcherRunning = false;
+      });
+      log("\u2705 Auto-Launcher inicializado correctamente");
+    } catch (error) {
+      log("\u274C Error inicializando Auto-Launcher:", error);
+      window.__wplaceBot.launcherRunning = false;
+      throw error;
+    }
+  }
+
+  // src/entries/launcher.js
+  (() => {
+    "use strict";
+    var _a, _b;
+    if (((_a = window.__wplaceBot) == null ? void 0 : _a.farmRunning) || ((_b = window.__wplaceBot) == null ? void 0 : _b.imageRunning)) {
+      alert("Ya hay un bot ejecut\xE1ndose. Ci\xE9rralo antes de usar el launcher.");
+      return;
+    }
+    if (!window.__wplaceBot) {
+      window.__wplaceBot = {};
+    }
+    runLauncher().catch((e) => {
+      console.error("[BOT] Error en Auto-Launcher:", e);
+      if (window.__wplaceBot) {
+        window.__wplaceBot.launcherRunning = false;
+      }
+      alert("Auto-Launcher: error inesperado. Revisa consola.");
+    });
+  })();
+})();
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsic3JjL2NvcmUvbG9nZ2VyLmpzIiwgInNyYy9jb3JlL3VpLXV0aWxzLmpzIiwgInNyYy9sb2NhbGVzL2VzLmpzIiwgInNyYy9sb2NhbGVzL2VuLmpzIiwgInNyYy9sb2NhbGVzL2ZyLmpzIiwgInNyYy9sb2NhbGVzL3J1LmpzIiwgInNyYy9sb2NhbGVzL3poLUhhbnMuanMiLCAic3JjL2xvY2FsZXMvemgtSGFudC5qcyIsICJzcmMvbG9jYWxlcy9pbmRleC5qcyIsICJzcmMvbGF1bmNoZXIvY29uZmlnLmpzIiwgInNyYy9sYXVuY2hlci91aS5qcyIsICJzcmMvbGF1bmNoZXIvYXBpLmpzIiwgInNyYy9jb3JlL2xhbmd1YWdlLXNlbGVjdG9yLmpzIiwgInNyYy9sYXVuY2hlci9pbmRleC5qcyIsICJzcmMvZW50cmllcy9sYXVuY2hlci5qcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiZXhwb3J0IGNvbnN0IGxvZ2dlciA9IHtcbiAgZGVidWdFbmFibGVkOiBmYWxzZSxcbiAgc2V0RGVidWcodikgeyB0aGlzLmRlYnVnRW5hYmxlZCA9ICEhdjsgfSxcbiAgZGVidWcoLi4uYSkgeyBpZiAodGhpcy5kZWJ1Z0VuYWJsZWQpIGNvbnNvbGUuZGVidWcoXCJbQk9UXVwiLCAuLi5hKTsgfSxcbiAgaW5mbyguLi5hKSAgeyBjb25zb2xlLmluZm8oXCJbQk9UXVwiLCAuLi5hKTsgfSxcbiAgd2FybiguLi5hKSAgeyBjb25zb2xlLndhcm4oXCJbQk9UXVwiLCAuLi5hKTsgfSxcbiAgZXJyb3IoLi4uYSkgeyBjb25zb2xlLmVycm9yKFwiW0JPVF1cIiwgLi4uYSk7IH1cbn07XG5cbi8vIEZhcm0tc3BlY2lmaWMgbG9nZ2VyXG5leHBvcnQgY29uc3QgbG9nID0gKC4uLmEpID0+IGNvbnNvbGUubG9nKCdbV1BBLVVJXScsIC4uLmEpO1xuXG4vLyBVdGlsaXR5IGZ1bmN0aW9uc1xuZXhwb3J0IGNvbnN0IG5vb3AgPSAoKSA9PiB7fTtcbmV4cG9ydCBjb25zdCBjbGFtcCA9IChuLCBhLCBiKSA9PiBNYXRoLm1heChhLCBNYXRoLm1pbihiLCBuKSk7XG4iLCAiZXhwb3J0IGZ1bmN0aW9uIGNyZWF0ZVNoYWRvd1Jvb3QoaG9zdElkID0gbnVsbCkge1xuICBjb25zdCBob3N0ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnZGl2Jyk7XG4gIGlmIChob3N0SWQpIHtcbiAgICBob3N0LmlkID0gaG9zdElkO1xuICB9XG4gIGhvc3Quc3R5bGUuY3NzVGV4dCA9IGBcbiAgICBwb3NpdGlvbjogZml4ZWQ7XG4gICAgdG9wOiAxMHB4O1xuICAgIHJpZ2h0OiAxMHB4O1xuICAgIHotaW5kZXg6IDIxNDc0ODM2NDc7XG4gICAgZm9udC1mYW1pbHk6IC1hcHBsZS1zeXN0ZW0sIEJsaW5rTWFjU3lzdGVtRm9udCwgJ1NlZ29lIFVJJywgJ1JvYm90bycsIHNhbnMtc2VyaWY7XG4gIGA7XG4gIFxuICBjb25zdCByb290ID0gaG9zdC5hdHRhY2hTaGFkb3coeyBtb2RlOiAnb3BlbicgfSk7XG4gIGRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQoaG9zdCk7XG4gIFxuICByZXR1cm4geyBob3N0LCByb290IH07XG59XG5cbmV4cG9ydCBmdW5jdGlvbiBtYWtlRHJhZ2dhYmxlKGRyYWdIYW5kbGUsIGVsZW1lbnQpIHtcbiAgbGV0IHBvczEgPSAwLCBwb3MyID0gMCwgcG9zMyA9IDAsIHBvczQgPSAwO1xuICBcbiAgZHJhZ0hhbmRsZS5zdHlsZS5jdXJzb3IgPSAnbW92ZSc7XG4gIGRyYWdIYW5kbGUuYWRkRXZlbnRMaXN0ZW5lcignbW91c2Vkb3duJywgZHJhZ01vdXNlRG93bik7XG4gIFxuICBmdW5jdGlvbiBkcmFnTW91c2VEb3duKGUpIHtcbiAgICAvLyBFdml0YXIgYXJyYXN0cmEgc2kgZXMgdW4gYm90XHUwMEYzbiBkZSBsYSBjYWJlY2VyYVxuICAgIGlmIChlLnRhcmdldC5jbG9zZXN0KCcuaGVhZGVyLWJ0biwgLndwbGFjZS1oZWFkZXItYnRuJykpIHJldHVybjtcbiAgICBcbiAgICBlLnByZXZlbnREZWZhdWx0KCk7XG4gICAgcG9zMyA9IGUuY2xpZW50WDtcbiAgICBwb3M0ID0gZS5jbGllbnRZO1xuICAgIGRvY3VtZW50LmFkZEV2ZW50TGlzdGVuZXIoJ21vdXNldXAnLCBjbG9zZURyYWdFbGVtZW50KTtcbiAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdtb3VzZW1vdmUnLCBlbGVtZW50RHJhZyk7XG4gIH1cbiAgXG4gIGZ1bmN0aW9uIGVsZW1lbnREcmFnKGUpIHtcbiAgICBlLnByZXZlbnREZWZhdWx0KCk7XG4gICAgcG9zMSA9IHBvczMgLSBlLmNsaWVudFg7XG4gICAgcG9zMiA9IHBvczQgLSBlLmNsaWVudFk7XG4gICAgcG9zMyA9IGUuY2xpZW50WDtcbiAgICBwb3M0ID0gZS5jbGllbnRZO1xuICAgIGVsZW1lbnQuc3R5bGUudG9wID0gKGVsZW1lbnQub2Zmc2V0VG9wIC0gcG9zMikgKyBcInB4XCI7XG4gICAgZWxlbWVudC5zdHlsZS5sZWZ0ID0gKGVsZW1lbnQub2Zmc2V0TGVmdCAtIHBvczEpICsgXCJweFwiO1xuICB9XG4gIFxuICBmdW5jdGlvbiBjbG9zZURyYWdFbGVtZW50KCkge1xuICAgIGRvY3VtZW50LnJlbW92ZUV2ZW50TGlzdGVuZXIoJ21vdXNldXAnLCBjbG9zZURyYWdFbGVtZW50KTtcbiAgICBkb2N1bWVudC5yZW1vdmVFdmVudExpc3RlbmVyKCdtb3VzZW1vdmUnLCBlbGVtZW50RHJhZyk7XG4gIH1cbn1cbiIsICJleHBvcnQgY29uc3QgZXMgPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgQXV0by1GYXJtJyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggQXV0by1JbWFnZScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIEF1dG8tR3VhcmQnLFxuICAgIHNlbGVjdGlvbjogJ1NlbGVjY2lcdTAwRjNuJyxcbiAgICB1c2VyOiAnVXN1YXJpbycsXG4gICAgY2hhcmdlczogJ0NhcmdhcycsXG4gICAgYmFja2VuZDogJ0JhY2tlbmQnLFxuICAgIGRhdGFiYXNlOiAnRGF0YWJhc2UnLFxuICAgIHVwdGltZTogJ1VwdGltZScsXG4gICAgY2xvc2U6ICdDZXJyYXInLFxuICAgIGxhdW5jaDogJ0xhbnphcicsXG4gICAgbG9hZGluZzogJ0NhcmdhbmRvXHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdFamVjdXRhbmRvXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ0Rlc2NhcmdhbmRvIHNjcmlwdFx1MjAyNicsXG4gICAgY2hvb3NlQm90OiAnRWxpZ2UgdW4gYm90IHkgcHJlc2lvbmEgTGFuemFyJyxcbiAgICByZWFkeVRvTGF1bmNoOiAnTGlzdG8gcGFyYSBsYW56YXInLFxuICAgIGxvYWRFcnJvcjogJ0Vycm9yIGFsIGNhcmdhcicsXG4gICAgbG9hZEVycm9yTXNnOiAnTm8gc2UgcHVkbyBjYXJnYXIgZWwgYm90IHNlbGVjY2lvbmFkby4gUmV2aXNhIHR1IGNvbmV4aVx1MDBGM24gbyBpbnRcdTAwRTludGFsbyBkZSBudWV2by4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFZlcmlmaWNhbmRvLi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgT25saW5lJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IE9mZmxpbmUnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIE9LJyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBFcnJvcicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tSW1hZ2VcIixcbiAgICBpbml0Qm90OiBcIkluaWNpYXIgQXV0by1CT1RcIixcbiAgICB1cGxvYWRJbWFnZTogXCJTdWJpciBJbWFnZW5cIixcbiAgICByZXNpemVJbWFnZTogXCJSZWRpbWVuc2lvbmFyIEltYWdlblwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNlbGVjY2lvbmFyIFBvc2ljaVx1MDBGM25cIixcbiAgICBzdGFydFBhaW50aW5nOiBcIkluaWNpYXIgUGludHVyYVwiLFxuICAgIHN0b3BQYWludGluZzogXCJEZXRlbmVyIFBpbnR1cmFcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiR3VhcmRhciBQcm9ncmVzb1wiLFxuICAgIGxvYWRQcm9ncmVzczogXCJDYXJnYXIgUHJvZ3Jlc29cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgVmVyaWZpY2FuZG8gY29sb3JlcyBkaXNwb25pYmxlcy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1MDBBMUFicmUgbGEgcGFsZXRhIGRlIGNvbG9yZXMgZW4gZWwgc2l0aW8gZSBpbnRcdTAwRTludGFsbyBkZSBudWV2byFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUge2NvdW50fSBjb2xvcmVzIGRpc3BvbmlibGVzIGVuY29udHJhZG9zXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBDYXJnYW5kbyBpbWFnZW4uLi5cIixcbiAgICBpbWFnZUxvYWRlZDogXCJcdTI3MDUgSW1hZ2VuIGNhcmdhZGEgY29uIHtjb3VudH0gcFx1MDBFRHhlbGVzIHZcdTAwRTFsaWRvc1wiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGFsIGNhcmdhciBsYSBpbWFnZW5cIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1MDBBMVBpbnRhIGVsIHByaW1lciBwXHUwMEVEeGVsIGVuIGxhIHViaWNhY2lcdTAwRjNuIGRvbmRlIHF1aWVyZXMgcXVlIGNvbWllbmNlIGVsIGFydGUhXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBFc3BlcmFuZG8gcXVlIHBpbnRlcyBlbCBwXHUwMEVEeGVsIGRlIHJlZmVyZW5jaWEuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHUwMEExUG9zaWNpXHUwMEYzbiBlc3RhYmxlY2lkYSBjb24gXHUwMEU5eGl0byFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpZW1wbyBhZ290YWRvIHBhcmEgc2VsZWNjaW9uYXIgcG9zaWNpXHUwMEYzblwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFBvc2ljaVx1MDBGM24gZGV0ZWN0YWRhLCBwcm9jZXNhbmRvLi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgRXJyb3IgZGV0ZWN0YW5kbyBwb3NpY2lcdTAwRjNuLCBpbnRcdTAwRTludGFsbyBkZSBudWV2b1wiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IEluaWNpYW5kbyBwaW50dXJhLi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgUHJvZ3Jlc286IHtwYWludGVkfS97dG90YWx9IHBcdTAwRUR4ZWxlcy4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgU2luIGNhcmdhcy4gRXNwZXJhbmRvIHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUGludHVyYSBkZXRlbmlkYSBwb3IgZWwgdXN1YXJpb1wiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1MDBBMVBpbnR1cmEgY29tcGxldGFkYSEge2NvdW50fSBwXHUwMEVEeGVsZXMgcGludGFkb3MuXCIsXG4gICAgcGFpbnRpbmdFcnJvcjogXCJcdTI3NEMgRXJyb3IgZHVyYW50ZSBsYSBwaW50dXJhXCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgQ2FyZ2EgdW5hIGltYWdlbiB5IHNlbGVjY2lvbmEgdW5hIHBvc2ljaVx1MDBGM24gcHJpbWVyb1wiLFxuICAgIHByb2dyZXNzOiBcIlByb2dyZXNvXCIsXG4gICAgdXNlck5hbWU6IFwiVXN1YXJpb1wiLFxuICAgIHBpeGVsczogXCJQXHUwMEVEeGVsZXNcIixcbiAgICBjaGFyZ2VzOiBcIkNhcmdhc1wiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiVGllbXBvIGVzdGltYWRvXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiSGF6IGNsaWMgZW4gJ0luaWNpYXIgQXV0by1CT1QnIHBhcmEgY29tZW56YXJcIixcbiAgICB3YWl0aW5nSW5pdDogXCJFc3BlcmFuZG8gaW5pY2lhbGl6YWNpXHUwMEYzbi4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IEltYWdlbiByZWRpbWVuc2lvbmFkYSBhIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgUGludHVyYSBwYXVzYWRhIGVuIGxhIHBvc2ljaVx1MDBGM24gWDoge3h9LCBZOiB7eX1cIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQXHUwMEVEeGVsZXMgcG9yIGxvdGVcIixcbiAgICBiYXRjaFNpemU6IFwiVGFtYVx1MDBGMW8gZGVsIGxvdGVcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlNpZ3VpZW50ZSBsb3RlIGVuXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJVc2FyIHRvZGFzIGxhcyBjYXJnYXMgZGlzcG9uaWJsZXNcIixcbiAgICBzaG93T3ZlcmxheTogXCJNb3N0cmFyIG92ZXJsYXlcIixcbiAgICBtYXhDaGFyZ2VzOiBcIkNhcmdhcyBtXHUwMEUxeGltYXMgcG9yIGxvdGVcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgRXNwZXJhbmRvIGNhcmdhczoge2N1cnJlbnR9L3tuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJUaWVtcG8gcmVzdGFudGVcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIEVzcGVyYW5kbyB7dGltZX0gcGFyYSBjb250aW51YXIuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBQcm9ncmVzbyBndWFyZGFkbyBjb21vIHtmaWxlbmFtZX1cIixcbiAgICBwcm9ncmVzc0xvYWRlZDogXCJcdTI3MDUgUHJvZ3Jlc28gY2FyZ2Fkbzoge3BhaW50ZWR9L3t0b3RhbH0gcFx1MDBFRHhlbGVzIHBpbnRhZG9zXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIEVycm9yIGFsIGNhcmdhciBwcm9ncmVzbzoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBhbCBndWFyZGFyIHByb2dyZXNvOiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJcdTAwQkZEZXNlYXMgZ3VhcmRhciBlbCBwcm9ncmVzbyBhY3R1YWwgYW50ZXMgZGUgZGV0ZW5lcj9cIixcbiAgICBzYXZlUHJvZ3Jlc3NUaXRsZTogXCJHdWFyZGFyIFByb2dyZXNvXCIsXG4gICAgZGlzY2FyZFByb2dyZXNzOiBcIkRlc2NhcnRhclwiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxhclwiLFxuICAgIG1pbmltaXplOiBcIk1pbmltaXphclwiLFxuICAgIHdpZHRoOiBcIkFuY2hvXCIsXG4gICAgaGVpZ2h0OiBcIkFsdG9cIiwgXG4gICAga2VlcEFzcGVjdDogXCJNYW50ZW5lciBwcm9wb3JjaVx1MDBGM25cIixcbiAgICBhcHBseTogXCJBcGxpY2FyXCIsXG4gIG92ZXJsYXlPbjogXCJPdmVybGF5OiBPTlwiLFxuICBvdmVybGF5T2ZmOiBcIk92ZXJsYXk6IE9GRlwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFBhc2FkYSBjb21wbGV0YWRhOiB7cGFpbnRlZH0gcFx1MDBFRHhlbGVzIHBpbnRhZG9zIHwgUHJvZ3Jlc286IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIEVzcGVyYW5kbyByZWdlbmVyYWNpXHUwMEYzbiBkZSBjYXJnYXM6IHtjdXJyZW50fS97bmVlZGVkfSAtIFRpZW1wbzoge3RpbWV9XCIsXG4gICAgd2FpdGluZ0NoYXJnZXNDb3VudGRvd246IFwiXHUyM0YzIEVzcGVyYW5kbyBjYXJnYXM6IHtjdXJyZW50fS97bmVlZGVkfSAtIFF1ZWRhbjoge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgSW5pY2lhbGl6YW5kbyBhdXRvbVx1MDBFMXRpY2FtZW50ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgQm90IGluaWNpYWRvIGF1dG9tXHUwMEUxdGljYW1lbnRlXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZG8gaW5pY2lhciBhdXRvbVx1MDBFMXRpY2FtZW50ZS4gVXNhIGVsIGJvdFx1MDBGM24gbWFudWFsLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXRhIGRlIGNvbG9yZXMgZGV0ZWN0YWRhXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBCdXNjYW5kbyBwYWxldGEgZGUgY29sb3Jlcy4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IEhhY2llbmRvIGNsaWMgZW4gZWwgYm90XHUwMEYzbiBQYWludC4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIEJvdFx1MDBGM24gUGFpbnQgbm8gZW5jb250cmFkb1wiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pY2lvIG1hbnVhbCByZXF1ZXJpZG9cIixcbiAgICByZXRyeUF0dGVtcHQ6IFwiXHVEODNEXHVERDA0IFJlaW50ZW50byB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSBlbiB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IEVycm9yIGVuIGludGVudG8ge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30sIHJlaW50ZW50YW5kbyBlbiB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RmFpbGVkOiBcIlx1Mjc0QyBGYWxsXHUwMEYzIGRlc3B1XHUwMEU5cyBkZSB7bWF4QXR0ZW1wdHN9IGludGVudG9zLiBDb250aW51YW5kbyBjb24gc2lndWllbnRlIGxvdGUuLi5cIixcbiAgICBuZXR3b3JrRXJyb3I6IFwiXHVEODNDXHVERjEwIEVycm9yIGRlIHJlZC4gUmVpbnRlbnRhbmRvLi4uXCIsXG4gICAgc2VydmVyRXJyb3I6IFwiXHVEODNEXHVERDI1IEVycm9yIGRlbCBzZXJ2aWRvci4gUmVpbnRlbnRhbmRvLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBUaW1lb3V0IGRlbCBzZXJ2aWRvci4gUmVpbnRlbnRhbmRvLi4uXCJcbiAgfSxcblxuICAvLyBGYXJtIE1vZHVsZSAocG9yIGltcGxlbWVudGFyKVxuICBmYXJtOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEZhcm0gQm90XCIsXG4gICAgc3RhcnQ6IFwiSW5pY2lhclwiLFxuICAgIHN0b3A6IFwiRGV0ZW5lclwiLCBcbiAgICBzdG9wcGVkOiBcIkJvdCBkZXRlbmlkb1wiLFxuICAgIGNhbGlicmF0ZTogXCJDYWxpYnJhclwiLFxuICAgIHBhaW50T25jZTogXCJVbmEgdmV6XCIsXG4gICAgY2hlY2tpbmdTdGF0dXM6IFwiVmVyaWZpY2FuZG8gZXN0YWRvLi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJDb25maWd1cmFjaVx1MDBGM25cIixcbiAgICBkZWxheTogXCJEZWxheSAobXMpXCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUFx1MDBFRHhlbGVzL2xvdGVcIixcbiAgICBtaW5DaGFyZ2VzOiBcIkNhcmdhcyBtXHUwMEVEblwiLFxuICAgIGNvbG9yTW9kZTogXCJNb2RvIGNvbG9yXCIsXG4gICAgcmFuZG9tOiBcIkFsZWF0b3Jpb1wiLFxuICAgIGZpeGVkOiBcIkZpam9cIixcbiAgICByYW5nZTogXCJSYW5nb1wiLFxuICAgIGZpeGVkQ29sb3I6IFwiQ29sb3IgZmlqb1wiLFxuICAgIGFkdmFuY2VkOiBcIkF2YW56YWRvXCIsXG4gICAgdGlsZVg6IFwiVGlsZSBYXCIsXG4gICAgdGlsZVk6IFwiVGlsZSBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJQYWxldGEgcGVyc29uYWxpemFkYVwiLFxuICAgIHBhbGV0dGVFeGFtcGxlOiBcImVqOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiQ2FwdHVyYXJcIixcbiAgICBwYWludGVkOiBcIlBpbnRhZG9zXCIsXG4gICAgY2hhcmdlczogXCJDYXJnYXNcIixcbiAgICByZXRyaWVzOiBcIkZhbGxvc1wiLFxuICAgIHRpbGU6IFwiVGlsZVwiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIkNvbmZpZ3VyYWNpXHUwMEYzbiBndWFyZGFkYVwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJDb25maWd1cmFjaVx1MDBGM24gY2FyZ2FkYVwiLFxuICAgIGNvbmZpZ1Jlc2V0OiBcIkNvbmZpZ3VyYWNpXHUwMEYzbiByZWluaWNpYWRhXCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJQaW50YSB1biBwXHUwMEVEeGVsIG1hbnVhbG1lbnRlIHBhcmEgY2FwdHVyYXIgY29vcmRlbmFkYXMuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIkJhY2tlbmQgT25saW5lXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiQmFja2VuZCBPZmZsaW5lXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiSW5pY2lhbmRvIGJvdC4uLlwiLFxuICAgIHN0b3BwaW5nQm90OiBcIkRldGVuaWVuZG8gYm90Li4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiQ2FsaWJyYW5kby4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIkF1dG8tRmFybSB5YSBlc3RcdTAwRTEgY29ycmllbmRvLlwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiQXV0by1JbWFnZSBlc3RcdTAwRTEgZWplY3V0XHUwMEUxbmRvc2UuIENpXHUwMEU5cnJhbG8gYW50ZXMgZGUgaW5pY2lhciBBdXRvLUZhcm0uXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU2VsZWNjaW9uYXIgWm9uYVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFBpbnRhIHVuIHBcdTAwRUR4ZWwgZW4gdW5hIHpvbmEgREVTUE9CTEFEQSBkZWwgbWFwYSBwYXJhIGVzdGFibGVjZXIgZWwgXHUwMEUxcmVhIGRlIGZhcm1pbmdcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBxdWUgcGludGVzIGVsIHBcdTAwRUR4ZWwgZGUgcmVmZXJlbmNpYS4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTAwQTFab25hIGVzdGFibGVjaWRhISBSYWRpbzogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpZW1wbyBhZ290YWRvIHBhcmEgc2VsZWNjaW9uYXIgem9uYVwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgU2VsZWNjaW9uYSB1bmEgem9uYSBwcmltZXJvIHVzYW5kbyAnU2VsZWNjaW9uYXIgWm9uYSdcIixcbiAgICBmYXJtUmFkaXVzOiBcIlJhZGlvIGZhcm1cIixcbiAgICBwb3NpdGlvbkluZm86IFwiWm9uYSBhY3R1YWxcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIEZhcm1pbmcgZW4gcmFkaW8ge3JhZGl1c31weCBkZXNkZSAoe3h9LHt5fSlcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIElNUE9SVEFOVEU6IFNlbGVjY2lvbmEgdW5hIHpvbmEgREVTUE9CTEFEQSBwYXJhIGV2aXRhciBjb25mbGljdG9zXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJTaW4gem9uYVwiLFxuICAgIGN1cnJlbnRab25lOiBcIlpvbmE6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgU2VsZWNjaW9uYSB1bmEgem9uYSBwcmltZXJvLiBQaW50YSB1biBwXHUwMEVEeGVsIGVuIGVsIG1hcGEgcGFyYSBlc3RhYmxlY2VyIGxhIHpvbmEgZGUgZmFybWluZ1wiXG4gIH0sXG5cbiAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiU1x1MDBFRFwiLFxuICAgIG5vOiBcIk5vXCIsXG4gICAgb2s6IFwiQWNlcHRhclwiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxhclwiLFxuICAgIGNsb3NlOiBcIkNlcnJhclwiLFxuICAgIHNhdmU6IFwiR3VhcmRhclwiLFxuICAgIGxvYWQ6IFwiQ2FyZ2FyXCIsXG4gICAgZGVsZXRlOiBcIkVsaW1pbmFyXCIsXG4gICAgZWRpdDogXCJFZGl0YXJcIixcbiAgICBzdGFydDogXCJJbmljaWFyXCIsXG4gICAgc3RvcDogXCJEZXRlbmVyXCIsXG4gICAgcGF1c2U6IFwiUGF1c2FyXCIsXG4gICAgcmVzdW1lOiBcIlJlYW51ZGFyXCIsXG4gICAgcmVzZXQ6IFwiUmVpbmljaWFyXCIsXG4gICAgc2V0dGluZ3M6IFwiQ29uZmlndXJhY2lcdTAwRjNuXCIsXG4gICAgaGVscDogXCJBeXVkYVwiLFxuICAgIGFib3V0OiBcIkFjZXJjYSBkZVwiLFxuICAgIGxhbmd1YWdlOiBcIklkaW9tYVwiLFxuICAgIGxvYWRpbmc6IFwiQ2FyZ2FuZG8uLi5cIixcbiAgICBlcnJvcjogXCJFcnJvclwiLFxuICAgIHN1Y2Nlc3M6IFwiXHUwMEM5eGl0b1wiLFxuICAgIHdhcm5pbmc6IFwiQWR2ZXJ0ZW5jaWFcIixcbiAgICBpbmZvOiBcIkluZm9ybWFjaVx1MDBGM25cIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiSWRpb21hIGNhbWJpYWRvIGEge2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gR3VhcmQgTW9kdWxlXG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tR3VhcmRcIixcbiAgICBpbml0Qm90OiBcIkluaWNpYWxpemFyIEd1YXJkLUJPVFwiLFxuICAgIHNlbGVjdEFyZWE6IFwiU2VsZWNjaW9uYXIgXHUwMEMxcmVhXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiQ2FwdHVyYXIgXHUwMEMxcmVhXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIkluaWNpYXIgUHJvdGVjY2lcdTAwRjNuXCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiRGV0ZW5lciBQcm90ZWNjaVx1MDBGM25cIixcbiAgICB1cHBlckxlZnQ6IFwiRXNxdWluYSBTdXBlcmlvciBJenF1aWVyZGFcIixcbiAgICBsb3dlclJpZ2h0OiBcIkVzcXVpbmEgSW5mZXJpb3IgRGVyZWNoYVwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJQXHUwMEVEeGVsZXMgUHJvdGVnaWRvc1wiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJDYW1iaW9zIERldGVjdGFkb3NcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJQXHUwMEVEeGVsZXMgUmVwYXJhZG9zXCIsXG4gICAgY2hhcmdlczogXCJDYXJnYXNcIixcbiAgICB3YWl0aW5nSW5pdDogXCJFc3BlcmFuZG8gaW5pY2lhbGl6YWNpXHUwMEYzbi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBWZXJpZmljYW5kbyBjb2xvcmVzIGRpc3BvbmlibGVzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgTm8gc2UgZW5jb250cmFyb24gY29sb3Jlcy4gQWJyZSBsYSBwYWxldGEgZGUgY29sb3JlcyBlbiBlbCBzaXRpby5cIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUge2NvdW50fSBjb2xvcmVzIGRpc3BvbmlibGVzIGVuY29udHJhZG9zXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBpbmljaWFsaXphZG8gY29ycmVjdGFtZW50ZVwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgRXJyb3IgaW5pY2lhbGl6YW5kbyBHdWFyZC1CT1RcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBDb29yZGVuYWRhcyBpbnZcdTAwRTFsaWRhc1wiLFxuICAgIGludmFsaWRBcmVhOiBcIlx1Mjc0QyBFbCBcdTAwRTFyZWEgZGViZSB0ZW5lciBlc3F1aW5hIHN1cGVyaW9yIGl6cXVpZXJkYSBtZW5vciBxdWUgaW5mZXJpb3IgZGVyZWNoYVwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHUwMEMxcmVhIGRlbWFzaWFkbyBncmFuZGU6IHtzaXplfSBwXHUwMEVEeGVsZXMgKG1cdTAwRTF4aW1vOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBDYXB0dXJhbmRvIFx1MDBFMXJlYSBkZSBwcm90ZWNjaVx1MDBGM24uLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDBDMXJlYSBjYXB0dXJhZGE6IHtjb3VudH0gcFx1MDBFRHhlbGVzIGJham8gcHJvdGVjY2lcdTAwRjNuXCIsXG4gICAgY2FwdHVyZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBjYXB0dXJhbmRvIFx1MDBFMXJlYToge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgUHJpbWVybyBjYXB0dXJhIHVuIFx1MDBFMXJlYSBkZSBwcm90ZWNjaVx1MDBGM25cIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgUHJvdGVjY2lcdTAwRjNuIGluaWNpYWRhIC0gbW9uaXRvcmVhbmRvIFx1MDBFMXJlYVwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQcm90ZWNjaVx1MDBGM24gZGV0ZW5pZGFcIixcbiAgICBub0NoYW5nZXM6IFwiXHUyNzA1IFx1MDBDMXJlYSBwcm90ZWdpZGEgLSBzaW4gY2FtYmlvcyBkZXRlY3RhZG9zXCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCB7Y291bnR9IGNhbWJpb3MgZGV0ZWN0YWRvcyBlbiBlbCBcdTAwRTFyZWEgcHJvdGVnaWRhXCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBSZXBhcmFuZG8ge2NvdW50fSBwXHUwMEVEeGVsZXMgYWx0ZXJhZG9zLi4uXCIsXG4gICAgcmVwYWlyZWRTdWNjZXNzOiBcIlx1MjcwNSBSZXBhcmFkb3Mge2NvdW50fSBwXHUwMEVEeGVsZXMgY29ycmVjdGFtZW50ZVwiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBFcnJvciByZXBhcmFuZG8gcFx1MDBFRHhlbGVzOiB7ZXJyb3J9XCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjZBMFx1RkUwRiBTaW4gY2FyZ2FzIHN1ZmljaWVudGVzIHBhcmEgcmVwYXJhciBjYW1iaW9zXCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBWZXJpZmljYW5kbyBjYW1iaW9zIGVuIFx1MDBFMXJlYSBwcm90ZWdpZGEuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBFcnJvciB2ZXJpZmljYW5kbyBjYW1iaW9zOiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIEd1YXJkaVx1MDBFMW4gYWN0aXZvIC0gXHUwMEUxcmVhIGJham8gcHJvdGVjY2lcdTAwRjNuXCIsXG4gICAgbGFzdENoZWNrOiBcIlx1MDBEQWx0aW1hIHZlcmlmaWNhY2lcdTAwRjNuOiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiUHJcdTAwRjN4aW1hIHZlcmlmaWNhY2lcdTAwRjNuIGVuOiB7dGltZX1zXCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgSW5pY2lhbGl6YW5kbyBhdXRvbVx1MDBFMXRpY2FtZW50ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaWNpYWRvIGF1dG9tXHUwMEUxdGljYW1lbnRlXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIE5vIHNlIHB1ZG8gaW5pY2lhciBhdXRvbVx1MDBFMXRpY2FtZW50ZS4gVXNhIGVsIGJvdFx1MDBGM24gbWFudWFsLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pY2lvIG1hbnVhbCByZXF1ZXJpZG9cIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFBhbGV0YSBkZSBjb2xvcmVzIGRldGVjdGFkYVwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgQnVzY2FuZG8gcGFsZXRhIGRlIGNvbG9yZXMuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBIYWNpZW5kbyBjbGljIGVuIGVsIGJvdFx1MDBGM24gUGFpbnQuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBCb3RcdTAwRjNuIFBhaW50IG5vIGVuY29udHJhZG9cIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFBpbnRhIHVuIHBcdTAwRUR4ZWwgZW4gbGEgZXNxdWluYSBTVVBFUklPUiBJWlFVSUVSREEgZGVsIFx1MDBFMXJlYSBhIHByb3RlZ2VyXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgQWhvcmEgcGludGEgdW4gcFx1MDBFRHhlbCBlbiBsYSBlc3F1aW5hIElORkVSSU9SIERFUkVDSEEgZGVsIFx1MDBFMXJlYVwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IEVzcGVyYW5kbyBzZWxlY2NpXHUwMEYzbiBkZSBlc3F1aW5hIHN1cGVyaW9yIGl6cXVpZXJkYS4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBFc3BlcmFuZG8gc2VsZWNjaVx1MDBGM24gZGUgZXNxdWluYSBpbmZlcmlvciBkZXJlY2hhLi4uXCIsXG4gICAgdXBwZXJMZWZ0Q2FwdHVyZWQ6IFwiXHUyNzA1IEVzcXVpbmEgc3VwZXJpb3IgaXpxdWllcmRhIGNhcHR1cmFkYTogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgRXNxdWluYSBpbmZlcmlvciBkZXJlY2hhIGNhcHR1cmFkYTogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFRpZW1wbyBhZ290YWRvIHBhcmEgc2VsZWNjaVx1MDBGM25cIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgRXJyb3IgZW4gc2VsZWNjaVx1MDBGM24sIGludFx1MDBFOW50YWxvIGRlIG51ZXZvXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgZW4gPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgQXV0by1GYXJtJyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggQXV0by1JbWFnZScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIEF1dG8tR3VhcmQnLFxuICAgIHNlbGVjdGlvbjogJ1NlbGVjdGlvbicsXG4gICAgdXNlcjogJ1VzZXInLFxuICAgIGNoYXJnZXM6ICdDaGFyZ2VzJyxcbiAgICBiYWNrZW5kOiAnQmFja2VuZCcsXG4gICAgZGF0YWJhc2U6ICdEYXRhYmFzZScsXG4gICAgdXB0aW1lOiAnVXB0aW1lJyxcbiAgICBjbG9zZTogJ0Nsb3NlJyxcbiAgICBsYXVuY2g6ICdMYXVuY2gnLFxuICAgIGxvYWRpbmc6ICdMb2FkaW5nXHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdFeGVjdXRpbmdcdTIwMjYnLFxuICAgIGRvd25sb2FkaW5nOiAnRG93bmxvYWRpbmcgc2NyaXB0XHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdDaG9vc2UgYSBib3QgYW5kIHByZXNzIExhdW5jaCcsXG4gICAgcmVhZHlUb0xhdW5jaDogJ1JlYWR5IHRvIGxhdW5jaCcsXG4gICAgbG9hZEVycm9yOiAnTG9hZCBlcnJvcicsXG4gICAgbG9hZEVycm9yTXNnOiAnQ291bGQgbm90IGxvYWQgdGhlIHNlbGVjdGVkIGJvdC4gQ2hlY2sgeW91ciBjb25uZWN0aW9uIG9yIHRyeSBhZ2Fpbi4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IENoZWNraW5nLi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgT25saW5lJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IE9mZmxpbmUnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIE9LJyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBFcnJvcicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tSW1hZ2VcIixcbiAgICBpbml0Qm90OiBcIkluaXRpYWxpemUgQXV0by1CT1RcIixcbiAgICB1cGxvYWRJbWFnZTogXCJVcGxvYWQgSW1hZ2VcIixcbiAgICByZXNpemVJbWFnZTogXCJSZXNpemUgSW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTZWxlY3QgUG9zaXRpb25cIixcbiAgICBzdGFydFBhaW50aW5nOiBcIlN0YXJ0IFBhaW50aW5nXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlN0b3AgUGFpbnRpbmdcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiU2F2ZSBQcm9ncmVzc1wiLFxuICAgIGxvYWRQcm9ncmVzczogXCJMb2FkIFByb2dyZXNzXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIENoZWNraW5nIGF2YWlsYWJsZSBjb2xvcnMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBPcGVuIHRoZSBjb2xvciBwYWxldHRlIG9uIHRoZSBzaXRlIGFuZCB0cnkgYWdhaW4hXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IEZvdW5kIHtjb3VudH0gYXZhaWxhYmxlIGNvbG9yc1wiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgTG9hZGluZyBpbWFnZS4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBJbWFnZSBsb2FkZWQgd2l0aCB7Y291bnR9IHZhbGlkIHBpeGVsc1wiLFxuICAgIGltYWdlRXJyb3I6IFwiXHUyNzRDIEVycm9yIGxvYWRpbmcgaW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlBhaW50IHRoZSBmaXJzdCBwaXhlbCBhdCB0aGUgbG9jYXRpb24gd2hlcmUgeW91IHdhbnQgdGhlIGFydCB0byBzdGFydCFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFdhaXRpbmcgZm9yIHlvdSB0byBwYWludCB0aGUgcmVmZXJlbmNlIHBpeGVsLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFBvc2l0aW9uIHNldCBzdWNjZXNzZnVsbHkhXCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBUaW1lb3V0IGZvciBwb3NpdGlvbiBzZWxlY3Rpb25cIixcbiAgICBwb3NpdGlvbkRldGVjdGVkOiBcIlx1RDgzQ1x1REZBRiBQb3NpdGlvbiBkZXRlY3RlZCwgcHJvY2Vzc2luZy4uLlwiLFxuICAgIHBvc2l0aW9uRXJyb3I6IFwiXHUyNzRDIEVycm9yIGRldGVjdGluZyBwb3NpdGlvbiwgcGxlYXNlIHRyeSBhZ2FpblwiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IFN0YXJ0aW5nIHBhaW50aW5nLi4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgUHJvZ3Jlc3M6IHtwYWludGVkfS97dG90YWx9IHBpeGVscy4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgTm8gY2hhcmdlcy4gV2FpdGluZyB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFBhaW50aW5nIHN0b3BwZWQgYnkgdXNlclwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFBhaW50aW5nIGNvbXBsZXRlZCEge2NvdW50fSBwaXhlbHMgcGFpbnRlZC5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBFcnJvciBkdXJpbmcgcGFpbnRpbmdcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBMb2FkIGFuIGltYWdlIGFuZCBzZWxlY3QgYSBwb3NpdGlvbiBmaXJzdFwiLFxuICAgIHByb2dyZXNzOiBcIlByb2dyZXNzXCIsXG4gICAgdXNlck5hbWU6IFwiVXNlclwiLFxuICAgIHBpeGVsczogXCJQaXhlbHNcIixcbiAgICBjaGFyZ2VzOiBcIkNoYXJnZXNcIixcbiAgICBlc3RpbWF0ZWRUaW1lOiBcIkVzdGltYXRlZCB0aW1lXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiQ2xpY2sgJ0luaXRpYWxpemUgQXV0by1CT1QnIHRvIGJlZ2luXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiV2FpdGluZyBmb3IgaW5pdGlhbGl6YXRpb24uLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBJbWFnZSByZXNpemVkIHRvIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgUGFpbnRpbmcgcGF1c2VkIGF0IHBvc2l0aW9uIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUGl4ZWxzIHBlciBiYXRjaFwiLFxuICAgIGJhdGNoU2l6ZTogXCJCYXRjaCBzaXplXCIsXG4gICAgbmV4dEJhdGNoVGltZTogXCJOZXh0IGJhdGNoIGluXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJVc2UgYWxsIGF2YWlsYWJsZSBjaGFyZ2VzXCIsXG4gICAgc2hvd092ZXJsYXk6IFwiU2hvdyBvdmVybGF5XCIsXG4gICAgbWF4Q2hhcmdlczogXCJNYXggY2hhcmdlcyBwZXIgYmF0Y2hcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgV2FpdGluZyBmb3IgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJUaW1lIHJlbWFpbmluZ1wiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgV2FpdGluZyB7dGltZX0gdG8gY29udGludWUuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBQcm9ncmVzcyBzYXZlZCBhcyB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFByb2dyZXNzIGxvYWRlZDoge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzIHBhaW50ZWRcIixcbiAgICBwcm9ncmVzc0xvYWRFcnJvcjogXCJcdTI3NEMgRXJyb3IgbG9hZGluZyBwcm9ncmVzczoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBzYXZpbmcgcHJvZ3Jlc3M6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIkRvIHlvdSB3YW50IHRvIHNhdmUgdGhlIGN1cnJlbnQgcHJvZ3Jlc3MgYmVmb3JlIHN0b3BwaW5nP1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlNhdmUgUHJvZ3Jlc3NcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiRGlzY2FyZFwiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxcIixcbiAgICBtaW5pbWl6ZTogXCJNaW5pbWl6ZVwiLFxuICAgIHdpZHRoOiBcIldpZHRoXCIsXG4gICAgaGVpZ2h0OiBcIkhlaWdodFwiLCBcbiAgICBrZWVwQXNwZWN0OiBcIktlZXAgYXNwZWN0IHJhdGlvXCIsXG4gICAgYXBwbHk6IFwiQXBwbHlcIixcbiAgb3ZlcmxheU9uOiBcIk92ZXJsYXk6IE9OXCIsXG4gIG92ZXJsYXlPZmY6IFwiT3ZlcmxheTogT0ZGXCIsXG4gICAgcGFzc0NvbXBsZXRlZDogXCJcdTI3MDUgUGFzcyBjb21wbGV0ZWQ6IHtwYWludGVkfSBwaXhlbHMgcGFpbnRlZCB8IFByb2dyZXNzOiB7cGVyY2VudH0lICh7Y3VycmVudH0ve3RvdGFsfSlcIixcbiAgICB3YWl0aW5nQ2hhcmdlc1JlZ2VuOiBcIlx1MjNGMyBXYWl0aW5nIGZvciBjaGFyZ2UgcmVnZW5lcmF0aW9uOiB7Y3VycmVudH0ve25lZWRlZH0gLSBUaW1lOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgV2FpdGluZyBmb3IgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gUmVtYWluaW5nOiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBBdXRvLWluaXRpYWxpemluZy4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgQm90IGF1dG8tc3RhcnRlZCBzdWNjZXNzZnVsbHlcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgQ291bGQgbm90IGF1dG8tc3RhcnQuIFVzZSBtYW51YWwgYnV0dG9uLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggQ29sb3IgcGFsZXR0ZSBkZXRlY3RlZFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgU2VhcmNoaW5nIGZvciBjb2xvciBwYWxldHRlLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpY2tpbmcgUGFpbnQgYnV0dG9uLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgUGFpbnQgYnV0dG9uIG5vdCBmb3VuZFwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgTWFudWFsIGluaXRpYWxpemF0aW9uIHJlcXVpcmVkXCIsXG4gICAgcmV0cnlBdHRlbXB0OiBcIlx1RDgzRFx1REQwNCBSZXRyeSB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSBpbiB7ZGVsYXl9cy4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IEVycm9yIGluIGF0dGVtcHQge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30sIHJldHJ5aW5nIGluIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIEZhaWxlZCBhZnRlciB7bWF4QXR0ZW1wdHN9IGF0dGVtcHRzLiBDb250aW51aW5nIHdpdGggbmV4dCBiYXRjaC4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgTmV0d29yayBlcnJvci4gUmV0cnlpbmcuLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgU2VydmVyIGVycm9yLiBSZXRyeWluZy4uLlwiLFxuICAgIHRpbWVvdXRFcnJvcjogXCJcdTIzRjAgU2VydmVyIHRpbWVvdXQuIFJldHJ5aW5nLi4uXCJcbiAgfSxcblxuICAvLyBGYXJtIE1vZHVsZSAodG8gYmUgaW1wbGVtZW50ZWQpXG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgRmFybSBCb3RcIixcbiAgICBzdGFydDogXCJTdGFydFwiLFxuICAgIHN0b3A6IFwiU3RvcFwiLFxuICAgIHN0b3BwZWQ6IFwiQm90IHN0b3BwZWRcIixcbiAgICBjYWxpYnJhdGU6IFwiQ2FsaWJyYXRlXCIsXG4gICAgcGFpbnRPbmNlOiBcIk9uY2VcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJDaGVja2luZyBzdGF0dXMuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIkNvbmZpZ3VyYXRpb25cIixcbiAgICBkZWxheTogXCJEZWxheSAobXMpXCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiUGl4ZWxzL2JhdGNoXCIsXG4gICAgbWluQ2hhcmdlczogXCJNaW4gY2hhcmdlc1wiLFxuICAgIGNvbG9yTW9kZTogXCJDb2xvciBtb2RlXCIsXG4gICAgcmFuZG9tOiBcIlJhbmRvbVwiLFxuICAgIGZpeGVkOiBcIkZpeGVkXCIsXG4gICAgcmFuZ2U6IFwiUmFuZ2VcIixcbiAgICBmaXhlZENvbG9yOiBcIkZpeGVkIGNvbG9yXCIsXG4gICAgYWR2YW5jZWQ6IFwiQWR2YW5jZWRcIixcbiAgICB0aWxlWDogXCJUaWxlIFhcIixcbiAgICB0aWxlWTogXCJUaWxlIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIkN1c3RvbSBwYWxldHRlXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiZS5nOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiQ2FwdHVyZVwiLFxuICAgIHBhaW50ZWQ6IFwiUGFpbnRlZFwiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIHJldHJpZXM6IFwiUmV0cmllc1wiLFxuICAgIHRpbGU6IFwiVGlsZVwiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIkNvbmZpZ3VyYXRpb24gc2F2ZWRcIixcbiAgICBjb25maWdMb2FkZWQ6IFwiQ29uZmlndXJhdGlvbiBsb2FkZWRcIixcbiAgICBjb25maWdSZXNldDogXCJDb25maWd1cmF0aW9uIHJlc2V0XCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJQYWludCBhIHBpeGVsIG1hbnVhbGx5IHRvIGNhcHR1cmUgY29vcmRpbmF0ZXMuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIkJhY2tlbmQgT25saW5lXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiQmFja2VuZCBPZmZsaW5lXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiU3RhcnRpbmcgYm90Li4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiU3RvcHBpbmcgYm90Li4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiQ2FsaWJyYXRpbmcuLi5cIixcbiAgICBhbHJlYWR5UnVubmluZzogXCJBdXRvLUZhcm0gaXMgYWxyZWFkeSBydW5uaW5nLlwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiQXV0by1JbWFnZSBpcyBydW5uaW5nLiBDbG9zZSBpdCBiZWZvcmUgc3RhcnRpbmcgQXV0by1GYXJtLlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlNlbGVjdCBBcmVhXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgUGFpbnQgYSBwaXhlbCBpbiBhbiBFTVBUWSBhcmVhIG9mIHRoZSBtYXAgdG8gc2V0IHRoZSBmYXJtaW5nIHpvbmVcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFdhaXRpbmcgZm9yIHlvdSB0byBwYWludCB0aGUgcmVmZXJlbmNlIHBpeGVsLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IEFyZWEgc2V0ISBSYWRpdXM6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBUaW1lb3V0IGZvciBhcmVhIHNlbGVjdGlvblwiLFxuICAgIG1pc3NpbmdQb3NpdGlvbjogXCJcdTI3NEMgU2VsZWN0IGFuIGFyZWEgZmlyc3QgdXNpbmcgJ1NlbGVjdCBBcmVhJ1wiLFxuICAgIGZhcm1SYWRpdXM6IFwiRmFybSByYWRpdXNcIixcbiAgICBwb3NpdGlvbkluZm86IFwiQ3VycmVudCBhcmVhXCIsXG4gICAgZmFybWluZ0luUmFkaXVzOiBcIlx1RDgzQ1x1REYzRSBGYXJtaW5nIGluIHtyYWRpdXN9cHggcmFkaXVzIGZyb20gKHt4fSx7eX0pXCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBJTVBPUlRBTlQ6IFNlbGVjdCBhbiBFTVBUWSBhcmVhIHRvIGF2b2lkIGNvbmZsaWN0c1wiLFxuICAgIG5vUG9zaXRpb246IFwiTm8gYXJlYVwiLFxuICAgIGN1cnJlbnRab25lOiBcIlpvbmU6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgU2VsZWN0IGFuIGFyZWEgZmlyc3QuIFBhaW50IGEgcGl4ZWwgb24gdGhlIG1hcCB0byBzZXQgdGhlIGZhcm1pbmcgem9uZVwiXG4gIH0sXG5cbiAgLy8gQ29tbW9uL1NoYXJlZFxuICBjb21tb246IHtcbiAgICB5ZXM6IFwiWWVzXCIsXG4gICAgbm86IFwiTm9cIixcbiAgICBvazogXCJPS1wiLFxuICAgIGNhbmNlbDogXCJDYW5jZWxcIixcbiAgICBjbG9zZTogXCJDbG9zZVwiLFxuICAgIHNhdmU6IFwiU2F2ZVwiLFxuICAgIGxvYWQ6IFwiTG9hZFwiLFxuICAgIGRlbGV0ZTogXCJEZWxldGVcIixcbiAgICBlZGl0OiBcIkVkaXRcIixcbiAgICBzdGFydDogXCJTdGFydFwiLFxuICAgIHN0b3A6IFwiU3RvcFwiLFxuICAgIHBhdXNlOiBcIlBhdXNlXCIsXG4gICAgcmVzdW1lOiBcIlJlc3VtZVwiLFxuICAgIHJlc2V0OiBcIlJlc2V0XCIsXG4gICAgc2V0dGluZ3M6IFwiU2V0dGluZ3NcIixcbiAgICBoZWxwOiBcIkhlbHBcIixcbiAgICBhYm91dDogXCJBYm91dFwiLFxuICAgIGxhbmd1YWdlOiBcIkxhbmd1YWdlXCIsXG4gICAgbG9hZGluZzogXCJMb2FkaW5nLi4uXCIsXG4gICAgZXJyb3I6IFwiRXJyb3JcIixcbiAgICBzdWNjZXNzOiBcIlN1Y2Nlc3NcIixcbiAgICB3YXJuaW5nOiBcIldhcm5pbmdcIixcbiAgICBpbmZvOiBcIkluZm9ybWF0aW9uXCIsXG4gICAgbGFuZ3VhZ2VDaGFuZ2VkOiBcIkxhbmd1YWdlIGNoYW5nZWQgdG8ge2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gR3VhcmQgTW9kdWxlXG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tR3VhcmRcIixcbiAgICBpbml0Qm90OiBcIkluaXRpYWxpemUgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJTZWxlY3QgQXJlYVwiLFxuICAgIGNhcHR1cmVBcmVhOiBcIkNhcHR1cmUgQXJlYVwiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJTdGFydCBQcm90ZWN0aW9uXCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiU3RvcCBQcm90ZWN0aW9uXCIsXG4gICAgdXBwZXJMZWZ0OiBcIlVwcGVyIExlZnQgQ29ybmVyXCIsXG4gICAgbG93ZXJSaWdodDogXCJMb3dlciBSaWdodCBDb3JuZXJcIixcbiAgICBwcm90ZWN0ZWRQaXhlbHM6IFwiUHJvdGVjdGVkIFBpeGVsc1wiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJEZXRlY3RlZCBDaGFuZ2VzXCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiUmVwYWlyZWQgUGl4ZWxzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiV2FpdGluZyBmb3IgaW5pdGlhbGl6YXRpb24uLi5cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0NcdURGQTggQ2hlY2tpbmcgYXZhaWxhYmxlIGNvbG9ycy4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIE5vIGNvbG9ycyBmb3VuZC4gT3BlbiB0aGUgY29sb3IgcGFsZXR0ZSBvbiB0aGUgc2l0ZS5cIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgRm91bmQge2NvdW50fSBhdmFpbGFibGUgY29sb3JzXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBpbml0aWFsaXplZCBzdWNjZXNzZnVsbHlcIixcbiAgICBpbml0RXJyb3I6IFwiXHUyNzRDIEVycm9yIGluaXRpYWxpemluZyBHdWFyZC1CT1RcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBJbnZhbGlkIGNvb3JkaW5hdGVzXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIEFyZWEgbXVzdCBoYXZlIHVwcGVyIGxlZnQgY29ybmVyIGxlc3MgdGhhbiBsb3dlciByaWdodCBjb3JuZXJcIixcbiAgICBhcmVhVG9vTGFyZ2U6IFwiXHUyNzRDIEFyZWEgdG9vIGxhcmdlOiB7c2l6ZX0gcGl4ZWxzIChtYXhpbXVtOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBDYXB0dXJpbmcgcHJvdGVjdGlvbiBhcmVhLi4uXCIsXG4gICAgYXJlYUNhcHR1cmVkOiBcIlx1MjcwNSBBcmVhIGNhcHR1cmVkOiB7Y291bnR9IHBpeGVscyB1bmRlciBwcm90ZWN0aW9uXCIsXG4gICAgY2FwdHVyZUVycm9yOiBcIlx1Mjc0QyBFcnJvciBjYXB0dXJpbmcgYXJlYToge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgRmlyc3QgY2FwdHVyZSBhIHByb3RlY3Rpb24gYXJlYVwiLFxuICAgIHByb3RlY3Rpb25TdGFydGVkOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBQcm90ZWN0aW9uIHN0YXJ0ZWQgLSBtb25pdG9yaW5nIGFyZWFcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUHJvdGVjdGlvbiBzdG9wcGVkXCIsXG4gICAgbm9DaGFuZ2VzOiBcIlx1MjcwNSBQcm90ZWN0ZWQgYXJlYSAtIG5vIGNoYW5nZXMgZGV0ZWN0ZWRcIixcbiAgICBjaGFuZ2VzRGV0ZWN0ZWQ6IFwiXHVEODNEXHVERUE4IHtjb3VudH0gY2hhbmdlcyBkZXRlY3RlZCBpbiBwcm90ZWN0ZWQgYXJlYVwiLFxuICAgIHJlcGFpcmluZzogXCJcdUQ4M0RcdURFRTBcdUZFMEYgUmVwYWlyaW5nIHtjb3VudH0gYWx0ZXJlZCBwaXhlbHMuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFN1Y2Nlc3NmdWxseSByZXBhaXJlZCB7Y291bnR9IHBpeGVsc1wiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBFcnJvciByZXBhaXJpbmcgcGl4ZWxzOiB7ZXJyb3J9XCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjZBMFx1RkUwRiBJbnN1ZmZpY2llbnQgY2hhcmdlcyB0byByZXBhaXIgY2hhbmdlc1wiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgQ2hlY2tpbmcgY2hhbmdlcyBpbiBwcm90ZWN0ZWQgYXJlYS4uLlwiLFxuICAgIGVycm9yQ2hlY2tpbmc6IFwiXHUyNzRDIEVycm9yIGNoZWNraW5nIGNoYW5nZXM6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgR3VhcmRpYW4gYWN0aXZlIC0gYXJlYSB1bmRlciBwcm90ZWN0aW9uXCIsXG4gICAgbGFzdENoZWNrOiBcIkxhc3QgY2hlY2s6IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJOZXh0IGNoZWNrIGluOiB7dGltZX1zXCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgQXV0by1pbml0aWFsaXppbmcuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEd1YXJkLUJPVCBhdXRvLXN0YXJ0ZWQgc3VjY2Vzc2Z1bGx5XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIENvdWxkIG5vdCBhdXRvLXN0YXJ0LiBVc2UgbWFudWFsIGJ1dHRvbi5cIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IE1hbnVhbCBpbml0aWFsaXphdGlvbiByZXF1aXJlZFwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggQ29sb3IgcGFsZXR0ZSBkZXRlY3RlZFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgU2VhcmNoaW5nIGZvciBjb2xvciBwYWxldHRlLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpY2tpbmcgUGFpbnQgYnV0dG9uLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgUGFpbnQgYnV0dG9uIG5vdCBmb3VuZFwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgUGFpbnQgYSBwaXhlbCBhdCB0aGUgVVBQRVIgTEVGVCBjb3JuZXIgb2YgdGhlIGFyZWEgdG8gcHJvdGVjdFwiLFxuICAgIHNlbGVjdExvd2VyUmlnaHQ6IFwiXHVEODNDXHVERkFGIE5vdyBwYWludCBhIHBpeGVsIGF0IHRoZSBMT1dFUiBSSUdIVCBjb3JuZXIgb2YgdGhlIGFyZWFcIixcbiAgICB3YWl0aW5nVXBwZXJMZWZ0OiBcIlx1RDgzRFx1REM0NiBXYWl0aW5nIGZvciB1cHBlciBsZWZ0IGNvcm5lciBzZWxlY3Rpb24uLi5cIixcbiAgICB3YWl0aW5nTG93ZXJSaWdodDogXCJcdUQ4M0RcdURDNDYgV2FpdGluZyBmb3IgbG93ZXIgcmlnaHQgY29ybmVyIHNlbGVjdGlvbi4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBVcHBlciBsZWZ0IGNvcm5lciBjYXB0dXJlZDogKHt4fSwge3l9KVwiLFxuICAgIGxvd2VyUmlnaHRDYXB0dXJlZDogXCJcdTI3MDUgTG93ZXIgcmlnaHQgY29ybmVyIGNhcHR1cmVkOiAoe3h9LCB7eX0pXCIsXG4gICAgc2VsZWN0aW9uVGltZW91dDogXCJcdTI3NEMgU2VsZWN0aW9uIHRpbWVvdXRcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgU2VsZWN0aW9uIGVycm9yLCBwbGVhc2UgdHJ5IGFnYWluXCJcbiAgfVxufTtcbiIsICJleHBvcnQgY29uc3QgZnIgPSB7XG4gIC8vIExhdW5jaGVyXG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgQXV0b0JPVCcsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgQXV0by1GYXJtJyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggQXV0by1JbWFnZScsXG4gICAgYXV0b0d1YXJkOiAnXHVEODNEXHVERUUxXHVGRTBGIEF1dG8tR3VhcmQnLFxuICAgIHNlbGVjdGlvbjogJ1NcdTAwRTlsZWN0aW9uJyxcbiAgICB1c2VyOiAnVXRpbGlzYXRldXInLFxuICAgIGNoYXJnZXM6ICdDaGFyZ2VzJyxcbiAgICBiYWNrZW5kOiAnQmFja2VuZCcsXG4gICAgZGF0YWJhc2U6ICdCYXNlIGRlIGRvbm5cdTAwRTllcycsXG4gICAgdXB0aW1lOiAnVGVtcHMgYWN0aWYnLFxuICAgIGNsb3NlOiAnRmVybWVyJyxcbiAgICBsYXVuY2g6ICdMYW5jZXInLFxuICAgIGxvYWRpbmc6ICdDaGFyZ2VtZW50XHUyMDI2JyxcbiAgICBleGVjdXRpbmc6ICdFeFx1MDBFOWN1dGlvblx1MjAyNicsXG4gICAgZG93bmxvYWRpbmc6ICdUXHUwMEU5bFx1MDBFOWNoYXJnZW1lbnQgZHUgc2NyaXB0XHUyMDI2JyxcbiAgICBjaG9vc2VCb3Q6ICdDaG9pc2lzc2V6IHVuIGJvdCBldCBhcHB1eWV6IHN1ciBMYW5jZXInLFxuICAgIHJlYWR5VG9MYXVuY2g6ICdQclx1MDBFQXQgXHUwMEUwIGxhbmNlcicsXG4gICAgbG9hZEVycm9yOiAnRXJyZXVyIGRlIGNoYXJnZW1lbnQnLFxuICAgIGxvYWRFcnJvck1zZzogJ0ltcG9zc2libGUgZGUgY2hhcmdlciBsZSBib3Qgc1x1MDBFOWxlY3Rpb25uXHUwMEU5LiBWXHUwMEU5cmlmaWV6IHZvdHJlIGNvbm5leGlvbiBvdSByXHUwMEU5ZXNzYXllei4nLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFZcdTAwRTlyaWZpY2F0aW9uLi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgRW4gbGlnbmUnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgSG9ycyBsaWduZScsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgT0snLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IEVycmV1cicsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIEF1dG8tSW1hZ2VcIixcbiAgICBpbml0Qm90OiBcIkluaXRpYWxpc2VyIEF1dG8tQk9UXCIsXG4gICAgdXBsb2FkSW1hZ2U6IFwiVFx1MDBFOWxcdTAwRTljaGFyZ2VyIEltYWdlXCIsXG4gICAgcmVzaXplSW1hZ2U6IFwiUmVkaW1lbnNpb25uZXIgSW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJTXHUwMEU5bGVjdGlvbm5lciBQb3NpdGlvblwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiQ29tbWVuY2VyIFBlaW50dXJlXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIkFyclx1MDBFQXRlciBQZWludHVyZVwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJTYXV2ZWdhcmRlciBQcm9nclx1MDBFOHNcIixcbiAgICBsb2FkUHJvZ3Jlc3M6IFwiQ2hhcmdlciBQcm9nclx1MDBFOHNcIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0RcdUREMEQgVlx1MDBFOXJpZmljYXRpb24gZGVzIGNvdWxldXJzIGRpc3BvbmlibGVzLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgT3V2cmV6IGxhIHBhbGV0dGUgZGUgY291bGV1cnMgc3VyIGxlIHNpdGUgZXQgclx1MDBFOWVzc2F5ZXohXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IHtjb3VudH0gY291bGV1cnMgZGlzcG9uaWJsZXMgdHJvdXZcdTAwRTllc1wiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgQ2hhcmdlbWVudCBkZSBsJ2ltYWdlLi4uXCIsXG4gICAgaW1hZ2VMb2FkZWQ6IFwiXHUyNzA1IEltYWdlIGNoYXJnXHUwMEU5ZSBhdmVjIHtjb3VudH0gcGl4ZWxzIHZhbGlkZXNcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkdSBjaGFyZ2VtZW50IGRlIGwnaW1hZ2VcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlBlaWduZXogbGUgcHJlbWllciBwaXhlbCBcdTAwRTAgbCdlbXBsYWNlbWVudCBvXHUwMEY5IHZvdXMgdm91bGV6IHF1ZSBsJ2FydCBjb21tZW5jZSFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IEVuIGF0dGVudGUgcXVlIHZvdXMgcGVpZ25pZXogbGUgcGl4ZWwgZGUgclx1MDBFOWZcdTAwRTlyZW5jZS4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBQb3NpdGlvbiBkXHUwMEU5ZmluaWUgYXZlYyBzdWNjXHUwMEU4cyFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIERcdTAwRTlsYWkgZFx1MDBFOXBhc3NcdTAwRTkgcG91ciBsYSBzXHUwMEU5bGVjdGlvbiBkZSBwb3NpdGlvblwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFBvc2l0aW9uIGRcdTAwRTl0ZWN0XHUwMEU5ZSwgdHJhaXRlbWVudC4uLlwiLFxuICAgIHBvc2l0aW9uRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBkXHUwMEU5dGVjdGFudCBsYSBwb3NpdGlvbiwgZXNzYXlleiBcdTAwRTAgbm91dmVhdVwiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IERcdTAwRTlidXQgZGUgbGEgcGVpbnR1cmUuLi5cIixcbiAgICBwYWludGluZ1Byb2dyZXNzOiBcIlx1RDgzRVx1RERGMSBQcm9nclx1MDBFOHM6IHtwYWludGVkfS97dG90YWx9IHBpeGVscy4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgQXVjdW5lIGNoYXJnZS4gQXR0ZW5kcmUge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBQZWludHVyZSBhcnJcdTAwRUF0XHUwMEU5ZSBwYXIgbCd1dGlsaXNhdGV1clwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFBlaW50dXJlIHRlcm1pblx1MDBFOWUhIHtjb3VudH0gcGl4ZWxzIHBlaW50cy5cIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBFcnJldXIgcGVuZGFudCBsYSBwZWludHVyZVwiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIENoYXJnZXogdW5lIGltYWdlIGV0IHNcdTAwRTlsZWN0aW9ubmV6IHVuZSBwb3NpdGlvbiBkJ2Fib3JkXCIsXG4gICAgcHJvZ3Jlc3M6IFwiUHJvZ3JcdTAwRThzXCIsXG4gICAgdXNlck5hbWU6IFwiVXNhZ2VyXCIsXG4gICAgcGl4ZWxzOiBcIlBpeGVsc1wiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiVGVtcHMgZXN0aW1cdTAwRTlcIixcbiAgICBpbml0TWVzc2FnZTogXCJDbGlxdWV6IHN1ciAnSW5pdGlhbGlzZXIgQXV0by1CT1QnIHBvdXIgY29tbWVuY2VyXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiRW4gYXR0ZW50ZSBkJ2luaXRpYWxpc2F0aW9uLi4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgSW1hZ2UgcmVkaW1lbnNpb25uXHUwMEU5ZSBcdTAwRTAge3dpZHRofXh7aGVpZ2h0fVwiLFxuICAgIHBhaW50aW5nUGF1c2VkOiBcIlx1MjNGOFx1RkUwRiBQZWludHVyZSBtaXNlIGVuIHBhdXNlIFx1MDBFMCBsYSBwb3NpdGlvbiBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlBpeGVscyBwYXIgbG90XCIsXG4gICAgYmF0Y2hTaXplOiBcIlRhaWxsZSBkdSBsb3RcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlByb2NoYWluIGxvdCBkYW5zXCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJVdGlsaXNlciB0b3V0ZXMgbGVzIGNoYXJnZXMgZGlzcG9uaWJsZXNcIixcbiAgICBzaG93T3ZlcmxheTogXCJBZmZpY2hlciBsJ292ZXJsYXlcIixcbiAgICBtYXhDaGFyZ2VzOiBcIkNoYXJnZXMgbWF4IHBhciBsb3RcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgRW4gYXR0ZW50ZSBkZSBjaGFyZ2VzOiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlRlbXBzIHJlc3RhbnRcIixcbiAgICBjb29sZG93bldhaXRpbmc6IFwiXHUyM0YzIEF0dGVuZHJlIHt0aW1lfSBwb3VyIGNvbnRpbnVlci4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFByb2dyXHUwMEU4cyBzYXV2ZWdhcmRcdTAwRTkgc291cyB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFByb2dyXHUwMEU4cyBjaGFyZ1x1MDBFOToge3BhaW50ZWR9L3t0b3RhbH0gcGl4ZWxzIHBlaW50c1wiLFxuICAgIHByb2dyZXNzTG9hZEVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkdSBjaGFyZ2VtZW50IGR1IHByb2dyXHUwMEU4czoge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsYSBzYXV2ZWdhcmRlIGR1IHByb2dyXHUwMEU4czoge2Vycm9yfVwiLFxuICAgIGNvbmZpcm1TYXZlUHJvZ3Jlc3M6IFwiVm91bGV6LXZvdXMgc2F1dmVnYXJkZXIgbGUgcHJvZ3JcdTAwRThzIGFjdHVlbCBhdmFudCBkJ2Fyclx1MDBFQXRlcj9cIixcbiAgICBzYXZlUHJvZ3Jlc3NUaXRsZTogXCJTYXV2ZWdhcmRlciBQcm9nclx1MDBFOHNcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiQWJhbmRvbm5lclwiLFxuICAgIGNhbmNlbDogXCJBbm51bGVyXCIsXG4gICAgbWluaW1pemU6IFwiTWluaW1pc2VyXCIsXG4gICAgd2lkdGg6IFwiTGFyZ2V1clwiLFxuICAgIGhlaWdodDogXCJIYXV0ZXVyXCIsIFxuICAgIGtlZXBBc3BlY3Q6IFwiR2FyZGVyIGxlcyBwcm9wb3J0aW9uc1wiLFxuICAgIGFwcGx5OiBcIkFwcGxpcXVlclwiLFxuICBvdmVybGF5T246IFwiT3ZlcmxheSA6IE9OXCIsXG4gIG92ZXJsYXlPZmY6IFwiT3ZlcmxheSA6IE9GRlwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFBhc3NhZ2UgdGVybWluXHUwMEU5OiB7cGFpbnRlZH0gcGl4ZWxzIHBlaW50cyB8IFByb2dyXHUwMEU4czoge3BlcmNlbnR9JSAoe2N1cnJlbnR9L3t0b3RhbH0pXCIsXG4gICAgd2FpdGluZ0NoYXJnZXNSZWdlbjogXCJcdTIzRjMgQXR0ZW50ZSBkZSByXHUwMEU5Z1x1MDBFOW5cdTAwRTlyYXRpb24gZGVzIGNoYXJnZXM6IHtjdXJyZW50fS97bmVlZGVkfSAtIFRlbXBzOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgQXR0ZW50ZSBkZXMgY2hhcmdlczoge2N1cnJlbnR9L3tuZWVkZWR9IC0gUmVzdGFudDoge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgSW5pdGlhbGlzYXRpb24gYXV0b21hdGlxdWUuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IEJvdCBkXHUwMEU5bWFyclx1MDBFOSBhdXRvbWF0aXF1ZW1lbnRcIixcbiAgICBhdXRvSW5pdEZhaWxlZDogXCJcdTI2QTBcdUZFMEYgSW1wb3NzaWJsZSBkZSBkXHUwMEU5bWFycmVyIGF1dG9tYXRpcXVlbWVudC4gVXRpbGlzZXogbGUgYm91dG9uIG1hbnVlbC5cIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFBhbGV0dGUgZGUgY291bGV1cnMgZFx1MDBFOXRlY3RcdTAwRTllXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBSZWNoZXJjaGUgZGUgbGEgcGFsZXR0ZSBkZSBjb3VsZXVycy4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IENsaWMgc3VyIGxlIGJvdXRvbiBQYWludC4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIEJvdXRvbiBQYWludCBpbnRyb3V2YWJsZVwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pdGlhbGlzYXRpb24gbWFudWVsbGUgcmVxdWlzZVwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgVGVudGF0aXZlIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IGRhbnMge2RlbGF5fXMuLi5cIixcbiAgICByZXRyeUVycm9yOiBcIlx1RDgzRFx1RENBNSBFcnJldXIgZGFucyB0ZW50YXRpdmUge2F0dGVtcHR9L3ttYXhBdHRlbXB0c30sIG5vdXZlbCBlc3NhaSBkYW5zIHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIFx1MDBDOWNoZWMgYXByXHUwMEU4cyB7bWF4QXR0ZW1wdHN9IHRlbnRhdGl2ZXMuIENvbnRpbnVhbnQgYXZlYyBsZSBsb3Qgc3VpdmFudC4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgRXJyZXVyIHJcdTAwRTlzZWF1LiBOb3V2ZWwgZXNzYWkuLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgRXJyZXVyIHNlcnZldXIuIE5vdXZlbCBlc3NhaS4uLlwiLFxuICAgIHRpbWVvdXRFcnJvcjogXCJcdTIzRjAgVGltZW91dCBzZXJ2ZXVyLiBOb3V2ZWwgZXNzYWkuLi5cIlxuICB9LFxuXG4gIC8vIEZhcm0gTW9kdWxlICh0byBiZSBpbXBsZW1lbnRlZClcbiAgZmFybToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBGYXJtIEJvdFwiLFxuICAgIHN0YXJ0OiBcIkRcdTAwRTltYXJyZXJcIixcbiAgICBzdG9wOiBcIkFyclx1MDBFQXRlclwiLFxuICAgIHN0b3BwZWQ6IFwiQm90IGFyclx1MDBFQXRcdTAwRTlcIixcbiAgICBjYWxpYnJhdGU6IFwiQ2FsaWJyZXJcIixcbiAgICBwYWludE9uY2U6IFwiVW5lIGZvaXNcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJWXHUwMEU5cmlmaWNhdGlvbiBkdSBzdGF0dXQuLi5cIixcbiAgICBjb25maWd1cmF0aW9uOiBcIkNvbmZpZ3VyYXRpb25cIixcbiAgICBkZWxheTogXCJEXHUwMEU5bGFpIChtcylcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJQaXhlbHMvbG90XCIsXG4gICAgbWluQ2hhcmdlczogXCJDaGFyZ2VzIG1pblwiLFxuICAgIGNvbG9yTW9kZTogXCJNb2RlIGNvdWxldXJcIixcbiAgICByYW5kb206IFwiQWxcdTAwRTlhdG9pcmVcIixcbiAgICBmaXhlZDogXCJGaXhlXCIsXG4gICAgcmFuZ2U6IFwiUGxhZ2VcIixcbiAgICBmaXhlZENvbG9yOiBcIkNvdWxldXIgZml4ZVwiLFxuICAgIGFkdmFuY2VkOiBcIkF2YW5jXHUwMEU5XCIsXG4gICAgdGlsZVg6IFwiVHVpbGUgWFwiLFxuICAgIHRpbGVZOiBcIlR1aWxlIFlcIixcbiAgICBjdXN0b21QYWxldHRlOiBcIlBhbGV0dGUgcGVyc29ubmFsaXNcdTAwRTllXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiZXg6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJDYXB0dXJlclwiLFxuICAgIHBhaW50ZWQ6IFwiUGVpbnRzXCIsXG4gICAgY2hhcmdlczogXCJDaGFyZ2VzXCIsXG4gICAgcmV0cmllczogXCJcdTAwQzljaGVjc1wiLFxuICAgIHRpbGU6IFwiVHVpbGVcIixcbiAgICBjb25maWdTYXZlZDogXCJDb25maWd1cmF0aW9uIHNhdXZlZ2FyZFx1MDBFOWVcIixcbiAgICBjb25maWdMb2FkZWQ6IFwiQ29uZmlndXJhdGlvbiBjaGFyZ1x1MDBFOWVcIixcbiAgICBjb25maWdSZXNldDogXCJDb25maWd1cmF0aW9uIHJcdTAwRTlpbml0aWFsaXNcdTAwRTllXCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJQZWluZHJlIHVuIHBpeGVsIG1hbnVlbGxlbWVudCBwb3VyIGNhcHR1cmVyIGxlcyBjb29yZG9ublx1MDBFOWVzLi4uXCIsXG4gICAgYmFja2VuZE9ubGluZTogXCJCYWNrZW5kIEVuIGxpZ25lXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiQmFja2VuZCBIb3JzIGxpZ25lXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiRFx1MDBFOW1hcnJhZ2UgZHUgYm90Li4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiQXJyXHUwMEVBdCBkdSBib3QuLi5cIixcbiAgICBjYWxpYnJhdGluZzogXCJDYWxpYnJhZ2UuLi5cIixcbiAgICBhbHJlYWR5UnVubmluZzogXCJBdXRvLUZhcm0gZXN0IGRcdTAwRTlqXHUwMEUwIGVuIGNvdXJzIGQnZXhcdTAwRTljdXRpb24uXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJBdXRvLUltYWdlIGVzdCBlbiBjb3VycyBkJ2V4XHUwMEU5Y3V0aW9uLiBGZXJtZXotbGUgYXZhbnQgZGUgZFx1MDBFOW1hcnJlciBBdXRvLUZhcm0uXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiU1x1MDBFOWxlY3Rpb25uZXIgWm9uZVwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFBlaWduZXogdW4gcGl4ZWwgZGFucyB1bmUgem9uZSBWSURFIGRlIGxhIGNhcnRlIHBvdXIgZFx1MDBFOWZpbmlyIGxhIHpvbmUgZGUgZmFybWluZ1wiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgRW4gYXR0ZW50ZSBxdWUgdm91cyBwZWlnbmlleiBsZSBwaXhlbCBkZSByXHUwMEU5Zlx1MDBFOXJlbmNlLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFpvbmUgZFx1MDBFOWZpbmllISBSYXlvbjogNTAwcHhcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIERcdTAwRTlsYWkgZFx1MDBFOXBhc3NcdTAwRTkgcG91ciBsYSBzXHUwMEU5bGVjdGlvbiBkZSB6b25lXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBTXHUwMEU5bGVjdGlvbm5leiB1bmUgem9uZSBkJ2Fib3JkIGVuIHV0aWxpc2FudCAnU1x1MDBFOWxlY3Rpb25uZXIgWm9uZSdcIixcbiAgICBmYXJtUmFkaXVzOiBcIlJheW9uIGZhcm1cIixcbiAgICBwb3NpdGlvbkluZm86IFwiWm9uZSBhY3R1ZWxsZVwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgRmFybWluZyBkYW5zIHVuIHJheW9uIGRlIHtyYWRpdXN9cHggZGVwdWlzICh7eH0se3l9KVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgSU1QT1JUQU5UOiBTXHUwMEU5bGVjdGlvbm5leiB1bmUgem9uZSBWSURFIHBvdXIgXHUwMEU5dml0ZXIgbGVzIGNvbmZsaXRzXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJBdWN1bmUgem9uZVwiLFxuICAgIGN1cnJlbnRab25lOiBcIlpvbmU6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgU1x1MDBFOWxlY3Rpb25uZXogdW5lIHpvbmUgZCdhYm9yZC4gUGVpZ25leiB1biBwaXhlbCBzdXIgbGEgY2FydGUgcG91ciBkXHUwMEU5ZmluaXIgbGEgem9uZSBkZSBmYXJtaW5nXCJcbiAgfSxcblxuICAgIC8vIENvbW1vbi9TaGFyZWRcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIk91aVwiLFxuICAgIG5vOiBcIk5vblwiLFxuICAgIG9rOiBcIk9LXCIsXG4gICAgY2FuY2VsOiBcIkFubnVsZXJcIixcbiAgICBjbG9zZTogXCJGZXJtZXJcIixcbiAgICBzYXZlOiBcIlNhdXZlZ2FyZGVyXCIsXG4gICAgbG9hZDogXCJDaGFyZ2VyXCIsXG4gICAgZGVsZXRlOiBcIlN1cHByaW1lclwiLFxuICAgIGVkaXQ6IFwiTW9kaWZpZXJcIixcbiAgICBzdGFydDogXCJEXHUwMEU5bWFycmVyXCIsXG4gICAgc3RvcDogXCJBcnJcdTAwRUF0ZXJcIixcbiAgICBwYXVzZTogXCJQYXVzZVwiLFxuICAgIHJlc3VtZTogXCJSZXByZW5kcmVcIixcbiAgICByZXNldDogXCJSXHUwMEU5aW5pdGlhbGlzZXJcIixcbiAgICBzZXR0aW5nczogXCJQYXJhbVx1MDBFOHRyZXNcIixcbiAgICBoZWxwOiBcIkFpZGVcIixcbiAgICBhYm91dDogXCJcdTAwQzAgcHJvcG9zXCIsXG4gICAgbGFuZ3VhZ2U6IFwiTGFuZ3VlXCIsXG4gICAgbG9hZGluZzogXCJDaGFyZ2VtZW50Li4uXCIsXG4gICAgZXJyb3I6IFwiRXJyZXVyXCIsXG4gICAgc3VjY2VzczogXCJTdWNjXHUwMEU4c1wiLFxuICAgIHdhcm5pbmc6IFwiQXZlcnRpc3NlbWVudFwiLFxuICAgIGluZm86IFwiSW5mb3JtYXRpb25cIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiTGFuZ3VlIGNoYW5nXHUwMEU5ZSBlbiB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgQXV0by1HdWFyZFwiLFxuICAgIGluaXRCb3Q6IFwiSW5pdGlhbGlzZXIgR3VhcmQtQk9UXCIsXG4gICAgc2VsZWN0QXJlYTogXCJTXHUwMEU5bGVjdGlvbm5lciBab25lXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiQ2FwdHVyZXIgWm9uZVwiLFxuICAgIHN0YXJ0UHJvdGVjdGlvbjogXCJEXHUwMEU5bWFycmVyIFByb3RlY3Rpb25cIixcbiAgICBzdG9wUHJvdGVjdGlvbjogXCJBcnJcdTAwRUF0ZXIgUHJvdGVjdGlvblwiLFxuICAgIHVwcGVyTGVmdDogXCJDb2luIFN1cFx1MDBFOXJpZXVyIEdhdWNoZVwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiQ29pbiBJbmZcdTAwRTlyaWV1ciBEcm9pdFwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJQaXhlbHMgUHJvdFx1MDBFOWdcdTAwRTlzXCIsXG4gICAgZGV0ZWN0ZWRDaGFuZ2VzOiBcIkNoYW5nZW1lbnRzIERcdTAwRTl0ZWN0XHUwMEU5c1wiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlBpeGVscyBSXHUwMEU5cGFyXHUwMEU5c1wiLFxuICAgIGNoYXJnZXM6IFwiQ2hhcmdlc1wiLFxuICAgIHdhaXRpbmdJbml0OiBcIkVuIGF0dGVudGUgZCdpbml0aWFsaXNhdGlvbi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBWXHUwMEU5cmlmaWNhdGlvbiBkZXMgY291bGV1cnMgZGlzcG9uaWJsZXMuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBBdWN1bmUgY291bGV1ciB0cm91dlx1MDBFOWUuIE91dnJleiBsYSBwYWxldHRlIGRlIGNvdWxldXJzIHN1ciBsZSBzaXRlLlwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSB7Y291bnR9IGNvdWxldXJzIGRpc3BvbmlibGVzIHRyb3V2XHUwMEU5ZXNcIixcbiAgICBpbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGluaXRpYWxpc1x1MDBFOSBhdmVjIHN1Y2NcdTAwRThzXCIsXG4gICAgaW5pdEVycm9yOiBcIlx1Mjc0QyBFcnJldXIgbG9ycyBkZSBsJ2luaXRpYWxpc2F0aW9uIGRlIEd1YXJkLUJPVFwiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIENvb3Jkb25uXHUwMEU5ZXMgaW52YWxpZGVzXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIExhIHpvbmUgZG9pdCBhdm9pciBsZSBjb2luIHN1cFx1MDBFOXJpZXVyIGdhdWNoZSBpbmZcdTAwRTlyaWV1ciBhdSBjb2luIGluZlx1MDBFOXJpZXVyIGRyb2l0XCIsXG4gICAgYXJlYVRvb0xhcmdlOiBcIlx1Mjc0QyBab25lIHRyb3AgZ3JhbmRlOiB7c2l6ZX0gcGl4ZWxzIChtYXhpbXVtOiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBDYXB0dXJlIGRlIGxhIHpvbmUgZGUgcHJvdGVjdGlvbi4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgWm9uZSBjYXB0dXJcdTAwRTllOiB7Y291bnR9IHBpeGVscyBzb3VzIHByb3RlY3Rpb25cIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIEVycmV1ciBsb3JzIGRlIGxhIGNhcHR1cmUgZGUgem9uZToge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgQ2FwdHVyZXogZCdhYm9yZCB1bmUgem9uZSBkZSBwcm90ZWN0aW9uXCIsXG4gICAgcHJvdGVjdGlvblN0YXJ0ZWQ6IFwiXHVEODNEXHVERUUxXHVGRTBGIFByb3RlY3Rpb24gZFx1MDBFOW1hcnJcdTAwRTllIC0gc3VydmVpbGxhbmNlIGRlIGxhIHpvbmVcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgUHJvdGVjdGlvbiBhcnJcdTAwRUF0XHUwMEU5ZVwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgWm9uZSBwcm90XHUwMEU5Z1x1MDBFOWUgLSBhdWN1biBjaGFuZ2VtZW50IGRcdTAwRTl0ZWN0XHUwMEU5XCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCB7Y291bnR9IGNoYW5nZW1lbnRzIGRcdTAwRTl0ZWN0XHUwMEU5cyBkYW5zIGxhIHpvbmUgcHJvdFx1MDBFOWdcdTAwRTllXCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBSXHUwMEU5cGFyYXRpb24gZGUge2NvdW50fSBwaXhlbHMgYWx0XHUwMEU5clx1MDBFOXMuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IHtjb3VudH0gcGl4ZWxzIHJcdTAwRTlwYXJcdTAwRTlzIGF2ZWMgc3VjY1x1MDBFOHNcIixcbiAgICByZXBhaXJFcnJvcjogXCJcdTI3NEMgRXJyZXVyIGxvcnMgZGUgbGEgclx1MDBFOXBhcmF0aW9uIGRlcyBwaXhlbHM6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIENoYXJnZXMgaW5zdWZmaXNhbnRlcyBwb3VyIHJcdTAwRTlwYXJlciBsZXMgY2hhbmdlbWVudHNcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFZcdTAwRTlyaWZpY2F0aW9uIGRlcyBjaGFuZ2VtZW50cyBkYW5zIGxhIHpvbmUgcHJvdFx1MDBFOWdcdTAwRTllLi4uXCIsXG4gICAgZXJyb3JDaGVja2luZzogXCJcdTI3NEMgRXJyZXVyIGxvcnMgZGUgbGEgdlx1MDBFOXJpZmljYXRpb24gZGVzIGNoYW5nZW1lbnRzOiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIEdhcmRpZW4gYWN0aWYgLSB6b25lIHNvdXMgcHJvdGVjdGlvblwiLFxuICAgIGxhc3RDaGVjazogXCJEZXJuaVx1MDBFOHJlIHZcdTAwRTlyaWZpY2F0aW9uOiB7dGltZX1cIixcbiAgICBuZXh0Q2hlY2s6IFwiUHJvY2hhaW5lIHZcdTAwRTlyaWZpY2F0aW9uIGRhbnM6IHt0aW1lfXNcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBJbml0aWFsaXNhdGlvbiBhdXRvbWF0aXF1ZS4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgR3VhcmQtQk9UIGRcdTAwRTltYXJyXHUwMEU5IGF1dG9tYXRpcXVlbWVudFwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBJbXBvc3NpYmxlIGRlIGRcdTAwRTltYXJyZXIgYXV0b21hdGlxdWVtZW50LiBVdGlsaXNleiBsZSBib3V0b24gbWFudWVsLlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgSW5pdGlhbGlzYXRpb24gbWFudWVsbGUgcmVxdWlzZVwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggUGFsZXR0ZSBkZSBjb3VsZXVycyBkXHUwMEU5dGVjdFx1MDBFOWVcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFJlY2hlcmNoZSBkZSBsYSBwYWxldHRlIGRlIGNvdWxldXJzLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgQ2xpYyBzdXIgbGUgYm91dG9uIFBhaW50Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgQm91dG9uIFBhaW50IGludHJvdXZhYmxlXCIsXG4gICAgc2VsZWN0VXBwZXJMZWZ0OiBcIlx1RDgzQ1x1REZBRiBQZWlnbmV6IHVuIHBpeGVsIGF1IGNvaW4gU1VQXHUwMEM5UklFVVIgR0FVQ0hFIGRlIGxhIHpvbmUgXHUwMEUwIHByb3RcdTAwRTlnZXJcIixcbiAgICBzZWxlY3RMb3dlclJpZ2h0OiBcIlx1RDgzQ1x1REZBRiBNYWludGVuYW50IHBlaWduZXogdW4gcGl4ZWwgYXUgY29pbiBJTkZcdTAwQzlSSUVVUiBEUk9JVCBkZSBsYSB6b25lXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgRW4gYXR0ZW50ZSBkZSBsYSBzXHUwMEU5bGVjdGlvbiBkdSBjb2luIHN1cFx1MDBFOXJpZXVyIGdhdWNoZS4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBFbiBhdHRlbnRlIGRlIGxhIHNcdTAwRTlsZWN0aW9uIGR1IGNvaW4gaW5mXHUwMEU5cmlldXIgZHJvaXQuLi5cIixcbiAgICB1cHBlckxlZnRDYXB0dXJlZDogXCJcdTI3MDUgQ29pbiBzdXBcdTAwRTlyaWV1ciBnYXVjaGUgY2FwdHVyXHUwMEU5OiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBDb2luIGluZlx1MDBFOXJpZXVyIGRyb2l0IGNhcHR1clx1MDBFOTogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIERcdTAwRTlsYWkgZGUgc1x1MDBFOWxlY3Rpb24gZFx1MDBFOXBhc3NcdTAwRTlcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgRXJyZXVyIGRlIHNcdTAwRTlsZWN0aW9uLCB2ZXVpbGxleiByXHUwMEU5ZXNzYXllclwiXG4gIH1cbn07XG4iLCAiZXhwb3J0IGNvbnN0IHJ1ID0ge1xuICAvLyBMYXVuY2hlclxuICBsYXVuY2hlcjoge1xuICAgIHRpdGxlOiAnV1BsYWNlIEF1dG9CT1QnLFxuICAgIGF1dG9GYXJtOiAnXHVEODNDXHVERjNFIFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MjRcdTA0MzBcdTA0NDBcdTA0M0MnLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDE4XHUwNDM3XHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1JyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzMCcsXG4gICAgc2VsZWN0aW9uOiAnXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDNEXHUwNDNFJyxcbiAgICB1c2VyOiAnXHUwNDFGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM1XHUwNDNCXHUwNDRDJyxcbiAgICBjaGFyZ2VzOiAnXHUwNDE4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDRGJyxcbiAgICBiYWNrZW5kOiAnXHUwNDExXHUwNDREXHUwNDNBXHUwNDM1XHUwNDNEXHUwNDM0JyxcbiAgICBkYXRhYmFzZTogJ1x1MDQxMVx1MDQzMFx1MDQzN1x1MDQzMCBcdTA0MzRcdTA0MzBcdTA0M0RcdTA0M0RcdTA0NEJcdTA0NDUnLFxuICAgIHVwdGltZTogJ1x1MDQxMlx1MDQ0MFx1MDQzNVx1MDQzQ1x1MDQ0RiBcdTA0NDBcdTA0MzBcdTA0MzFcdTA0M0VcdTA0NDJcdTA0NEInLFxuICAgIGNsb3NlOiAnXHUwNDE3XHUwNDMwXHUwNDNBXHUwNDQwXHUwNDRCXHUwNDQyXHUwNDRDJyxcbiAgICBsYXVuY2g6ICdcdTA0MTdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzhcdTA0NDJcdTA0NEMnLFxuICAgIGxvYWRpbmc6ICdcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzAnLFxuICAgIGV4ZWN1dGluZzogJ1x1MDQxMlx1MDQ0Qlx1MDQzRlx1MDQzRVx1MDQzQlx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNScsXG4gICAgZG93bmxvYWRpbmc6ICdcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDNBXHUwNDQwXHUwNDM4XHUwNDNGXHUwNDQyXHUwNDMwLi4uJyxcbiAgICBjaG9vc2VCb3Q6ICdcdTA0MTJcdTA0NEJcdTA0MzFcdTA0MzVcdTA0NDBcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwIFx1MDQzOCBcdTA0M0RcdTA0MzBcdTA0MzZcdTA0M0NcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDE3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDRDJyxcbiAgICByZWFkeVRvTGF1bmNoOiAnXHUwNDEzXHUwNDNFXHUwNDQyXHUwNDNFXHUwNDMyXHUwNDNFIFx1MDQzQSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0M0FcdTA0NDMnLFxuICAgIGxvYWRFcnJvcjogJ1x1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzgnLFxuICAgIGxvYWRFcnJvck1zZzogJ1x1MDQxRFx1MDQzNVx1MDQzMlx1MDQzRVx1MDQzN1x1MDQzQ1x1MDQzRVx1MDQzNlx1MDQzRFx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDNEXHUwNDNEXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQzMVx1MDQzRVx1MDQ0Mlx1MDQzMC4gXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDRDXHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzRVx1MDQzNFx1MDQzQVx1MDQzQlx1MDQ0RVx1MDQ0N1x1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0M0JcdTA0MzggXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzNVx1MDQ0OVx1MDQzNSBcdTA0NDBcdTA0MzBcdTA0MzcuJyxcbiAgICBjaGVja2luZzogJ1x1RDgzRFx1REQwNCBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAuLi4nLFxuICAgIG9ubGluZTogJ1x1RDgzRFx1REZFMiBcdTA0MUVcdTA0M0RcdTA0M0JcdTA0MzBcdTA0MzlcdTA0M0QnLFxuICAgIG9mZmxpbmU6ICdcdUQ4M0RcdUREMzQgXHUwNDFFXHUwNDQ0XHUwNDNCXHUwNDMwXHUwNDM5XHUwNDNEJyxcbiAgICBvazogJ1x1RDgzRFx1REZFMiBcdTA0MUVcdTA0MUEnLFxuICAgIGVycm9yOiAnXHVEODNEXHVERDM0IFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCcsXG4gICAgdW5rbm93bjogJy0nXG4gIH0sXG5cbiAgLy8gSW1hZ2UgTW9kdWxlXG4gIGltYWdlOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBpbml0Qm90OiBcIlx1MDQxOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQ0QyBBdXRvLUJPVFwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlx1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MzhcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICByZXNpemVJbWFnZTogXCJcdTA0MThcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDQwXHUwNDMwXHUwNDM3XHUwNDNDXHUwNDM1XHUwNDQwIFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0NcdTA0MzVcdTA0NDFcdTA0NDJcdTA0M0UgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDMwXCIsXG4gICAgc3RhcnRQYWludGluZzogXCJcdTA0MURcdTA0MzBcdTA0NDdcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlx1MDQxRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MVwiLFxuICAgIGxvYWRQcm9ncmVzczogXCJcdTA0MTdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0MzRcdTA0M0VcdTA0NDFcdTA0NDJcdTA0NDNcdTA0M0ZcdTA0M0RcdTA0NEJcdTA0NDUgXHUwNDQ2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHUwNDFFXHUwNDQyXHUwNDNBXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQ0MyBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIgXHUwNDNEXHUwNDMwIFx1MDQ0MVx1MDQzMFx1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0MzggXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQ0MVx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzMCFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHUwNDFEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDNFIHtjb3VudH0gXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlwiLFxuICAgIGxvYWRpbmdJbWFnZTogXCJcdUQ4M0RcdUREQkNcdUZFMEYgXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDNBXHUwNDMwIFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBcdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQ0MSB7Y291bnR9IFx1MDQzNFx1MDQzNVx1MDQzOVx1MDQ0MVx1MDQ0Mlx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQzNVx1MDQzQlx1MDQ0Q1x1MDQzRFx1MDQ0Qlx1MDQzQ1x1MDQzOCBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEZcdTA0M0NcdTA0MzhcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDNBXHUwNDM4IFx1MDQzOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQ0MFx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQ0Mlx1MDQzRVx1MDQzQyBcdTA0M0NcdTA0MzVcdTA0NDFcdTA0NDJcdTA0MzUsIFx1MDQzM1x1MDQzNFx1MDQzNSBcdTA0MzJcdTA0NEIgXHUwNDQ1XHUwNDNFXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDM1LCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDNEXHUwNDNFXHUwNDNBIFx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzOFx1MDQzRFx1MDQzMFx1MDQzQlx1MDQ0MVx1MDQ0RiFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDFcdTA0NDJcdTA0MzBcdTA0NDBcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRGLi4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTA0MUZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDQzXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXHUwNDMwIFx1MDQ0M1x1MDQ0MVx1MDQzRlx1MDQzNVx1MDQ0OFx1MDQzRFx1MDQzRSFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1MDQyMlx1MDQzMFx1MDQzOVx1MDQzQ1x1MDQzMFx1MDQ0M1x1MDQ0MiBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzAgXHUwNDNGXHUwNDNFXHUwNDM3XHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDM4XCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgXHUwNDFGXHUwNDNFXHUwNDM3XHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDRGIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzMCwgXHUwNDNFXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0ZcdTA0M0VcdTA0MzdcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzgsIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzMVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0MzVcdTA0NDlcdTA0MzUgXHUwNDQwXHUwNDMwXHUwNDM3XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDNFIFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIHBhaW50aW5nUHJvZ3Jlc3M6IFwiXHVEODNFXHVEREYxIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MToge3BhaW50ZWR9IFx1MDQzOFx1MDQzNyB7dG90YWx9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOS4uLlwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTIzMUIgXHUwNDFEXHUwNDM1XHUwNDQyIFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMi4gXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IHt0aW1lfS4uLlwiLFxuICAgIHBhaW50aW5nU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHUwNDIwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzVcdTA0M0JcdTA0MzVcdTA0M0NcIixcbiAgICBwYWludGluZ0NvbXBsZXRlOiBcIlx1MjcwNSBcdTA0MjBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ4XHUwNDM1XHUwNDNEXHUwNDNFISB7Y291bnR9IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0M0RcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0M0UuXCIsXG4gICAgcGFpbnRpbmdFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDZcdTA0MzVcdTA0NDFcdTA0NDFcdTA0MzUgXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDRGXCIsXG4gICAgbWlzc2luZ1JlcXVpcmVtZW50czogXCJcdTI3NEMgXHUwNDIxXHUwNDNGXHUwNDM1XHUwNDQwXHUwNDMyXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0MzhcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM4IFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0M0NcdTA0MzVcdTA0NDFcdTA0NDJcdTA0M0UgXHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDNCXHUwNDMwXCIsXG4gICAgcHJvZ3Jlc3M6IFwiXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXCIsXG4gICAgdXNlck5hbWU6IFwiXHUwNDFGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM1XHUwNDNCXHUwNDRDXCIsXG4gICAgcGl4ZWxzOiBcIlx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzOFwiLFxuICAgIGNoYXJnZXM6IFwiXHUwNDE3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDRCXCIsXG4gICAgZXN0aW1hdGVkVGltZTogXCJcdTA0MUZcdTA0NDBcdTA0MzVcdTA0MzRcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0M0VcdTA0MzZcdTA0MzhcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NENcdTA0M0RcdTA0M0VcdTA0MzUgXHUwNDMyXHUwNDQwXHUwNDM1XHUwNDNDXHUwNDRGXCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiXHUwNDFEXHUwNDMwXHUwNDM2XHUwNDNDXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDBBQlx1MDQxN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QyBBdXRvLUJPVFx1MDBCQiwgXHUwNDQ3XHUwNDQyXHUwNDNFXHUwNDMxXHUwNDRCIFx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0MzguLi5cIixcbiAgICByZXNpemVTdWNjZXNzOiBcIlx1MjcwNSBcdTA0MThcdTA0MzdcdTA0M0VcdTA0MzFcdTA0NDBcdTA0MzBcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEXHUwNDNFIFx1MDQzNFx1MDQzRSB7d2lkdGh9eHtoZWlnaHR9XCIsXG4gICAgcGFpbnRpbmdQYXVzZWQ6IFwiXHUyM0Y4XHVGRTBGIFx1MDQyMFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0M0ZcdTA0NDBcdTA0MzhcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDNEXHUwNDMwIFx1MDQzRlx1MDQzRVx1MDQzN1x1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzOCBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1MDQxRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQzNVx1MDQzOSBcdTA0MzIgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDQ1XHUwNDNFXHUwNDM0XHUwNDM1XCIsXG4gICAgYmF0Y2hTaXplOiBcIlx1MDQyMFx1MDQzMFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQ0MCBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDVcdTA0M0VcdTA0MzRcdTA0MzBcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlx1MDQyMVx1MDQzQlx1MDQzNVx1MDQzNFx1MDQ0M1x1MDQ0RVx1MDQ0OVx1MDQzOFx1MDQzOSBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0NDVcdTA0M0VcdTA0MzQgXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3XCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJcdTA0MThcdTA0NDFcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0NENcdTA0MzdcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDMyXHUwNDQxXHUwNDM1IFx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQ0M1x1MDQzRlx1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0NEJcIixcbiAgICBzaG93T3ZlcmxheTogXCJcdTA0MUZcdTA0M0VcdTA0M0FcdTA0MzBcdTA0MzdcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDNEXHUwNDMwXHUwNDNCXHUwNDNFXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDM4XHUwNDM1XCIsXG4gICAgbWF4Q2hhcmdlczogXCJcdTA0MUNcdTA0MzBcdTA0M0FcdTA0NDFcdTA0MzhcdTA0M0NcdTA0MzBcdTA0M0JcdTA0NENcdTA0M0RcdTA0M0VcdTA0MzUgXHUwNDNBXHUwNDNFXHUwNDNCLVx1MDQzMlx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0M0VcdTA0MzIgXHUwNDM3XHUwNDMwIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDNFXHUwNDMyOiB7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHtuZWVkZWR9XCIsXG4gICAgdGltZVJlbWFpbmluZzogXCJcdTA0MTJcdTA0NDBcdTA0MzVcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzggXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNCXHUwNDNFXHUwNDQxXHUwNDRDXCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUge3RpbWV9IFx1MDQzNFx1MDQzQlx1MDQ0RiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzRcdTA0M0VcdTA0M0JcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDEgXHUwNDQxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM1XHUwNDNEIFx1MDQzQVx1MDQzMFx1MDQzQSB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0Q6IHtwYWludGVkfSBcdTA0MzhcdTA0Mzcge3RvdGFsfSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDNEXHUwNDNFXCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0MzNcdTA0NDBcdTA0NDNcdTA0MzdcdTA0M0FcdTA0MzggXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXHUwNDMwOiB7ZXJyb3J9XCIsXG4gICAgcHJvZ3Jlc3NTYXZlRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0NDFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMzXHUwNDQwXHUwNDM1XHUwNDQxXHUwNDQxXHUwNDMwOiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJcdTA0MjFcdTA0M0VcdTA0NDVcdTA0NDBcdTA0MzBcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDQyXHUwNDM1XHUwNDNBXHUwNDQzXHUwNDQ5XHUwNDM4XHUwNDM5IFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MSBcdTA0M0ZcdTA0MzVcdTA0NDBcdTA0MzVcdTA0MzQgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNBXHUwNDNFXHUwNDM5P1wiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlx1MDQyMVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiXHUwNDFEXHUwNDM1IFx1MDQ0MVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQ0Rlx1MDQ0Mlx1MDQ0QyBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzNcdTA0NDBcdTA0MzVcdTA0NDFcdTA0NDFcIixcbiAgICBjYW5jZWw6IFwiXHUwNDFFXHUwNDQyXHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgbWluaW1pemU6IFwiXHUwNDIxXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNEXHUwNDQzXHUwNDQyXHUwNDRDXCIsXG4gICAgd2lkdGg6IFwiXHUwNDI4XHUwNDM4XHUwNDQwXHUwNDM4XHUwNDNEXHUwNDMwXCIsXG4gICAgaGVpZ2h0OiBcIlx1MDQxMlx1MDQ0Qlx1MDQ0MVx1MDQzRVx1MDQ0Mlx1MDQzMFwiLFxuICAgIGtlZXBBc3BlY3Q6IFwiXHUwNDIxXHUwNDNFXHUwNDQ1XHUwNDQwXHUwNDMwXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQ0MVx1MDQzRVx1MDQzRVx1MDQ0Mlx1MDQzRFx1MDQzRVx1MDQ0OFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0NDFcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0VcdTA0M0RcIixcbiAgICBhcHBseTogXCJcdTA0MUZcdTA0NDBcdTA0MzhcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBwYXNzQ29tcGxldGVkOiBcIlx1MjcwNSBcdTA0MUZcdTA0NDBcdTA0M0VcdTA0NDZcdTA0MzVcdTA0NDFcdTA0NDEgXHUwNDM3XHUwNDMwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ4XHUwNDM1XHUwNDNEOiB7cGFpbnRlZH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRSB8IFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzM1x1MDQ0MFx1MDQzNVx1MDQ0MVx1MDQ0MToge3BlcmNlbnR9JSAoe2N1cnJlbnR9IFx1MDQzOFx1MDQzNyB7dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzJcdTA0M0VcdTA0NDFcdTA0M0ZcdTA0M0VcdTA0M0JcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDQwXHUwNDRGXHUwNDM0XHUwNDMwOiB7Y3VycmVudH0gXHUwNDM4XHUwNDM3IHtuZWVkZWR9IC0gXHUwNDEyXHUwNDQwXHUwNDM1XHUwNDNDXHUwNDRGOiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQzRVx1MDQzMjoge2N1cnJlbnR9IFx1MDQzOFx1MDQzNyB7bmVlZGVkfSAtIFx1MDQyMlx1MDQ0MFx1MDQzNVx1MDQzMVx1MDQ0M1x1MDQzNVx1MDQ0Mlx1MDQ0MVx1MDQ0Rjoge3RpbWV9XCIsXG4gICAgYXV0b0luaXRpYWxpemluZzogXCJcdUQ4M0VcdUREMTYgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDNDXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQ3XHUwNDM1XHUwNDQxXHUwNDNBXHUwNDMwXHUwNDRGIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0Ri4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHUwNDExXHUwNDNFXHUwNDQyIFx1MDQ0M1x1MDQ0MVx1MDQzRlx1MDQzNVx1MDQ0OFx1MDQzRFx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0MzhcdTA0M0JcdTA0NDFcdTA0NEYgXHUwNDMwXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDNDXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQ3XHUwNDM1XHUwNDQxXHUwNDNBXHUwNDM4XCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1MDQxRFx1MDQzNSBcdTA0NDNcdTA0MzRcdTA0MzBcdTA0M0JcdTA0M0VcdTA0NDFcdTA0NEMgXHUwNDMyXHUwNDRCXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQS4gXHUwNDE4XHUwNDQxXHUwNDNGXHUwNDNFXHUwNDNCXHUwNDRDXHUwNDM3XHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQ0MyBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0M0VcdTA0MzNcdTA0M0UgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQxXHUwNDNBXHUwNDMwLlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHUwNDI2XHUwNDMyXHUwNDM1XHUwNDQyXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQzMCBcdTA0M0VcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1MDQxRlx1MDQzRVx1MDQzOFx1MDQ0MVx1MDQzQSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzJcdTA0M0VcdTA0MzkgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDRCLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgXHUwNDFEXHUwNDMwXHUwNDM2XHUwNDMwXHUwNDQyXHUwNDM4XHUwNDM1IFx1MDQzQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQzOCBcdTAwQUJQYWludFx1MDBCQi4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1MDQxQVx1MDQzRFx1MDQzRVx1MDQzRlx1MDQzQVx1MDQzMCBcdTAwQUJQYWludFx1MDBCQiBcdTA0M0RcdTA0MzUgXHUwNDNEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBcdTA0MjJcdTA0NDBcdTA0MzVcdTA0MzFcdTA0NDNcdTA0MzVcdTA0NDJcdTA0NDFcdTA0NEYgXHUwNDQwXHUwNDQzXHUwNDQ3XHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgXHUwNDFGXHUwNDNFXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDQwXHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzMCB7YXR0ZW1wdH0gXHUwNDM4XHUwNDM3IHttYXhBdHRlbXB0c30gXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3IHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMiBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0FcdTA0MzUge2F0dGVtcHR9IFx1MDQzOFx1MDQzNyB7bWF4QXR0ZW1wdHN9LCBcdTA0M0ZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3IHtkZWxheX1zLi4uXCIsXG4gICAgcmV0cnlGYWlsZWQ6IFwiXHUyNzRDIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRSBcdTA0NDFcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0NDJcdTA0NEYge21heEF0dGVtcHRzfSBcdTA0M0ZcdTA0M0VcdTA0M0ZcdTA0NEJcdTA0NDJcdTA0M0VcdTA0M0EuIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzNFx1MDQzRVx1MDQzQlx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzIgXHUwNDQxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDQzXHUwNDRFXHUwNDQ5XHUwNDM1XHUwNDNDIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFx1MDQzNS4uLlwiLFxuICAgIG5ldHdvcmtFcnJvcjogXCJcdUQ4M0NcdURGMTAgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQ0MVx1MDQzNVx1MDQ0Mlx1MDQzOC4gXHUwNDFGXHUwNDNFXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDQwXHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzMC4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDM1XHUwNDQwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDMwLiBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBcdTA0MjJcdTA0MzBcdTA0MzlcdTA0M0NcdTA0MzBcdTA0NDNcdTA0NDIgXHUwNDQxXHUwNDM1XHUwNDQwXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDMwLiBcdTA0MUZcdTA0M0VcdTA0MzJcdTA0NDJcdTA0M0VcdTA0NDBcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDRCXHUwNDQyXHUwNDNBXHUwNDMwLi4uXCJcbiAgfSxcblxuICAvLyBGYXJtIE1vZHVsZSAodG8gYmUgaW1wbGVtZW50ZWQpXG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQ1wiLFxuICAgIHN0YXJ0OiBcIlx1MDQxRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHN0b3A6IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcHBlZDogXCJcdTA0MTFcdTA0M0VcdTA0NDIgXHUwNDNFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNCXHUwNDM1XHUwNDNEXCIsXG4gICAgY2FsaWJyYXRlOiBcIlx1MDQxQVx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzMVx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHBhaW50T25jZTogXCJcdTA0MTVcdTA0MzRcdTA0MzhcdTA0M0RcdTA0M0VcdTA0NDBcdTA0MzBcdTA0MzdcdTA0M0VcdTA0MzJcdTA0M0VcIixcbiAgICBjaGVja2luZ1N0YXR1czogXCJcdTA0MUZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAgXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQyXHUwNDQzXHUwNDQxXHUwNDMwLi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJcdTA0MUFcdTA0M0VcdTA0M0RcdTA0NDRcdTA0MzhcdTA0MzNcdTA0NDNcdTA0NDBcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEZcIixcbiAgICBkZWxheTogXCJcdTA0MTdcdTA0MzBcdTA0MzRcdTA0MzVcdTA0NDBcdTA0MzZcdTA0M0FcdTA0MzAgKFx1MDQzQ1x1MDQ0MSlcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTA0MUZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgXHUwNDM3XHUwNDMwIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQ0NVx1MDQzRVx1MDQzNFwiLFxuICAgIG1pbkNoYXJnZXM6IFwiXHUwNDFDXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDNDXHUwNDMwXHUwNDNCXHUwNDRDXHUwNDNEXHUwNDNFXHUwNDM1IFx1MDQzQVx1MDQzRVx1MDQzQi1cdTA0MzJcdTA0M0VcIixcbiAgICBjb2xvck1vZGU6IFwiXHUwNDIwXHUwNDM1XHUwNDM2XHUwNDM4XHUwNDNDIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlwiLFxuICAgIHJhbmRvbTogXCJcdTA0MjFcdTA0M0JcdTA0NDNcdTA0NDdcdTA0MzBcdTA0MzlcdTA0M0RcdTA0NEJcdTA0MzlcIixcbiAgICBmaXhlZDogXCJcdTA0MjRcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzhcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzBcdTA0M0RcdTA0M0RcdTA0NEJcdTA0MzlcIixcbiAgICByYW5nZTogXCJcdTA0MTRcdTA0MzhcdTA0MzBcdTA0M0ZcdTA0MzBcdTA0MzdcdTA0M0VcdTA0M0RcIixcbiAgICBmaXhlZENvbG9yOiBcIlx1MDQyNFx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzOSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcIixcbiAgICBhZHZhbmNlZDogXCJcdTA0MjBcdTA0MzBcdTA0NDFcdTA0NDhcdTA0MzhcdTA0NDBcdTA0MzVcdTA0M0RcdTA0M0RcdTA0NEJcdTA0MzVcIixcbiAgICB0aWxlWDogXCJcdTA0MUZcdTA0M0JcdTA0MzhcdTA0NDJcdTA0M0FcdTA0MzAgWFwiLFxuICAgIHRpbGVZOiBcIlx1MDQxRlx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQzQVx1MDQzMCBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJcdTA0MjFcdTA0MzJcdTA0M0VcdTA0NEYgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDMwXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiXHUwNDNGXHUwNDQwXHUwNDM4XHUwNDNDXHUwNDM1XHUwNDQwOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiXHUwNDE3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXCIsXG4gICAgcGFpbnRlZDogXCJcdTA0MTdcdTA0MzBcdTA0M0FcdTA0NDBcdTA0MzBcdTA0NDhcdTA0MzVcdTA0M0RcdTA0M0VcIixcbiAgICBjaGFyZ2VzOiBcIlx1MDQxN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQ0QlwiLFxuICAgIHJldHJpZXM6IFwiXHUwNDFGXHUwNDNFXHUwNDMyXHUwNDQyXHUwNDNFXHUwNDQwXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQzRlx1MDQzRVx1MDQzRlx1MDQ0Qlx1MDQ0Mlx1MDQzQVx1MDQzOFwiLFxuICAgIHRpbGU6IFwiXHUwNDFGXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDNBXHUwNDMwXCIsXG4gICAgY29uZmlnU2F2ZWQ6IFwiXHUwNDFBXHUwNDNFXHUwNDNEXHUwNDQ0XHUwNDM4XHUwNDMzXHUwNDQzXHUwNDQwXHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGIFx1MDQ0MVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJcdTA0MUFcdTA0M0VcdTA0M0RcdTA0NDRcdTA0MzhcdTA0MzNcdTA0NDNcdTA0NDBcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDMwXCIsXG4gICAgY29uZmlnUmVzZXQ6IFwiXHUwNDIxXHUwNDMxXHUwNDQwXHUwNDNFXHUwNDQxIFx1MDQzQVx1MDQzRVx1MDQzRFx1MDQ0NFx1MDQzOFx1MDQzM1x1MDQ0M1x1MDQ0MFx1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOFwiLFxuICAgIGNhcHR1cmVJbnN0cnVjdGlvbnM6IFwiXHUwNDFEXHUwNDMwXHUwNDQwXHUwNDM4XHUwNDQxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0QyBcdTA0MzJcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0NDNcdTA0NEUgXHUwNDM0XHUwNDNCXHUwNDRGIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzMCBcdTA0M0FcdTA0M0VcdTA0M0VcdTA0NDBcdTA0MzRcdTA0MzhcdTA0M0RcdTA0MzBcdTA0NDIuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIlx1MDQxMVx1MDQ0RFx1MDQzQVx1MDQ0RFx1MDQzRFx1MDQzNCBcdTA0MUVcdTA0M0RcdTA0M0JcdTA0MzBcdTA0MzlcdTA0M0RcIixcbiAgICBiYWNrZW5kT2ZmbGluZTogXCJcdTA0MTFcdTA0NERcdTA0M0FcdTA0NERcdTA0M0RcdTA0MzRcIixcbiAgICBzdGFydGluZ0JvdDogXCJcdTA0MTdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDFcdTA0M0EgXHUwNDMxXHUwNDNFXHUwNDQyXHUwNDMwLi4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiXHUwNDFFXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDNEXHUwNDNFXHUwNDMyXHUwNDNBXHUwNDMwIFx1MDQzMVx1MDQzRVx1MDQ0Mlx1MDQzMC4uLlwiLFxuICAgIGNhbGlicmF0aW5nOiBcIlx1MDQxQVx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzMVx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzQVx1MDQzMC4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIlx1MDQxMFx1MDQzMlx1MDQ0Mlx1MDQzRS1cdTA0MjRcdTA0MzBcdTA0NDBcdTA0M0MgXHUwNDQzXHUwNDM2XHUwNDM1IFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0OVx1MDQzNVx1MDQzRFwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxOFx1MDQzN1x1MDQzRVx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQzNlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzdcdTA0MzBcdTA0M0ZcdTA0NDNcdTA0NDlcdTA0MzVcdTA0M0RcdTA0M0UuIFx1MDQxN1x1MDQzMFx1MDQzQVx1MDQ0MFx1MDQzRVx1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM0IFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQVx1MDQzRVx1MDQzQyBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0UtXHUwNDI0XHUwNDMwXHUwNDQwXHUwNDNDXHUwNDMwLlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQ0MFx1MDQzMFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIHNlbGVjdFBvc2l0aW9uQWxlcnQ6IFwiXHVEODNDXHVERkFGIFx1MDQxRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQxRlx1MDQyM1x1MDQyMVx1MDQyMlx1MDQxRVx1MDQxOSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzggXHUwNDNBXHUwNDMwXHUwNDQwXHUwNDQyXHUwNDRCLCBcdTA0NDdcdTA0NDJcdTA0M0VcdTA0MzFcdTA0NEIgXHUwNDNFXHUwNDMxXHUwNDNFXHUwNDM3XHUwNDNEXHUwNDMwXHUwNDQ3XHUwNDM4XHUwNDQyXHUwNDRDIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0NDRcdTA0MzBcdTA0NDBcdTA0M0NcdTA0MzAuXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBcdTA0MUVcdTA0MzZcdTA0MzhcdTA0MzRcdTA0MzBcdTA0M0RcdTA0MzhcdTA0MzUgXHUwNDQxXHUwNDQyXHUwNDMwXHUwNDQwXHUwNDQyXHUwNDNFXHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQzRlx1MDQzOFx1MDQzQVx1MDQ0MVx1MDQzNVx1MDQzQlx1MDQ0Ri4uLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzMCEgXHUwNDIwXHUwNDMwXHUwNDM0XHUwNDM4XHUwNDQzXHUwNDQxOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHUwNDIyXHUwNDMwXHUwNDM5XHUwNDNDXHUwNDMwXHUwNDQzXHUwNDQyIFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFx1MDQxMlx1MDQ0Qlx1MDQzMVx1MDQzNVx1MDQ0MFx1MDQzOFx1MDQ0Mlx1MDQzNSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NEMgXHUwNDQxIFx1MDQzRlx1MDQzRVx1MDQzQ1x1MDQzRVx1MDQ0OVx1MDQ0Q1x1MDQ0RSBcdTAwQUJcdTA0MTJcdTA0NEJcdTA0MzFcdTA0NDBcdTA0MzBcdTA0NDJcdTA0NEMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDXHUwMEJCXCIsXG4gICAgZmFybVJhZGl1czogXCJcdTA0MjBcdTA0MzBcdTA0MzRcdTA0MzhcdTA0NDNcdTA0NDEgXHUwNDQ0XHUwNDMwXHUwNDQwXHUwNDNDXHUwNDMwXCIsXG4gICAgcG9zaXRpb25JbmZvOiBcIlx1MDQyMlx1MDQzNVx1MDQzQVx1MDQ0M1x1MDQ0OVx1MDQzMFx1MDQ0RiBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NENcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIFx1MDQyNFx1MDQzMFx1MDQ0MFx1MDQzQyBcdTA0MzIgXHUwNDQwXHUwNDMwXHUwNDM0XHUwNDM4XHUwNDQzXHUwNDQxXHUwNDM1IHtyYWRpdXN9cHggXHUwNDNFXHUwNDQyICh7eH0se3l9KVwiLFxuICAgIHNlbGVjdEVtcHR5QXJlYTogXCJcdTI2QTBcdUZFMEYgXHUwNDEyXHUwNDEwXHUwNDE2XHUwNDFEXHUwNDFFOiBcdTA0MTJcdTA0NEJcdTA0MzFcdTA0MzVcdTA0NDBcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDFGXHUwNDIzXHUwNDIxXHUwNDIyXHUwNDIzXHUwNDJFIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QywgXHUwNDQ3XHUwNDQyXHUwNDNFXHUwNDMxXHUwNDRCIFx1MDQzOFx1MDQzN1x1MDQzMVx1MDQzNVx1MDQzNlx1MDQzMFx1MDQ0Mlx1MDQ0QyBcdTA0M0FcdTA0M0VcdTA0M0RcdTA0NDRcdTA0M0JcdTA0MzhcdTA0M0FcdTA0NDJcdTA0M0VcdTA0MzIuXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJcdTA0MURcdTA0MzVcdTA0NDIgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4XCIsXG4gICAgY3VycmVudFpvbmU6IFwiXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDOiAoe3h9LHt5fSlcIixcbiAgICBhdXRvU2VsZWN0UG9zaXRpb246IFwiXHVEODNDXHVERkFGIFx1MDQyMVx1MDQzRFx1MDQzMFx1MDQ0N1x1MDQzMFx1MDQzQlx1MDQzMCBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0MzVcdTA0NDBcdTA0MzhcdTA0NDJcdTA0MzUgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDLiBcdTA0MURcdTA0MzBcdTA0NDBcdTA0MzhcdTA0NDFcdTA0NDNcdTA0MzlcdTA0NDJcdTA0MzUgXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDRDIFx1MDQzRFx1MDQzMCBcdTA0M0FcdTA0MzBcdTA0NDBcdTA0NDJcdTA0MzUsIFx1MDQ0N1x1MDQ0Mlx1MDQzRVx1MDQzMVx1MDQ0QiBcdTA0M0VcdTA0MzFcdTA0M0VcdTA0MzdcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzhcdTA0NDJcdTA0NEMgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0NFx1MDQzMFx1MDQ0MFx1MDQzQ1x1MDQzMC5cIlxuICB9LFxuXG4gIC8vIENvbW1vbi9TaGFyZWRcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIlx1MDQxNFx1MDQzMFwiLFxuICAgIG5vOiBcIlx1MDQxRFx1MDQzNVx1MDQ0MlwiLFxuICAgIG9rOiBcIlx1MDQxRVx1MDQxQVwiLFxuICAgIGNhbmNlbDogXCJcdTA0MUVcdTA0NDJcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBjbG9zZTogXCJcdTA0MTdcdTA0MzBcdTA0M0FcdTA0NDBcdTA0NEJcdTA0NDJcdTA0NENcIixcbiAgICBzYXZlOiBcIlx1MDQyMVx1MDQzRVx1MDQ0NVx1MDQ0MFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGxvYWQ6IFwiXHUwNDE3XHUwNDMwXHUwNDMzXHUwNDQwXHUwNDQzXHUwNDM3XHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgZGVsZXRlOiBcIlx1MDQyM1x1MDQzNFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGVkaXQ6IFwiXHUwNDE4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgc3RhcnQ6IFwiXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDXCIsXG4gICAgc3RvcDogXCJcdTA0MTdcdTA0MzBcdTA0M0FcdTA0M0VcdTA0M0RcdTA0NDdcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICBwYXVzZTogXCJcdTA0MUZcdTA0NDBcdTA0MzhcdTA0M0VcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0MzhcdTA0NDJcdTA0NENcIixcbiAgICByZXN1bWU6IFwiXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDM0XHUwNDNFXHUwNDNCXHUwNDM2XHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgcmVzZXQ6IFwiXHUwNDIxXHUwNDMxXHUwNDQwXHUwNDNFXHUwNDQxXHUwNDM4XHUwNDQyXHUwNDRDXCIsXG4gICAgc2V0dGluZ3M6IFwiXHUwNDFEXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDNBXHUwNDM4XCIsXG4gICAgaGVscDogXCJcdTA0MUZcdTA0M0VcdTA0M0NcdTA0M0VcdTA0NDlcdTA0NENcIixcbiAgICBhYm91dDogXCJcdTA0MThcdTA0M0RcdTA0NDRcdTA0M0VcdTA0NDBcdTA0M0NcdTA0MzBcdTA0NDZcdTA0MzhcdTA0NEZcIixcbiAgICBsYW5ndWFnZTogXCJcdTA0MkZcdTA0MzdcdTA0NEJcdTA0M0FcIixcbiAgICBsb2FkaW5nOiBcIlx1MDQxN1x1MDQzMFx1MDQzM1x1MDQ0MFx1MDQ0M1x1MDQzN1x1MDQzQVx1MDQzMC4uLlwiLFxuICAgIGVycm9yOiBcIlx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMFwiLFxuICAgIHN1Y2Nlc3M6IFwiXHUwNDIzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ1XCIsXG4gICAgd2FybmluZzogXCJcdTA0MUZcdTA0NDBcdTA0MzVcdTA0MzRcdTA0NDNcdTA0M0ZcdTA0NDBcdTA0MzVcdTA0MzZcdTA0MzRcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzVcIixcbiAgICBpbmZvOiBcIlx1MDQxOFx1MDQzRFx1MDQ0NFx1MDQzRVx1MDQ0MFx1MDQzQ1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQ0RlwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJcdTA0MkZcdTA0MzdcdTA0NEJcdTA0M0EgXHUwNDM4XHUwNDM3XHUwNDNDXHUwNDM1XHUwNDNEXHUwNDM1XHUwNDNEIFx1MDQzRFx1MDQzMCB7bGFuZ3VhZ2V9XCJcbiAgfSxcblxuICAvLyBHdWFyZCBNb2R1bGVcbiAgZ3VhcmQ6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHUwNDEwXHUwNDMyXHUwNDQyXHUwNDNFLVx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQzMFwiLFxuICAgIGluaXRCb3Q6IFwiXHUwNDE4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDM4XHUwNDQwXHUwNDNFXHUwNDMyXHUwNDMwXHUwNDQyXHUwNDRDIEd1YXJkLUJPVFwiLFxuICAgIHNlbGVjdEFyZWE6IFwiXHUwNDEyXHUwNDRCXHUwNDMxXHUwNDQwXHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0Q1wiLFxuICAgIGNhcHR1cmVBcmVhOiBcIlx1MDQxN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MUVcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0NENcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiXHUwNDFEXHUwNDMwXHUwNDQ3XHUwNDMwXHUwNDQyXHUwNDRDIFx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0Mlx1MDQ0M1wiLFxuICAgIHN0b3BQcm90ZWN0aW9uOiBcIlx1MDQxRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MTdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NDNcIixcbiAgICB1cHBlckxlZnQ6IFwiXHUwNDEyXHUwNDM1XHUwNDQwXHUwNDQ1XHUwNDNEXHUwNDM4XHUwNDM5IFx1MDQxQlx1MDQzNVx1MDQzMlx1MDQ0Qlx1MDQzOSBcdTA0MjNcdTA0MzNcdTA0M0VcdTA0M0JcIixcbiAgICBsb3dlclJpZ2h0OiBcIlx1MDQxRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0MUZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDIzXHUwNDMzXHUwNDNFXHUwNDNCXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlx1MDQxN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0MUZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzhcIixcbiAgICBkZXRlY3RlZENoYW5nZXM6IFwiXHUwNDFFXHUwNDMxXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDRCXHUwNDM1IFx1MDQxOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RlwiLFxuICAgIHJlcGFpcmVkUGl4ZWxzOiBcIlx1MDQxMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQzNSBcdTA0MUZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzhcIixcbiAgICBjaGFyZ2VzOiBcIlx1MDQxN1x1MDQzMFx1MDQ0MFx1MDQ0Rlx1MDQzNFx1MDQ0QlwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzhcdTA0M0RcdTA0MzhcdTA0NDZcdTA0MzhcdTA0MzBcdTA0M0JcdTA0MzhcdTA0MzdcdTA0MzBcdTA0NDZcdTA0MzhcdTA0MzguLi5cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0NcdURGQTggXHUwNDFGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDMwIFx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQ0M1x1MDQzRlx1MDQzRFx1MDQ0Qlx1MDQ0NSBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTA0MjZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0MzAgXHUwNDNEXHUwNDM1IFx1MDQzRFx1MDQzMFx1MDQzOVx1MDQzNFx1MDQzNVx1MDQzRFx1MDQ0Qi4gXHUwNDFFXHUwNDQyXHUwNDNBXHUwNDQwXHUwNDNFXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQzRlx1MDQzMFx1MDQzQlx1MDQzOFx1MDQ0Mlx1MDQ0MFx1MDQ0MyBcdTA0NDZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzIgXHUwNDNEXHUwNDMwIFx1MDQ0MVx1MDQzMFx1MDQzOVx1MDQ0Mlx1MDQzNS5cIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHUwNDFEXHUwNDMwXHUwNDM5XHUwNDM0XHUwNDM1XHUwNDNEXHUwNDNFIHtjb3VudH0gXHUwNDM0XHUwNDNFXHUwNDQxXHUwNDQyXHUwNDQzXHUwNDNGXHUwNDNEXHUwNDRCXHUwNDQ1IFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlwiLFxuICAgIGluaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgXHUwNDQzXHUwNDQxXHUwNDNGXHUwNDM1XHUwNDQ4XHUwNDNEXHUwNDNFIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzOFx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzMFx1MDQzRFwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzOFx1MDQzRFx1MDQzOFx1MDQ0Nlx1MDQzOFx1MDQzMFx1MDQzQlx1MDQzOFx1MDQzN1x1MDQzMFx1MDQ0Nlx1MDQzOFx1MDQzOCBHdWFyZC1CT1RcIixcbiAgICBpbnZhbGlkQ29vcmRzOiBcIlx1Mjc0QyBcdTA0MURcdTA0MzVcdTA0MzRcdTA0MzVcdTA0MzlcdTA0NDFcdTA0NDJcdTA0MzJcdTA0MzhcdTA0NDJcdTA0MzVcdTA0M0JcdTA0NENcdTA0M0RcdTA0NEJcdTA0MzUgXHUwNDNBXHUwNDNFXHUwNDNFXHUwNDQwXHUwNDM0XHUwNDM4XHUwNDNEXHUwNDMwXHUwNDQyXHUwNDRCXCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0MzRcdTA0M0VcdTA0M0JcdTA0MzZcdTA0M0RcdTA0MzAgXHUwNDM4XHUwNDNDXHUwNDM1XHUwNDQyXHUwNDRDIFx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQ0NVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0JcdTA0MzVcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDQzXHUwNDMzXHUwNDNFXHUwNDNCIFx1MDQzQ1x1MDQzNVx1MDQzRFx1MDQ0Q1x1MDQ0OFx1MDQzNSBcdTA0M0RcdTA0MzhcdTA0MzZcdTA0M0RcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDQwXHUwNDMwXHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQ0M1x1MDQzM1x1MDQzQlx1MDQzMFwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHUwNDFFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQ0MVx1MDQzQlx1MDQzOFx1MDQ0OFx1MDQzQVx1MDQzRVx1MDQzQyBcdTA0MzFcdTA0M0VcdTA0M0JcdTA0NENcdTA0NDhcdTA0MzBcdTA0NEY6IHtzaXplfSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkgKFx1MDQzQ1x1MDQzMFx1MDQzQVx1MDQ0MVx1MDQzOFx1MDQzQ1x1MDQ0M1x1MDQzQzoge21heH0pXCIsXG4gICAgY2FwdHVyaW5nQXJlYTogXCJcdUQ4M0RcdURDRjggXHUwNDE3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOCBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NEIuLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDQxRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDdcdTA0MzVcdTA0M0RcdTA0MzA6IHtjb3VudH0gXHUwNDNGXHUwNDM4XHUwNDNBXHUwNDQxXHUwNDM1XHUwNDNCXHUwNDM1XHUwNDM5IFx1MDQzRlx1MDQzRVx1MDQzNCBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0M0VcdTA0MzlcIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDJcdTA0MzAgXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDM4OiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBcdTA0MjFcdTA0M0RcdTA0MzBcdTA0NDdcdTA0MzBcdTA0M0JcdTA0MzAgXHUwNDM3XHUwNDMwXHUwNDQ1XHUwNDMyXHUwNDMwXHUwNDQyXHUwNDM4XHUwNDQyXHUwNDM1IFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0NEJcIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzMCAtIFx1MDQzQ1x1MDQzRVx1MDQzRFx1MDQzOFx1MDQ0Mlx1MDQzRVx1MDQ0MFx1MDQzOFx1MDQzRFx1MDQzMyBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICBwcm90ZWN0aW9uU3RvcHBlZDogXCJcdTIzRjlcdUZFMEYgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDMwIFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHUwNDE3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQ5XHUwNDM1XHUwNDNEXHUwNDNEXHUwNDMwXHUwNDRGIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQ0QyAtIFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0RcdTA0MzUgXHUwNDNFXHUwNDMxXHUwNDNEXHUwNDMwXHUwNDQwXHUwNDQzXHUwNDM2XHUwNDM1XHUwNDNEXHUwNDNFXCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCB7Y291bnR9IFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0VcdTA0MzFcdTA0M0RcdTA0MzBcdTA0NDBcdTA0NDNcdTA0MzZcdTA0MzVcdTA0M0RcdTA0M0UgXHUwNDMyIFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRFx1MDQzRVx1MDQzOSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzhcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFx1MDQxMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzNSB7Y291bnR9IFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzRFx1MDQ0Qlx1MDQ0NSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzkuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFx1MDQyM1x1MDQ0MVx1MDQzRlx1MDQzNVx1MDQ0OFx1MDQzRFx1MDQzRSBcdTA0MzJcdTA0M0VcdTA0NDFcdTA0NDFcdTA0NDJcdTA0MzBcdTA0M0RcdTA0M0VcdTA0MzJcdTA0M0JcdTA0MzVcdTA0M0RcdTA0M0Uge2NvdW50fSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0MzlcIixcbiAgICByZXBhaXJFcnJvcjogXCJcdTI3NEMgXHUwNDFFXHUwNDQ4XHUwNDM4XHUwNDMxXHUwNDNBXHUwNDMwIFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0MzVcdTA0Mzk6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIFx1MDQxRFx1MDQzNVx1MDQzNFx1MDQzRVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQ0Mlx1MDQzRVx1MDQ0N1x1MDQzRFx1MDQzRSBcdTA0MzdcdTA0MzBcdTA0NDBcdTA0NEZcdTA0MzRcdTA0M0VcdTA0MzIgXHUwNDM0XHUwNDNCXHUwNDRGIFx1MDQzMlx1MDQzRVx1MDQ0MVx1MDQ0MVx1MDQ0Mlx1MDQzMFx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzQlx1MDQzNVx1MDQzRFx1MDQzOFx1MDQ0RiBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzlcIixcbiAgICBjaGVja2luZ0NoYW5nZXM6IFwiXHVEODNEXHVERDBEIFx1MDQxRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMCBcdTA0MzhcdTA0MzdcdTA0M0NcdTA0MzVcdTA0M0RcdTA0MzVcdTA0M0RcdTA0MzhcdTA0MzkgXHUwNDMyIFx1MDQzN1x1MDQzMFx1MDQ0OVx1MDQzOFx1MDQ0OVx1MDQzNVx1MDQzRFx1MDQzRFx1MDQzRVx1MDQzOSBcdTA0M0VcdTA0MzFcdTA0M0JcdTA0MzBcdTA0NDFcdTA0NDJcdTA0MzguLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBcdTA0MUVcdTA0NDhcdTA0MzhcdTA0MzFcdTA0M0FcdTA0MzAgXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDNBXHUwNDM4IFx1MDQzOFx1MDQzN1x1MDQzQ1x1MDQzNVx1MDQzRFx1MDQzNVx1MDQzRFx1MDQzOFx1MDQzOToge2Vycm9yfVwiLFxuICAgIGd1YXJkQWN0aXZlOiBcIlx1RDgzRFx1REVFMVx1RkUwRiBcdTA0MjFcdTA0NDJcdTA0NDBcdTA0MzBcdTA0MzYgXHUwNDMwXHUwNDNBXHUwNDQyXHUwNDM4XHUwNDMyXHUwNDM1XHUwNDNEIC0gXHUwNDNFXHUwNDMxXHUwNDNCXHUwNDMwXHUwNDQxXHUwNDQyXHUwNDRDIFx1MDQzRlx1MDQzRVx1MDQzNCBcdTA0MzdcdTA0MzBcdTA0NDlcdTA0MzhcdTA0NDJcdTA0M0VcdTA0MzlcIixcbiAgICBsYXN0Q2hlY2s6IFwiXHUwNDFGXHUwNDNFXHUwNDQxXHUwNDNCXHUwNDM1XHUwNDM0XHUwNDNEXHUwNDRGXHUwNDRGIFx1MDQzRlx1MDQ0MFx1MDQzRVx1MDQzMlx1MDQzNVx1MDQ0MFx1MDQzQVx1MDQzMDoge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIlx1MDQyMVx1MDQzQlx1MDQzNVx1MDQzNFx1MDQ0M1x1MDQ0RVx1MDQ0OVx1MDQzMFx1MDQ0RiBcdTA0M0ZcdTA0NDBcdTA0M0VcdTA0MzJcdTA0MzVcdTA0NDBcdTA0M0FcdTA0MzAgXHUwNDQ3XHUwNDM1XHUwNDQwXHUwNDM1XHUwNDM3OiB7dGltZX1cdTA0NDFcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTA0MTBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGLi4uXCIsXG4gICAgYXV0b0luaXRTdWNjZXNzOiBcIlx1MjcwNSBHdWFyZC1CT1QgXHUwNDM3XHUwNDMwXHUwNDNGXHUwNDQzXHUwNDQ5XHUwNDM1XHUwNDNEIFx1MDQzMFx1MDQzMlx1MDQ0Mlx1MDQzRVx1MDQzQ1x1MDQzMFx1MDQ0Mlx1MDQzOFx1MDQ0N1x1MDQzNVx1MDQ0MVx1MDQzQVx1MDQzOFwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBcdTA0MURcdTA0MzUgXHUwNDQzXHUwNDM0XHUwNDMwXHUwNDNCXHUwNDNFXHUwNDQxXHUwNDRDIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQ0Mlx1MDQzOFx1MDQ0Mlx1MDQ0QyBcdTA0MzBcdTA0MzJcdTA0NDJcdTA0M0VcdTA0M0NcdTA0MzBcdTA0NDJcdTA0MzhcdTA0NDdcdTA0MzVcdTA0NDFcdTA0M0FcdTA0MzguIFx1MDQxOFx1MDQ0MVx1MDQzRlx1MDQzRVx1MDQzQlx1MDQ0Q1x1MDQzN1x1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0FcdTA0M0RcdTA0M0VcdTA0M0ZcdTA0M0FcdTA0NDMgXHUwNDQwXHUwNDQzXHUwNDQ3XHUwNDNEXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQzN1x1MDQzMFx1MDQzRlx1MDQ0M1x1MDQ0MVx1MDQzQVx1MDQzMC5cIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1MDQyMlx1MDQ0MFx1MDQzNVx1MDQzMVx1MDQ0M1x1MDQzNVx1MDQ0Mlx1MDQ0MVx1MDQ0RiBcdTA0NDBcdTA0NDNcdTA0NDdcdTA0M0RcdTA0MzBcdTA0NEYgXHUwNDM4XHUwNDNEXHUwNDM4XHUwNDQ2XHUwNDM4XHUwNDMwXHUwNDNCXHUwNDM4XHUwNDM3XHUwNDMwXHUwNDQ2XHUwNDM4XHUwNDRGXCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTA0MjZcdTA0MzJcdTA0MzVcdTA0NDJcdTA0M0VcdTA0MzJcdTA0MzBcdTA0NEYgXHUwNDNGXHUwNDMwXHUwNDNCXHUwNDM4XHUwNDQyXHUwNDQwXHUwNDMwIFx1MDQzRVx1MDQzMVx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQ0M1x1MDQzNlx1MDQzNVx1MDQzRFx1MDQzMFwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHUwNDFGXHUwNDNFXHUwNDM4XHUwNDQxXHUwNDNBIFx1MDQ0Nlx1MDQzMlx1MDQzNVx1MDQ0Mlx1MDQzRVx1MDQzMlx1MDQzRVx1MDQzOSBcdTA0M0ZcdTA0MzBcdTA0M0JcdTA0MzhcdTA0NDJcdTA0NDBcdTA0NEIuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTA0MURcdTA0MzBcdTA0MzZcdTA0MzBcdTA0NDJcdTA0MzhcdTA0MzUgXHUwNDNBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDM4IFx1MDBBQlBhaW50XHUwMEJCLi4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHUwNDFBXHUwNDNEXHUwNDNFXHUwNDNGXHUwNDNBXHUwNDMwIFx1MDBBQlBhaW50XHUwMEJCIFx1MDQzRFx1MDQzNSBcdTA0M0RcdTA0MzBcdTA0MzlcdTA0MzRcdTA0MzVcdTA0M0RcdTA0MzBcIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFx1MDQxRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQxMlx1MDQxNVx1MDQyMFx1MDQyNVx1MDQxRFx1MDQxNVx1MDQxQyBcdTA0MUJcdTA0MTVcdTA0MTJcdTA0MUVcdTA0MUMgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDQzIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOCBcdTA0MzRcdTA0M0JcdTA0NEYgXHUwNDM3XHUwNDMwXHUwNDQ5XHUwNDM4XHUwNDQyXHUwNDRCXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgXHUwNDIyXHUwNDM1XHUwNDNGXHUwNDM1XHUwNDQwXHUwNDRDIFx1MDQzRFx1MDQzMFx1MDQ0MFx1MDQzOFx1MDQ0MVx1MDQ0M1x1MDQzOVx1MDQ0Mlx1MDQzNSBcdTA0M0ZcdTA0MzhcdTA0M0FcdTA0NDFcdTA0MzVcdTA0M0JcdTA0NEMgXHUwNDMyIFx1MDQxRFx1MDQxOFx1MDQxNlx1MDQxRFx1MDQxNVx1MDQxQyBcdTA0MUZcdTA0MjBcdTA0MTBcdTA0MTJcdTA0MUVcdTA0MUMgXHUwNDQzXHUwNDMzXHUwNDNCXHUwNDQzIFx1MDQzRVx1MDQzMVx1MDQzQlx1MDQzMFx1MDQ0MVx1MDQ0Mlx1MDQzOFwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IFx1MDQxRVx1MDQzNlx1MDQzOFx1MDQzNFx1MDQzMFx1MDQzRFx1MDQzOFx1MDQzNSBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzAgXHUwNDMyXHUwNDM1XHUwNDQwXHUwNDQ1XHUwNDNEXHUwNDM1XHUwNDMzXHUwNDNFIFx1MDQzQlx1MDQzNVx1MDQzMlx1MDQzRVx1MDQzM1x1MDQzRSBcdTA0NDNcdTA0MzNcdTA0M0JcdTA0MzAuLi5cIixcbiAgICB3YWl0aW5nTG93ZXJSaWdodDogXCJcdUQ4M0RcdURDNDYgXHUwNDFFXHUwNDM2XHUwNDM4XHUwNDM0XHUwNDMwXHUwNDNEXHUwNDM4XHUwNDM1IFx1MDQzMlx1MDQ0Qlx1MDQzMVx1MDQzRVx1MDQ0MFx1MDQzMCBcdTA0M0RcdTA0MzhcdTA0MzZcdTA0M0RcdTA0MzVcdTA0MzNcdTA0M0UgXHUwNDNGXHUwNDQwXHUwNDMwXHUwNDMyXHUwNDNFXHUwNDMzXHUwNDNFIFx1MDQ0M1x1MDQzM1x1MDQzQlx1MDQzMC4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBcdTA0MTJcdTA0MzVcdTA0NDBcdTA0NDVcdTA0M0RcdTA0MzhcdTA0MzkgXHUwNDNCXHUwNDM1XHUwNDMyXHUwNDRCXHUwNDM5IFx1MDQ0M1x1MDQzM1x1MDQzRVx1MDQzQiBcdTA0MzdcdTA0MzBcdTA0NDVcdTA0MzJcdTA0MzBcdTA0NDdcdTA0MzVcdTA0M0Q6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1MDQxRFx1MDQzOFx1MDQzNlx1MDQzRFx1MDQzOFx1MDQzOSBcdTA0M0ZcdTA0NDBcdTA0MzBcdTA0MzJcdTA0NEJcdTA0MzkgXHUwNDQzXHUwNDMzXHUwNDNFXHUwNDNCIFx1MDQzN1x1MDQzMFx1MDQ0NVx1MDQzMlx1MDQzMFx1MDQ0N1x1MDQzNVx1MDQzRDogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1MDQyMlx1MDQzMFx1MDQzOVx1MDQzQy1cdTA0MzBcdTA0NDNcdTA0NDIgXHUwNDMyXHUwNDRCXHUwNDMxXHUwNDNFXHUwNDQwXHUwNDMwXCIsXG4gICAgc2VsZWN0aW9uRXJyb3I6IFwiXHUyNzRDIFx1MDQxRVx1MDQ0OFx1MDQzOFx1MDQzMVx1MDQzQVx1MDQzMCBcdTA0MzJcdTA0NEJcdTA0MzFcdTA0M0VcdTA0NDBcdTA0MzAsIFx1MDQzRlx1MDQzRVx1MDQzNlx1MDQzMFx1MDQzQlx1MDQ0M1x1MDQzOVx1MDQ0MVx1MDQ0Mlx1MDQzMCwgXHUwNDNGXHUwNDNFXHUwNDNGXHUwNDQwXHUwNDNFXHUwNDMxXHUwNDQzXHUwNDM5XHUwNDQyXHUwNDM1IFx1MDQ0MVx1MDQzRFx1MDQzRVx1MDQzMlx1MDQzMFwiXG4gIH1cbn07XG4iLCAiZXhwb3J0IGNvbnN0IHpoSGFucyA9IHtcbiAgLy8gXHU1NDJGXHU1MkE4XHU1NjY4XG4gIGxhdW5jaGVyOiB7XG4gICAgdGl0bGU6ICdXUGxhY2UgXHU4MUVBXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBJyxcbiAgICBhdXRvRmFybTogJ1x1RDgzQ1x1REYzRSBcdTgxRUFcdTUyQThcdTUxOUNcdTU3M0EnLFxuICAgIGF1dG9JbWFnZTogJ1x1RDgzQ1x1REZBOCBcdTgxRUFcdTUyQThcdTdFRDhcdTU2RkUnLFxuICAgIGF1dG9HdWFyZDogJ1x1RDgzRFx1REVFMVx1RkUwRiBcdTgxRUFcdTUyQThcdTVCODhcdTYyQTQnLFxuICAgIHNlbGVjdGlvbjogJ1x1OTAwOVx1NjJFOScsXG4gICAgdXNlcjogJ1x1NzUyOFx1NjIzNycsXG4gICAgY2hhcmdlczogJ1x1NkIyMVx1NjU3MCcsXG4gICAgYmFja2VuZDogJ1x1NTQwRVx1N0FFRicsXG4gICAgZGF0YWJhc2U6ICdcdTY1NzBcdTYzNkVcdTVFOTMnLFxuICAgIHVwdGltZTogJ1x1OEZEMFx1ODg0Q1x1NjVGNlx1OTVGNCcsXG4gICAgY2xvc2U6ICdcdTUxNzNcdTk1RUQnLFxuICAgIGxhdW5jaDogJ1x1NTQyRlx1NTJBOCcsXG4gICAgbG9hZGluZzogJ1x1NTJBMFx1OEY3RFx1NEUyRFx1MjAyNicsXG4gICAgZXhlY3V0aW5nOiAnXHU2MjY3XHU4ODRDXHU0RTJEXHUyMDI2JyxcbiAgICBkb3dubG9hZGluZzogJ1x1NkI2M1x1NTcyOFx1NEUwQlx1OEY3RFx1ODExQVx1NjcyQ1x1MjAyNicsXG4gICAgY2hvb3NlQm90OiAnXHU5MDA5XHU2MkU5XHU0RTAwXHU0RTJBXHU2NzNBXHU1NjY4XHU0RUJBXHU1RTc2XHU3MEI5XHU1MUZCXHU1NDJGXHU1MkE4JyxcbiAgICByZWFkeVRvTGF1bmNoOiAnXHU1MUM2XHU1OTA3XHU1NDJGXHU1MkE4JyxcbiAgICBsb2FkRXJyb3I6ICdcdTUyQTBcdThGN0RcdTk1MTlcdThCRUYnLFxuICAgIGxvYWRFcnJvck1zZzogJ1x1NjVFMFx1NkNENVx1NTJBMFx1OEY3RFx1NjI0MFx1OTAwOVx1NjczQVx1NTY2OFx1NEVCQVx1MzAwMlx1OEJGN1x1NjhDMFx1NjdFNVx1N0Y1MVx1N0VEQ1x1OEZERVx1NjNBNVx1NjIxNlx1OTFDRFx1OEJENVx1MzAwMicsXG4gICAgY2hlY2tpbmc6ICdcdUQ4M0RcdUREMDQgXHU2OEMwXHU2N0U1XHU0RTJELi4uJyxcbiAgICBvbmxpbmU6ICdcdUQ4M0RcdURGRTIgXHU1NzI4XHU3RUJGJyxcbiAgICBvZmZsaW5lOiAnXHVEODNEXHVERDM0IFx1NzlCQlx1N0VCRicsXG4gICAgb2s6ICdcdUQ4M0RcdURGRTIgXHU2QjYzXHU1RTM4JyxcbiAgICBlcnJvcjogJ1x1RDgzRFx1REQzNCBcdTk1MTlcdThCRUYnLFxuICAgIHVua25vd246ICctJ1xuICB9LFxuXG4gIC8vIFx1N0VEOFx1NTZGRVx1NkEyMVx1NTc1N1xuICBpbWFnZToge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTgxRUFcdTUyQThcdTdFRDhcdTU2RkVcIixcbiAgICBpbml0Qm90OiBcIlx1NTIxRFx1NTlDQlx1NTMxNlx1ODFFQVx1NTJBOFx1NjczQVx1NTY2OFx1NEVCQVwiLFxuICAgIHVwbG9hZEltYWdlOiBcIlx1NEUwQVx1NEYyMFx1NTZGRVx1NzI0N1wiLFxuICAgIHJlc2l6ZUltYWdlOiBcIlx1OEMwM1x1NjU3NFx1NTZGRVx1NzI0N1x1NTkyN1x1NUMwRlwiLFxuICAgIHNlbGVjdFBvc2l0aW9uOiBcIlx1OTAwOVx1NjJFOVx1NEY0RFx1N0Y2RVwiLFxuICAgIHN0YXJ0UGFpbnRpbmc6IFwiXHU1RjAwXHU1OUNCXHU3RUQ4XHU1MjM2XCIsXG4gICAgc3RvcFBhaW50aW5nOiBcIlx1NTA1Q1x1NkI2Mlx1N0VEOFx1NTIzNlwiLFxuICAgIHNhdmVQcm9ncmVzczogXCJcdTRGRERcdTVCNThcdThGREJcdTVFQTZcIixcbiAgICBsb2FkUHJvZ3Jlc3M6IFwiXHU1MkEwXHU4RjdEXHU4RkRCXHU1RUE2XCIsXG4gICAgY2hlY2tpbmdDb2xvcnM6IFwiXHVEODNEXHVERDBEIFx1NjhDMFx1NjdFNVx1NTNFRlx1NzUyOFx1OTg5Q1x1ODI3Mi4uLlwiLFxuICAgIG5vQ29sb3JzRm91bmQ6IFwiXHUyNzRDIFx1OEJGN1x1NTcyOFx1N0Y1MVx1N0FEOVx1NEUwQVx1NjI1M1x1NUYwMFx1OEMwM1x1ODI3Mlx1Njc3Rlx1NTQwRVx1OTFDRFx1OEJENVx1RkYwMVwiLFxuICAgIGNvbG9yc0ZvdW5kOiBcIlx1MjcwNSBcdTYyN0VcdTUyMzAge2NvdW50fSBcdTc5Q0RcdTUzRUZcdTc1MjhcdTk4OUNcdTgyNzJcIixcbiAgICBsb2FkaW5nSW1hZ2U6IFwiXHVEODNEXHVEREJDXHVGRTBGIFx1NkI2M1x1NTcyOFx1NTJBMFx1OEY3RFx1NTZGRVx1NzI0Ny4uLlwiLFxuICAgIGltYWdlTG9hZGVkOiBcIlx1MjcwNSBcdTU2RkVcdTcyNDdcdTVERjJcdTUyQTBcdThGN0RcdUZGMENcdTY3MDlcdTY1NDhcdTUwQ0ZcdTdEMjAge2NvdW50fSBcdTRFMkFcIixcbiAgICBpbWFnZUVycm9yOiBcIlx1Mjc0QyBcdTU2RkVcdTcyNDdcdTUyQTBcdThGN0RcdTU5MzFcdThEMjVcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1OEJGN1x1NTcyOFx1NEY2MFx1NjBGM1x1NUYwMFx1NTlDQlx1N0VEOFx1NTIzNlx1NzY4NFx1NTczMFx1NjVCOVx1NkQ4Mlx1N0IyQ1x1NEUwMFx1NEUyQVx1NTBDRlx1N0QyMFx1RkYwMVwiLFxuICAgIHdhaXRpbmdQb3NpdGlvbjogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU0RjYwXHU2RDgyXHU1M0MyXHU4MDAzXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgcG9zaXRpb25TZXQ6IFwiXHUyNzA1IFx1NEY0RFx1N0Y2RVx1OEJCRVx1N0Y2RVx1NjIxMFx1NTI5Rlx1RkYwMVwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU5MDA5XHU2MkU5XHU4RDg1XHU2NUY2XCIsXG4gICAgcG9zaXRpb25EZXRlY3RlZDogXCJcdUQ4M0NcdURGQUYgXHU1REYyXHU2OEMwXHU2RDRCXHU1MjMwXHU0RjREXHU3RjZFXHVGRjBDXHU1OTA0XHU3NDA2XHU0RTJELi4uXCIsXG4gICAgcG9zaXRpb25FcnJvcjogXCJcdTI3NEMgXHU0RjREXHU3RjZFXHU2OEMwXHU2RDRCXHU1OTMxXHU4RDI1XHVGRjBDXHU4QkY3XHU5MUNEXHU4QkQ1XCIsXG4gICAgc3RhcnRQYWludGluZ01zZzogXCJcdUQ4M0NcdURGQTggXHU1RjAwXHU1OUNCXHU3RUQ4XHU1MjM2Li4uXCIsXG4gICAgcGFpbnRpbmdQcm9ncmVzczogXCJcdUQ4M0VcdURERjEgXHU4RkRCXHU1RUE2OiB7cGFpbnRlZH0ve3RvdGFsfSBcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyMzFCIFx1NkNBMVx1NjcwOVx1NkIyMVx1NjU3MFx1MzAwMlx1N0I0OVx1NUY4NSB7dGltZX0uLi5cIixcbiAgICBwYWludGluZ1N0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NzUyOFx1NjIzN1x1NURGMlx1NTA1Q1x1NkI2Mlx1N0VEOFx1NTIzNlwiLFxuICAgIHBhaW50aW5nQ29tcGxldGU6IFwiXHUyNzA1IFx1N0VEOFx1NTIzNlx1NUI4Q1x1NjIxMFx1RkYwMVx1NTE3MVx1N0VEOFx1NTIzNiB7Y291bnR9IFx1NEUyQVx1NTBDRlx1N0QyMFx1MzAwMlwiLFxuICAgIHBhaW50aW5nRXJyb3I6IFwiXHUyNzRDIFx1N0VEOFx1NTIzNlx1OEZDN1x1N0EwQlx1NEUyRFx1NTFGQVx1OTUxOVwiLFxuICAgIG1pc3NpbmdSZXF1aXJlbWVudHM6IFwiXHUyNzRDIFx1OEJGN1x1NTE0OFx1NTJBMFx1OEY3RFx1NTZGRVx1NzI0N1x1NUU3Nlx1OTAwOVx1NjJFOVx1NEY0RFx1N0Y2RVwiLFxuICAgIHByb2dyZXNzOiBcIlx1OEZEQlx1NUVBNlwiLFxuICAgIHVzZXJOYW1lOiBcIlx1NzUyOFx1NjIzN1wiLFxuICAgIHBpeGVsczogXCJcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3MFwiLFxuICAgIGVzdGltYXRlZFRpbWU6IFwiXHU5ODg0XHU4QkExXHU2NUY2XHU5NUY0XCIsXG4gICAgaW5pdE1lc3NhZ2U6IFwiXHU3MEI5XHU1MUZCXHUyMDFDXHU1MjFEXHU1OUNCXHU1MzE2XHU4MUVBXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBXHUyMDFEXHU1RjAwXHU1OUNCXCIsXG4gICAgd2FpdGluZ0luaXQ6IFwiXHU3QjQ5XHU1Rjg1XHU1MjFEXHU1OUNCXHU1MzE2Li4uXCIsXG4gICAgcmVzaXplU3VjY2VzczogXCJcdTI3MDUgXHU1NkZFXHU3MjQ3XHU1REYyXHU4QzAzXHU2NTc0XHU0RTNBIHt3aWR0aH14e2hlaWdodH1cIixcbiAgICBwYWludGluZ1BhdXNlZDogXCJcdTIzRjhcdUZFMEYgXHU3RUQ4XHU1MjM2XHU2NjgyXHU1MDVDXHU0RThFXHU0RjREXHU3RjZFIFg6IHt4fSwgWToge3l9XCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHU2QkNGXHU2Mjc5XHU1MENGXHU3RDIwXHU2NTcwXCIsXG4gICAgYmF0Y2hTaXplOiBcIlx1NjI3OVx1NkIyMVx1NTkyN1x1NUMwRlwiLFxuICAgIG5leHRCYXRjaFRpbWU6IFwiXHU0RTBCXHU2QjIxXHU2Mjc5XHU2QjIxXHU2NUY2XHU5NUY0XCIsXG4gICAgdXNlQWxsQ2hhcmdlczogXCJcdTRGN0ZcdTc1MjhcdTYyNDBcdTY3MDlcdTUzRUZcdTc1MjhcdTZCMjFcdTY1NzBcIixcbiAgICBzaG93T3ZlcmxheTogXCJcdTY2M0VcdTc5M0FcdTg5ODZcdTc2RDZcdTVDNDJcIixcbiAgICBtYXhDaGFyZ2VzOiBcIlx1NkJDRlx1NjI3OVx1NjcwMFx1NTkyN1x1NkIyMVx1NjU3MFwiLFxuICAgIHdhaXRpbmdGb3JDaGFyZ2VzOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1NzA6IHtjdXJyZW50fS97bmVlZGVkfVwiLFxuICAgIHRpbWVSZW1haW5pbmc6IFwiXHU1MjY5XHU0RjU5XHU2NUY2XHU5NUY0XCIsXG4gICAgY29vbGRvd25XYWl0aW5nOiBcIlx1MjNGMyBcdTdCNDlcdTVGODUge3RpbWV9IFx1NTQwRVx1N0VFN1x1N0VFRC4uLlwiLFxuICAgIHByb2dyZXNzU2F2ZWQ6IFwiXHUyNzA1IFx1OEZEQlx1NUVBNlx1NURGMlx1NEZERFx1NUI1OFx1NEUzQSB7ZmlsZW5hbWV9XCIsXG4gICAgcHJvZ3Jlc3NMb2FkZWQ6IFwiXHUyNzA1IFx1NURGMlx1NTJBMFx1OEY3RFx1OEZEQlx1NUVBNjoge3BhaW50ZWR9L3t0b3RhbH0gXHU1MENGXHU3RDIwXHU1REYyXHU3RUQ4XHU1MjM2XCIsXG4gICAgcHJvZ3Jlc3NMb2FkRXJyb3I6IFwiXHUyNzRDIFx1NTJBMFx1OEY3RFx1OEZEQlx1NUVBNlx1NTkzMVx1OEQyNToge2Vycm9yfVwiLFxuICAgIHByb2dyZXNzU2F2ZUVycm9yOiBcIlx1Mjc0QyBcdTRGRERcdTVCNThcdThGREJcdTVFQTZcdTU5MzFcdThEMjU6IHtlcnJvcn1cIixcbiAgICBjb25maXJtU2F2ZVByb2dyZXNzOiBcIlx1NTcyOFx1NTA1Q1x1NkI2Mlx1NEU0Qlx1NTI0RFx1ODk4MVx1NEZERFx1NUI1OFx1NUY1M1x1NTI0RFx1OEZEQlx1NUVBNlx1NTQxN1x1RkYxRlwiLFxuICAgIHNhdmVQcm9ncmVzc1RpdGxlOiBcIlx1NEZERFx1NUI1OFx1OEZEQlx1NUVBNlwiLFxuICAgIGRpc2NhcmRQcm9ncmVzczogXCJcdTY1M0VcdTVGMDNcIixcbiAgICBjYW5jZWw6IFwiXHU1M0Q2XHU2RDg4XCIsXG4gICAgbWluaW1pemU6IFwiXHU2NzAwXHU1QzBGXHU1MzE2XCIsXG4gICAgd2lkdGg6IFwiXHU1QkJEXHU1RUE2XCIsXG4gICAgaGVpZ2h0OiBcIlx1OUFEOFx1NUVBNlwiLFxuICAgIGtlZXBBc3BlY3Q6IFwiXHU0RkREXHU2MzAxXHU3RUI1XHU2QTJBXHU2QkQ0XCIsXG4gICAgYXBwbHk6IFwiXHU1RTk0XHU3NTI4XCIsXG4gICAgb3ZlcmxheU9uOiBcIlx1ODk4Nlx1NzZENlx1NUM0MjogXHU1RjAwXHU1NDJGXCIsXG4gICAgb3ZlcmxheU9mZjogXCJcdTg5ODZcdTc2RDZcdTVDNDI6IFx1NTE3M1x1OTVFRFwiLFxuICAgIHBhc3NDb21wbGV0ZWQ6IFwiXHUyNzA1IFx1NjI3OVx1NkIyMVx1NUI4Q1x1NjIxMDogXHU1REYyXHU3RUQ4XHU1MjM2IHtwYWludGVkfSBcdTUwQ0ZcdTdEMjAgfCBcdThGREJcdTVFQTY6IHtwZXJjZW50fSUgKHtjdXJyZW50fS97dG90YWx9KVwiLFxuICAgIHdhaXRpbmdDaGFyZ2VzUmVnZW46IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3MFx1NjA2Mlx1NTkwRDoge2N1cnJlbnR9L3tuZWVkZWR9IC0gXHU2NUY2XHU5NUY0OiB7dGltZX1cIixcbiAgICB3YWl0aW5nQ2hhcmdlc0NvdW50ZG93bjogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTcwOiB7Y3VycmVudH0ve25lZWRlZH0gLSBcdTUyNjlcdTRGNTk6IHt0aW1lfVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJBOFx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NjVFMFx1NkNENVx1ODFFQVx1NTJBOFx1NTQyRlx1NTJBOFx1RkYwQ1x1OEJGN1x1NjI0Qlx1NTJBOFx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHU1REYyXHU2OEMwXHU2RDRCXHU1MjMwXHU4QzAzXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY0MUNcdTdEMjJcdThDMDNcdTgyNzJcdTY3N0YuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTZCNjNcdTU3MjhcdTcwQjlcdTUxRkJcdTdFRDhcdTUyMzZcdTYzMDlcdTk0QUUuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTdFRDhcdTUyMzZcdTYzMDlcdTk0QUVcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1OTcwMFx1ODk4MVx1NjI0Qlx1NTJBOFx1NTIxRFx1NTlDQlx1NTMxNlwiLFxuICAgIHJldHJ5QXR0ZW1wdDogXCJcdUQ4M0RcdUREMDQgXHU5MUNEXHU4QkQ1IHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9XHVGRjBDXHU3QjQ5XHU1Rjg1IHtkZWxheX0gXHU3OUQyLi4uXCIsXG4gICAgcmV0cnlFcnJvcjogXCJcdUQ4M0RcdURDQTUgXHU3QjJDIHthdHRlbXB0fS97bWF4QXR0ZW1wdHN9IFx1NkIyMVx1NUMxRFx1OEJENVx1NTFGQVx1OTUxOVx1RkYwQ1x1NUMwNlx1NTcyOCB7ZGVsYXl9IFx1NzlEMlx1NTQwRVx1OTFDRFx1OEJENS4uLlwiLFxuICAgIHJldHJ5RmFpbGVkOiBcIlx1Mjc0QyBcdThEODVcdThGQzcge21heEF0dGVtcHRzfSBcdTZCMjFcdTVDMURcdThCRDVcdTU5MzFcdThEMjVcdTMwMDJcdTdFRTdcdTdFRURcdTRFMEJcdTRFMDBcdTYyNzkuLi5cIixcbiAgICBuZXR3b3JrRXJyb3I6IFwiXHVEODNDXHVERjEwIFx1N0Y1MVx1N0VEQ1x1OTUxOVx1OEJFRlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEJENS4uLlwiLFxuICAgIHNlcnZlckVycm9yOiBcIlx1RDgzRFx1REQyNSBcdTY3MERcdTUyQTFcdTU2NjhcdTk1MTlcdThCRUZcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThCRDUuLi5cIixcbiAgICB0aW1lb3V0RXJyb3I6IFwiXHUyM0YwIFx1NjcwRFx1NTJBMVx1NTY2OFx1OEQ4NVx1NjVGNlx1RkYwQ1x1NkI2M1x1NTcyOFx1OTFDRFx1OEJENS4uLlwiXG4gIH0sXG5cbiAgLy8gXHU1MTlDXHU1NzNBXHU2QTIxXHU1NzU3XHVGRjA4XHU1Rjg1XHU1QjlFXHU3M0IwXHVGRjA5XG4gIGZhcm06IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU1MTlDXHU1NzNBXHU2NzNBXHU1NjY4XHU0RUJBXCIsXG4gICAgc3RhcnQ6IFwiXHU1RjAwXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBzdG9wcGVkOiBcIlx1NjczQVx1NTY2OFx1NEVCQVx1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIGNhbGlicmF0ZTogXCJcdTY4MjFcdTUxQzZcIixcbiAgICBwYWludE9uY2U6IFwiXHU0RTAwXHU2QjIxXCIsXG4gICAgY2hlY2tpbmdTdGF0dXM6IFwiXHU2OEMwXHU2N0U1XHU3MkI2XHU2MDAxXHU0RTJELi4uXCIsXG4gICAgY29uZmlndXJhdGlvbjogXCJcdTkxNERcdTdGNkVcIixcbiAgICBkZWxheTogXCJcdTVFRjZcdThGREYgKFx1NkJFQlx1NzlEMilcIixcbiAgICBwaXhlbHNQZXJCYXRjaDogXCJcdTZCQ0ZcdTYyNzlcdTUwQ0ZcdTdEMjBcIixcbiAgICBtaW5DaGFyZ2VzOiBcIlx1NjcwMFx1NUMxMVx1NkIyMVx1NjU3MFwiLFxuICAgIGNvbG9yTW9kZTogXCJcdTk4OUNcdTgyNzJcdTZBMjFcdTVGMEZcIixcbiAgICByYW5kb206IFwiXHU5NjhGXHU2NzNBXCIsXG4gICAgZml4ZWQ6IFwiXHU1NkZBXHU1QjlBXCIsXG4gICAgcmFuZ2U6IFwiXHU4MzAzXHU1NkY0XCIsXG4gICAgZml4ZWRDb2xvcjogXCJcdTU2RkFcdTVCOUFcdTk4OUNcdTgyNzJcIixcbiAgICBhZHZhbmNlZDogXCJcdTlBRDhcdTdFQTdcIixcbiAgICB0aWxlWDogXCJcdTc0RTZcdTcyNDcgWFwiLFxuICAgIHRpbGVZOiBcIlx1NzRFNlx1NzI0NyBZXCIsXG4gICAgY3VzdG9tUGFsZXR0ZTogXCJcdTgxRUFcdTVCOUFcdTRFNDlcdThDMDNcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlRXhhbXBsZTogXCJcdTRGOEJcdTU5ODI6ICNGRjAwMDAsIzAwRkYwMCwjMDAwMEZGXCIsXG4gICAgY2FwdHVyZTogXCJcdTYzNTVcdTgzQjdcIixcbiAgICBwYWludGVkOiBcIlx1NURGMlx1N0VEOFx1NTIzNlwiLFxuICAgIGNoYXJnZXM6IFwiXHU2QjIxXHU2NTcwXCIsXG4gICAgcmV0cmllczogXCJcdTkxQ0RcdThCRDVcIixcbiAgICB0aWxlOiBcIlx1NzRFNlx1NzI0N1wiLFxuICAgIGNvbmZpZ1NhdmVkOiBcIlx1OTE0RFx1N0Y2RVx1NURGMlx1NEZERFx1NUI1OFwiLFxuICAgIGNvbmZpZ0xvYWRlZDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTUyQTBcdThGN0RcIixcbiAgICBjb25maWdSZXNldDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTkxQ0RcdTdGNkVcIixcbiAgICBjYXB0dXJlSW5zdHJ1Y3Rpb25zOiBcIlx1OEJGN1x1NjI0Qlx1NTJBOFx1N0VEOFx1NTIzNlx1NEUwMFx1NEUyQVx1NTBDRlx1N0QyMFx1NEVFNVx1NjM1NVx1ODNCN1x1NTc1MFx1NjgwNy4uLlwiLFxuICAgIGJhY2tlbmRPbmxpbmU6IFwiXHU1NDBFXHU3QUVGXHU1NzI4XHU3RUJGXCIsXG4gICAgYmFja2VuZE9mZmxpbmU6IFwiXHU1NDBFXHU3QUVGXHU3OUJCXHU3RUJGXCIsXG4gICAgc3RhcnRpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1NDJGXHU1MkE4XHU2NzNBXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgc3RvcHBpbmdCb3Q6IFwiXHU2QjYzXHU1NzI4XHU1MDVDXHU2QjYyXHU2NzNBXHU1NjY4XHU0RUJBLi4uXCIsXG4gICAgY2FsaWJyYXRpbmc6IFwiXHU2ODIxXHU1MUM2XHU0RTJELi4uXCIsXG4gICAgYWxyZWFkeVJ1bm5pbmc6IFwiXHU4MUVBXHU1MkE4XHU1MTlDXHU1NzNBXHU1REYyXHU1NzI4XHU4RkQwXHU4ODRDXHUzMDAyXCIsXG4gICAgaW1hZ2VSdW5uaW5nV2FybmluZzogXCJcdTgxRUFcdTUyQThcdTdFRDhcdTU2RkVcdTZCNjNcdTU3MjhcdThGRDBcdTg4NENcdUZGMENcdThCRjdcdTUxNDhcdTUxNzNcdTk1RURcdTUxOERcdTU0MkZcdTUyQThcdTgxRUFcdTUyQThcdTUxOUNcdTU3M0FcdTMwMDJcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcIixcbiAgICBzZWxlY3RQb3NpdGlvbkFsZXJ0OiBcIlx1RDgzQ1x1REZBRiBcdTU3MjhcdTU3MzBcdTU2RkVcdTc2ODRcdTdBN0FcdTc2N0RcdTUzM0FcdTU3REZcdTZEODJcdTRFMDBcdTRFMkFcdTUwQ0ZcdTdEMjBcdTRFRTVcdThCQkVcdTdGNkVcdTUxOUNcdTU3M0FcdTUzM0FcdTU3REZcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1NEY2MFx1NkQ4Mlx1NTNDMlx1ODAwM1x1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTUzM0FcdTU3REZcdThCQkVcdTdGNkVcdTYyMTBcdTUyOUZcdUZGMDFcdTUzNEFcdTVGODQ6IDUwMHB4XCIsXG4gICAgcG9zaXRpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTUzM0FcdTU3REZcdTkwMDlcdTYyRTlcdThEODVcdTY1RjZcIixcbiAgICBtaXNzaW5nUG9zaXRpb246IFwiXHUyNzRDIFx1OEJGN1x1NTE0OFx1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlx1RkYwOFx1NEY3Rlx1NzUyOFx1MjAxQ1x1OTAwOVx1NjJFOVx1NTMzQVx1NTdERlx1MjAxRFx1NjMwOVx1OTRBRVx1RkYwOVwiLFxuICAgIGZhcm1SYWRpdXM6IFwiXHU1MTlDXHU1NzNBXHU1MzRBXHU1Rjg0XCIsXG4gICAgcG9zaXRpb25JbmZvOiBcIlx1NUY1M1x1NTI0RFx1NTMzQVx1NTdERlwiLFxuICAgIGZhcm1pbmdJblJhZGl1czogXCJcdUQ4M0NcdURGM0UgXHU2QjYzXHU1NzI4XHU0RUU1XHU1MzRBXHU1Rjg0IHtyYWRpdXN9cHggXHU1NzI4ICh7eH0se3l9KSBcdTUxOUNcdTU3M0FcIixcbiAgICBzZWxlY3RFbXB0eUFyZWE6IFwiXHUyNkEwXHVGRTBGIFx1OTFDRFx1ODk4MTogXHU4QkY3XHU5MDA5XHU2MkU5XHU3QTdBXHU3NjdEXHU1MzNBXHU1N0RGXHU0RUU1XHU5MDdGXHU1MTREXHU1MUIyXHU3QTgxXCIsXG4gICAgbm9Qb3NpdGlvbjogXCJcdTY3MkFcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcIixcbiAgICBjdXJyZW50Wm9uZTogXCJcdTUzM0FcdTU3REY6ICh7eH0se3l9KVwiLFxuICAgIGF1dG9TZWxlY3RQb3NpdGlvbjogXCJcdUQ4M0NcdURGQUYgXHU4QkY3XHU1MTQ4XHU5MDA5XHU2MkU5XHU1MzNBXHU1N0RGXHVGRjBDXHU1NzI4XHU1NzMwXHU1NkZFXHU0RTBBXHU2RDgyXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXHU0RUU1XHU4QkJFXHU3RjZFXHU1MTlDXHU1NzNBXHU1MzNBXHU1N0RGXCJcbiAgfSxcblxuICAvLyBcdTUxNkNcdTUxNzFcbiAgY29tbW9uOiB7XG4gICAgeWVzOiBcIlx1NjYyRlwiLFxuICAgIG5vOiBcIlx1NTQyNlwiLFxuICAgIG9rOiBcIlx1Nzg2RVx1OEJBNFwiLFxuICAgIGNhbmNlbDogXCJcdTUzRDZcdTZEODhcIixcbiAgICBjbG9zZTogXCJcdTUxNzNcdTk1RURcIixcbiAgICBzYXZlOiBcIlx1NEZERFx1NUI1OFwiLFxuICAgIGxvYWQ6IFwiXHU1MkEwXHU4RjdEXCIsXG4gICAgZGVsZXRlOiBcIlx1NTIyMFx1OTY2NFwiLFxuICAgIGVkaXQ6IFwiXHU3RjE2XHU4RjkxXCIsXG4gICAgc3RhcnQ6IFwiXHU1RjAwXHU1OUNCXCIsXG4gICAgc3RvcDogXCJcdTUwNUNcdTZCNjJcIixcbiAgICBwYXVzZTogXCJcdTY2ODJcdTUwNUNcIixcbiAgICByZXN1bWU6IFwiXHU3RUU3XHU3RUVEXCIsXG4gICAgcmVzZXQ6IFwiXHU5MUNEXHU3RjZFXCIsXG4gICAgc2V0dGluZ3M6IFwiXHU4QkJFXHU3RjZFXCIsXG4gICAgaGVscDogXCJcdTVFMkVcdTUyQTlcIixcbiAgICBhYm91dDogXCJcdTUxNzNcdTRFOEVcIixcbiAgICBsYW5ndWFnZTogXCJcdThCRURcdThBMDBcIixcbiAgICBsb2FkaW5nOiBcIlx1NTJBMFx1OEY3RFx1NEUyRC4uLlwiLFxuICAgIGVycm9yOiBcIlx1OTUxOVx1OEJFRlwiLFxuICAgIHN1Y2Nlc3M6IFwiXHU2MjEwXHU1MjlGXCIsXG4gICAgd2FybmluZzogXCJcdThCNjZcdTU0NEFcIixcbiAgICBpbmZvOiBcIlx1NEZFMVx1NjA2RlwiLFxuICAgIGxhbmd1YWdlQ2hhbmdlZDogXCJcdThCRURcdThBMDBcdTVERjJcdTUyMDdcdTYzNjJcdTRFM0Ege2xhbmd1YWdlfVwiXG4gIH0sXG5cbiAgLy8gXHU1Qjg4XHU2MkE0XHU2QTIxXHU1NzU3XG4gIGd1YXJkOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1ODFFQVx1NTJBOFx1NUI4OFx1NjJBNFwiLFxuICAgIGluaXRCb3Q6IFwiXHU1MjFEXHU1OUNCXHU1MzE2XHU1Qjg4XHU2MkE0XHU2NzNBXHU1NjY4XHU0RUJBXCIsXG4gICAgc2VsZWN0QXJlYTogXCJcdTkwMDlcdTYyRTlcdTUzM0FcdTU3REZcIixcbiAgICBjYXB0dXJlQXJlYTogXCJcdTYzNTVcdTgzQjdcdTUzM0FcdTU3REZcIixcbiAgICBzdGFydFByb3RlY3Rpb246IFwiXHU1RjAwXHU1OUNCXHU1Qjg4XHU2MkE0XCIsXG4gICAgc3RvcFByb3RlY3Rpb246IFwiXHU1MDVDXHU2QjYyXHU1Qjg4XHU2MkE0XCIsXG4gICAgdXBwZXJMZWZ0OiBcIlx1NURFNlx1NEUwQVx1ODlEMlwiLFxuICAgIGxvd2VyUmlnaHQ6IFwiXHU1M0YzXHU0RTBCXHU4OUQyXCIsXG4gICAgcHJvdGVjdGVkUGl4ZWxzOiBcIlx1NTNEN1x1NEZERFx1NjJBNFx1NTBDRlx1N0QyMFwiLFxuICAgIGRldGVjdGVkQ2hhbmdlczogXCJcdTY4QzBcdTZENEJcdTUyMzBcdTc2ODRcdTUzRDhcdTUzMTZcIixcbiAgICByZXBhaXJlZFBpeGVsczogXCJcdTRGRUVcdTU5MERcdTc2ODRcdTUwQ0ZcdTdEMjBcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3MFwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1N0I0OVx1NUY4NVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzQ1x1REZBOCBcdTY4QzBcdTY3RTVcdTUzRUZcdTc1MjhcdTk4OUNcdTgyNzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTk4OUNcdTgyNzJcdUZGMENcdThCRjdcdTU3MjhcdTdGNTFcdTdBRDlcdTRFMEFcdTYyNTNcdTVGMDBcdThDMDNcdTgyNzJcdTY3N0ZcdTMwMDJcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHU2MjdFXHU1MjMwIHtjb3VudH0gXHU3OUNEXHU1M0VGXHU3NTI4XHU5ODlDXHU4MjcyXCIsXG4gICAgaW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1NUI4OFx1NjJBNFx1NjczQVx1NTY2OFx1NEVCQVx1NTIxRFx1NTlDQlx1NTMxNlx1NjIxMFx1NTI5RlwiLFxuICAgIGluaXRFcnJvcjogXCJcdTI3NEMgXHU1Qjg4XHU2MkE0XHU2NzNBXHU1NjY4XHU0RUJBXHU1MjFEXHU1OUNCXHU1MzE2XHU1OTMxXHU4RDI1XCIsXG4gICAgaW52YWxpZENvb3JkczogXCJcdTI3NEMgXHU1NzUwXHU2ODA3XHU2NUUwXHU2NTQ4XCIsXG4gICAgaW52YWxpZEFyZWE6IFwiXHUyNzRDIFx1NTMzQVx1NTdERlx1NjVFMFx1NjU0OFx1RkYwQ1x1NURFNlx1NEUwQVx1ODlEMlx1NUZDNVx1OTg3Qlx1NUMwRlx1NEU4RVx1NTNGM1x1NEUwQlx1ODlEMlwiLFxuICAgIGFyZWFUb29MYXJnZTogXCJcdTI3NEMgXHU1MzNBXHU1N0RGXHU4RkM3XHU1OTI3OiB7c2l6ZX0gXHU1MENGXHU3RDIwIChcdTY3MDBcdTU5Mjc6IHttYXh9KVwiLFxuICAgIGNhcHR1cmluZ0FyZWE6IFwiXHVEODNEXHVEQ0Y4IFx1NjM1NVx1ODNCN1x1NUI4OFx1NjJBNFx1NTMzQVx1NTdERlx1NEUyRC4uLlwiLFxuICAgIGFyZWFDYXB0dXJlZDogXCJcdTI3MDUgXHU1MzNBXHU1N0RGXHU2MzU1XHU4M0I3XHU2MjEwXHU1MjlGOiB7Y291bnR9IFx1NTBDRlx1N0QyMFx1NTNEN1x1NEZERFx1NjJBNFwiLFxuICAgIGNhcHR1cmVFcnJvcjogXCJcdTI3NEMgXHU2MzU1XHU4M0I3XHU1MzNBXHU1N0RGXHU1MUZBXHU5NTE5OiB7ZXJyb3J9XCIsXG4gICAgY2FwdHVyZUZpcnN0OiBcIlx1Mjc0QyBcdThCRjdcdTUxNDhcdTYzNTVcdTgzQjdcdTRFMDBcdTRFMkFcdTVCODhcdTYyQTRcdTUzM0FcdTU3REZcIixcbiAgICBwcm90ZWN0aW9uU3RhcnRlZDogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU2MkE0XHU1REYyXHU1NDJGXHU1MkE4IC0gXHU1MzNBXHU1N0RGXHU3NkQxXHU2M0E3XHU0RTJEXCIsXG4gICAgcHJvdGVjdGlvblN0b3BwZWQ6IFwiXHUyM0Y5XHVGRTBGIFx1NUI4OFx1NjJBNFx1NURGMlx1NTA1Q1x1NkI2MlwiLFxuICAgIG5vQ2hhbmdlczogXCJcdTI3MDUgXHU1MzNBXHU1N0RGXHU1Qjg5XHU1MTY4IC0gXHU2NzJBXHU2OEMwXHU2RDRCXHU1MjMwXHU1M0Q4XHU1MzE2XCIsXG4gICAgY2hhbmdlc0RldGVjdGVkOiBcIlx1RDgzRFx1REVBOCBcdTY4QzBcdTZENEJcdTUyMzAge2NvdW50fSBcdTRFMkFcdTUzRDhcdTUzMTZcIixcbiAgICByZXBhaXJpbmc6IFwiXHVEODNEXHVERUUwXHVGRTBGIFx1NkI2M1x1NTcyOFx1NEZFRVx1NTkwRCB7Y291bnR9IFx1NEUyQVx1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHJlcGFpcmVkU3VjY2VzczogXCJcdTI3MDUgXHU1REYyXHU2MjEwXHU1MjlGXHU0RkVFXHU1OTBEIHtjb3VudH0gXHU0RTJBXHU1MENGXHU3RDIwXCIsXG4gICAgcmVwYWlyRXJyb3I6IFwiXHUyNzRDIFx1NEZFRVx1NTkwRFx1NTFGQVx1OTUxOToge2Vycm9yfVwiLFxuICAgIG5vQ2hhcmdlczogXCJcdTI2QTBcdUZFMEYgXHU2QjIxXHU2NTcwXHU0RTBEXHU4REIzXHVGRjBDXHU2NUUwXHU2Q0Q1XHU0RkVFXHU1OTBEXCIsXG4gICAgY2hlY2tpbmdDaGFuZ2VzOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY4QzBcdTY3RTVcdTUzM0FcdTU3REZcdTUzRDhcdTUzMTYuLi5cIixcbiAgICBlcnJvckNoZWNraW5nOiBcIlx1Mjc0QyBcdTY4QzBcdTY3RTVcdTUxRkFcdTk1MTk6IHtlcnJvcn1cIixcbiAgICBndWFyZEFjdGl2ZTogXCJcdUQ4M0RcdURFRTFcdUZFMEYgXHU1Qjg4XHU2MkE0XHU0RTJEIC0gXHU1MzNBXHU1N0RGXHU1M0Q3XHU0RkREXHU2MkE0XCIsXG4gICAgbGFzdENoZWNrOiBcIlx1NEUwQVx1NkIyMVx1NjhDMFx1NjdFNToge3RpbWV9XCIsXG4gICAgbmV4dENoZWNrOiBcIlx1NEUwQlx1NkIyMVx1NjhDMFx1NjdFNToge3RpbWV9IFx1NzlEMlx1NTQwRVwiLFxuICAgIGF1dG9Jbml0aWFsaXppbmc6IFwiXHVEODNFXHVERDE2IFx1NkI2M1x1NTcyOFx1ODFFQVx1NTJBOFx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIGF1dG9Jbml0U3VjY2VzczogXCJcdTI3MDUgXHU4MUVBXHU1MkE4XHU1NDJGXHU1MkE4XHU2MjEwXHU1MjlGXCIsXG4gICAgYXV0b0luaXRGYWlsZWQ6IFwiXHUyNkEwXHVGRTBGIFx1NjVFMFx1NkNENVx1ODFFQVx1NTJBOFx1NTQyRlx1NTJBOFx1RkYwQ1x1OEJGN1x1NjI0Qlx1NTJBOFx1NjRDRFx1NEY1Q1x1MzAwMlwiLFxuICAgIG1hbnVhbEluaXRSZXF1aXJlZDogXCJcdUQ4M0RcdUREMjcgXHU5NzAwXHU4OTgxXHU2MjRCXHU1MkE4XHU1MjFEXHU1OUNCXHU1MzE2XCIsXG4gICAgcGFsZXR0ZURldGVjdGVkOiBcIlx1RDgzQ1x1REZBOCBcdTVERjJcdTY4QzBcdTZENEJcdTUyMzBcdThDMDNcdTgyNzJcdTY3N0ZcIixcbiAgICBwYWxldHRlTm90Rm91bmQ6IFwiXHVEODNEXHVERDBEIFx1NkI2M1x1NTcyOFx1NjQxQ1x1N0QyMlx1OEMwM1x1ODI3Mlx1Njc3Ri4uLlwiLFxuICAgIGNsaWNraW5nUGFpbnRCdXR0b246IFwiXHVEODNEXHVEQzQ2IFx1NkI2M1x1NTcyOFx1NzBCOVx1NTFGQlx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRS4uLlwiLFxuICAgIHBhaW50QnV0dG9uTm90Rm91bmQ6IFwiXHUyNzRDIFx1NjcyQVx1NjI3RVx1NTIzMFx1N0VEOFx1NTIzNlx1NjMwOVx1OTRBRVwiLFxuICAgIHNlbGVjdFVwcGVyTGVmdDogXCJcdUQ4M0NcdURGQUYgXHU1NzI4XHU5NzAwXHU4OTgxXHU0RkREXHU2MkE0XHU1MzNBXHU1N0RGXHU3Njg0XHU1REU2XHU0RTBBXHU4OUQyXHU2RDgyXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXCIsXG4gICAgc2VsZWN0TG93ZXJSaWdodDogXCJcdUQ4M0NcdURGQUYgXHU3M0IwXHU1NzI4XHU1NzI4XHU1M0YzXHU0RTBCXHU4OUQyXHU2RDgyXHU0RTAwXHU0RTJBXHU1MENGXHU3RDIwXCIsXG4gICAgd2FpdGluZ1VwcGVyTGVmdDogXCJcdUQ4M0RcdURDNDYgXHU3QjQ5XHU1Rjg1XHU5MDA5XHU2MkU5XHU1REU2XHU0RTBBXHU4OUQyLi4uXCIsXG4gICAgd2FpdGluZ0xvd2VyUmlnaHQ6IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1OTAwOVx1NjJFOVx1NTNGM1x1NEUwQlx1ODlEMi4uLlwiLFxuICAgIHVwcGVyTGVmdENhcHR1cmVkOiBcIlx1MjcwNSBcdTVERjJcdTYzNTVcdTgzQjdcdTVERTZcdTRFMEFcdTg5RDI6ICh7eH0sIHt5fSlcIixcbiAgICBsb3dlclJpZ2h0Q2FwdHVyZWQ6IFwiXHUyNzA1IFx1NURGMlx1NjM1NVx1ODNCN1x1NTNGM1x1NEUwQlx1ODlEMjogKHt4fSwge3l9KVwiLFxuICAgIHNlbGVjdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1OTAwOVx1NjJFOVx1OEQ4NVx1NjVGNlwiLFxuICAgIHNlbGVjdGlvbkVycm9yOiBcIlx1Mjc0QyBcdTkwMDlcdTYyRTlcdTUxRkFcdTk1MTlcdUZGMENcdThCRjdcdTkxQ0RcdThCRDVcIlxuICB9XG59O1xuIiwgImV4cG9ydCBjb25zdCB6aEhhbnQgPSB7XG4gIC8vIFx1NTU1M1x1NTJENVx1NTY2OFxuICBsYXVuY2hlcjoge1xuICAgIHRpdGxlOiAnV1BsYWNlIFx1ODFFQVx1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQScsXG4gICAgYXV0b0Zhcm06ICdcdUQ4M0NcdURGM0UgXHU4MUVBXHU1MkQ1XHU4RkIyXHU1ODM0JyxcbiAgICBhdXRvSW1hZ2U6ICdcdUQ4M0NcdURGQTggXHU4MUVBXHU1MkQ1XHU3RTZBXHU1NzE2JyxcbiAgICBhdXRvR3VhcmQ6ICdcdUQ4M0RcdURFRTFcdUZFMEYgXHU4MUVBXHU1MkQ1XHU1Qjg4XHU4Qjc3JyxcbiAgICBzZWxlY3Rpb246ICdcdTkwNzhcdTY0QzcnLFxuICAgIHVzZXI6ICdcdTc1MjhcdTYyMzcnLFxuICAgIGNoYXJnZXM6ICdcdTZCMjFcdTY1NzgnLFxuICAgIGJhY2tlbmQ6ICdcdTVGOENcdTdBRUYnLFxuICAgIGRhdGFiYXNlOiAnXHU2NTc4XHU2NERBXHU1RUFCJyxcbiAgICB1cHRpbWU6ICdcdTkwNEJcdTg4NENcdTY2NDJcdTk1OTMnLFxuICAgIGNsb3NlOiAnXHU5NURDXHU5NTg5JyxcbiAgICBsYXVuY2g6ICdcdTU1NTNcdTUyRDUnLFxuICAgIGxvYWRpbmc6ICdcdTUyQTBcdThGMDlcdTRFMkRcdTIwMjYnLFxuICAgIGV4ZWN1dGluZzogJ1x1NTdGN1x1ODg0Q1x1NEUyRFx1MjAyNicsXG4gICAgZG93bmxvYWRpbmc6ICdcdTZCNjNcdTU3MjhcdTRFMEJcdThGMDlcdTgxNzNcdTY3MkNcdTIwMjYnLFxuICAgIGNob29zZUJvdDogJ1x1OTA3OFx1NjRDN1x1NEUwMFx1NTAwQlx1NkE1Rlx1NTY2OFx1NEVCQVx1NEUyNlx1OUVERVx1NjRDQVx1NTU1M1x1NTJENScsXG4gICAgcmVhZHlUb0xhdW5jaDogJ1x1NkU5Nlx1NTA5OVx1NTU1M1x1NTJENScsXG4gICAgbG9hZEVycm9yOiAnXHU1MkEwXHU4RjA5XHU5MzJGXHU4QUE0JyxcbiAgICBsb2FkRXJyb3JNc2c6ICdcdTcxMjFcdTZDRDVcdTUyQTBcdThGMDlcdTYyNDBcdTkwNzhcdTZBNUZcdTU2NjhcdTRFQkFcdTMwMDJcdThBQ0JcdTZBQTJcdTY3RTVcdTdEQjJcdTdENjFcdTkwMjNcdTYzQTVcdTYyMTZcdTkxQ0RcdThBNjZcdTMwMDInLFxuICAgIGNoZWNraW5nOiAnXHVEODNEXHVERDA0IFx1NkFBMlx1NjdFNVx1NEUyRC4uLicsXG4gICAgb25saW5lOiAnXHVEODNEXHVERkUyIFx1NTcyOFx1N0REQScsXG4gICAgb2ZmbGluZTogJ1x1RDgzRFx1REQzNCBcdTk2RTJcdTdEREEnLFxuICAgIG9rOiAnXHVEODNEXHVERkUyIFx1NkI2M1x1NUUzOCcsXG4gICAgZXJyb3I6ICdcdUQ4M0RcdUREMzQgXHU5MzJGXHU4QUE0JyxcbiAgICB1bmtub3duOiAnLSdcbiAgfSxcblxuICAvLyBcdTdFNkFcdTU3MTZcdTZBMjFcdTU4NEFcbiAgaW1hZ2U6IHtcbiAgICB0aXRsZTogXCJXUGxhY2UgXHU4MUVBXHU1MkQ1XHU3RTZBXHU1NzE2XCIsXG4gICAgaW5pdEJvdDogXCJcdTUyMURcdTU5Q0JcdTUzMTZcdTgxRUFcdTUyRDVcdTZBNUZcdTU2NjhcdTRFQkFcIixcbiAgICB1cGxvYWRJbWFnZTogXCJcdTRFMEFcdTUwQjNcdTU3MTZcdTcyNDdcIixcbiAgICByZXNpemVJbWFnZTogXCJcdThBQkZcdTY1NzRcdTU3MTZcdTcyNDdcdTU5MjdcdTVDMEZcIixcbiAgICBzZWxlY3RQb3NpdGlvbjogXCJcdTkwNzhcdTY0QzdcdTRGNERcdTdGNkVcIixcbiAgICBzdGFydFBhaW50aW5nOiBcIlx1OTU4Qlx1NTlDQlx1N0U2QVx1ODhGRFwiLFxuICAgIHN0b3BQYWludGluZzogXCJcdTUwNUNcdTZCNjJcdTdFNkFcdTg4RkRcIixcbiAgICBzYXZlUHJvZ3Jlc3M6IFwiXHU0RkREXHU1QjU4XHU5MDMyXHU1RUE2XCIsXG4gICAgbG9hZFByb2dyZXNzOiBcIlx1NTJBMFx1OEYwOVx1OTAzMlx1NUVBNlwiLFxuICAgIGNoZWNraW5nQ29sb3JzOiBcIlx1RDgzRFx1REQwRCBcdTZBQTJcdTY3RTVcdTUzRUZcdTc1MjhcdTk4NEZcdTgyNzIuLi5cIixcbiAgICBub0NvbG9yc0ZvdW5kOiBcIlx1Mjc0QyBcdThBQ0JcdTU3MjhcdTdEQjJcdTdBRDlcdTRFMEFcdTYyNTNcdTk1OEJcdThBQkZcdTgyNzJcdTY3N0ZcdTVGOENcdTkxQ0RcdThBNjZcdUZGMDFcIixcbiAgICBjb2xvcnNGb3VuZDogXCJcdTI3MDUgXHU2MjdFXHU1MjMwIHtjb3VudH0gXHU3QTJFXHU1M0VGXHU3NTI4XHU5ODRGXHU4MjcyXCIsXG4gICAgbG9hZGluZ0ltYWdlOiBcIlx1RDgzRFx1RERCQ1x1RkUwRiBcdTZCNjNcdTU3MjhcdTUyQTBcdThGMDlcdTU3MTZcdTcyNDcuLi5cIixcbiAgICBpbWFnZUxvYWRlZDogXCJcdTI3MDUgXHU1NzE2XHU3MjQ3XHU1REYyXHU1MkEwXHU4RjA5XHVGRjBDXHU2NzA5XHU2NTQ4XHU1MENGXHU3RDIwIHtjb3VudH0gXHU1MDBCXCIsXG4gICAgaW1hZ2VFcnJvcjogXCJcdTI3NEMgXHU1NzE2XHU3MjQ3XHU1MkEwXHU4RjA5XHU1OTMxXHU2NTU3XCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdThBQ0JcdTU3MjhcdTRGNjBcdTYwRjNcdTk1OEJcdTU5Q0JcdTdFNkFcdTg4RkRcdTc2ODRcdTU3MzBcdTY1QjlcdTU4NTdcdTdCMkNcdTRFMDBcdTUwMEJcdTUwQ0ZcdTdEMjBcdUZGMDFcIixcbiAgICB3YWl0aW5nUG9zaXRpb246IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1NEY2MFx1NTg1N1x1NTNDM1x1ODAwM1x1NTBDRlx1N0QyMC4uLlwiLFxuICAgIHBvc2l0aW9uU2V0OiBcIlx1MjcwNSBcdTRGNERcdTdGNkVcdThBMkRcdTdGNkVcdTYyMTBcdTUyOUZcdUZGMDFcIixcbiAgICBwb3NpdGlvblRpbWVvdXQ6IFwiXHUyNzRDIFx1NEY0RFx1N0Y2RVx1OTA3OFx1NjRDN1x1OEQ4NVx1NjY0MlwiLFxuICAgIHBvc2l0aW9uRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkFGIFx1NURGMlx1NkFBMlx1NkUyQ1x1NTIzMFx1NEY0RFx1N0Y2RVx1RkYwQ1x1ODY1NVx1NzQwNlx1NEUyRC4uLlwiLFxuICAgIHBvc2l0aW9uRXJyb3I6IFwiXHUyNzRDIFx1NEY0RFx1N0Y2RVx1NkFBMlx1NkUyQ1x1NTkzMVx1NjU1N1x1RkYwQ1x1OEFDQlx1OTFDRFx1OEE2NlwiLFxuICAgIHN0YXJ0UGFpbnRpbmdNc2c6IFwiXHVEODNDXHVERkE4IFx1OTU4Qlx1NTlDQlx1N0U2QVx1ODhGRC4uLlwiLFxuICAgIHBhaW50aW5nUHJvZ3Jlc3M6IFwiXHVEODNFXHVEREYxIFx1OTAzMlx1NUVBNjoge3BhaW50ZWR9L3t0b3RhbH0gXHU1MENGXHU3RDIwLi4uXCIsXG4gICAgbm9DaGFyZ2VzOiBcIlx1MjMxQiBcdTZDOTJcdTY3MDlcdTZCMjFcdTY1NzhcdTMwMDJcdTdCNDlcdTVGODUge3RpbWV9Li4uXCIsXG4gICAgcGFpbnRpbmdTdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTc1MjhcdTYyMzdcdTVERjJcdTUwNUNcdTZCNjJcdTdFNkFcdTg4RkRcIixcbiAgICBwYWludGluZ0NvbXBsZXRlOiBcIlx1MjcwNSBcdTdFNkFcdTg4RkRcdTVCOENcdTYyMTBcdUZGMDFcdTUxNzFcdTdFNkFcdTg4RkQge2NvdW50fSBcdTUwMEJcdTUwQ0ZcdTdEMjBcdTMwMDJcIixcbiAgICBwYWludGluZ0Vycm9yOiBcIlx1Mjc0QyBcdTdFNkFcdTg4RkRcdTkwNEVcdTdBMEJcdTRFMkRcdTUxRkFcdTkzMkZcIixcbiAgICBtaXNzaW5nUmVxdWlyZW1lbnRzOiBcIlx1Mjc0QyBcdThBQ0JcdTUxNDhcdTUyQTBcdThGMDlcdTU3MTZcdTcyNDdcdTRFMjZcdTkwNzhcdTY0QzdcdTRGNERcdTdGNkVcIixcbiAgICBwcm9ncmVzczogXCJcdTkwMzJcdTVFQTZcIixcbiAgICB1c2VyTmFtZTogXCJcdTc1MjhcdTYyMzdcIixcbiAgICBwaXhlbHM6IFwiXHU1MENGXHU3RDIwXCIsXG4gICAgY2hhcmdlczogXCJcdTZCMjFcdTY1NzhcIixcbiAgICBlc3RpbWF0ZWRUaW1lOiBcIlx1OTgxMFx1OEEwOFx1NjY0Mlx1OTU5M1wiLFxuICAgIGluaXRNZXNzYWdlOiBcIlx1OUVERVx1NjRDQVx1MjAxQ1x1NTIxRFx1NTlDQlx1NTMxNlx1ODFFQVx1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQVx1MjAxRFx1OTU4Qlx1NTlDQlwiLFxuICAgIHdhaXRpbmdJbml0OiBcIlx1N0I0OVx1NUY4NVx1NTIxRFx1NTlDQlx1NTMxNi4uLlwiLFxuICAgIHJlc2l6ZVN1Y2Nlc3M6IFwiXHUyNzA1IFx1NTcxNlx1NzI0N1x1NURGMlx1OEFCRlx1NjU3NFx1NzBCQSB7d2lkdGh9eHtoZWlnaHR9XCIsXG4gICAgcGFpbnRpbmdQYXVzZWQ6IFwiXHUyM0Y4XHVGRTBGIFx1N0U2QVx1ODhGRFx1NjZBQlx1NTA1Q1x1NjVCQ1x1NEY0RFx1N0Y2RSBYOiB7eH0sIFk6IHt5fVwiLFxuICAgIHBpeGVsc1BlckJhdGNoOiBcIlx1NkJDRlx1NjI3OVx1NTBDRlx1N0QyMFx1NjU3OFwiLFxuICAgIGJhdGNoU2l6ZTogXCJcdTYyNzlcdTZCMjFcdTU5MjdcdTVDMEZcIixcbiAgICBuZXh0QmF0Y2hUaW1lOiBcIlx1NEUwQlx1NkIyMVx1NjI3OVx1NkIyMVx1NjY0Mlx1OTU5M1wiLFxuICAgIHVzZUFsbENoYXJnZXM6IFwiXHU0RjdGXHU3NTI4XHU2MjQwXHU2NzA5XHU1M0VGXHU3NTI4XHU2QjIxXHU2NTc4XCIsXG4gICAgc2hvd092ZXJsYXk6IFwiXHU5ODZGXHU3OTNBXHU4OTg2XHU4NENCXHU1QzY0XCIsXG4gICAgbWF4Q2hhcmdlczogXCJcdTZCQ0ZcdTYyNzlcdTY3MDBcdTU5MjdcdTZCMjFcdTY1NzhcIixcbiAgICB3YWl0aW5nRm9yQ2hhcmdlczogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1XHU2QjIxXHU2NTc4OiB7Y3VycmVudH0ve25lZWRlZH1cIixcbiAgICB0aW1lUmVtYWluaW5nOiBcIlx1NTI2OVx1OTkxOFx1NjY0Mlx1OTU5M1wiLFxuICAgIGNvb2xkb3duV2FpdGluZzogXCJcdTIzRjMgXHU3QjQ5XHU1Rjg1IHt0aW1lfSBcdTVGOENcdTdFN0NcdTdFOEMuLi5cIixcbiAgICBwcm9ncmVzc1NhdmVkOiBcIlx1MjcwNSBcdTkwMzJcdTVFQTZcdTVERjJcdTRGRERcdTVCNThcdTcwQkEge2ZpbGVuYW1lfVwiLFxuICAgIHByb2dyZXNzTG9hZGVkOiBcIlx1MjcwNSBcdTVERjJcdTUyQTBcdThGMDlcdTkwMzJcdTVFQTY6IHtwYWludGVkfS97dG90YWx9IFx1NTBDRlx1N0QyMFx1NURGMlx1N0U2QVx1ODhGRFwiLFxuICAgIHByb2dyZXNzTG9hZEVycm9yOiBcIlx1Mjc0QyBcdTUyQTBcdThGMDlcdTkwMzJcdTVFQTZcdTU5MzFcdTY1NTc6IHtlcnJvcn1cIixcbiAgICBwcm9ncmVzc1NhdmVFcnJvcjogXCJcdTI3NEMgXHU0RkREXHU1QjU4XHU5MDMyXHU1RUE2XHU1OTMxXHU2NTU3OiB7ZXJyb3J9XCIsXG4gICAgY29uZmlybVNhdmVQcm9ncmVzczogXCJcdTU3MjhcdTUwNUNcdTZCNjJcdTRFNEJcdTUyNERcdTg5ODFcdTRGRERcdTVCNThcdTc1NzZcdTUyNERcdTkwMzJcdTVFQTZcdTU1Q0VcdUZGMUZcIixcbiAgICBzYXZlUHJvZ3Jlc3NUaXRsZTogXCJcdTRGRERcdTVCNThcdTkwMzJcdTVFQTZcIixcbiAgICBkaXNjYXJkUHJvZ3Jlc3M6IFwiXHU2NTNFXHU2OEM0XCIsXG4gICAgY2FuY2VsOiBcIlx1NTNENlx1NkQ4OFwiLFxuICAgIG1pbmltaXplOiBcIlx1NjcwMFx1NUMwRlx1NTMxNlwiLFxuICAgIHdpZHRoOiBcIlx1NUJFQ1x1NUVBNlwiLFxuICAgIGhlaWdodDogXCJcdTlBRDhcdTVFQTZcIixcbiAgICBrZWVwQXNwZWN0OiBcIlx1NEZERFx1NjMwMVx1N0UzMVx1NkE2Qlx1NkJENFwiLFxuICAgIGFwcGx5OiBcIlx1NjFDOVx1NzUyOFwiLFxuICAgIG92ZXJsYXlPbjogXCJcdTg5ODZcdTg0Q0JcdTVDNjQ6IFx1OTU4Qlx1NTU1M1wiLFxuICAgIG92ZXJsYXlPZmY6IFwiXHU4OTg2XHU4NENCXHU1QzY0OiBcdTk1RENcdTk1ODlcIixcbiAgICBwYXNzQ29tcGxldGVkOiBcIlx1MjcwNSBcdTYyNzlcdTZCMjFcdTVCOENcdTYyMTA6IFx1NURGMlx1N0U2QVx1ODhGRCB7cGFpbnRlZH0gXHU1MENGXHU3RDIwIHwgXHU5MDMyXHU1RUE2OiB7cGVyY2VudH0lICh7Y3VycmVudH0ve3RvdGFsfSlcIixcbiAgICB3YWl0aW5nQ2hhcmdlc1JlZ2VuOiBcIlx1MjNGMyBcdTdCNDlcdTVGODVcdTZCMjFcdTY1NzhcdTYwNjJcdTVGQTk6IHtjdXJyZW50fS97bmVlZGVkfSAtIFx1NjY0Mlx1OTU5Mzoge3RpbWV9XCIsXG4gICAgd2FpdGluZ0NoYXJnZXNDb3VudGRvd246IFwiXHUyM0YzIFx1N0I0OVx1NUY4NVx1NkIyMVx1NjU3ODoge2N1cnJlbnR9L3tuZWVkZWR9IC0gXHU1MjY5XHU5OTE4OiB7dGltZX1cIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTZCNjNcdTU3MjhcdTgxRUFcdTUyRDVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1NjIxMFx1NTI5RlwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBcdTcxMjFcdTZDRDVcdTgxRUFcdTUyRDVcdTU1NTNcdTUyRDVcdUZGMENcdThBQ0JcdTYyNEJcdTUyRDVcdTY0Q0RcdTRGNUNcdTMwMDJcIixcbiAgICBwYWxldHRlRGV0ZWN0ZWQ6IFwiXHVEODNDXHVERkE4IFx1NURGMlx1NkFBMlx1NkUyQ1x1NTIzMFx1OEFCRlx1ODI3Mlx1Njc3RlwiLFxuICAgIHBhbGV0dGVOb3RGb3VuZDogXCJcdUQ4M0RcdUREMEQgXHU2QjYzXHU1NzI4XHU2NDFDXHU3RDIyXHU4QUJGXHU4MjcyXHU2NzdGLi4uXCIsXG4gICAgY2xpY2tpbmdQYWludEJ1dHRvbjogXCJcdUQ4M0RcdURDNDYgXHU2QjYzXHU1NzI4XHU5RURFXHU2NENBXHU3RTZBXHU4OEZEXHU2MzA5XHU5MjE1Li4uXCIsXG4gICAgcGFpbnRCdXR0b25Ob3RGb3VuZDogXCJcdTI3NEMgXHU2NzJBXHU2MjdFXHU1MjMwXHU3RTZBXHU4OEZEXHU2MzA5XHU5MjE1XCIsXG4gICAgbWFudWFsSW5pdFJlcXVpcmVkOiBcIlx1RDgzRFx1REQyNyBcdTk3MDBcdTg5ODFcdTYyNEJcdTUyRDVcdTUyMURcdTU5Q0JcdTUzMTZcIixcbiAgICByZXRyeUF0dGVtcHQ6IFwiXHVEODNEXHVERDA0IFx1OTFDRFx1OEE2NiB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfVx1RkYwQ1x1N0I0OVx1NUY4NSB7ZGVsYXl9IFx1NzlEMi4uLlwiLFxuICAgIHJldHJ5RXJyb3I6IFwiXHVEODNEXHVEQ0E1IFx1N0IyQyB7YXR0ZW1wdH0ve21heEF0dGVtcHRzfSBcdTZCMjFcdTU2MTdcdThBNjZcdTUxRkFcdTkzMkZcdUZGMENcdTVDMDdcdTU3Mjgge2RlbGF5fSBcdTc5RDJcdTVGOENcdTkxQ0RcdThBNjYuLi5cIixcbiAgICByZXRyeUZhaWxlZDogXCJcdTI3NEMgXHU4RDg1XHU5MDRFIHttYXhBdHRlbXB0c30gXHU2QjIxXHU1NjE3XHU4QTY2XHU1OTMxXHU2NTU3XHUzMDAyXHU3RTdDXHU3RThDXHU0RTBCXHU0RTAwXHU2Mjc5Li4uXCIsXG4gICAgbmV0d29ya0Vycm9yOiBcIlx1RDgzQ1x1REYxMCBcdTdEQjJcdTdENjFcdTkzMkZcdThBQTRcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThBNjYuLi5cIixcbiAgICBzZXJ2ZXJFcnJvcjogXCJcdUQ4M0RcdUREMjUgXHU2NzBEXHU1MkQ5XHU1NjY4XHU5MzJGXHU4QUE0XHVGRjBDXHU2QjYzXHU1NzI4XHU5MUNEXHU4QTY2Li4uXCIsXG4gICAgdGltZW91dEVycm9yOiBcIlx1MjNGMCBcdTY3MERcdTUyRDlcdTU2NjhcdThEODVcdTY2NDJcdUZGMENcdTZCNjNcdTU3MjhcdTkxQ0RcdThBNjYuLi5cIlxuICB9LFxuXG4gIC8vIFx1OEZCMlx1NTgzNFx1NkEyMVx1NTg0QVx1RkYwOFx1NUY4NVx1NUJFNlx1NzNGRVx1RkYwOVxuICBmYXJtOiB7XG4gICAgdGl0bGU6IFwiV1BsYWNlIFx1OEZCMlx1NTgzNFx1NkE1Rlx1NTY2OFx1NEVCQVwiLFxuICAgIHN0YXJ0OiBcIlx1OTU4Qlx1NTlDQlwiLFxuICAgIHN0b3A6IFwiXHU1MDVDXHU2QjYyXCIsXG4gICAgc3RvcHBlZDogXCJcdTZBNUZcdTU2NjhcdTRFQkFcdTVERjJcdTUwNUNcdTZCNjJcIixcbiAgICBjYWxpYnJhdGU6IFwiXHU2ODIxXHU2RTk2XCIsXG4gICAgcGFpbnRPbmNlOiBcIlx1NEUwMFx1NkIyMVwiLFxuICAgIGNoZWNraW5nU3RhdHVzOiBcIlx1NkFBMlx1NjdFNVx1NzJDMFx1NjE0Qlx1NEUyRC4uLlwiLFxuICAgIGNvbmZpZ3VyYXRpb246IFwiXHU5MTREXHU3RjZFXCIsXG4gICAgZGVsYXk6IFwiXHU1RUY2XHU5MDcyIChcdTZCRUJcdTc5RDIpXCIsXG4gICAgcGl4ZWxzUGVyQmF0Y2g6IFwiXHU2QkNGXHU2Mjc5XHU1MENGXHU3RDIwXCIsXG4gICAgbWluQ2hhcmdlczogXCJcdTY3MDBcdTVDMTFcdTZCMjFcdTY1NzhcIixcbiAgICBjb2xvck1vZGU6IFwiXHU5ODRGXHU4MjcyXHU2QTIxXHU1RjBGXCIsXG4gICAgcmFuZG9tOiBcIlx1OTZBOFx1NkE1RlwiLFxuICAgIGZpeGVkOiBcIlx1NTZGQVx1NUI5QVwiLFxuICAgIHJhbmdlOiBcIlx1N0JDNFx1NTcwRFwiLFxuICAgIGZpeGVkQ29sb3I6IFwiXHU1NkZBXHU1QjlBXHU5ODRGXHU4MjcyXCIsXG4gICAgYWR2YW5jZWQ6IFwiXHU5QUQ4XHU3RDFBXCIsXG4gICAgdGlsZVg6IFwiXHU3NEU2XHU3MjQ3IFhcIixcbiAgICB0aWxlWTogXCJcdTc0RTZcdTcyNDcgWVwiLFxuICAgIGN1c3RvbVBhbGV0dGU6IFwiXHU4MUVBXHU1QjlBXHU3RkE5XHU4QUJGXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZUV4YW1wbGU6IFwiXHU0RjhCXHU1OTgyOiAjRkYwMDAwLCMwMEZGMDAsIzAwMDBGRlwiLFxuICAgIGNhcHR1cmU6IFwiXHU2MzU1XHU3MzcyXCIsXG4gICAgcGFpbnRlZDogXCJcdTVERjJcdTdFNkFcdTg4RkRcIixcbiAgICBjaGFyZ2VzOiBcIlx1NkIyMVx1NjU3OFwiLFxuICAgIHJldHJpZXM6IFwiXHU5MUNEXHU4QTY2XCIsXG4gICAgdGlsZTogXCJcdTc0RTZcdTcyNDdcIixcbiAgICBjb25maWdTYXZlZDogXCJcdTkxNERcdTdGNkVcdTVERjJcdTRGRERcdTVCNThcIixcbiAgICBjb25maWdMb2FkZWQ6IFwiXHU5MTREXHU3RjZFXHU1REYyXHU1MkEwXHU4RjA5XCIsXG4gICAgY29uZmlnUmVzZXQ6IFwiXHU5MTREXHU3RjZFXHU1REYyXHU5MUNEXHU3RjZFXCIsXG4gICAgY2FwdHVyZUluc3RydWN0aW9uczogXCJcdThBQ0JcdTYyNEJcdTUyRDVcdTdFNkFcdTg4RkRcdTRFMDBcdTUwMEJcdTUwQ0ZcdTdEMjBcdTRFRTVcdTYzNTVcdTczNzJcdTVFQTdcdTZBMTkuLi5cIixcbiAgICBiYWNrZW5kT25saW5lOiBcIlx1NUY4Q1x1N0FFRlx1NTcyOFx1N0REQVwiLFxuICAgIGJhY2tlbmRPZmZsaW5lOiBcIlx1NUY4Q1x1N0FFRlx1OTZFMlx1N0REQVwiLFxuICAgIHN0YXJ0aW5nQm90OiBcIlx1NkI2M1x1NTcyOFx1NTU1M1x1NTJENVx1NkE1Rlx1NTY2OFx1NEVCQS4uLlwiLFxuICAgIHN0b3BwaW5nQm90OiBcIlx1NkI2M1x1NTcyOFx1NTA1Q1x1NkI2Mlx1NkE1Rlx1NTY2OFx1NEVCQS4uLlwiLFxuICAgIGNhbGlicmF0aW5nOiBcIlx1NjgyMVx1NkU5Nlx1NEUyRC4uLlwiLFxuICAgIGFscmVhZHlSdW5uaW5nOiBcIlx1ODFFQVx1NTJENVx1OEZCMlx1NTgzNFx1NURGMlx1NTcyOFx1OTA0Qlx1ODg0Q1x1MzAwMlwiLFxuICAgIGltYWdlUnVubmluZ1dhcm5pbmc6IFwiXHU4MUVBXHU1MkQ1XHU3RTZBXHU1NzE2XHU2QjYzXHU1NzI4XHU5MDRCXHU4ODRDXHVGRjBDXHU4QUNCXHU1MTQ4XHU5NURDXHU5NTg5XHU1MThEXHU1NTUzXHU1MkQ1XHU4MUVBXHU1MkQ1XHU4RkIyXHU1ODM0XHUzMDAyXCIsXG4gICAgc2VsZWN0UG9zaXRpb246IFwiXHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXCIsXG4gICAgc2VsZWN0UG9zaXRpb25BbGVydDogXCJcdUQ4M0NcdURGQUYgXHU1NzI4XHU1NzMwXHU1NzE2XHU3Njg0XHU3QTdBXHU3NjdEXHU1MzQwXHU1N0RGXHU1ODU3XHU0RTAwXHU1MDBCXHU1MENGXHU3RDIwXHU0RUU1XHU4QTJEXHU3RjZFXHU4RkIyXHU1ODM0XHU1MzQwXHU1N0RGXCIsXG4gICAgd2FpdGluZ1Bvc2l0aW9uOiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTRGNjBcdTU4NTdcdTUzQzNcdTgwMDNcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICBwb3NpdGlvblNldDogXCJcdTI3MDUgXHU1MzQwXHU1N0RGXHU4QTJEXHU3RjZFXHU2MjEwXHU1MjlGXHVGRjAxXHU1MzRBXHU1RjkxOiA1MDBweFwiLFxuICAgIHBvc2l0aW9uVGltZW91dDogXCJcdTI3NEMgXHU1MzQwXHU1N0RGXHU5MDc4XHU2NEM3XHU4RDg1XHU2NjQyXCIsXG4gICAgbWlzc2luZ1Bvc2l0aW9uOiBcIlx1Mjc0QyBcdThBQ0JcdTUxNDhcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcdUZGMDhcdTRGN0ZcdTc1MjhcdTIwMUNcdTkwNzhcdTY0QzdcdTUzNDBcdTU3REZcdTIwMURcdTYzMDlcdTkyMTVcdUZGMDlcIixcbiAgICBmYXJtUmFkaXVzOiBcIlx1OEZCMlx1NTgzNFx1NTM0QVx1NUY5MVwiLFxuICAgIHBvc2l0aW9uSW5mbzogXCJcdTc1NzZcdTUyNERcdTUzNDBcdTU3REZcIixcbiAgICBmYXJtaW5nSW5SYWRpdXM6IFwiXHVEODNDXHVERjNFIFx1NkI2M1x1NTcyOFx1NEVFNVx1NTM0QVx1NUY5MSB7cmFkaXVzfXB4IFx1NTcyOCAoe3h9LHt5fSkgXHU4RkIyXHU1ODM0XCIsXG4gICAgc2VsZWN0RW1wdHlBcmVhOiBcIlx1MjZBMFx1RkUwRiBcdTkxQ0RcdTg5ODE6IFx1OEFDQlx1OTA3OFx1NjRDN1x1N0E3QVx1NzY3RFx1NTM0MFx1NTdERlx1NEVFNVx1OTA3Rlx1NTE0RFx1ODg1RFx1N0E4MVwiLFxuICAgIG5vUG9zaXRpb246IFwiXHU2NzJBXHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXCIsXG4gICAgY3VycmVudFpvbmU6IFwiXHU1MzQwXHU1N0RGOiAoe3h9LHt5fSlcIixcbiAgICBhdXRvU2VsZWN0UG9zaXRpb246IFwiXHVEODNDXHVERkFGIFx1OEFDQlx1NTE0OFx1OTA3OFx1NjRDN1x1NTM0MFx1NTdERlx1RkYwQ1x1NTcyOFx1NTczMFx1NTcxNlx1NEUwQVx1NTg1N1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFx1NEVFNVx1OEEyRFx1N0Y2RVx1OEZCMlx1NTgzNFx1NTM0MFx1NTdERlwiXG4gIH0sXG5cbiAgLy8gXHU1MTZDXHU1MTcxXG4gIGNvbW1vbjoge1xuICAgIHllczogXCJcdTY2MkZcIixcbiAgICBubzogXCJcdTU0MjZcIixcbiAgICBvazogXCJcdTc4QkFcdThBOERcIixcbiAgICBjYW5jZWw6IFwiXHU1M0Q2XHU2RDg4XCIsXG4gICAgY2xvc2U6IFwiXHU5NURDXHU5NTg5XCIsXG4gICAgc2F2ZTogXCJcdTRGRERcdTVCNThcIixcbiAgICBsb2FkOiBcIlx1NTJBMFx1OEYwOVwiLFxuICAgIGRlbGV0ZTogXCJcdTUyMkFcdTk2NjRcIixcbiAgICBlZGl0OiBcIlx1N0RFOFx1OEYyRlwiLFxuICAgIHN0YXJ0OiBcIlx1OTU4Qlx1NTlDQlwiLFxuICAgIHN0b3A6IFwiXHU1MDVDXHU2QjYyXCIsXG4gICAgcGF1c2U6IFwiXHU2NkFCXHU1MDVDXCIsXG4gICAgcmVzdW1lOiBcIlx1N0U3Q1x1N0U4Q1wiLFxuICAgIHJlc2V0OiBcIlx1OTFDRFx1N0Y2RVwiLFxuICAgIHNldHRpbmdzOiBcIlx1OEEyRFx1N0Y2RVwiLFxuICAgIGhlbHA6IFwiXHU1RTZCXHU1MkE5XCIsXG4gICAgYWJvdXQ6IFwiXHU5NURDXHU2NUJDXCIsXG4gICAgbGFuZ3VhZ2U6IFwiXHU4QTlFXHU4QTAwXCIsXG4gICAgbG9hZGluZzogXCJcdTUyQTBcdThGMDlcdTRFMkQuLi5cIixcbiAgICBlcnJvcjogXCJcdTkzMkZcdThBQTRcIixcbiAgICBzdWNjZXNzOiBcIlx1NjIxMFx1NTI5RlwiLFxuICAgIHdhcm5pbmc6IFwiXHU4QjY2XHU1NDRBXCIsXG4gICAgaW5mbzogXCJcdTRGRTFcdTYwNkZcIixcbiAgICBsYW5ndWFnZUNoYW5nZWQ6IFwiXHU4QTlFXHU4QTAwXHU1REYyXHU1MjA3XHU2M0RCXHU3MEJBIHtsYW5ndWFnZX1cIlxuICB9LFxuXG4gIC8vIFx1NUI4OFx1OEI3N1x1NkEyMVx1NTg0QVxuICBndWFyZDoge1xuICAgIHRpdGxlOiBcIldQbGFjZSBcdTgxRUFcdTUyRDVcdTVCODhcdThCNzdcIixcbiAgICBpbml0Qm90OiBcIlx1NTIxRFx1NTlDQlx1NTMxNlx1NUI4OFx1OEI3N1x1NkE1Rlx1NTY2OFx1NEVCQVwiLFxuICAgIHNlbGVjdEFyZWE6IFwiXHU5MDc4XHU2NEM3XHU1MzQwXHU1N0RGXCIsXG4gICAgY2FwdHVyZUFyZWE6IFwiXHU2MzU1XHU3MzcyXHU1MzQwXHU1N0RGXCIsXG4gICAgc3RhcnRQcm90ZWN0aW9uOiBcIlx1OTU4Qlx1NTlDQlx1NUI4OFx1OEI3N1wiLFxuICAgIHN0b3BQcm90ZWN0aW9uOiBcIlx1NTA1Q1x1NkI2Mlx1NUI4OFx1OEI3N1wiLFxuICAgIHVwcGVyTGVmdDogXCJcdTVERTZcdTRFMEFcdTg5RDJcIixcbiAgICBsb3dlclJpZ2h0OiBcIlx1NTNGM1x1NEUwQlx1ODlEMlwiLFxuICAgIHByb3RlY3RlZFBpeGVsczogXCJcdTUzRDdcdTRGRERcdThCNzdcdTUwQ0ZcdTdEMjBcIixcbiAgICBkZXRlY3RlZENoYW5nZXM6IFwiXHU2QUEyXHU2RTJDXHU1MjMwXHU3Njg0XHU4QjhBXHU1MzE2XCIsXG4gICAgcmVwYWlyZWRQaXhlbHM6IFwiXHU0RkVFXHU1RkE5XHU3Njg0XHU1MENGXHU3RDIwXCIsXG4gICAgY2hhcmdlczogXCJcdTZCMjFcdTY1NzhcIixcbiAgICB3YWl0aW5nSW5pdDogXCJcdTdCNDlcdTVGODVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICBjaGVja2luZ0NvbG9yczogXCJcdUQ4M0NcdURGQTggXHU2QUEyXHU2N0U1XHU1M0VGXHU3NTI4XHU5ODRGXHU4MjcyLi4uXCIsXG4gICAgbm9Db2xvcnNGb3VuZDogXCJcdTI3NEMgXHU2NzJBXHU2MjdFXHU1MjMwXHU5ODRGXHU4MjcyXHVGRjBDXHU4QUNCXHU1NzI4XHU3REIyXHU3QUQ5XHU0RTBBXHU2MjUzXHU5NThCXHU4QUJGXHU4MjcyXHU2NzdGXHUzMDAyXCIsXG4gICAgY29sb3JzRm91bmQ6IFwiXHUyNzA1IFx1NjI3RVx1NTIzMCB7Y291bnR9IFx1N0EyRVx1NTNFRlx1NzUyOFx1OTg0Rlx1ODI3MlwiLFxuICAgIGluaXRTdWNjZXNzOiBcIlx1MjcwNSBcdTVCODhcdThCNzdcdTZBNUZcdTU2NjhcdTRFQkFcdTUyMURcdTU5Q0JcdTUzMTZcdTYyMTBcdTUyOUZcIixcbiAgICBpbml0RXJyb3I6IFwiXHUyNzRDIFx1NUI4OFx1OEI3N1x1NkE1Rlx1NTY2OFx1NEVCQVx1NTIxRFx1NTlDQlx1NTMxNlx1NTkzMVx1NjU1N1wiLFxuICAgIGludmFsaWRDb29yZHM6IFwiXHUyNzRDIFx1NUVBN1x1NkExOVx1NzEyMVx1NjU0OFwiLFxuICAgIGludmFsaWRBcmVhOiBcIlx1Mjc0QyBcdTUzNDBcdTU3REZcdTcxMjFcdTY1NDhcdUZGMENcdTVERTZcdTRFMEFcdTg5RDJcdTVGQzVcdTk4MDhcdTVDMEZcdTY1QkNcdTUzRjNcdTRFMEJcdTg5RDJcIixcbiAgICBhcmVhVG9vTGFyZ2U6IFwiXHUyNzRDIFx1NTM0MFx1NTdERlx1OTA0RVx1NTkyNzoge3NpemV9IFx1NTBDRlx1N0QyMCAoXHU2NzAwXHU1OTI3OiB7bWF4fSlcIixcbiAgICBjYXB0dXJpbmdBcmVhOiBcIlx1RDgzRFx1RENGOCBcdTYzNTVcdTczNzJcdTVCODhcdThCNzdcdTUzNDBcdTU3REZcdTRFMkQuLi5cIixcbiAgICBhcmVhQ2FwdHVyZWQ6IFwiXHUyNzA1IFx1NTM0MFx1NTdERlx1NjM1NVx1NzM3Mlx1NjIxMFx1NTI5Rjoge2NvdW50fSBcdTUwQ0ZcdTdEMjBcdTUzRDdcdTRGRERcdThCNzdcIixcbiAgICBjYXB0dXJlRXJyb3I6IFwiXHUyNzRDIFx1NjM1NVx1NzM3Mlx1NTM0MFx1NTdERlx1NTFGQVx1OTMyRjoge2Vycm9yfVwiLFxuICAgIGNhcHR1cmVGaXJzdDogXCJcdTI3NEMgXHU4QUNCXHU1MTQ4XHU2MzU1XHU3MzcyXHU0RTAwXHU1MDBCXHU1Qjg4XHU4Qjc3XHU1MzQwXHU1N0RGXCIsXG4gICAgcHJvdGVjdGlvblN0YXJ0ZWQ6IFwiXHVEODNEXHVERUUxXHVGRTBGIFx1NUI4OFx1OEI3N1x1NURGMlx1NTU1M1x1NTJENSAtIFx1NTM0MFx1NTdERlx1NzZFM1x1NjNBN1x1NEUyRFwiLFxuICAgIHByb3RlY3Rpb25TdG9wcGVkOiBcIlx1MjNGOVx1RkUwRiBcdTVCODhcdThCNzdcdTVERjJcdTUwNUNcdTZCNjJcIixcbiAgICBub0NoYW5nZXM6IFwiXHUyNzA1IFx1NTM0MFx1NTdERlx1NUI4OVx1NTE2OCAtIFx1NjcyQVx1NkFBMlx1NkUyQ1x1NTIzMFx1OEI4QVx1NTMxNlwiLFxuICAgIGNoYW5nZXNEZXRlY3RlZDogXCJcdUQ4M0RcdURFQTggXHU2QUEyXHU2RTJDXHU1MjMwIHtjb3VudH0gXHU1MDBCXHU4QjhBXHU1MzE2XCIsXG4gICAgcmVwYWlyaW5nOiBcIlx1RDgzRFx1REVFMFx1RkUwRiBcdTZCNjNcdTU3MjhcdTRGRUVcdTVGQTkge2NvdW50fSBcdTUwMEJcdTUwQ0ZcdTdEMjAuLi5cIixcbiAgICByZXBhaXJlZFN1Y2Nlc3M6IFwiXHUyNzA1IFx1NURGMlx1NjIxMFx1NTI5Rlx1NEZFRVx1NUZBOSB7Y291bnR9IFx1NTAwQlx1NTBDRlx1N0QyMFwiLFxuICAgIHJlcGFpckVycm9yOiBcIlx1Mjc0QyBcdTRGRUVcdTVGQTlcdTUxRkFcdTkzMkY6IHtlcnJvcn1cIixcbiAgICBub0NoYXJnZXM6IFwiXHUyNkEwXHVGRTBGIFx1NkIyMVx1NjU3OFx1NEUwRFx1OERCM1x1RkYwQ1x1NzEyMVx1NkNENVx1NEZFRVx1NUZBOVwiLFxuICAgIGNoZWNraW5nQ2hhbmdlczogXCJcdUQ4M0RcdUREMEQgXHU2QjYzXHU1NzI4XHU2QUEyXHU2N0U1XHU1MzQwXHU1N0RGXHU4QjhBXHU1MzE2Li4uXCIsXG4gICAgZXJyb3JDaGVja2luZzogXCJcdTI3NEMgXHU2QUEyXHU2N0U1XHU1MUZBXHU5MzJGOiB7ZXJyb3J9XCIsXG4gICAgZ3VhcmRBY3RpdmU6IFwiXHVEODNEXHVERUUxXHVGRTBGIFx1NUI4OFx1OEI3N1x1NEUyRCAtIFx1NTM0MFx1NTdERlx1NTNEN1x1NEZERFx1OEI3N1wiLFxuICAgIGxhc3RDaGVjazogXCJcdTRFMEFcdTZCMjFcdTZBQTJcdTY3RTU6IHt0aW1lfVwiLFxuICAgIG5leHRDaGVjazogXCJcdTRFMEJcdTZCMjFcdTZBQTJcdTY3RTU6IHt0aW1lfSBcdTc5RDJcdTVGOENcIixcbiAgICBhdXRvSW5pdGlhbGl6aW5nOiBcIlx1RDgzRVx1REQxNiBcdTZCNjNcdTU3MjhcdTgxRUFcdTUyRDVcdTUyMURcdTU5Q0JcdTUzMTYuLi5cIixcbiAgICBhdXRvSW5pdFN1Y2Nlc3M6IFwiXHUyNzA1IFx1ODFFQVx1NTJENVx1NTU1M1x1NTJENVx1NjIxMFx1NTI5RlwiLFxuICAgIGF1dG9Jbml0RmFpbGVkOiBcIlx1MjZBMFx1RkUwRiBcdTcxMjFcdTZDRDVcdTgxRUFcdTUyRDVcdTU1NTNcdTUyRDVcdUZGMENcdThBQ0JcdTYyNEJcdTUyRDVcdTY0Q0RcdTRGNUNcdTMwMDJcIixcbiAgICBtYW51YWxJbml0UmVxdWlyZWQ6IFwiXHVEODNEXHVERDI3IFx1OTcwMFx1ODk4MVx1NjI0Qlx1NTJENVx1NTIxRFx1NTlDQlx1NTMxNlwiLFxuICAgIHBhbGV0dGVEZXRlY3RlZDogXCJcdUQ4M0NcdURGQTggXHU1REYyXHU2QUEyXHU2RTJDXHU1MjMwXHU4QUJGXHU4MjcyXHU2NzdGXCIsXG4gICAgcGFsZXR0ZU5vdEZvdW5kOiBcIlx1RDgzRFx1REQwRCBcdTZCNjNcdTU3MjhcdTY0MUNcdTdEMjJcdThBQkZcdTgyNzJcdTY3N0YuLi5cIixcbiAgICBjbGlja2luZ1BhaW50QnV0dG9uOiBcIlx1RDgzRFx1REM0NiBcdTZCNjNcdTU3MjhcdTlFREVcdTY0Q0FcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTUuLi5cIixcbiAgICBwYWludEJ1dHRvbk5vdEZvdW5kOiBcIlx1Mjc0QyBcdTY3MkFcdTYyN0VcdTUyMzBcdTdFNkFcdTg4RkRcdTYzMDlcdTkyMTVcIixcbiAgICBzZWxlY3RVcHBlckxlZnQ6IFwiXHVEODNDXHVERkFGIFx1NTcyOFx1OTcwMFx1ODk4MVx1NEZERFx1OEI3N1x1NTM0MFx1NTdERlx1NzY4NFx1NURFNlx1NEUwQVx1ODlEMlx1NTg1N1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFwiLFxuICAgIHNlbGVjdExvd2VyUmlnaHQ6IFwiXHVEODNDXHVERkFGIFx1NzNGRVx1NTcyOFx1NTcyOFx1NTNGM1x1NEUwQlx1ODlEMlx1NTg1N1x1NEUwMFx1NTAwQlx1NTBDRlx1N0QyMFwiLFxuICAgIHdhaXRpbmdVcHBlckxlZnQ6IFwiXHVEODNEXHVEQzQ2IFx1N0I0OVx1NUY4NVx1OTA3OFx1NjRDN1x1NURFNlx1NEUwQVx1ODlEMi4uLlwiLFxuICAgIHdhaXRpbmdMb3dlclJpZ2h0OiBcIlx1RDgzRFx1REM0NiBcdTdCNDlcdTVGODVcdTkwNzhcdTY0QzdcdTUzRjNcdTRFMEJcdTg5RDIuLi5cIixcbiAgICB1cHBlckxlZnRDYXB0dXJlZDogXCJcdTI3MDUgXHU1REYyXHU2MzU1XHU3MzcyXHU1REU2XHU0RTBBXHU4OUQyOiAoe3h9LCB7eX0pXCIsXG4gICAgbG93ZXJSaWdodENhcHR1cmVkOiBcIlx1MjcwNSBcdTVERjJcdTYzNTVcdTczNzJcdTUzRjNcdTRFMEJcdTg5RDI6ICh7eH0sIHt5fSlcIixcbiAgICBzZWxlY3Rpb25UaW1lb3V0OiBcIlx1Mjc0QyBcdTkwNzhcdTY0QzdcdThEODVcdTY2NDJcIixcbiAgICBzZWxlY3Rpb25FcnJvcjogXCJcdTI3NEMgXHU5MDc4XHU2NEM3XHU1MUZBXHU5MzJGXHVGRjBDXHU4QUNCXHU5MUNEXHU4QTY2XCJcbiAgfVxufTsiLCAiaW1wb3J0IHsgZXMgfSBmcm9tICcuL2VzLmpzJztcbmltcG9ydCB7IGVuIH0gZnJvbSAnLi9lbi5qcyc7XG5pbXBvcnQgeyBmciB9IGZyb20gJy4vZnIuanMnO1xuaW1wb3J0IHsgcnUgfSBmcm9tICcuL3J1LmpzJztcbmltcG9ydCB7IHpoSGFucyB9IGZyb20gJy4vemgtSGFucy5qcyc7XG5pbXBvcnQgeyB6aEhhbnQgfSBmcm9tICcuL3poLUhhbnQuanMnO1xuXG4vLyBJZGlvbWFzIGRpc3BvbmlibGVzXG5leHBvcnQgY29uc3QgQVZBSUxBQkxFX0xBTkdVQUdFUyA9IHtcbiAgZXM6IHsgbmFtZTogJ0VzcGFcdTAwRjFvbCcsIGZsYWc6ICdcdUQ4M0NcdURERUFcdUQ4M0NcdURERjgnLCBjb2RlOiAnZXMnIH0sXG4gIGVuOiB7IG5hbWU6ICdFbmdsaXNoJywgZmxhZzogJ1x1RDgzQ1x1RERGQVx1RDgzQ1x1RERGOCcsIGNvZGU6ICdlbicgfSxcbiAgZnI6IHsgbmFtZTogJ0ZyYW5cdTAwRTdhaXMnLCBmbGFnOiAnXHVEODNDXHVEREVCXHVEODNDXHVEREY3JywgY29kZTogJ2ZyJyB9LFxuICBydTogeyBuYW1lOiAnXHUwNDIwXHUwNDQzXHUwNDQxXHUwNDQxXHUwNDNBXHUwNDM4XHUwNDM5JywgZmxhZzogJ1x1RDgzQ1x1RERGN1x1RDgzQ1x1RERGQScsIGNvZGU6ICdydScgfSxcbiAgemhIYW5zOiB7IG5hbWU6ICdcdTdCODBcdTRGNTNcdTRFMkRcdTY1ODcnLCBmbGFnOiAnXHVEODNDXHVEREU4XHVEODNDXHVEREYzJywgY29kZTogJ3poLUhhbnMnIH0sXG4gIHpoSGFudDogeyBuYW1lOiAnXHU3RTQxXHU5QUQ0XHU0RTJEXHU2NTg3JywgZmxhZzogJ1x1RDgzQ1x1RERFOFx1RDgzQ1x1RERGMycsIGNvZGU6ICd6aC1IYW50JyB9XG59O1xuXG4vLyBUb2RhcyBsYXMgdHJhZHVjY2lvbmVzXG5jb25zdCB0cmFuc2xhdGlvbnMgPSB7XG4gIGVzLFxuICBlbixcbiAgZnIsXG4gIHJ1LFxuICB6aEhhbnMsXG4gIHpoSGFudFxufTtcblxuLy8gRXN0YWRvIGRlbCBpZGlvbWEgYWN0dWFsXG5sZXQgY3VycmVudExhbmd1YWdlID0gJ2VzJztcbmxldCBjdXJyZW50VHJhbnNsYXRpb25zID0gdHJhbnNsYXRpb25zW2N1cnJlbnRMYW5ndWFnZV07XG5cbi8qKlxuICogRGV0ZWN0YSBlbCBpZGlvbWEgZGVsIG5hdmVnYWRvclxuICogQHJldHVybnMge3N0cmluZ30gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYSBkZXRlY3RhZG9cbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGRldGVjdEJyb3dzZXJMYW5ndWFnZSgpIHtcbiAgY29uc3QgYnJvd3NlckxhbmcgPSB3aW5kb3cubmF2aWdhdG9yLmxhbmd1YWdlIHx8IHdpbmRvdy5uYXZpZ2F0b3IudXNlckxhbmd1YWdlIHx8ICdlcyc7XG5cbiAgLy8gRXh0cmFlciBzb2xvIGVsIGNcdTAwRjNkaWdvIGRlbCBpZGlvbWEgKGVqOiAnZXMtRVMnIC0+ICdlcycpXG4gIGNvbnN0IGxhbmdDb2RlID0gYnJvd3Nlckxhbmcuc3BsaXQoJy0nKVswXS50b0xvd2VyQ2FzZSgpO1xuXG4gIC8vIFZlcmlmaWNhciBzaSB0ZW5lbW9zIHNvcG9ydGUgcGFyYSBlc3RlIGlkaW9tYVxuICBpZiAodHJhbnNsYXRpb25zW2xhbmdDb2RlXSkge1xuICAgIHJldHVybiBsYW5nQ29kZTtcbiAgfVxuXG4gIC8vIEZhbGxiYWNrIGEgZXNwYVx1MDBGMW9sIHBvciBkZWZlY3RvXG4gIHJldHVybiAnZXMnO1xufVxuXG4vKipcbiAqIE9idGllbmUgZWwgaWRpb21hIGd1YXJkYWRvIChkZXNoYWJpbGl0YWRvIC0gbm8gdXNhciBsb2NhbFN0b3JhZ2UpXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBTaWVtcHJlIHJldG9ybmEgbnVsbFxuICovXG5leHBvcnQgZnVuY3Rpb24gZ2V0U2F2ZWRMYW5ndWFnZSgpIHtcbiAgLy8gTm8gdXNhciBsb2NhbFN0b3JhZ2UgLSBzaWVtcHJlIHJldG9ybmFyIG51bGxcbiAgcmV0dXJuIG51bGw7XG59XG5cbi8qKlxuICogR3VhcmRhIGVsIGlkaW9tYSAoZGVzaGFiaWxpdGFkbyAtIG5vIHVzYXIgbG9jYWxTdG9yYWdlKVxuICogQHBhcmFtIHtzdHJpbmd9IGxhbmdDb2RlIC0gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYVxuICovXG5leHBvcnQgZnVuY3Rpb24gc2F2ZUxhbmd1YWdlKGxhbmdDb2RlKSB7XG4gIC8vIE5vIGd1YXJkYXIgZW4gbG9jYWxTdG9yYWdlIC0gZnVuY2lcdTAwRjNuIGRlc2hhYmlsaXRhZGFcbiAgcmV0dXJuO1xufVxuXG4vKipcbiAqIEluaWNpYWxpemEgZWwgc2lzdGVtYSBkZSBpZGlvbWFzXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBDXHUwMEYzZGlnbyBkZWwgaWRpb21hIGluaWNpYWxpemFkb1xuICovXG5leHBvcnQgZnVuY3Rpb24gaW5pdGlhbGl6ZUxhbmd1YWdlKCkge1xuICAvLyBQcmlvcmlkYWQ6IGd1YXJkYWRvID4gbmF2ZWdhZG9yID4gZXNwYVx1MDBGMW9sXG4gIGNvbnN0IHNhdmVkTGFuZyA9IGdldFNhdmVkTGFuZ3VhZ2UoKTtcbiAgY29uc3QgYnJvd3NlckxhbmcgPSBkZXRlY3RCcm93c2VyTGFuZ3VhZ2UoKTtcblxuICBsZXQgc2VsZWN0ZWRMYW5nID0gJ2VzJzsgLy8gZmFsbGJhY2sgcG9yIGRlZmVjdG9cblxuICBpZiAoc2F2ZWRMYW5nICYmIHRyYW5zbGF0aW9uc1tzYXZlZExhbmddKSB7XG4gICAgc2VsZWN0ZWRMYW5nID0gc2F2ZWRMYW5nO1xuICB9IGVsc2UgaWYgKGJyb3dzZXJMYW5nICYmIHRyYW5zbGF0aW9uc1ticm93c2VyTGFuZ10pIHtcbiAgICBzZWxlY3RlZExhbmcgPSBicm93c2VyTGFuZztcbiAgfVxuXG4gIHNldExhbmd1YWdlKHNlbGVjdGVkTGFuZyk7XG4gIHJldHVybiBzZWxlY3RlZExhbmc7XG59XG5cbi8qKlxuICogQ2FtYmlhIGVsIGlkaW9tYSBhY3R1YWxcbiAqIEBwYXJhbSB7c3RyaW5nfSBsYW5nQ29kZSAtIENcdTAwRjNkaWdvIGRlbCBpZGlvbWFcbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIHNldExhbmd1YWdlKGxhbmdDb2RlKSB7XG4gIGlmICghdHJhbnNsYXRpb25zW2xhbmdDb2RlXSkge1xuICAgIGNvbnNvbGUud2FybihgSWRpb21hICcke2xhbmdDb2RlfScgbm8gZGlzcG9uaWJsZS4gVXNhbmRvICcke2N1cnJlbnRMYW5ndWFnZX0nYCk7XG4gICAgcmV0dXJuO1xuICB9XG5cbiAgY3VycmVudExhbmd1YWdlID0gbGFuZ0NvZGU7XG4gIGN1cnJlbnRUcmFuc2xhdGlvbnMgPSB0cmFuc2xhdGlvbnNbbGFuZ0NvZGVdO1xuICBzYXZlTGFuZ3VhZ2UobGFuZ0NvZGUpO1xuXG4gIC8vIEVtaXRpciBldmVudG8gcGVyc29uYWxpemFkbyBwYXJhIHF1ZSBsb3MgbVx1MDBGM2R1bG9zIHB1ZWRhbiByZWFjY2lvbmFyXG4gIGlmICh0eXBlb2Ygd2luZG93ICE9PSAndW5kZWZpbmVkJyAmJiB3aW5kb3cuQ3VzdG9tRXZlbnQpIHtcbiAgICB3aW5kb3cuZGlzcGF0Y2hFdmVudChuZXcgd2luZG93LkN1c3RvbUV2ZW50KCdsYW5ndWFnZUNoYW5nZWQnLCB7XG4gICAgICBkZXRhaWw6IHsgbGFuZ3VhZ2U6IGxhbmdDb2RlLCB0cmFuc2xhdGlvbnM6IGN1cnJlbnRUcmFuc2xhdGlvbnMgfVxuICAgIH0pKTtcbiAgfVxufVxuXG4vKipcbiAqIE9idGllbmUgZWwgaWRpb21hIGFjdHVhbFxuICogQHJldHVybnMge3N0cmluZ30gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYSBhY3R1YWxcbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGdldEN1cnJlbnRMYW5ndWFnZSgpIHtcbiAgcmV0dXJuIGN1cnJlbnRMYW5ndWFnZTtcbn1cblxuLyoqXG4gKiBPYnRpZW5lIGxhcyB0cmFkdWNjaW9uZXMgYWN0dWFsZXNcbiAqIEByZXR1cm5zIHtvYmplY3R9IE9iamV0byBjb24gdG9kYXMgbGFzIHRyYWR1Y2Npb25lcyBkZWwgaWRpb21hIGFjdHVhbFxuICovXG5leHBvcnQgZnVuY3Rpb24gZ2V0Q3VycmVudFRyYW5zbGF0aW9ucygpIHtcbiAgcmV0dXJuIGN1cnJlbnRUcmFuc2xhdGlvbnM7XG59XG5cbi8qKlxuICogT2J0aWVuZSB1biB0ZXh0byB0cmFkdWNpZG8gdXNhbmRvIG5vdGFjaVx1MDBGM24gZGUgcHVudG9cbiAqIEBwYXJhbSB7c3RyaW5nfSBrZXkgLSBDbGF2ZSBkZWwgdGV4dG8gKGVqOiAnaW1hZ2UudGl0bGUnLCAnY29tbW9uLmNhbmNlbCcpXG4gKiBAcGFyYW0ge29iamVjdH0gcGFyYW1zIC0gUGFyXHUwMEUxbWV0cm9zIHBhcmEgaW50ZXJwb2xhY2lcdTAwRjNuIChlajoge2NvdW50OiA1fSlcbiAqIEByZXR1cm5zIHtzdHJpbmd9IFRleHRvIHRyYWR1Y2lkb1xuICovXG5leHBvcnQgZnVuY3Rpb24gdChrZXksIHBhcmFtcyA9IHt9KSB7XG4gIGNvbnN0IGtleXMgPSBrZXkuc3BsaXQoJy4nKTtcbiAgbGV0IHZhbHVlID0gY3VycmVudFRyYW5zbGF0aW9ucztcblxuICAvLyBOYXZlZ2FyIHBvciBsYSBlc3RydWN0dXJhIGRlIG9iamV0b3NcbiAgZm9yIChjb25zdCBrIG9mIGtleXMpIHtcbiAgICBpZiAodmFsdWUgJiYgdHlwZW9mIHZhbHVlID09PSAnb2JqZWN0JyAmJiBrIGluIHZhbHVlKSB7XG4gICAgICB2YWx1ZSA9IHZhbHVlW2tdO1xuICAgIH0gZWxzZSB7XG4gICAgICBjb25zb2xlLndhcm4oYENsYXZlIGRlIHRyYWR1Y2NpXHUwMEYzbiBubyBlbmNvbnRyYWRhOiAnJHtrZXl9J2ApO1xuICAgICAgcmV0dXJuIGtleTsgLy8gUmV0b3JuYXIgbGEgY2xhdmUgY29tbyBmYWxsYmFja1xuICAgIH1cbiAgfVxuXG4gIGlmICh0eXBlb2YgdmFsdWUgIT09ICdzdHJpbmcnKSB7XG4gICAgY29uc29sZS53YXJuKGBDbGF2ZSBkZSB0cmFkdWNjaVx1MDBGM24gbm8gZXMgc3RyaW5nOiAnJHtrZXl9J2ApO1xuICAgIHJldHVybiBrZXk7XG4gIH1cblxuICAvLyBJbnRlcnBvbGFyIHBhclx1MDBFMW1ldHJvc1xuICByZXR1cm4gaW50ZXJwb2xhdGUodmFsdWUsIHBhcmFtcyk7XG59XG5cbi8qKlxuICogSW50ZXJwb2xhIHBhclx1MDBFMW1ldHJvcyBlbiB1biBzdHJpbmdcbiAqIEBwYXJhbSB7c3RyaW5nfSB0ZXh0IC0gVGV4dG8gY29uIG1hcmNhZG9yZXMge2tleX1cbiAqIEBwYXJhbSB7b2JqZWN0fSBwYXJhbXMgLSBQYXJcdTAwRTFtZXRyb3MgYSBpbnRlcnBvbGFyXG4gKiBAcmV0dXJucyB7c3RyaW5nfSBUZXh0byBjb24gcGFyXHUwMEUxbWV0cm9zIGludGVycG9sYWRvc1xuICovXG5mdW5jdGlvbiBpbnRlcnBvbGF0ZSh0ZXh0LCBwYXJhbXMpIHtcbiAgaWYgKCFwYXJhbXMgfHwgT2JqZWN0LmtleXMocGFyYW1zKS5sZW5ndGggPT09IDApIHtcbiAgICByZXR1cm4gdGV4dDtcbiAgfVxuXG4gIHJldHVybiB0ZXh0LnJlcGxhY2UoL1xceyhcXHcrKVxcfS9nLCAobWF0Y2gsIGtleSkgPT4ge1xuICAgIHJldHVybiBwYXJhbXNba2V5XSAhPT0gdW5kZWZpbmVkID8gcGFyYW1zW2tleV0gOiBtYXRjaDtcbiAgfSk7XG59XG5cbi8qKlxuICogT2J0aWVuZSB0cmFkdWNjaW9uZXMgZGUgdW5hIHNlY2NpXHUwMEYzbiBlc3BlY1x1MDBFRGZpY2FcbiAqIEBwYXJhbSB7c3RyaW5nfSBzZWN0aW9uIC0gU2VjY2lcdTAwRjNuIChlajogJ2ltYWdlJywgJ2xhdW5jaGVyJywgJ2NvbW1vbicpXG4gKiBAcmV0dXJucyB7b2JqZWN0fSBPYmpldG8gY29uIGxhcyB0cmFkdWNjaW9uZXMgZGUgbGEgc2VjY2lcdTAwRjNuXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBnZXRTZWN0aW9uKHNlY3Rpb24pIHtcbiAgaWYgKGN1cnJlbnRUcmFuc2xhdGlvbnNbc2VjdGlvbl0pIHtcbiAgICByZXR1cm4gY3VycmVudFRyYW5zbGF0aW9uc1tzZWN0aW9uXTtcbiAgfVxuXG4gIGNvbnNvbGUud2FybihgU2VjY2lcdTAwRjNuIGRlIHRyYWR1Y2NpXHUwMEYzbiBubyBlbmNvbnRyYWRhOiAnJHtzZWN0aW9ufSdgKTtcbiAgcmV0dXJuIHt9O1xufVxuXG4vKipcbiAqIFZlcmlmaWNhIHNpIHVuIGlkaW9tYSBlc3RcdTAwRTEgZGlzcG9uaWJsZVxuICogQHBhcmFtIHtzdHJpbmd9IGxhbmdDb2RlIC0gQ1x1MDBGM2RpZ28gZGVsIGlkaW9tYVxuICogQHJldHVybnMge2Jvb2xlYW59IFRydWUgc2kgZXN0XHUwMEUxIGRpc3BvbmlibGVcbiAqL1xuZXhwb3J0IGZ1bmN0aW9uIGlzTGFuZ3VhZ2VBdmFpbGFibGUobGFuZ0NvZGUpIHtcbiAgcmV0dXJuICEhdHJhbnNsYXRpb25zW2xhbmdDb2RlXTtcbn1cblxuLy8gSW5pY2lhbGl6YXIgYXV0b21cdTAwRTF0aWNhbWVudGUgYWwgY2FyZ2FyIGVsIG1cdTAwRjNkdWxvXG5pbml0aWFsaXplTGFuZ3VhZ2UoKTtcbiIsICJpbXBvcnQgeyBnZXRTZWN0aW9uIH0gZnJvbSAnLi4vbG9jYWxlcy9pbmRleC5qcyc7XG5cbmV4cG9ydCBjb25zdCBMQVVOQ0hFUl9DT05GSUcgPSB7XG4gIFJBV19CQVNFOiAnaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL0FsYXJpc2NvL1dQbGFjZS1BdXRvQk9UL3JlZnMvaGVhZHMvbWFpbicsXG4gIFJFRlJFU0hfSU5URVJWQUw6IDYwMDAwLCAvLyAxIG1pbnV0b1xuICBUSEVNRToge1xuICAgIHByaW1hcnk6ICcjMDAwMDAwJyxcbiAgICBzZWNvbmRhcnk6ICcjMTExMTExJyxcbiAgICBhY2NlbnQ6ICcjMjIyMjIyJyxcbiAgICB0ZXh0OiAnI2ZmZmZmZicsXG4gICAgaGlnaGxpZ2h0OiAnIzc3NWNlMycsXG4gICAgc3VjY2VzczogJyMwMGZmMDAnLFxuICAgIGVycm9yOiAnI2ZmMDAwMCdcbiAgfVxufTtcblxuLy8gRXN0YSBmdW5jaVx1MDBGM24gYWhvcmEgcmV0b3JuYSBsYXMgdHJhZHVjY2lvbmVzIGRpblx1MDBFMW1pY2FtZW50ZVxuZXhwb3J0IGZ1bmN0aW9uIGdldExhdW5jaGVyVGV4dHMoKSB7XG4gIHJldHVybiBnZXRTZWN0aW9uKCdsYXVuY2hlcicpO1xufVxuXG4vLyBGdW5jaVx1MDBGM24gcGFyYSBvYnRlbmVyIHRleHRvcyBjb24gcGFyXHUwMEUxbWV0cm9zXG5leHBvcnQgZnVuY3Rpb24gZ2V0TGF1bmNoZXJUZXh0KGtleSwgcGFyYW1zID0ge30pIHtcbiAgY29uc3QgdGV4dHMgPSBnZXRMYXVuY2hlclRleHRzKCk7XG4gIGxldCB0ZXh0ID0gdGV4dHNba2V5XSB8fCBrZXk7XG4gIFxuICAvLyBJbnRlcnBvbGFyIHBhclx1MDBFMW1ldHJvc1xuICBpZiAocGFyYW1zICYmIE9iamVjdC5rZXlzKHBhcmFtcykubGVuZ3RoID4gMCkge1xuICAgIHRleHQgPSB0ZXh0LnJlcGxhY2UoL1xceyhcXHcrKVxcfS9nLCAobWF0Y2gsIHBhcmFtS2V5KSA9PiB7XG4gICAgICByZXR1cm4gcGFyYW1zW3BhcmFtS2V5XSAhPT0gdW5kZWZpbmVkID8gcGFyYW1zW3BhcmFtS2V5XSA6IG1hdGNoO1xuICAgIH0pO1xuICB9XG4gIFxuICByZXR1cm4gdGV4dDtcbn1cblxuLy8gTWFudGVuZXIgTEFVTkNIRVJfVEVYVFMgcG9yIGNvbXBhdGliaWxpZGFkIHBlcm8gbWFyY2FybG8gY29tbyBkZXByZWNhdGVkXG5leHBvcnQgY29uc3QgTEFVTkNIRVJfVEVYVFMgPSB7XG4gIGdldCBlcygpIHtcbiAgICBjb25zb2xlLndhcm4oJ0xBVU5DSEVSX1RFWFRTLmVzIGVzdFx1MDBFMSBkZXByZWNhdGVkLiBVc2EgZ2V0TGF1bmNoZXJUZXh0cygpIGVuIHN1IGx1Z2FyLicpO1xuICAgIHJldHVybiBnZXRMYXVuY2hlclRleHRzKCk7XG4gIH1cbn07XG5cbmV4cG9ydCBjb25zdCBsYXVuY2hlclN0YXRlID0ge1xuICBtZTogbnVsbCxcbiAgaGVhbHRoOiBudWxsLFxuICByZWZyZXNoVGltZXI6IG51bGwsXG4gIHNlbGVjdGVkQm90OiBudWxsXG59O1xuIiwgImltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuaW1wb3J0IHsgY3JlYXRlU2hhZG93Um9vdCwgbWFrZURyYWdnYWJsZSB9IGZyb20gXCIuLi9jb3JlL3VpLXV0aWxzLmpzXCI7XG5pbXBvcnQgeyBsYXVuY2hlclN0YXRlLCBMQVVOQ0hFUl9DT05GSUcsIGdldExhdW5jaGVyVGV4dHMgfSBmcm9tIFwiLi9jb25maWcuanNcIjtcbmltcG9ydCB7IGdldEN1cnJlbnRMYW5ndWFnZSwgdCB9IGZyb20gXCIuLi9sb2NhbGVzL2luZGV4LmpzXCI7XG5cbmV4cG9ydCBmdW5jdGlvbiBjcmVhdGVMYXVuY2hlclVJKHsgXG4gIG9uU2VsZWN0Qm90LCBcbiAgb25MYXVuY2gsIFxuICBvbkNsb3NlLFxuICB1cGRhdGVVc2VySW5mbyxcbiAgdXBkYXRlSGVhbHRoSW5mbyBcbn0pIHtcbiAgbG9nKCdcdUQ4M0NcdURGOUJcdUZFMEYgQ3JlYW5kbyBpbnRlcmZheiBkZWwgTGF1bmNoZXInKTtcbiAgXG4gIC8vIFZlcmlmaWNhciBzaSB5YSBleGlzdGUgdW4gcGFuZWwgcGFyYSBldml0YXIgZHVwbGljYWRvc1xuICBjb25zdCBleGlzdGluZyA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCd3cGwtcGFuZWwnKTtcbiAgaWYgKGV4aXN0aW5nKSB7XG4gICAgZXhpc3RpbmcucmVtb3ZlKCk7XG4gICAgbG9nKCdcdUQ4M0RcdURERDFcdUZFMEYgUGFuZWwgZXhpc3RlbnRlIHJlbW92aWRvJyk7XG4gIH1cbiAgXG4gIGNvbnN0IHRleHRzID0gZ2V0TGF1bmNoZXJUZXh0cygpO1xuICBjb25zdCB7IGhvc3QsIHJvb3QgfSA9IGNyZWF0ZVNoYWRvd1Jvb3QoJ3dwbC1wYW5lbCcpO1xuICBcbiAgLy8gQ3JlYXIgZXN0aWxvc1xuICBjb25zdCBzdHlsZSA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ3N0eWxlJyk7XG4gIHN0eWxlLnRleHRDb250ZW50ID0gYFxuICAgIEBrZXlmcmFtZXMgc2xpZGVJbiB7XG4gICAgICBmcm9tIHsgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKDIwcHgpOyBvcGFjaXR5OiAwOyB9XG4gICAgICB0byB7IHRyYW5zZm9ybTogdHJhbnNsYXRlWSgwKTsgb3BhY2l0eTogMTsgfVxuICAgIH1cbiAgICBcbiAgICAucGFuZWwge1xuICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgdG9wOiAyMHB4O1xuICAgICAgcmlnaHQ6IDIwcHg7XG4gICAgICB3aWR0aDogMzAwcHg7XG4gICAgICBiYWNrZ3JvdW5kOiAke0xBVU5DSEVSX0NPTkZJRy5USEVNRS5wcmltYXJ5fTtcbiAgICAgIGJvcmRlcjogMXB4IHNvbGlkICR7TEFVTkNIRVJfQ09ORklHLlRIRU1FLmFjY2VudH07XG4gICAgICBib3JkZXItcmFkaXVzOiAxMHB4O1xuICAgICAgY29sb3I6ICR7TEFVTkNIRVJfQ09ORklHLlRIRU1FLnRleHR9O1xuICAgICAgZm9udC1mYW1pbHk6IHN5c3RlbS11aSwgJ1NlZ29lIFVJJywgUm9ib3RvLCBIZWx2ZXRpY2EsIEFyaWFsO1xuICAgICAgei1pbmRleDogOTk5OTk5O1xuICAgICAgYm94LXNoYWRvdzogMCA4cHggMjRweCByZ2JhKDAsMCwwLDAuNSk7XG4gICAgICBvdmVyZmxvdzogaGlkZGVuO1xuICAgICAgYW5pbWF0aW9uOiBzbGlkZUluIDAuM3MgZWFzZS1vdXQ7XG4gICAgfVxuICAgIFxuICAgIC5oZWFkZXIge1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGp1c3RpZnktY29udGVudDogc3BhY2UtYmV0d2VlbjtcbiAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICBiYWNrZ3JvdW5kOiAke0xBVU5DSEVSX0NPTkZJRy5USEVNRS5zZWNvbmRhcnl9O1xuICAgICAgcGFkZGluZzogMTBweCAxMnB4O1xuICAgICAgY29sb3I6ICR7TEFVTkNIRVJfQ09ORklHLlRIRU1FLmhpZ2hsaWdodH07XG4gICAgICBmb250LXdlaWdodDogNjAwO1xuICAgICAgY3Vyc29yOiBtb3ZlO1xuICAgICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgfVxuICAgIFxuICAgIC5ib2R5IHtcbiAgICAgIHBhZGRpbmc6IDEycHg7XG4gICAgfVxuICAgIFxuICAgIC5yb3cge1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGdhcDogOHB4O1xuICAgICAgbWFyZ2luOiA4cHggMDtcbiAgICB9XG4gICAgXG4gICAgLmJ0biB7XG4gICAgICBmbGV4OiAxO1xuICAgICAgcGFkZGluZzogOXB4O1xuICAgICAgYm9yZGVyOiBub25lO1xuICAgICAgYm9yZGVyLXJhZGl1czogOHB4O1xuICAgICAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICAgIHRyYW5zaXRpb246IGFsbCAwLjJzO1xuICAgICAgZm9udC1zaXplOiAxNHB4O1xuICAgIH1cbiAgICBcbiAgICAuYnRuOmRpc2FibGVkIHtcbiAgICAgIG9wYWNpdHk6IDAuNTtcbiAgICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7XG4gICAgfVxuICAgIFxuICAgIC5idG4ucHJpbWFyeSB7XG4gICAgICBiYWNrZ3JvdW5kOiAke0xBVU5DSEVSX0NPTkZJRy5USEVNRS5hY2NlbnR9O1xuICAgICAgY29sb3I6IHdoaXRlO1xuICAgIH1cbiAgICBcbiAgICAuYnRuLnByaW1hcnk6aG92ZXI6bm90KDpkaXNhYmxlZCkge1xuICAgICAgYmFja2dyb3VuZDogJHtMQVVOQ0hFUl9DT05GSUcuVEhFTUUuaGlnaGxpZ2h0fTtcbiAgICB9XG4gICAgXG4gICAgLmJ0bi5naG9zdCB7XG4gICAgICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgICAgIGJvcmRlcjogMXB4IHNvbGlkICR7TEFVTkNIRVJfQ09ORklHLlRIRU1FLmFjY2VudH07XG4gICAgICBjb2xvcjogJHtMQVVOQ0hFUl9DT05GSUcuVEhFTUUudGV4dH07XG4gICAgfVxuICAgIFxuICAgIC5idG4uZ2hvc3Q6aG92ZXI6bm90KDpkaXNhYmxlZCkge1xuICAgICAgYmFja2dyb3VuZDogJHtMQVVOQ0hFUl9DT05GSUcuVEhFTUUuYWNjZW50fTIyO1xuICAgIH1cbiAgICBcbiAgICAuYnRuLmNsb3NlIHtcbiAgICAgIGZsZXg6IDAgMCBhdXRvO1xuICAgICAgcGFkZGluZzogNnB4IDhweDtcbiAgICB9XG4gICAgXG4gICAgLmNhcmQge1xuICAgICAgYmFja2dyb3VuZDogJHtMQVVOQ0hFUl9DT05GSUcuVEhFTUUuc2Vjb25kYXJ5fTtcbiAgICAgIHBhZGRpbmc6IDEwcHg7XG4gICAgICBib3JkZXItcmFkaXVzOiA4cHg7XG4gICAgICBtYXJnaW4tdG9wOiAxMHB4O1xuICAgIH1cbiAgICBcbiAgICAuc3RhdCB7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuICAgICAgbWFyZ2luOiA0cHggMDtcbiAgICAgIGZvbnQtc2l6ZTogMTNweDtcbiAgICAgIG9wYWNpdHk6IDAuOTU7XG4gICAgfVxuICAgIFxuICAgIC5zdGF0dXMge1xuICAgICAgbWFyZ2luLXRvcDogMTBweDtcbiAgICAgIHBhZGRpbmc6IDhweDtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDZweDtcbiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICAgIGZvbnQtc2l6ZTogMTNweDtcbiAgICAgIGJhY2tncm91bmQ6IHJnYmEoMjU1LDI1NSwyNTUsMC4wOCk7XG4gICAgfVxuICAgIFxuICAgIC5zZWxlY3RlZCB7XG4gICAgICBvdXRsaW5lOiAycHggc29saWQgJHtMQVVOQ0hFUl9DT05GSUcuVEhFTUUuaGlnaGxpZ2h0fTtcbiAgICB9XG4gIGA7XG4gIHJvb3QuYXBwZW5kQ2hpbGQoc3R5bGUpO1xuICBcbiAgLy8gQ3JlYXIgcGFuZWwgcHJpbmNpcGFsXG4gIGNvbnN0IHBhbmVsID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnZGl2Jyk7XG4gIHBhbmVsLmNsYXNzTmFtZSA9ICdwYW5lbCc7XG4gIHBhbmVsLmlubmVySFRNTCA9IGBcbiAgICA8ZGl2IGNsYXNzPVwiaGVhZGVyXCI+XG4gICAgICA8ZGl2PiR7dGV4dHMudGl0bGV9PC9kaXY+XG4gICAgICA8YnV0dG9uIGNsYXNzPVwiYnRuIGdob3N0IGNsb3NlIGNsb3NlLWJ0blwiPlx1MjcxNTwvYnV0dG9uPlxuICAgIDwvZGl2PlxuICAgIDxkaXYgY2xhc3M9XCJib2R5XCI+XG4gICAgICA8ZGl2IGNsYXNzPVwicm93XCI+XG4gICAgICAgIDxidXR0b24gY2xhc3M9XCJidG4gcHJpbWFyeSBmYXJtLWJ0blwiPiR7dGV4dHMuYXV0b0Zhcm19PC9idXR0b24+XG4gICAgICAgIDxidXR0b24gY2xhc3M9XCJidG4gZ2hvc3QgaW1hZ2UtYnRuXCI+JHt0ZXh0cy5hdXRvSW1hZ2V9PC9idXR0b24+XG4gICAgICA8L2Rpdj5cbiAgICAgIDxkaXYgY2xhc3M9XCJyb3dcIj5cbiAgICAgICAgPGJ1dHRvbiBjbGFzcz1cImJ0biBnaG9zdCBndWFyZC1idG5cIj4ke3RleHRzLmF1dG9HdWFyZH08L2J1dHRvbj5cbiAgICAgIDwvZGl2PlxuICAgICAgPGRpdiBjbGFzcz1cImNhcmRcIj5cbiAgICAgICAgPGRpdiBjbGFzcz1cInN0YXRcIj5cbiAgICAgICAgICA8c3Bhbj4ke3RleHRzLnNlbGVjdGlvbn08L3NwYW4+XG4gICAgICAgICAgPHNwYW4gY2xhc3M9XCJjaG9pY2VcIj5cdTIwMTQ8L3NwYW4+XG4gICAgICAgIDwvZGl2PlxuICAgICAgPC9kaXY+XG4gICAgICA8ZGl2IGNsYXNzPVwiY2FyZCB1c2VyLWNhcmRcIj5cbiAgICAgICAgPGRpdiBjbGFzcz1cInN0YXRcIj5cbiAgICAgICAgICA8c3Bhbj4ke3RleHRzLnVzZXJ9PC9zcGFuPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwidXNlci1uYW1lXCI+LTwvc3Bhbj5cbiAgICAgICAgPC9kaXY+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJzdGF0XCI+XG4gICAgICAgICAgPHNwYW4+JHt0ZXh0cy5jaGFyZ2VzfTwvc3Bhbj5cbiAgICAgICAgICA8c3BhbiBjbGFzcz1cInVzZXItY2hhcmdlc1wiPi08L3NwYW4+XG4gICAgICAgIDwvZGl2PlxuICAgICAgPC9kaXY+XG4gICAgICA8ZGl2IGNsYXNzPVwiY2FyZCBoZWFsdGgtY2FyZFwiPlxuICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdFwiPlxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMuYmFja2VuZH08L3NwYW4+XG4gICAgICAgICAgPHNwYW4gY2xhc3M9XCJiYWNrZW5kLXN0YXR1c1wiPiR7dGV4dHMuY2hlY2tpbmd9PC9zcGFuPlxuICAgICAgICA8L2Rpdj5cbiAgICAgICAgPGRpdiBjbGFzcz1cInN0YXRcIj5cbiAgICAgICAgICA8c3Bhbj4ke3RleHRzLmRhdGFiYXNlfTwvc3Bhbj5cbiAgICAgICAgICA8c3BhbiBjbGFzcz1cImRhdGFiYXNlLXN0YXR1c1wiPi08L3NwYW4+XG4gICAgICAgIDwvZGl2PlxuICAgICAgICA8ZGl2IGNsYXNzPVwic3RhdFwiPlxuICAgICAgICAgIDxzcGFuPiR7dGV4dHMudXB0aW1lfTwvc3Bhbj5cbiAgICAgICAgICA8c3BhbiBjbGFzcz1cInVwdGltZVwiPi08L3NwYW4+XG4gICAgICAgIDwvZGl2PlxuICAgICAgPC9kaXY+XG4gICAgICA8ZGl2IGNsYXNzPVwic3RhdHVzIHN0YXR1cy10ZXh0XCI+JHt0ZXh0cy5jaG9vc2VCb3R9PC9kaXY+XG4gICAgICA8ZGl2IGNsYXNzPVwicm93XCIgc3R5bGU9XCJtYXJnaW4tdG9wOiAxMnB4O1wiPlxuICAgICAgICA8YnV0dG9uIGNsYXNzPVwiYnRuIHByaW1hcnkgbGF1bmNoLWJ0blwiIGRpc2FibGVkPiR7dGV4dHMubGF1bmNofTwvYnV0dG9uPlxuICAgICAgICA8YnV0dG9uIGNsYXNzPVwiYnRuIGdob3N0IGNhbmNlbC1idG5cIj4ke3RleHRzLmNsb3NlfTwvYnV0dG9uPlxuICAgICAgPC9kaXY+XG4gICAgPC9kaXY+XG4gIGA7XG4gIFxuICByb290LmFwcGVuZENoaWxkKHBhbmVsKTtcbiAgXG4gIC8vIFJlZmVyZW5jaWFzIGEgZWxlbWVudG9zXG4gIGNvbnN0IGVsZW1lbnRzID0ge1xuICAgIGhlYWRlcjogcGFuZWwucXVlcnlTZWxlY3RvcignLmhlYWRlcicpLFxuICAgIGZhcm1CdG46IHBhbmVsLnF1ZXJ5U2VsZWN0b3IoJy5mYXJtLWJ0bicpLFxuICAgIGltYWdlQnRuOiBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuaW1hZ2UtYnRuJyksXG4gICAgZ3VhcmRCdG46IHBhbmVsLnF1ZXJ5U2VsZWN0b3IoJy5ndWFyZC1idG4nKSxcbiAgICBsYXVuY2hCdG46IHBhbmVsLnF1ZXJ5U2VsZWN0b3IoJy5sYXVuY2gtYnRuJyksXG4gICAgY2FuY2VsQnRuOiBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuY2FuY2VsLWJ0bicpLFxuICAgIGNsb3NlQnRuOiBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuY2xvc2UtYnRuJyksXG4gICAgc3RhdHVzVGV4dDogcGFuZWwucXVlcnlTZWxlY3RvcignLnN0YXR1cy10ZXh0JyksXG4gICAgY2hvaWNlOiBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuY2hvaWNlJyksXG4gICAgdXNlck5hbWU6IHBhbmVsLnF1ZXJ5U2VsZWN0b3IoJy51c2VyLW5hbWUnKSxcbiAgICB1c2VyQ2hhcmdlczogcGFuZWwucXVlcnlTZWxlY3RvcignLnVzZXItY2hhcmdlcycpLFxuICAgIGJhY2tlbmRTdGF0dXM6IHBhbmVsLnF1ZXJ5U2VsZWN0b3IoJy5iYWNrZW5kLXN0YXR1cycpLFxuICAgIGRhdGFiYXNlU3RhdHVzOiBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuZGF0YWJhc2Utc3RhdHVzJyksXG4gICAgdXB0aW1lOiBwYW5lbC5xdWVyeVNlbGVjdG9yKCcudXB0aW1lJylcbiAgfTtcbiAgXG4gIC8vIEhhY2VyIGRyYWdnYWJsZVxuICBtYWtlRHJhZ2dhYmxlKGVsZW1lbnRzLmhlYWRlciwgcGFuZWwpO1xuICBcbiAgLy8gRXN0YWRvIGludGVybm9cbiAgbGV0IHNlbGVjdGVkQm90ID0gbnVsbDtcbiAgXG4gIC8vIEZ1bmNpXHUwMEYzbiBwYXJhIHNlbGVjY2lvbmFyIGJvdFxuICBmdW5jdGlvbiBzZWxlY3RCb3QoYm90VHlwZSkge1xuICAgIHNlbGVjdGVkQm90ID0gYm90VHlwZTtcbiAgICBsYXVuY2hlclN0YXRlLnNlbGVjdGVkQm90ID0gYm90VHlwZTtcbiAgICBcbiAgICBlbGVtZW50cy5jaG9pY2UudGV4dENvbnRlbnQgPSBib3RUeXBlID09PSAnZmFybScgPyB0KCdsYXVuY2hlci5hdXRvRmFybScpIDogXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYm90VHlwZSA9PT0gJ2ltYWdlJyA/IHQoJ2xhdW5jaGVyLmF1dG9JbWFnZScpIDogXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdCgnbGF1bmNoZXIuYXV0b0d1YXJkJyk7XG4gICAgZWxlbWVudHMubGF1bmNoQnRuLmRpc2FibGVkID0gZmFsc2U7XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBlc3RpbG9zIGRlIGJvdG9uZXNcbiAgICBlbGVtZW50cy5mYXJtQnRuLmNsYXNzTGlzdC5yZW1vdmUoJ3ByaW1hcnknKTtcbiAgICBlbGVtZW50cy5mYXJtQnRuLmNsYXNzTGlzdC5hZGQoJ2dob3N0Jyk7XG4gICAgZWxlbWVudHMuaW1hZ2VCdG4uY2xhc3NMaXN0LnJlbW92ZSgncHJpbWFyeScpO1xuICAgIGVsZW1lbnRzLmltYWdlQnRuLmNsYXNzTGlzdC5hZGQoJ2dob3N0Jyk7XG4gICAgZWxlbWVudHMuZ3VhcmRCdG4uY2xhc3NMaXN0LnJlbW92ZSgncHJpbWFyeScpO1xuICAgIGVsZW1lbnRzLmd1YXJkQnRuLmNsYXNzTGlzdC5hZGQoJ2dob3N0Jyk7XG4gICAgXG4gICAgaWYgKGJvdFR5cGUgPT09ICdmYXJtJykge1xuICAgICAgZWxlbWVudHMuZmFybUJ0bi5jbGFzc0xpc3QuYWRkKCdwcmltYXJ5Jyk7XG4gICAgICBlbGVtZW50cy5mYXJtQnRuLmNsYXNzTGlzdC5yZW1vdmUoJ2dob3N0Jyk7XG4gICAgfSBlbHNlIGlmIChib3RUeXBlID09PSAnaW1hZ2UnKSB7XG4gICAgICBlbGVtZW50cy5pbWFnZUJ0bi5jbGFzc0xpc3QuYWRkKCdwcmltYXJ5Jyk7XG4gICAgICBlbGVtZW50cy5pbWFnZUJ0bi5jbGFzc0xpc3QucmVtb3ZlKCdnaG9zdCcpO1xuICAgIH0gZWxzZSBpZiAoYm90VHlwZSA9PT0gJ2d1YXJkJykge1xuICAgICAgZWxlbWVudHMuZ3VhcmRCdG4uY2xhc3NMaXN0LmFkZCgncHJpbWFyeScpO1xuICAgICAgZWxlbWVudHMuZ3VhcmRCdG4uY2xhc3NMaXN0LnJlbW92ZSgnZ2hvc3QnKTtcbiAgICB9XG4gICAgXG4gICAgZWxlbWVudHMuc3RhdHVzVGV4dC50ZXh0Q29udGVudCA9IHQoJ2xhdW5jaGVyLnJlYWR5VG9MYXVuY2gnKTtcbiAgICBcbiAgICBpZiAob25TZWxlY3RCb3QpIHtcbiAgICAgIG9uU2VsZWN0Qm90KGJvdFR5cGUpO1xuICAgIH1cbiAgfVxuICBcbiAgLy8gRXZlbnQgbGlzdGVuZXJzXG4gIGVsZW1lbnRzLmZhcm1CdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiBzZWxlY3RCb3QoJ2Zhcm0nKSk7XG4gIGVsZW1lbnRzLmltYWdlQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKCkgPT4gc2VsZWN0Qm90KCdpbWFnZScpKTtcbiAgZWxlbWVudHMuZ3VhcmRCdG4uYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiBzZWxlY3RCb3QoJ2d1YXJkJykpO1xuICBcbiAgZWxlbWVudHMubGF1bmNoQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgYXN5bmMgKCkgPT4ge1xuICAgIGlmICghc2VsZWN0ZWRCb3QpIHJldHVybjtcbiAgICBcbiAgICBlbGVtZW50cy5sYXVuY2hCdG4uZGlzYWJsZWQgPSB0cnVlO1xuICAgIGVsZW1lbnRzLmxhdW5jaEJ0bi50ZXh0Q29udGVudCA9IHQoJ2xhdW5jaGVyLmxvYWRpbmcnKTtcbiAgICBlbGVtZW50cy5zdGF0dXNUZXh0LnRleHRDb250ZW50ID0gdCgnbGF1bmNoZXIuZG93bmxvYWRpbmcnKTtcbiAgICBcbiAgICB0cnkge1xuICAgICAgaWYgKG9uTGF1bmNoKSB7XG4gICAgICAgIGF3YWl0IG9uTGF1bmNoKHNlbGVjdGVkQm90KTtcbiAgICAgICAgLy8gU2kgbGxlZ2Ftb3MgYXF1XHUwMEVELCBlbCBib3Qgc2UgZWplY3V0XHUwMEYzIGNvcnJlY3RhbWVudGVcbiAgICAgICAgY2xlYW51cCgpO1xuICAgICAgfVxuICAgIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgICBsb2coJ1x1Mjc0QyBFcnJvciBlbiBsYXVuY2g6JywgZXJyb3IpO1xuICAgICAgYWxlcnQodCgnbGF1bmNoZXIubG9hZEVycm9yTXNnJykpO1xuICAgICAgZWxlbWVudHMubGF1bmNoQnRuLmRpc2FibGVkID0gZmFsc2U7XG4gICAgICBlbGVtZW50cy5sYXVuY2hCdG4udGV4dENvbnRlbnQgPSB0KCdsYXVuY2hlci5sYXVuY2gnKTtcbiAgICAgIGVsZW1lbnRzLnN0YXR1c1RleHQudGV4dENvbnRlbnQgPSB0KCdsYXVuY2hlci5sb2FkRXJyb3InKTtcbiAgICB9XG4gIH0pO1xuICBcbiAgLy8gRnVuY2lcdTAwRjNuIGRlIGxpbXBpZXphXG4gIGZ1bmN0aW9uIGNsZWFudXAoKSB7XG4gICAgd2luZG93LnJlbW92ZUV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsIGhhbmRsZUxhbmd1YWdlQ2hhbmdlKTtcbiAgICBpZiAobGF1bmNoZXJTdGF0ZS5yZWZyZXNoVGltZXIpIHtcbiAgICAgIHdpbmRvdy5jbGVhckludGVydmFsKGxhdW5jaGVyU3RhdGUucmVmcmVzaFRpbWVyKTtcbiAgICAgIGxhdW5jaGVyU3RhdGUucmVmcmVzaFRpbWVyID0gbnVsbDtcbiAgICB9XG4gICAgaG9zdC5yZW1vdmUoKTtcbiAgICBsb2coJ1x1RDgzRVx1RERGOSBMYXVuY2hlciBVSSBlbGltaW5hZG8nKTtcbiAgfVxuICBcbiAgZWxlbWVudHMuY2FuY2VsQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgY2xlYW51cCk7XG4gIGVsZW1lbnRzLmNsb3NlQnRuLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgY2xlYW51cCk7XG4gIFxuICAvLyBDZXJyYXIgY29uIEVzY2FwZVxuICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdrZXlkb3duJywgKGUpID0+IHtcbiAgICBpZiAoZS5rZXkgPT09ICdFc2NhcGUnKSB7XG4gICAgICBjbGVhbnVwKCk7XG4gICAgfVxuICB9LCB7IG9uY2U6IHRydWUgfSk7XG4gIFxuICAvLyBFc2N1Y2hhciBjYW1iaW9zIGRlIGlkaW9tYVxuICBjb25zdCBoYW5kbGVMYW5ndWFnZUNoYW5nZSA9ICgpID0+IHtcbiAgICB1cGRhdGVUZXh0cygpO1xuICB9O1xuICBcbiAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsIGhhbmRsZUxhbmd1YWdlQ2hhbmdlKTtcbiAgXG4gIC8vIEZ1bmNpb25lcyBkZSBhY3R1YWxpemFjaVx1MDBGM24gZGUgVUlcbiAgZnVuY3Rpb24gc2V0VXNlckluZm8odXNlckluZm8pIHtcbiAgICBpZiAoIXVzZXJJbmZvKSB7XG4gICAgICBlbGVtZW50cy51c2VyTmFtZS50ZXh0Q29udGVudCA9ICctJztcbiAgICAgIGVsZW1lbnRzLnVzZXJDaGFyZ2VzLnRleHRDb250ZW50ID0gJy0nO1xuICAgICAgcmV0dXJuO1xuICAgIH1cbiAgICBcbiAgICBjb25zdCBuYW1lID0gdXNlckluZm8ubmFtZSB8fCB1c2VySW5mby51c2VybmFtZSB8fCAnLSc7XG4gICAgY29uc3QgY2hhcmdlcyA9IE1hdGguZmxvb3IoTnVtYmVyKHVzZXJJbmZvLmNoYXJnZXM/LmNvdW50ID8/IE5hTikpO1xuICAgIFxuICAgIGVsZW1lbnRzLnVzZXJOYW1lLnRleHRDb250ZW50ID0gbmFtZTtcbiAgICBlbGVtZW50cy51c2VyQ2hhcmdlcy50ZXh0Q29udGVudCA9IE51bWJlci5pc0Zpbml0ZShjaGFyZ2VzKSA/IFN0cmluZyhjaGFyZ2VzKSA6ICctJztcbiAgfVxuICBcbiAgZnVuY3Rpb24gc2V0SGVhbHRoSW5mbyhoZWFsdGhJbmZvKSB7XG4gICAgaWYgKCFoZWFsdGhJbmZvKSB7XG4gICAgICBlbGVtZW50cy5iYWNrZW5kU3RhdHVzLnRleHRDb250ZW50ID0gdCgnbGF1bmNoZXIub2ZmbGluZScpO1xuICAgICAgZWxlbWVudHMuZGF0YWJhc2VTdGF0dXMudGV4dENvbnRlbnQgPSAnLSc7XG4gICAgICBlbGVtZW50cy51cHRpbWUudGV4dENvbnRlbnQgPSAnLSc7XG4gICAgICByZXR1cm47XG4gICAgfVxuICAgIFxuICAgIGNvbnN0IHVwID0gQm9vbGVhbihoZWFsdGhJbmZvLnVwKTtcbiAgICBjb25zdCBkYiA9IGhlYWx0aEluZm8uZGF0YWJhc2U7XG4gICAgY29uc3QgdXB0aW1lID0gaGVhbHRoSW5mby51cHRpbWUgfHwgJy0nO1xuICAgIFxuICAgIGVsZW1lbnRzLmJhY2tlbmRTdGF0dXMudGV4dENvbnRlbnQgPSB1cCA/IHQoJ2xhdW5jaGVyLm9ubGluZScpIDogdCgnbGF1bmNoZXIub2ZmbGluZScpO1xuICAgIFxuICAgIGlmIChkYiA9PT0gdW5kZWZpbmVkIHx8IGRiID09PSBudWxsKSB7XG4gICAgICBlbGVtZW50cy5kYXRhYmFzZVN0YXR1cy50ZXh0Q29udGVudCA9ICctJztcbiAgICB9IGVsc2Uge1xuICAgICAgZWxlbWVudHMuZGF0YWJhc2VTdGF0dXMudGV4dENvbnRlbnQgPSBkYiA/IHQoJ2xhdW5jaGVyLm9rJykgOiB0KCdsYXVuY2hlci5lcnJvcicpO1xuICAgIH1cbiAgICBcbiAgICBlbGVtZW50cy51cHRpbWUudGV4dENvbnRlbnQgPSB0eXBlb2YgdXB0aW1lID09PSAnbnVtYmVyJyA/IGAke3VwdGltZX1zYCA6ICh1cHRpbWUgfHwgJy0nKTtcbiAgfVxuICBcbiAgZnVuY3Rpb24gdXBkYXRlVGV4dHMoKSB7XG4gICAgLy8gT2J0ZW5lciBudWV2YXMgdHJhZHVjY2lvbmVzXG4gICAgY29uc3QgbmV3VGV4dHMgPSBnZXRMYXVuY2hlclRleHRzKCk7XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBlbGVtZW50b3MgcHJpbmNpcGFsZXNcbiAgICBjb25zdCB0aXRsZUVsZW1lbnQgPSBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuaGVhZGVyIGRpdjpmaXJzdC1jaGlsZCcpO1xuICAgIGlmICh0aXRsZUVsZW1lbnQpIHtcbiAgICAgIHRpdGxlRWxlbWVudC50ZXh0Q29udGVudCA9IG5ld1RleHRzLnRpdGxlO1xuICAgIH1cbiAgICBcbiAgICBpZiAoZWxlbWVudHMuZmFybUJ0bikge1xuICAgICAgZWxlbWVudHMuZmFybUJ0bi50ZXh0Q29udGVudCA9IG5ld1RleHRzLmF1dG9GYXJtO1xuICAgIH1cbiAgICBcbiAgICBpZiAoZWxlbWVudHMuaW1hZ2VCdG4pIHtcbiAgICAgIGVsZW1lbnRzLmltYWdlQnRuLnRleHRDb250ZW50ID0gbmV3VGV4dHMuYXV0b0ltYWdlO1xuICAgIH1cbiAgICBcbiAgICBpZiAoZWxlbWVudHMuZ3VhcmRCdG4pIHtcbiAgICAgIGVsZW1lbnRzLmd1YXJkQnRuLnRleHRDb250ZW50ID0gbmV3VGV4dHMuYXV0b0d1YXJkO1xuICAgIH1cbiAgICBcbiAgICBpZiAoZWxlbWVudHMubGF1bmNoQnRuKSB7XG4gICAgICBlbGVtZW50cy5sYXVuY2hCdG4udGV4dENvbnRlbnQgPSBuZXdUZXh0cy5sYXVuY2g7XG4gICAgfVxuICAgIFxuICAgIGlmIChlbGVtZW50cy5jbG9zZUJ0bikge1xuICAgICAgZWxlbWVudHMuY2xvc2VCdG4udGV4dENvbnRlbnQgPSBuZXdUZXh0cy5jbG9zZTtcbiAgICB9XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBsYWJlbHMgZGUgZXN0YWRcdTAwRURzdGljYXNcbiAgICBjb25zdCBzZWxlY3Rpb25TcGFuID0gcGFuZWwucXVlcnlTZWxlY3RvcignLmNhcmQ6Zmlyc3Qtb2YtdHlwZSAuc3RhdCBzcGFuOmZpcnN0LWNoaWxkJyk7XG4gICAgaWYgKHNlbGVjdGlvblNwYW4pIHtcbiAgICAgIHNlbGVjdGlvblNwYW4udGV4dENvbnRlbnQgPSBuZXdUZXh0cy5zZWxlY3Rpb247XG4gICAgfVxuICAgIFxuICAgIGNvbnN0IHVzZXJTcGFuID0gcGFuZWwucXVlcnlTZWxlY3RvcignLnVzZXItY2FyZCAuc3RhdDpmaXJzdC1jaGlsZCBzcGFuOmZpcnN0LWNoaWxkJyk7XG4gICAgaWYgKHVzZXJTcGFuKSB7XG4gICAgICB1c2VyU3Bhbi50ZXh0Q29udGVudCA9IG5ld1RleHRzLnVzZXI7XG4gICAgfVxuICAgIFxuICAgIGNvbnN0IGNoYXJnZXNTcGFuID0gcGFuZWwucXVlcnlTZWxlY3RvcignLnVzZXItY2FyZCAuc3RhdDpsYXN0LWNoaWxkIHNwYW46Zmlyc3QtY2hpbGQnKTtcbiAgICBpZiAoY2hhcmdlc1NwYW4pIHtcbiAgICAgIGNoYXJnZXNTcGFuLnRleHRDb250ZW50ID0gbmV3VGV4dHMuY2hhcmdlcztcbiAgICB9XG4gICAgXG4gICAgY29uc3QgYmFja2VuZFNwYW4gPSBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuaGVhbHRoLWNhcmQgLnN0YXQ6Zmlyc3QtY2hpbGQgc3BhbjpmaXJzdC1jaGlsZCcpO1xuICAgIGlmIChiYWNrZW5kU3Bhbikge1xuICAgICAgYmFja2VuZFNwYW4udGV4dENvbnRlbnQgPSBuZXdUZXh0cy5iYWNrZW5kO1xuICAgIH1cbiAgICBcbiAgICBjb25zdCBkYXRhYmFzZVNwYW4gPSBwYW5lbC5xdWVyeVNlbGVjdG9yKCcuaGVhbHRoLWNhcmQgLnN0YXQ6bnRoLWNoaWxkKDIpIHNwYW46Zmlyc3QtY2hpbGQnKTtcbiAgICBpZiAoZGF0YWJhc2VTcGFuKSB7XG4gICAgICBkYXRhYmFzZVNwYW4udGV4dENvbnRlbnQgPSBuZXdUZXh0cy5kYXRhYmFzZTtcbiAgICB9XG4gICAgXG4gICAgY29uc3QgdXB0aW1lU3BhbiA9IHBhbmVsLnF1ZXJ5U2VsZWN0b3IoJy5oZWFsdGgtY2FyZCAuc3RhdDpsYXN0LWNoaWxkIHNwYW46Zmlyc3QtY2hpbGQnKTtcbiAgICBpZiAodXB0aW1lU3Bhbikge1xuICAgICAgdXB0aW1lU3Bhbi50ZXh0Q29udGVudCA9IG5ld1RleHRzLnVwdGltZTtcbiAgICB9XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBzdGF0dXMgc2kgZXN0XHUwMEUxIGVuIG1lbnNhamUgcG9yIGRlZmVjdG9cbiAgICBpZiAoZWxlbWVudHMuc3RhdHVzVGV4dCkge1xuICAgICAgY29uc3QgY3VycmVudFN0YXR1cyA9IGVsZW1lbnRzLnN0YXR1c1RleHQudGV4dENvbnRlbnQ7XG4gICAgICBpZiAoY3VycmVudFN0YXR1cyA9PT0gdGV4dHMuY2hvb3NlQm90IHx8IGN1cnJlbnRTdGF0dXMgPT09IG5ld1RleHRzLmNob29zZUJvdCkge1xuICAgICAgICBlbGVtZW50cy5zdGF0dXNUZXh0LnRleHRDb250ZW50ID0gbmV3VGV4dHMuY2hvb3NlQm90O1xuICAgICAgfSBlbHNlIGlmIChjdXJyZW50U3RhdHVzID09PSB0ZXh0cy5sb2FkaW5nIHx8IGN1cnJlbnRTdGF0dXMgPT09IG5ld1RleHRzLmxvYWRpbmcpIHtcbiAgICAgICAgZWxlbWVudHMuc3RhdHVzVGV4dC50ZXh0Q29udGVudCA9IG5ld1RleHRzLmxvYWRpbmc7XG4gICAgICB9IGVsc2UgaWYgKGN1cnJlbnRTdGF0dXMgPT09IHRleHRzLmRvd25sb2FkaW5nIHx8IGN1cnJlbnRTdGF0dXMgPT09IG5ld1RleHRzLmRvd25sb2FkaW5nKSB7XG4gICAgICAgIGVsZW1lbnRzLnN0YXR1c1RleHQudGV4dENvbnRlbnQgPSBuZXdUZXh0cy5kb3dubG9hZGluZztcbiAgICAgIH0gZWxzZSBpZiAoY3VycmVudFN0YXR1cyA9PT0gdGV4dHMucmVhZHlUb0xhdW5jaCB8fCBjdXJyZW50U3RhdHVzID09PSBuZXdUZXh0cy5yZWFkeVRvTGF1bmNoKSB7XG4gICAgICAgIGVsZW1lbnRzLnN0YXR1c1RleHQudGV4dENvbnRlbnQgPSBuZXdUZXh0cy5yZWFkeVRvTGF1bmNoO1xuICAgICAgfSBlbHNlIGlmIChjdXJyZW50U3RhdHVzID09PSB0ZXh0cy5sb2FkRXJyb3IgfHwgY3VycmVudFN0YXR1cyA9PT0gbmV3VGV4dHMubG9hZEVycm9yKSB7XG4gICAgICAgIGVsZW1lbnRzLnN0YXR1c1RleHQudGV4dENvbnRlbnQgPSBuZXdUZXh0cy5sb2FkRXJyb3I7XG4gICAgICB9XG4gICAgfVxuICAgIFxuICAgIC8vIEFjdHVhbGl6YXIgZXN0YWRvcyBkaW5cdTAwRTFtaWNvcyBkZSBzYWx1ZCBkZWwgYmFja2VuZFxuICAgIGlmIChlbGVtZW50cy5iYWNrZW5kU3RhdHVzKSB7XG4gICAgICBjb25zdCBjdXJyZW50QmFja2VuZCA9IGVsZW1lbnRzLmJhY2tlbmRTdGF0dXMudGV4dENvbnRlbnQ7XG4gICAgICBpZiAoY3VycmVudEJhY2tlbmQgPT09IHRleHRzLm9ubGluZSB8fCBjdXJyZW50QmFja2VuZCA9PT0gbmV3VGV4dHMub25saW5lKSB7XG4gICAgICAgIGVsZW1lbnRzLmJhY2tlbmRTdGF0dXMudGV4dENvbnRlbnQgPSBuZXdUZXh0cy5vbmxpbmU7XG4gICAgICB9IGVsc2UgaWYgKGN1cnJlbnRCYWNrZW5kID09PSB0ZXh0cy5vZmZsaW5lIHx8IGN1cnJlbnRCYWNrZW5kID09PSBuZXdUZXh0cy5vZmZsaW5lKSB7XG4gICAgICAgIGVsZW1lbnRzLmJhY2tlbmRTdGF0dXMudGV4dENvbnRlbnQgPSBuZXdUZXh0cy5vZmZsaW5lO1xuICAgICAgfSBlbHNlIGlmIChjdXJyZW50QmFja2VuZCA9PT0gdGV4dHMuY2hlY2tpbmcgfHwgY3VycmVudEJhY2tlbmQgPT09IG5ld1RleHRzLmNoZWNraW5nKSB7XG4gICAgICAgIGVsZW1lbnRzLmJhY2tlbmRTdGF0dXMudGV4dENvbnRlbnQgPSBuZXdUZXh0cy5jaGVja2luZztcbiAgICAgIH1cbiAgICB9XG4gICAgXG4gICAgLy8gQWN0dWFsaXphciBlc3RhZG8gZGUgbGEgYmFzZSBkZSBkYXRvc1xuICAgIGlmIChlbGVtZW50cy5kYXRhYmFzZVN0YXR1cykge1xuICAgICAgY29uc3QgY3VycmVudERiID0gZWxlbWVudHMuZGF0YWJhc2VTdGF0dXMudGV4dENvbnRlbnQ7XG4gICAgICBpZiAoY3VycmVudERiID09PSB0ZXh0cy5vayB8fCBjdXJyZW50RGIgPT09IG5ld1RleHRzLm9rKSB7XG4gICAgICAgIGVsZW1lbnRzLmRhdGFiYXNlU3RhdHVzLnRleHRDb250ZW50ID0gbmV3VGV4dHMub2s7XG4gICAgICB9IGVsc2UgaWYgKGN1cnJlbnREYiA9PT0gdGV4dHMuZXJyb3IgfHwgY3VycmVudERiID09PSBuZXdUZXh0cy5lcnJvcikge1xuICAgICAgICBlbGVtZW50cy5kYXRhYmFzZVN0YXR1cy50ZXh0Q29udGVudCA9IG5ld1RleHRzLmVycm9yO1xuICAgICAgfVxuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIGxhIHNlbGVjY2lcdTAwRjNuIGFjdHVhbCBzaSBoYXkgYWxndW5hXG4gICAgaWYgKHNlbGVjdGVkQm90ICYmIGVsZW1lbnRzLmNob2ljZSkge1xuICAgICAgZWxlbWVudHMuY2hvaWNlLnRleHRDb250ZW50ID0gc2VsZWN0ZWRCb3QgPT09ICdmYXJtJyA/IG5ld1RleHRzLmF1dG9GYXJtIDogXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBzZWxlY3RlZEJvdCA9PT0gJ2ltYWdlJyA/IG5ld1RleHRzLmF1dG9JbWFnZSA6IFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbmV3VGV4dHMuYXV0b0d1YXJkO1xuICAgIH1cbiAgICBcbiAgICAvLyBBY3R1YWxpemFyIHRleHRvcyBkZSByZWZlcmVuY2lhIGxvY2FsXG4gICAgT2JqZWN0LmFzc2lnbih0ZXh0cywgbmV3VGV4dHMpO1xuICAgIFxuICAgIGxvZyhgXHVEODNDXHVERjBEIFRleHRvcyBkZWwgbGF1bmNoZXIgYWN0dWFsaXphZG9zIGFsIGlkaW9tYTogJHtnZXRDdXJyZW50TGFuZ3VhZ2UoKX1gKTtcbiAgfVxuICBcbiAgbG9nKCdcdTI3MDUgTGF1bmNoZXIgVUkgY3JlYWRvIGV4aXRvc2FtZW50ZScpO1xuICBcbiAgcmV0dXJuIHtcbiAgICBzZXRVc2VySW5mbyxcbiAgICBzZXRIZWFsdGhJbmZvLFxuICAgIGNsZWFudXAsXG4gICAgc2VsZWN0Qm90LFxuICAgIHVwZGF0ZVRleHRzLFxuICAgIGdldFNlbGVjdGVkQm90OiAoKSA9PiBzZWxlY3RlZEJvdFxuICB9O1xufVxuIiwgImltcG9ydCB7IGxvZyB9IGZyb20gXCIuLi9jb3JlL2xvZ2dlci5qc1wiO1xuaW1wb3J0IHsgbGF1bmNoZXJTdGF0ZSB9IGZyb20gXCIuL2NvbmZpZy5qc1wiO1xuXG4vLyBBUEkgY2FsbHMgcGFyYSBvYnRlbmVyIGluZm9ybWFjaVx1MDBGM24gZGVsIHVzdWFyaW8geSBlc3RhZG8gZGVsIGJhY2tlbmRcbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBnZXRTZXNzaW9uKCkge1xuICBsb2coJ1x1RDgzRFx1RENFMSBPYnRlbmllbmRvIGluZm9ybWFjaVx1MDBGM24gZGUgc2VzaVx1MDBGM24uLi4nKTtcbiAgXG4gIHRyeSB7XG4gICAgY29uc3QgcmVzID0gYXdhaXQgZmV0Y2goJ2h0dHBzOi8vYmFja2VuZC53cGxhY2UubGl2ZS9tZScsIHsgXG4gICAgICBjcmVkZW50aWFsczogJ2luY2x1ZGUnIFxuICAgIH0pO1xuICAgIFxuICAgIGlmICghcmVzLm9rKSB7XG4gICAgICB0aHJvdyBuZXcgRXJyb3IoYEhUVFAgJHtyZXMuc3RhdHVzfWApO1xuICAgIH1cbiAgICBcbiAgICBsYXVuY2hlclN0YXRlLm1lID0gYXdhaXQgcmVzLmpzb24oKTtcbiAgICBsb2coJ1x1MjcwNSBJbmZvcm1hY2lcdTAwRjNuIGRlIHNlc2lcdTAwRjNuIG9idGVuaWRhOicsIGxhdW5jaGVyU3RhdGUubWU/Lm5hbWUgfHwgbGF1bmNoZXJTdGF0ZS5tZT8udXNlcm5hbWUgfHwgJ1VzdWFyaW8nKTtcbiAgICBcbiAgICByZXR1cm4gbGF1bmNoZXJTdGF0ZS5tZTtcbiAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICBsb2coJ1x1Mjc0QyBFcnJvciBvYnRlbmllbmRvIHNlc2lcdTAwRjNuOicsIGVycm9yLm1lc3NhZ2UpO1xuICAgIGxhdW5jaGVyU3RhdGUubWUgPSBudWxsO1xuICAgIHJldHVybiBudWxsO1xuICB9XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBjaGVja0JhY2tlbmRIZWFsdGgoKSB7XG4gIGxvZygnXHVEODNDXHVERkU1IFZlcmlmaWNhbmRvIGVzdGFkbyBkZWwgYmFja2VuZC4uLicpO1xuICBcbiAgdHJ5IHtcbiAgICBjb25zdCByZXMgPSBhd2FpdCBmZXRjaCgnaHR0cHM6Ly9iYWNrZW5kLndwbGFjZS5saXZlL2hlYWx0aCcsIHsgXG4gICAgICBtZXRob2Q6ICdHRVQnLCBcbiAgICAgIGNyZWRlbnRpYWxzOiAnaW5jbHVkZScgXG4gICAgfSk7XG4gICAgXG4gICAgbGV0IGpzb24gPSBudWxsO1xuICAgIHRyeSB7IFxuICAgICAganNvbiA9IGF3YWl0IHJlcy5qc29uKCk7IFxuICAgIH0gY2F0Y2ggeyBcbiAgICAgIGpzb24gPSBudWxsOyBcbiAgICB9XG4gICAgXG4gICAgaWYgKHJlcy5vayAmJiBqc29uKSB7XG4gICAgICBsYXVuY2hlclN0YXRlLmhlYWx0aCA9IHtcbiAgICAgICAgdXA6IEJvb2xlYW4oanNvbi51cCA/PyB0cnVlKSxcbiAgICAgICAgZGF0YWJhc2U6IGpzb24uZGF0YWJhc2U/Lm9rID8/IGpzb24uZGF0YWJhc2UgPz8gdW5kZWZpbmVkLFxuICAgICAgICB1cHRpbWU6IGpzb24udXB0aW1lID8/IGpzb24udXB0aW1lSHVtYW4gPz8gKHR5cGVvZiBqc29uLnVwdGltZVNlY29uZHMgPT09ICdudW1iZXInID8gYCR7anNvbi51cHRpbWVTZWNvbmRzfXNgIDogdW5kZWZpbmVkKVxuICAgICAgfTtcbiAgICAgIGxvZygnXHUyNzA1IEVzdGFkbyBkZWwgYmFja2VuZCBvYnRlbmlkbzonLCBsYXVuY2hlclN0YXRlLmhlYWx0aCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIGxhdW5jaGVyU3RhdGUuaGVhbHRoID0geyBcbiAgICAgICAgdXA6IGZhbHNlLCBcbiAgICAgICAgZGF0YWJhc2U6IGZhbHNlLCBcbiAgICAgICAgdXB0aW1lOiB1bmRlZmluZWQgXG4gICAgICB9O1xuICAgICAgbG9nKCdcdTI2QTBcdUZFMEYgQmFja2VuZCBubyByZXNwb25kZSBjb3JyZWN0YW1lbnRlJyk7XG4gICAgfVxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZygnXHUyNzRDIEVycm9yIHZlcmlmaWNhbmRvIGJhY2tlbmQ6JywgZXJyb3IubWVzc2FnZSk7XG4gICAgbGF1bmNoZXJTdGF0ZS5oZWFsdGggPSB7IFxuICAgICAgdXA6IGZhbHNlLCBcbiAgICAgIGRhdGFiYXNlOiBmYWxzZSwgXG4gICAgICB1cHRpbWU6IHVuZGVmaW5lZCBcbiAgICB9O1xuICB9XG4gIFxuICByZXR1cm4gbGF1bmNoZXJTdGF0ZS5oZWFsdGg7XG59XG5cbmV4cG9ydCBhc3luYyBmdW5jdGlvbiBkb3dubG9hZEFuZEV4ZWN1dGVCb3QoYm90VHlwZSwgcmF3QmFzZSkge1xuICBsb2coYFx1RDgzRFx1RENFNSBEZXNjYXJnYW5kbyBib3Q6ICR7Ym90VHlwZX1gKTtcbiAgXG4gIHRyeSB7XG4gICAgY29uc3QgYm90RmlsZXMgPSB7XG4gICAgICAnZmFybSc6ICdBdXRvLUZhcm0uanMnLFxuICAgICAgJ2ltYWdlJzogJ0F1dG8tSW1hZ2UuanMnLFxuICAgICAgJ2d1YXJkJzogJ0F1dG8tR3VhcmQuanMnXG4gICAgfTtcbiAgICBcbiAgICBjb25zdCBmaWxlTmFtZSA9IGJvdEZpbGVzW2JvdFR5cGVdO1xuICAgIGlmICghZmlsZU5hbWUpIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcihgVGlwbyBkZSBib3QgZGVzY29ub2NpZG86ICR7Ym90VHlwZX1gKTtcbiAgICB9XG4gICAgXG4gICAgY29uc3QgdXJsID0gYCR7cmF3QmFzZX0vJHtmaWxlTmFtZX1gO1xuICAgIFxuICAgIGxvZyhgXHVEODNDXHVERjEwIFVSTDogJHt1cmx9YCk7XG4gICAgXG4gICAgY29uc3QgcmVzcG9uc2UgPSBhd2FpdCBmZXRjaCh1cmwpO1xuICAgIGlmICghcmVzcG9uc2Uub2spIHtcbiAgICAgIHRocm93IG5ldyBFcnJvcihgSFRUUCAke3Jlc3BvbnNlLnN0YXR1c31gKTtcbiAgICB9XG4gICAgXG4gICAgY29uc3QgY29kZSA9IGF3YWl0IHJlc3BvbnNlLnRleHQoKTtcbiAgICBsb2coYFx1MjcwNSBCb3QgZGVzY2FyZ2FkbyAoJHtjb2RlLmxlbmd0aH0gY2hhcnMpLCBlamVjdXRhbmRvLi4uYCk7XG4gICAgXG4gICAgLy8gRXZhbHVhciBlbCBjXHUwMEYzZGlnbyBkZWwgYm90XG4gICAgKDAsIGV2YWwpKGNvZGUpO1xuICAgIFxuICAgIGxvZygnXHVEODNEXHVERTgwIEJvdCBlamVjdXRhZG8gZXhpdG9zYW1lbnRlJyk7XG4gICAgcmV0dXJuIHRydWU7XG4gIH0gY2F0Y2ggKGVycm9yKSB7XG4gICAgbG9nKCdcdTI3NEMgRXJyb3IgZGVzY2FyZ2FuZG8vZWplY3V0YW5kbyBib3Q6JywgZXJyb3IubWVzc2FnZSk7XG4gICAgdGhyb3cgZXJyb3I7XG4gIH1cbn1cbiIsICJpbXBvcnQgeyBcbiAgQVZBSUxBQkxFX0xBTkdVQUdFUywgXG4gIGdldEN1cnJlbnRMYW5ndWFnZSwgXG4gIHNldExhbmd1YWdlIFxufSBmcm9tICcuLi9sb2NhbGVzL2luZGV4LmpzJztcblxuLyoqXG4gKiBDcmVhIHVuIHNlbGVjdG9yIGRlIGlkaW9tYVxuICogQHBhcmFtIHtPYmplY3R9IG9wdGlvbnMgLSBPcGNpb25lcyBkZSBjb25maWd1cmFjaVx1MDBGM25cbiAqIEBwYXJhbSB7RnVuY3Rpb259IG9wdGlvbnMub25MYW5ndWFnZUNoYW5nZSAtIENhbGxiYWNrIGN1YW5kbyBjYW1iaWEgZWwgaWRpb21hXG4gKiBAcGFyYW0ge3N0cmluZ30gb3B0aW9ucy5wb3NpdGlvbiAtIFBvc2ljaVx1MDBGM24gZGVsIHNlbGVjdG9yICgndG9wLXJpZ2h0JywgJ3RvcC1sZWZ0JywgZXRjLilcbiAqIEBwYXJhbSB7Ym9vbGVhbn0gb3B0aW9ucy5zaG93RmxhZ3MgLSBTaSBtb3N0cmFyIGJhbmRlcmFzIGRlIHBhXHUwMEVEc2VzXG4gKiBAcmV0dXJucyB7T2JqZWN0fSBPYmpldG8gY29uIG1cdTAwRTl0b2RvcyBwYXJhIGNvbnRyb2xhciBlbCBzZWxlY3RvclxuICovXG5leHBvcnQgZnVuY3Rpb24gY3JlYXRlTGFuZ3VhZ2VTZWxlY3RvcihvcHRpb25zID0ge30pIHtcbiAgY29uc3Qge1xuICAgIG9uTGFuZ3VhZ2VDaGFuZ2UgPSBudWxsLFxuICAgIHBvc2l0aW9uID0gJ3RvcC1yaWdodCcsXG4gICAgc2hvd0ZsYWdzID0gdHJ1ZVxuICB9ID0gb3B0aW9ucztcblxuICAvLyBDcmVhciBjb250ZW5lZG9yXG4gIGNvbnN0IGNvbnRhaW5lciA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpO1xuICBjb250YWluZXIuY2xhc3NOYW1lID0gJ2xhbmd1YWdlLXNlbGVjdG9yJztcbiAgXG4gIC8vIEVzdGlsb3MgQ1NTXG4gIGNvbnN0IHN0eWxlcyA9IGBcbiAgICAubGFuZ3VhZ2Utc2VsZWN0b3Ige1xuICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgJHtnZXRQb3NpdGlvblN0eWxlcyhwb3NpdGlvbil9XG4gICAgICB6LWluZGV4OiA5OTk5OTg7XG4gICAgICBiYWNrZ3JvdW5kOiAjMWExYTFhO1xuICAgICAgYm9yZGVyOiAxcHggc29saWQgIzMzMztcbiAgICAgIGJvcmRlci1yYWRpdXM6IDhweDtcbiAgICAgIHBhZGRpbmc6IDhweDtcbiAgICAgIGJveC1zaGFkb3c6IDAgNHB4IDEycHggcmdiYSgwLDAsMCwwLjMpO1xuICAgICAgZm9udC1mYW1pbHk6IHN5c3RlbS11aSwgJ1NlZ29lIFVJJywgUm9ib3RvLCBzYW5zLXNlcmlmO1xuICAgICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgfVxuICAgIFxuICAgIC5sYW5ndWFnZS1zZWxlY3Rvci1idXR0b24ge1xuICAgICAgYmFja2dyb3VuZDogdHJhbnNwYXJlbnQ7XG4gICAgICBib3JkZXI6IG5vbmU7XG4gICAgICBjb2xvcjogI2VlZTtcbiAgICAgIHBhZGRpbmc6IDZweCAxMHB4O1xuICAgICAgYm9yZGVyLXJhZGl1czogNnB4O1xuICAgICAgY3Vyc29yOiBwb2ludGVyO1xuICAgICAgZm9udC1zaXplOiAxNHB4O1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICBnYXA6IDZweDtcbiAgICAgIHRyYW5zaXRpb246IGJhY2tncm91bmQgMC4ycztcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgICB9XG4gICAgXG4gICAgLmxhbmd1YWdlLXNlbGVjdG9yLWJ1dHRvbjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwyNTUsMjU1LDAuMSk7XG4gICAgfVxuICAgIFxuICAgIC5sYW5ndWFnZS1zZWxlY3Rvci1kcm9wZG93biB7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICB0b3A6IDEwMCU7XG4gICAgICBsZWZ0OiAwO1xuICAgICAgcmlnaHQ6IDA7XG4gICAgICBiYWNrZ3JvdW5kOiAjMWExYTFhO1xuICAgICAgYm9yZGVyOiAxcHggc29saWQgIzMzMztcbiAgICAgIGJvcmRlci1yYWRpdXM6IDZweDtcbiAgICAgIG1hcmdpbi10b3A6IDRweDtcbiAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgICBib3gtc2hhZG93OiAwIDRweCAxMnB4IHJnYmEoMCwwLDAsMC4zKTtcbiAgICB9XG4gICAgXG4gICAgLmxhbmd1YWdlLXNlbGVjdG9yLWRyb3Bkb3duLnZpc2libGUge1xuICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgfVxuICAgIFxuICAgIC5sYW5ndWFnZS1vcHRpb24ge1xuICAgICAgYmFja2dyb3VuZDogdHJhbnNwYXJlbnQ7XG4gICAgICBib3JkZXI6IG5vbmU7XG4gICAgICBjb2xvcjogI2VlZTtcbiAgICAgIHBhZGRpbmc6IDhweCAxMnB4O1xuICAgICAgY3Vyc29yOiBwb2ludGVyO1xuICAgICAgZm9udC1zaXplOiAxNHB4O1xuICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICBnYXA6IDhweDtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgICAgIHRyYW5zaXRpb246IGJhY2tncm91bmQgMC4ycztcbiAgICB9XG4gICAgXG4gICAgLmxhbmd1YWdlLW9wdGlvbjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwyNTUsMjU1LDAuMSk7XG4gICAgfVxuICAgIFxuICAgIC5sYW5ndWFnZS1vcHRpb24uYWN0aXZlIHtcbiAgICAgIGJhY2tncm91bmQ6IHJnYmEoMTE5LCA5MiwgMjI3LCAwLjIpO1xuICAgICAgY29sb3I6ICM3NzVjZTM7XG4gICAgfVxuICAgIFxuICAgIC5sYW5ndWFnZS1vcHRpb246Zmlyc3QtY2hpbGQge1xuICAgICAgYm9yZGVyLXJhZGl1czogNnB4IDZweCAwIDA7XG4gICAgfVxuICAgIFxuICAgIC5sYW5ndWFnZS1vcHRpb246bGFzdC1jaGlsZCB7XG4gICAgICBib3JkZXItcmFkaXVzOiAwIDAgNnB4IDZweDtcbiAgICB9XG4gICAgXG4gICAgLmxhbmd1YWdlLWZsYWcge1xuICAgICAgZm9udC1zaXplOiAxNnB4O1xuICAgIH1cbiAgICBcbiAgICAubGFuZ3VhZ2UtbmFtZSB7XG4gICAgICBmb250LXdlaWdodDogNTAwO1xuICAgIH1cbiAgICBcbiAgICBAbWVkaWEgKG1heC13aWR0aDogNzY4cHgpIHtcbiAgICAgIC5sYW5ndWFnZS1zZWxlY3RvciB7XG4gICAgICAgIHBvc2l0aW9uOiBmaXhlZDtcbiAgICAgICAgdG9wOiAxMHB4O1xuICAgICAgICByaWdodDogMTBweDtcbiAgICAgIH1cbiAgICB9XG4gIGA7XG4gIFxuICAvLyBBXHUwMEYxYWRpciBlc3RpbG9zIGFsIGRvY3VtZW50b1xuICBpZiAoIWRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJyNsYW5ndWFnZS1zZWxlY3Rvci1zdHlsZXMnKSkge1xuICAgIGNvbnN0IHN0eWxlU2hlZXQgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzdHlsZScpO1xuICAgIHN0eWxlU2hlZXQuaWQgPSAnbGFuZ3VhZ2Utc2VsZWN0b3Itc3R5bGVzJztcbiAgICBzdHlsZVNoZWV0LnRleHRDb250ZW50ID0gc3R5bGVzO1xuICAgIGRvY3VtZW50LmhlYWQuYXBwZW5kQ2hpbGQoc3R5bGVTaGVldCk7XG4gIH1cbiAgXG4gIC8vIEVzdGFkb1xuICBsZXQgaXNPcGVuID0gZmFsc2U7XG4gIGxldCBjdXJyZW50TGFuZyA9IGdldEN1cnJlbnRMYW5ndWFnZSgpO1xuICBcbiAgLy8gQ3JlYXIgZXN0cnVjdHVyYSBIVE1MXG4gIGZ1bmN0aW9uIHJlbmRlcigpIHtcbiAgICBjb25zdCBsYW5nSW5mbyA9IEFWQUlMQUJMRV9MQU5HVUFHRVNbY3VycmVudExhbmddO1xuICAgIFxuICAgIGNvbnRhaW5lci5pbm5lckhUTUwgPSBgXG4gICAgICA8YnV0dG9uIGNsYXNzPVwibGFuZ3VhZ2Utc2VsZWN0b3ItYnV0dG9uXCI+XG4gICAgICAgICR7c2hvd0ZsYWdzID8gYDxzcGFuIGNsYXNzPVwibGFuZ3VhZ2UtZmxhZ1wiPiR7bGFuZ0luZm8uZmxhZ308L3NwYW4+YCA6ICcnfVxuICAgICAgICA8c3BhbiBjbGFzcz1cImxhbmd1YWdlLW5hbWVcIj4ke2xhbmdJbmZvLm5hbWV9PC9zcGFuPlxuICAgICAgICA8c3BhbiBzdHlsZT1cIm1hcmdpbi1sZWZ0OiBhdXRvOyB0cmFuc2Zvcm06ICR7aXNPcGVuID8gJ3JvdGF0ZSgxODBkZWcpJyA6ICdyb3RhdGUoMGRlZyknfTsgdHJhbnNpdGlvbjogdHJhbnNmb3JtIDAuMnM7XCI+XHUyNUJDPC9zcGFuPlxuICAgICAgPC9idXR0b24+XG4gICAgICA8ZGl2IGNsYXNzPVwibGFuZ3VhZ2Utc2VsZWN0b3ItZHJvcGRvd24gJHtpc09wZW4gPyAndmlzaWJsZScgOiAnJ31cIj5cbiAgICAgICAgJHtPYmplY3QuZW50cmllcyhBVkFJTEFCTEVfTEFOR1VBR0VTKS5tYXAoKFtjb2RlLCBpbmZvXSkgPT4gYFxuICAgICAgICAgIDxidXR0b24gY2xhc3M9XCJsYW5ndWFnZS1vcHRpb24gJHtjb2RlID09PSBjdXJyZW50TGFuZyA/ICdhY3RpdmUnIDogJyd9XCIgZGF0YS1sYW5nPVwiJHtjb2RlfVwiPlxuICAgICAgICAgICAgJHtzaG93RmxhZ3MgPyBgPHNwYW4gY2xhc3M9XCJsYW5ndWFnZS1mbGFnXCI+JHtpbmZvLmZsYWd9PC9zcGFuPmAgOiAnJ31cbiAgICAgICAgICAgIDxzcGFuIGNsYXNzPVwibGFuZ3VhZ2UtbmFtZVwiPiR7aW5mby5uYW1lfTwvc3Bhbj5cbiAgICAgICAgICA8L2J1dHRvbj5cbiAgICAgICAgYCkuam9pbignJyl9XG4gICAgICA8L2Rpdj5cbiAgICBgO1xuICAgIFxuICAgIC8vIEFcdTAwRjFhZGlyIGV2ZW50IGxpc3RlbmVyc1xuICAgIHNldHVwRXZlbnRMaXN0ZW5lcnMoKTtcbiAgfVxuICBcbiAgLy8gQ29uZmlndXJhciBldmVudCBsaXN0ZW5lcnNcbiAgZnVuY3Rpb24gc2V0dXBFdmVudExpc3RlbmVycygpIHtcbiAgICBjb25zdCBidXR0b24gPSBjb250YWluZXIucXVlcnlTZWxlY3RvcignLmxhbmd1YWdlLXNlbGVjdG9yLWJ1dHRvbicpO1xuICAgIGNvbnN0IG9wdGlvbnMgPSBjb250YWluZXIucXVlcnlTZWxlY3RvckFsbCgnLmxhbmd1YWdlLW9wdGlvbicpO1xuICAgIFxuICAgIC8vIFRvZ2dsZSBkcm9wZG93blxuICAgIGJ1dHRvbi5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7XG4gICAgICBlLnN0b3BQcm9wYWdhdGlvbigpO1xuICAgICAgaXNPcGVuID0gIWlzT3BlbjtcbiAgICAgIHJlbmRlcigpO1xuICAgIH0pO1xuICAgIFxuICAgIC8vIFNlbGVjY2lcdTAwRjNuIGRlIGlkaW9tYVxuICAgIG9wdGlvbnMuZm9yRWFjaChvcHRpb24gPT4ge1xuICAgICAgb3B0aW9uLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGUpID0+IHtcbiAgICAgICAgZS5zdG9wUHJvcGFnYXRpb24oKTtcbiAgICAgICAgY29uc3Qgc2VsZWN0ZWRMYW5nID0gb3B0aW9uLmRhdGFzZXQubGFuZztcbiAgICAgICAgXG4gICAgICAgIGlmIChzZWxlY3RlZExhbmcgIT09IGN1cnJlbnRMYW5nKSB7XG4gICAgICAgICAgY3VycmVudExhbmcgPSBzZWxlY3RlZExhbmc7XG4gICAgICAgICAgc2V0TGFuZ3VhZ2Uoc2VsZWN0ZWRMYW5nKTtcbiAgICAgICAgICBcbiAgICAgICAgICBpZiAob25MYW5ndWFnZUNoYW5nZSkge1xuICAgICAgICAgICAgb25MYW5ndWFnZUNoYW5nZShzZWxlY3RlZExhbmcpO1xuICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICBcbiAgICAgICAgaXNPcGVuID0gZmFsc2U7XG4gICAgICAgIHJlbmRlcigpO1xuICAgICAgfSk7XG4gICAgfSk7XG4gICAgXG4gICAgLy8gQ2VycmFyIGFsIGhhY2VyIGNsaWNrIGZ1ZXJhXG4gICAgZG9jdW1lbnQuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7XG4gICAgICBpZiAoaXNPcGVuKSB7XG4gICAgICAgIGlzT3BlbiA9IGZhbHNlO1xuICAgICAgICByZW5kZXIoKTtcbiAgICAgIH1cbiAgICB9KTtcbiAgfVxuICBcbiAgLy8gRXNjdWNoYXIgY2FtYmlvcyBkZSBpZGlvbWEgZGVzZGUgb3Ryb3MgY29tcG9uZW50ZXNcbiAgZnVuY3Rpb24gaGFuZGxlTGFuZ3VhZ2VDaGFuZ2UoZXZlbnQpIHtcbiAgICBpZiAoZXZlbnQuZGV0YWlsLmxhbmd1YWdlICE9PSBjdXJyZW50TGFuZykge1xuICAgICAgY3VycmVudExhbmcgPSBldmVudC5kZXRhaWwubGFuZ3VhZ2U7XG4gICAgICByZW5kZXIoKTtcbiAgICB9XG4gIH1cbiAgXG4gIC8vIEFcdTAwRjFhZGlyIGxpc3RlbmVyIHBhcmEgY2FtYmlvcyBleHRlcm5vcyBkZSBpZGlvbWFcbiAgd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2xhbmd1YWdlQ2hhbmdlZCcsIGhhbmRsZUxhbmd1YWdlQ2hhbmdlKTtcbiAgXG4gIC8vIFJlbmRlcml6YXIgaW5pY2lhbG1lbnRlXG4gIHJlbmRlcigpO1xuICBcbiAgLy8gTVx1MDBFOXRvZG9zIHBcdTAwRkFibGljb3NcbiAgcmV0dXJuIHtcbiAgICAvKipcbiAgICAgKiBBXHUwMEYxYWRlIGVsIHNlbGVjdG9yIGFsIERPTVxuICAgICAqIEBwYXJhbSB7SFRNTEVsZW1lbnR9IHBhcmVudCAtIEVsZW1lbnRvIHBhZHJlIChvcGNpb25hbCwgcG9yIGRlZmVjdG8gZG9jdW1lbnQuYm9keSlcbiAgICAgKi9cbiAgICBtb3VudChwYXJlbnQgPSBkb2N1bWVudC5ib2R5KSB7XG4gICAgICBwYXJlbnQuYXBwZW5kQ2hpbGQoY29udGFpbmVyKTtcbiAgICB9LFxuICAgIFxuICAgIC8qKlxuICAgICAqIFJlbXVldmUgZWwgc2VsZWN0b3IgZGVsIERPTVxuICAgICAqL1xuICAgIHVubW91bnQoKSB7XG4gICAgICB3aW5kb3cucmVtb3ZlRXZlbnRMaXN0ZW5lcignbGFuZ3VhZ2VDaGFuZ2VkJywgaGFuZGxlTGFuZ3VhZ2VDaGFuZ2UpO1xuICAgICAgaWYgKGNvbnRhaW5lci5wYXJlbnROb2RlKSB7XG4gICAgICAgIGNvbnRhaW5lci5wYXJlbnROb2RlLnJlbW92ZUNoaWxkKGNvbnRhaW5lcik7XG4gICAgICB9XG4gICAgfSxcbiAgICBcbiAgICAvKipcbiAgICAgKiBBY3R1YWxpemEgbGEgcG9zaWNpXHUwMEYzbiBkZWwgc2VsZWN0b3JcbiAgICAgKiBAcGFyYW0ge3N0cmluZ30gbmV3UG9zaXRpb24gLSBOdWV2YSBwb3NpY2lcdTAwRjNuXG4gICAgICovXG4gICAgc2V0UG9zaXRpb24obmV3UG9zaXRpb24pIHtcbiAgICAgIGNvbnRhaW5lci5zdHlsZS5jc3NUZXh0ID0gZ2V0UG9zaXRpb25TdHlsZXMobmV3UG9zaXRpb24pO1xuICAgIH0sXG4gICAgXG4gICAgLyoqXG4gICAgICogT2J0aWVuZSBlbCBlbGVtZW50byBET00gZGVsIHNlbGVjdG9yXG4gICAgICogQHJldHVybnMge0hUTUxFbGVtZW50fSBFbGVtZW50byBET01cbiAgICAgKi9cbiAgICBnZXRFbGVtZW50KCkge1xuICAgICAgcmV0dXJuIGNvbnRhaW5lcjtcbiAgICB9LFxuICAgIFxuICAgIC8qKlxuICAgICAqIEZ1ZXJ6YSB1bmEgYWN0dWFsaXphY2lcdTAwRjNuIGRlbCBjb21wb25lbnRlXG4gICAgICovXG4gICAgdXBkYXRlKCkge1xuICAgICAgY3VycmVudExhbmcgPSBnZXRDdXJyZW50TGFuZ3VhZ2UoKTtcbiAgICAgIHJlbmRlcigpO1xuICAgIH1cbiAgfTtcbn1cblxuLyoqXG4gKiBPYnRpZW5lIGxvcyBlc3RpbG9zIENTUyBwYXJhIHBvc2ljaW9uYXIgZWwgc2VsZWN0b3JcbiAqIEBwYXJhbSB7c3RyaW5nfSBwb3NpdGlvbiAtIFBvc2ljaVx1MDBGM24gZGVzZWFkYVxuICogQHJldHVybnMge3N0cmluZ30gRXN0aWxvcyBDU1NcbiAqL1xuZnVuY3Rpb24gZ2V0UG9zaXRpb25TdHlsZXMocG9zaXRpb24pIHtcbiAgY29uc3QgcG9zaXRpb25zID0ge1xuICAgICd0b3AtcmlnaHQnOiAndG9wOiAxNXB4OyByaWdodDogMTVweDsnLFxuICAgICd0b3AtbGVmdCc6ICd0b3A6IDE1cHg7IGxlZnQ6IDE1cHg7JyxcbiAgICAnYm90dG9tLXJpZ2h0JzogJ2JvdHRvbTogMTVweDsgcmlnaHQ6IDE1cHg7JyxcbiAgICAnYm90dG9tLWxlZnQnOiAnYm90dG9tOiAxNXB4OyBsZWZ0OiAxNXB4OycsXG4gICAgJ3RvcC1jZW50ZXInOiAndG9wOiAxNXB4OyBsZWZ0OiA1MCU7IHRyYW5zZm9ybTogdHJhbnNsYXRlWCgtNTAlKTsnLFxuICAgICdib3R0b20tY2VudGVyJzogJ2JvdHRvbTogMTVweDsgbGVmdDogNTAlOyB0cmFuc2Zvcm06IHRyYW5zbGF0ZVgoLTUwJSk7J1xuICB9O1xuICBcbiAgcmV0dXJuIHBvc2l0aW9uc1twb3NpdGlvbl0gfHwgcG9zaXRpb25zWyd0b3AtcmlnaHQnXTtcbn1cbiIsICJpbXBvcnQgeyBsb2cgfSBmcm9tIFwiLi4vY29yZS9sb2dnZXIuanNcIjtcbmltcG9ydCB7IGNyZWF0ZUxhdW5jaGVyVUkgfSBmcm9tIFwiLi91aS5qc1wiO1xuaW1wb3J0IHsgZ2V0U2Vzc2lvbiwgY2hlY2tCYWNrZW5kSGVhbHRoLCBkb3dubG9hZEFuZEV4ZWN1dGVCb3QgfSBmcm9tIFwiLi9hcGkuanNcIjtcbmltcG9ydCB7IGxhdW5jaGVyU3RhdGUsIExBVU5DSEVSX0NPTkZJRyB9IGZyb20gXCIuL2NvbmZpZy5qc1wiO1xuaW1wb3J0IHsgaW5pdGlhbGl6ZUxhbmd1YWdlIH0gZnJvbSBcIi4uL2xvY2FsZXMvaW5kZXguanNcIjtcbmltcG9ydCB7IGNyZWF0ZUxhbmd1YWdlU2VsZWN0b3IgfSBmcm9tIFwiLi4vY29yZS9sYW5ndWFnZS1zZWxlY3Rvci5qc1wiO1xuXG5leHBvcnQgYXN5bmMgZnVuY3Rpb24gcnVuTGF1bmNoZXIoKSB7XG4gIGxvZygnXHVEODNEXHVERTgwIEluaWNpYW5kbyBXUGxhY2UgQXV0by1MYXVuY2hlciAodmVyc2lcdTAwRjNuIG1vZHVsYXIpJyk7XG4gIFxuICAvLyBJbmljaWFsaXphciBzaXN0ZW1hIGRlIGlkaW9tYXNcbiAgaW5pdGlhbGl6ZUxhbmd1YWdlKCk7XG4gIFxuICAvLyBWZXJpZmljYXIgc2kgeWEgZXN0XHUwMEUxIGVqZWN1dFx1MDBFMW5kb3NlXG4gIGlmICh3aW5kb3cuX193cGxhY2VCb3Q/LmxhdW5jaGVyUnVubmluZykge1xuICAgIGFsZXJ0KFwiQXV0by1MYXVuY2hlciB5YSBlc3RcdTAwRTEgZWplY3V0XHUwMEUxbmRvc2UuXCIpO1xuICAgIHJldHVybjtcbiAgfVxuICBcbiAgLy8gSW5pY2lhbGl6YXIgbyBwcmVzZXJ2YXIgZWwgZXN0YWRvIGdsb2JhbFxuICB3aW5kb3cuX193cGxhY2VCb3QgPSB7IC4uLndpbmRvdy5fX3dwbGFjZUJvdCwgbGF1bmNoZXJSdW5uaW5nOiB0cnVlIH07XG4gIFxuICB0cnkge1xuICAgIC8vIFZhcmlhYmxlIHBhcmEgZWwgc2VsZWN0b3IgZGUgaWRpb21hXG4gICAgbGV0IGxhbmd1YWdlU2VsZWN0b3IgPSBudWxsO1xuICAgIFxuICAgIC8vIENyZWFyIGludGVyZmF6IGRlIHVzdWFyaW9cbiAgICBjb25zdCB1aSA9IGNyZWF0ZUxhdW5jaGVyVUkoe1xuICAgICAgb25TZWxlY3RCb3Q6IChib3RUeXBlKSA9PiB7XG4gICAgICAgIGxvZyhgXHVEODNDXHVERkFGIEJvdCBzZWxlY2Npb25hZG86ICR7Ym90VHlwZX1gKTtcbiAgICAgICAgLy8gT2N1bHRhciBlbCBzZWxlY3RvciBkZSBpZGlvbWEgY3VhbmRvIHNlIHNlbGVjY2lvbmEgdW4gYm90XG4gICAgICAgIGlmIChsYW5ndWFnZVNlbGVjdG9yKSB7XG4gICAgICAgICAgbGFuZ3VhZ2VTZWxlY3Rvci51bm1vdW50KCk7XG4gICAgICAgICAgbGFuZ3VhZ2VTZWxlY3RvciA9IG51bGw7XG4gICAgICAgIH1cbiAgICAgIH0sXG4gICAgICBcbiAgICAgIG9uTGF1bmNoOiBhc3luYyAoYm90VHlwZSkgPT4ge1xuICAgICAgICBsb2coYFx1RDgzRFx1REU4MCBMYW56YW5kbyBib3Q6ICR7Ym90VHlwZX1gKTtcbiAgICAgICAgYXdhaXQgZG93bmxvYWRBbmRFeGVjdXRlQm90KGJvdFR5cGUsIExBVU5DSEVSX0NPTkZJRy5SQVdfQkFTRSk7XG4gICAgICB9LFxuICAgICAgXG4gICAgICBvbkNsb3NlOiAoKSA9PiB7XG4gICAgICAgIGxvZygnXHVEODNEXHVEQzRCIENlcnJhbmRvIGxhdW5jaGVyJyk7XG4gICAgICAgIC8vIEFzZWd1cmFyIHF1ZSBlbCBzZWxlY3RvciBzZSBkZXNtb250ZSBhbCBjZXJyYXJcbiAgICAgICAgaWYgKGxhbmd1YWdlU2VsZWN0b3IpIHtcbiAgICAgICAgICBsYW5ndWFnZVNlbGVjdG9yLnVubW91bnQoKTtcbiAgICAgICAgICBsYW5ndWFnZVNlbGVjdG9yID0gbnVsbDtcbiAgICAgICAgfVxuICAgICAgICB3aW5kb3cuX193cGxhY2VCb3QubGF1bmNoZXJSdW5uaW5nID0gZmFsc2U7XG4gICAgICB9XG4gICAgfSk7XG4gICAgXG4gICAgLy8gQ3JlYXIgc2VsZWN0b3IgZGUgaWRpb21hIGRlc3B1XHUwMEU5cyBkZSBsYSBVSVxuICAgIGxhbmd1YWdlU2VsZWN0b3IgPSBjcmVhdGVMYW5ndWFnZVNlbGVjdG9yKHtcbiAgICAgIHBvc2l0aW9uOiAndG9wLWxlZnQnLCAvLyBFc3F1aW5hIG9wdWVzdGEgYWwgbGF1bmNoZXJcbiAgICAgIHNob3dGbGFnczogdHJ1ZSxcbiAgICAgIG9uTGFuZ3VhZ2VDaGFuZ2U6IChuZXdMYW5ndWFnZSkgPT4ge1xuICAgICAgICBsb2coYFx1RDgzQ1x1REYwRCBJZGlvbWEgY2FtYmlhZG8gYTogJHtuZXdMYW5ndWFnZX0gZGVzZGUgZWwgbGF1bmNoZXJgKTtcbiAgICAgICAgXG4gICAgICAgIC8vIEFjdHVhbGl6YXIgdGV4dG9zIGRlIGxhIFVJIGRlbCBsYXVuY2hlclxuICAgICAgICB1aS51cGRhdGVUZXh0cygpO1xuICAgICAgICBcbiAgICAgICAgLy8gRW1pdGlyIGV2ZW50byBwZXJzb25hbGl6YWRvIHBhcmEgbm90aWZpY2FyIGEgb3Ryb3MgbVx1MDBGM2R1bG9zXG4gICAgICAgIGlmICh0eXBlb2Ygd2luZG93ICE9PSAndW5kZWZpbmVkJyAmJiB3aW5kb3cuQ3VzdG9tRXZlbnQpIHtcbiAgICAgICAgICB3aW5kb3cuZGlzcGF0Y2hFdmVudChuZXcgd2luZG93LkN1c3RvbUV2ZW50KCdsYXVuY2hlckxhbmd1YWdlQ2hhbmdlZCcsIHtcbiAgICAgICAgICAgIGRldGFpbDogeyBsYW5ndWFnZTogbmV3TGFuZ3VhZ2UgfVxuICAgICAgICAgIH0pKTtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH0pO1xuICAgIFxuICAgIC8vIE1vbnRhciBlbCBzZWxlY3RvclxuICAgIGxhbmd1YWdlU2VsZWN0b3IubW91bnQoKTtcbiAgICBcbiAgICAvLyBDYXJnYXIgaW5mb3JtYWNpXHUwMEYzbiBpbmljaWFsXG4gICAgbG9nKCdcdUQ4M0RcdURDQ0EgQ2FyZ2FuZG8gaW5mb3JtYWNpXHUwMEYzbiBpbmljaWFsLi4uJyk7XG4gICAgXG4gICAgLy8gQ2FyZ2FyIGVzdGFkbyBkZWwgYmFja2VuZFxuICAgIGNvbnN0IGhlYWx0aCA9IGF3YWl0IGNoZWNrQmFja2VuZEhlYWx0aCgpO1xuICAgIHVpLnNldEhlYWx0aEluZm8oaGVhbHRoKTtcbiAgICBcbiAgICAvLyBDYXJnYXIgaW5mb3JtYWNpXHUwMEYzbiBkZWwgdXN1YXJpb1xuICAgIGNvbnN0IHVzZXIgPSBhd2FpdCBnZXRTZXNzaW9uKCk7XG4gICAgdWkuc2V0VXNlckluZm8odXNlcik7XG4gICAgXG4gICAgLy8gQ29uZmlndXJhciByZWZyZXNjbyBwZXJpXHUwMEYzZGljb1xuICAgIGxhdW5jaGVyU3RhdGUucmVmcmVzaFRpbWVyID0gd2luZG93LnNldEludGVydmFsKGFzeW5jICgpID0+IHtcbiAgICAgIGxvZygnXHVEODNEXHVERDA0IEFjdHVhbGl6YW5kbyBpbmZvcm1hY2lcdTAwRjNuLi4uJyk7XG4gICAgICBcbiAgICAgIHRyeSB7XG4gICAgICAgIGNvbnN0IFtuZXdIZWFsdGgsIG5ld1VzZXJdID0gYXdhaXQgUHJvbWlzZS5hbGwoW1xuICAgICAgICAgIGNoZWNrQmFja2VuZEhlYWx0aCgpLFxuICAgICAgICAgIGdldFNlc3Npb24oKVxuICAgICAgICBdKTtcbiAgICAgICAgXG4gICAgICAgIHVpLnNldEhlYWx0aEluZm8obmV3SGVhbHRoKTtcbiAgICAgICAgdWkuc2V0VXNlckluZm8obmV3VXNlcik7XG4gICAgICB9IGNhdGNoIChlcnJvcikge1xuICAgICAgICBsb2coJ1x1Mjc0QyBFcnJvciBlbiBhY3R1YWxpemFjaVx1MDBGM24gcGVyaVx1MDBGM2RpY2E6JywgZXJyb3IpO1xuICAgICAgfVxuICAgIH0sIExBVU5DSEVSX0NPTkZJRy5SRUZSRVNIX0lOVEVSVkFMKTtcbiAgICBcbiAgICAvLyBDbGVhbnVwIGN1YW5kbyBzZSBjaWVycmUgbGEgcFx1MDBFMWdpbmFcbiAgICB3aW5kb3cuYWRkRXZlbnRMaXN0ZW5lcignYmVmb3JldW5sb2FkJywgKCkgPT4ge1xuICAgICAgdWkuY2xlYW51cCgpO1xuICAgICAgaWYgKGxhbmd1YWdlU2VsZWN0b3IpIHtcbiAgICAgICAgbGFuZ3VhZ2VTZWxlY3Rvci51bm1vdW50KCk7XG4gICAgICB9XG4gICAgICB3aW5kb3cuX193cGxhY2VCb3QubGF1bmNoZXJSdW5uaW5nID0gZmFsc2U7XG4gICAgfSk7XG4gICAgXG4gICAgbG9nKCdcdTI3MDUgQXV0by1MYXVuY2hlciBpbmljaWFsaXphZG8gY29ycmVjdGFtZW50ZScpO1xuICAgIFxuICB9IGNhdGNoIChlcnJvcikge1xuICAgIGxvZygnXHUyNzRDIEVycm9yIGluaWNpYWxpemFuZG8gQXV0by1MYXVuY2hlcjonLCBlcnJvcik7XG4gICAgd2luZG93Ll9fd3BsYWNlQm90LmxhdW5jaGVyUnVubmluZyA9IGZhbHNlO1xuICAgIHRocm93IGVycm9yO1xuICB9XG59XG4iLCAiaW1wb3J0IHsgcnVuTGF1bmNoZXIgfSBmcm9tIFwiLi4vbGF1bmNoZXIvaW5kZXguanNcIjtcblxuKCgpID0+IHtcbiAgXCJ1c2Ugc3RyaWN0XCI7XG4gIC8vIFZlcmlmaWNhciBzaSBoYXkgYm90cyBlc3BlY1x1MDBFRGZpY29zIGVqZWN1dFx1MDBFMW5kb3NlLCBubyBlbCBsYXVuY2hlclxuICBpZiAod2luZG93Ll9fd3BsYWNlQm90Py5mYXJtUnVubmluZyB8fCB3aW5kb3cuX193cGxhY2VCb3Q/LmltYWdlUnVubmluZykge1xuICAgIGFsZXJ0KFwiWWEgaGF5IHVuIGJvdCBlamVjdXRcdTAwRTFuZG9zZS4gQ2lcdTAwRTlycmFsbyBhbnRlcyBkZSB1c2FyIGVsIGxhdW5jaGVyLlwiKTtcbiAgICByZXR1cm47XG4gIH1cbiAgXG4gIC8vIEluaWNpYWxpemFyIGVsIGVzdGFkbyBnbG9iYWwgc2kgbm8gZXhpc3RlXG4gIGlmICghd2luZG93Ll9fd3BsYWNlQm90KSB7XG4gICAgd2luZG93Ll9fd3BsYWNlQm90ID0ge307XG4gIH1cbiAgXG4gIHJ1bkxhdW5jaGVyKCkuY2F0Y2goKGUpID0+IHtcbiAgICBjb25zb2xlLmVycm9yKFwiW0JPVF0gRXJyb3IgZW4gQXV0by1MYXVuY2hlcjpcIiwgZSk7XG4gICAgLy8gTGltcGlhciBzb2xvIGVsIGVzdGFkbyBkZWwgbGF1bmNoZXIsIG5vIGRlIG90cm9zIGJvdHNcbiAgICBpZiAod2luZG93Ll9fd3BsYWNlQm90KSB7XG4gICAgICB3aW5kb3cuX193cGxhY2VCb3QubGF1bmNoZXJSdW5uaW5nID0gZmFsc2U7XG4gICAgfVxuICAgIGFsZXJ0KFwiQXV0by1MYXVuY2hlcjogZXJyb3IgaW5lc3BlcmFkby4gUmV2aXNhIGNvbnNvbGEuXCIpO1xuICB9KTtcbn0pKCk7XG4iXSwKICAibWFwcGluZ3MiOiAiOzs7QUFVTyxNQUFNLE1BQU0sSUFBSSxNQUFNLFFBQVEsSUFBSSxZQUFZLEdBQUcsQ0FBQzs7O0FDVmxELFdBQVMsaUJBQWlCLFNBQVMsTUFBTTtBQUM5QyxVQUFNLE9BQU8sU0FBUyxjQUFjLEtBQUs7QUFDekMsUUFBSSxRQUFRO0FBQ1YsV0FBSyxLQUFLO0FBQUEsSUFDWjtBQUNBLFNBQUssTUFBTSxVQUFVO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBUXJCLFVBQU0sT0FBTyxLQUFLLGFBQWEsRUFBRSxNQUFNLE9BQU8sQ0FBQztBQUMvQyxhQUFTLEtBQUssWUFBWSxJQUFJO0FBRTlCLFdBQU8sRUFBRSxNQUFNLEtBQUs7QUFBQSxFQUN0QjtBQUVPLFdBQVMsY0FBYyxZQUFZLFNBQVM7QUFDakQsUUFBSSxPQUFPLEdBQUcsT0FBTyxHQUFHLE9BQU8sR0FBRyxPQUFPO0FBRXpDLGVBQVcsTUFBTSxTQUFTO0FBQzFCLGVBQVcsaUJBQWlCLGFBQWEsYUFBYTtBQUV0RCxhQUFTLGNBQWMsR0FBRztBQUV4QixVQUFJLEVBQUUsT0FBTyxRQUFRLGlDQUFpQyxFQUFHO0FBRXpELFFBQUUsZUFBZTtBQUNqQixhQUFPLEVBQUU7QUFDVCxhQUFPLEVBQUU7QUFDVCxlQUFTLGlCQUFpQixXQUFXLGdCQUFnQjtBQUNyRCxlQUFTLGlCQUFpQixhQUFhLFdBQVc7QUFBQSxJQUNwRDtBQUVBLGFBQVMsWUFBWSxHQUFHO0FBQ3RCLFFBQUUsZUFBZTtBQUNqQixhQUFPLE9BQU8sRUFBRTtBQUNoQixhQUFPLE9BQU8sRUFBRTtBQUNoQixhQUFPLEVBQUU7QUFDVCxhQUFPLEVBQUU7QUFDVCxjQUFRLE1BQU0sTUFBTyxRQUFRLFlBQVksT0FBUTtBQUNqRCxjQUFRLE1BQU0sT0FBUSxRQUFRLGFBQWEsT0FBUTtBQUFBLElBQ3JEO0FBRUEsYUFBUyxtQkFBbUI7QUFDMUIsZUFBUyxvQkFBb0IsV0FBVyxnQkFBZ0I7QUFDeEQsZUFBUyxvQkFBb0IsYUFBYSxXQUFXO0FBQUEsSUFDdkQ7QUFBQSxFQUNGOzs7QUNsRE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDVixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDVixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDVixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxLQUFLO0FBQUE7QUFBQSxJQUVoQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDUCxlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUN6UE8sTUFBTSxTQUFTO0FBQUE7QUFBQSxJQUVwQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDUCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUMzUE8sTUFBTSxTQUFTO0FBQUE7QUFBQSxJQUVwQixVQUFVO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxVQUFVO0FBQUEsTUFDVixXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxXQUFXO0FBQUEsTUFDWCxNQUFNO0FBQUEsTUFDTixTQUFTO0FBQUEsTUFDVCxTQUFTO0FBQUEsTUFDVCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxXQUFXO0FBQUEsTUFDWCxhQUFhO0FBQUEsTUFDYixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixXQUFXO0FBQUEsTUFDWCxjQUFjO0FBQUEsTUFDZCxVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxJQUFJO0FBQUEsTUFDSixPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsSUFDWDtBQUFBO0FBQUEsSUFHQSxPQUFPO0FBQUEsTUFDTCxPQUFPO0FBQUEsTUFDUCxTQUFTO0FBQUEsTUFDVCxhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxjQUFjO0FBQUEsTUFDZCxnQkFBZ0I7QUFBQSxNQUNoQixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixxQkFBcUI7QUFBQSxNQUNyQixpQkFBaUI7QUFBQSxNQUNqQixhQUFhO0FBQUEsTUFDYixpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixrQkFBa0I7QUFBQSxNQUNsQixrQkFBa0I7QUFBQSxNQUNsQixXQUFXO0FBQUEsTUFDWCxpQkFBaUI7QUFBQSxNQUNqQixrQkFBa0I7QUFBQSxNQUNsQixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQixVQUFVO0FBQUEsTUFDVixVQUFVO0FBQUEsTUFDVixRQUFRO0FBQUEsTUFDUixTQUFTO0FBQUEsTUFDVCxlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixhQUFhO0FBQUEsTUFDYixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixnQkFBZ0I7QUFBQSxNQUNoQixXQUFXO0FBQUEsTUFDWCxlQUFlO0FBQUEsTUFDZixlQUFlO0FBQUEsTUFDZixhQUFhO0FBQUEsTUFDYixZQUFZO0FBQUEsTUFDWixtQkFBbUI7QUFBQSxNQUNuQixlQUFlO0FBQUEsTUFDZixpQkFBaUI7QUFBQSxNQUNqQixlQUFlO0FBQUEsTUFDZixnQkFBZ0I7QUFBQSxNQUNoQixtQkFBbUI7QUFBQSxNQUNuQixtQkFBbUI7QUFBQSxNQUNuQixxQkFBcUI7QUFBQSxNQUNyQixtQkFBbUI7QUFBQSxNQUNuQixpQkFBaUI7QUFBQSxNQUNqQixRQUFRO0FBQUEsTUFDUixVQUFVO0FBQUEsTUFDVixPQUFPO0FBQUEsTUFDUCxRQUFRO0FBQUEsTUFDUixZQUFZO0FBQUEsTUFDWixPQUFPO0FBQUEsTUFDUCxXQUFXO0FBQUEsTUFDWCxZQUFZO0FBQUEsTUFDWixlQUFlO0FBQUEsTUFDZixxQkFBcUI7QUFBQSxNQUNyQix5QkFBeUI7QUFBQSxNQUN6QixrQkFBa0I7QUFBQSxNQUNsQixpQkFBaUI7QUFBQSxNQUNqQixnQkFBZ0I7QUFBQSxNQUNoQixpQkFBaUI7QUFBQSxNQUNqQixpQkFBaUI7QUFBQSxNQUNqQixxQkFBcUI7QUFBQSxNQUNyQixxQkFBcUI7QUFBQSxNQUNyQixvQkFBb0I7QUFBQSxNQUNwQixjQUFjO0FBQUEsTUFDZCxZQUFZO0FBQUEsTUFDWixhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsTUFDZCxhQUFhO0FBQUEsTUFDYixjQUFjO0FBQUEsSUFDaEI7QUFBQTtBQUFBLElBR0EsTUFBTTtBQUFBLE1BQ0osT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsT0FBTztBQUFBLE1BQ1AsZ0JBQWdCO0FBQUEsTUFDaEIsWUFBWTtBQUFBLE1BQ1osV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsWUFBWTtBQUFBLE1BQ1osVUFBVTtBQUFBLE1BQ1YsT0FBTztBQUFBLE1BQ1AsT0FBTztBQUFBLE1BQ1AsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04sYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsYUFBYTtBQUFBLE1BQ2IscUJBQXFCO0FBQUEsTUFDckIsZUFBZTtBQUFBLE1BQ2YsZ0JBQWdCO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsZ0JBQWdCO0FBQUEsTUFDaEIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2Isb0JBQW9CO0FBQUEsSUFDdEI7QUFBQTtBQUFBLElBR0EsUUFBUTtBQUFBLE1BQ04sS0FBSztBQUFBLE1BQ0wsSUFBSTtBQUFBLE1BQ0osSUFBSTtBQUFBLE1BQ0osUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sTUFBTTtBQUFBLE1BQ04sUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsUUFBUTtBQUFBLE1BQ1IsT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsTUFBTTtBQUFBLE1BQ04sT0FBTztBQUFBLE1BQ1AsVUFBVTtBQUFBLE1BQ1YsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsU0FBUztBQUFBLE1BQ1QsTUFBTTtBQUFBLE1BQ04saUJBQWlCO0FBQUEsSUFDbkI7QUFBQTtBQUFBLElBR0EsT0FBTztBQUFBLE1BQ0wsT0FBTztBQUFBLE1BQ1AsU0FBUztBQUFBLE1BQ1QsWUFBWTtBQUFBLE1BQ1osYUFBYTtBQUFBLE1BQ2IsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsV0FBVztBQUFBLE1BQ1gsWUFBWTtBQUFBLE1BQ1osaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsU0FBUztBQUFBLE1BQ1QsYUFBYTtBQUFBLE1BQ2IsZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsY0FBYztBQUFBLE1BQ2QsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsY0FBYztBQUFBLE1BQ2QsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsaUJBQWlCO0FBQUEsTUFDakIsZUFBZTtBQUFBLE1BQ2YsYUFBYTtBQUFBLE1BQ2IsV0FBVztBQUFBLE1BQ1gsV0FBVztBQUFBLE1BQ1gsa0JBQWtCO0FBQUEsTUFDbEIsaUJBQWlCO0FBQUEsTUFDakIsZ0JBQWdCO0FBQUEsTUFDaEIsb0JBQW9CO0FBQUEsTUFDcEIsaUJBQWlCO0FBQUEsTUFDakIsaUJBQWlCO0FBQUEsTUFDakIscUJBQXFCO0FBQUEsTUFDckIscUJBQXFCO0FBQUEsTUFDckIsaUJBQWlCO0FBQUEsTUFDakIsa0JBQWtCO0FBQUEsTUFDbEIsa0JBQWtCO0FBQUEsTUFDbEIsbUJBQW1CO0FBQUEsTUFDbkIsbUJBQW1CO0FBQUEsTUFDbkIsb0JBQW9CO0FBQUEsTUFDcEIsa0JBQWtCO0FBQUEsTUFDbEIsZ0JBQWdCO0FBQUEsSUFDbEI7QUFBQSxFQUNGOzs7QUNuUE8sTUFBTSxzQkFBc0I7QUFBQSxJQUNqQyxJQUFJLEVBQUUsTUFBTSxjQUFXLE1BQU0sc0JBQVEsTUFBTSxLQUFLO0FBQUEsSUFDaEQsSUFBSSxFQUFFLE1BQU0sV0FBVyxNQUFNLHNCQUFRLE1BQU0sS0FBSztBQUFBLElBQ2hELElBQUksRUFBRSxNQUFNLGVBQVksTUFBTSxzQkFBUSxNQUFNLEtBQUs7QUFBQSxJQUNqRCxJQUFJLEVBQUUsTUFBTSw4Q0FBVyxNQUFNLHNCQUFRLE1BQU0sS0FBSztBQUFBLElBQ2hELFFBQVEsRUFBRSxNQUFNLDRCQUFRLE1BQU0sc0JBQVEsTUFBTSxVQUFVO0FBQUEsSUFDdEQsUUFBUSxFQUFFLE1BQU0sNEJBQVEsTUFBTSxzQkFBUSxNQUFNLFVBQVU7QUFBQSxFQUN4RDtBQUdBLE1BQU0sZUFBZTtBQUFBLElBQ25CO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxFQUNGO0FBR0EsTUFBSSxrQkFBa0I7QUFDdEIsTUFBSSxzQkFBc0IsYUFBYSxlQUFlO0FBTS9DLFdBQVMsd0JBQXdCO0FBQ3RDLFVBQU0sY0FBYyxPQUFPLFVBQVUsWUFBWSxPQUFPLFVBQVUsZ0JBQWdCO0FBR2xGLFVBQU0sV0FBVyxZQUFZLE1BQU0sR0FBRyxFQUFFLENBQUMsRUFBRSxZQUFZO0FBR3ZELFFBQUksYUFBYSxRQUFRLEdBQUc7QUFDMUIsYUFBTztBQUFBLElBQ1Q7QUFHQSxXQUFPO0FBQUEsRUFDVDtBQU1PLFdBQVMsbUJBQW1CO0FBRWpDLFdBQU87QUFBQSxFQUNUO0FBTU8sV0FBUyxhQUFhLFVBQVU7QUFFckM7QUFBQSxFQUNGO0FBTU8sV0FBUyxxQkFBcUI7QUFFbkMsVUFBTSxZQUFZLGlCQUFpQjtBQUNuQyxVQUFNLGNBQWMsc0JBQXNCO0FBRTFDLFFBQUksZUFBZTtBQUVuQixRQUFJLGFBQWEsYUFBYSxTQUFTLEdBQUc7QUFDeEMscUJBQWU7QUFBQSxJQUNqQixXQUFXLGVBQWUsYUFBYSxXQUFXLEdBQUc7QUFDbkQscUJBQWU7QUFBQSxJQUNqQjtBQUVBLGdCQUFZLFlBQVk7QUFDeEIsV0FBTztBQUFBLEVBQ1Q7QUFNTyxXQUFTLFlBQVksVUFBVTtBQUNwQyxRQUFJLENBQUMsYUFBYSxRQUFRLEdBQUc7QUFDM0IsY0FBUSxLQUFLLFdBQVcsUUFBUSw0QkFBNEIsZUFBZSxHQUFHO0FBQzlFO0FBQUEsSUFDRjtBQUVBLHNCQUFrQjtBQUNsQiwwQkFBc0IsYUFBYSxRQUFRO0FBQzNDLGlCQUFhLFFBQVE7QUFHckIsUUFBSSxPQUFPLFdBQVcsZUFBZSxPQUFPLGFBQWE7QUFDdkQsYUFBTyxjQUFjLElBQUksT0FBTyxZQUFZLG1CQUFtQjtBQUFBLFFBQzdELFFBQVEsRUFBRSxVQUFVLFVBQVUsY0FBYyxvQkFBb0I7QUFBQSxNQUNsRSxDQUFDLENBQUM7QUFBQSxJQUNKO0FBQUEsRUFDRjtBQU1PLFdBQVMscUJBQXFCO0FBQ25DLFdBQU87QUFBQSxFQUNUO0FBZ0JPLFdBQVMsRUFBRSxLQUFLLFNBQVMsQ0FBQyxHQUFHO0FBQ2xDLFVBQU0sT0FBTyxJQUFJLE1BQU0sR0FBRztBQUMxQixRQUFJLFFBQVE7QUFHWixlQUFXLEtBQUssTUFBTTtBQUNwQixVQUFJLFNBQVMsT0FBTyxVQUFVLFlBQVksS0FBSyxPQUFPO0FBQ3BELGdCQUFRLE1BQU0sQ0FBQztBQUFBLE1BQ2pCLE9BQU87QUFDTCxnQkFBUSxLQUFLLDBDQUF1QyxHQUFHLEdBQUc7QUFDMUQsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBRUEsUUFBSSxPQUFPLFVBQVUsVUFBVTtBQUM3QixjQUFRLEtBQUsseUNBQXNDLEdBQUcsR0FBRztBQUN6RCxhQUFPO0FBQUEsSUFDVDtBQUdBLFdBQU8sWUFBWSxPQUFPLE1BQU07QUFBQSxFQUNsQztBQVFBLFdBQVMsWUFBWSxNQUFNLFFBQVE7QUFDakMsUUFBSSxDQUFDLFVBQVUsT0FBTyxLQUFLLE1BQU0sRUFBRSxXQUFXLEdBQUc7QUFDL0MsYUFBTztBQUFBLElBQ1Q7QUFFQSxXQUFPLEtBQUssUUFBUSxjQUFjLENBQUMsT0FBTyxRQUFRO0FBQ2hELGFBQU8sT0FBTyxHQUFHLE1BQU0sU0FBWSxPQUFPLEdBQUcsSUFBSTtBQUFBLElBQ25ELENBQUM7QUFBQSxFQUNIO0FBT08sV0FBUyxXQUFXLFNBQVM7QUFDbEMsUUFBSSxvQkFBb0IsT0FBTyxHQUFHO0FBQ2hDLGFBQU8sb0JBQW9CLE9BQU87QUFBQSxJQUNwQztBQUVBLFlBQVEsS0FBSywrQ0FBeUMsT0FBTyxHQUFHO0FBQ2hFLFdBQU8sQ0FBQztBQUFBLEVBQ1Y7QUFZQSxxQkFBbUI7OztBQ2xNWixNQUFNLGtCQUFrQjtBQUFBLElBQzdCLFVBQVU7QUFBQSxJQUNWLGtCQUFrQjtBQUFBO0FBQUEsSUFDbEIsT0FBTztBQUFBLE1BQ0wsU0FBUztBQUFBLE1BQ1QsV0FBVztBQUFBLE1BQ1gsUUFBUTtBQUFBLE1BQ1IsTUFBTTtBQUFBLE1BQ04sV0FBVztBQUFBLE1BQ1gsU0FBUztBQUFBLE1BQ1QsT0FBTztBQUFBLElBQ1Q7QUFBQSxFQUNGO0FBR08sV0FBUyxtQkFBbUI7QUFDakMsV0FBTyxXQUFXLFVBQVU7QUFBQSxFQUM5QjtBQXlCTyxNQUFNLGdCQUFnQjtBQUFBLElBQzNCLElBQUk7QUFBQSxJQUNKLFFBQVE7QUFBQSxJQUNSLGNBQWM7QUFBQSxJQUNkLGFBQWE7QUFBQSxFQUNmOzs7QUM1Q08sV0FBUyxpQkFBaUI7QUFBQSxJQUMvQjtBQUFBLElBQ0E7QUFBQSxJQUNBO0FBQUEsSUFDQTtBQUFBLElBQ0E7QUFBQSxFQUNGLEdBQUc7QUFDRCxRQUFJLCtDQUFtQztBQUd2QyxVQUFNLFdBQVcsU0FBUyxlQUFlLFdBQVc7QUFDcEQsUUFBSSxVQUFVO0FBQ1osZUFBUyxPQUFPO0FBQ2hCLFVBQUksMENBQThCO0FBQUEsSUFDcEM7QUFFQSxVQUFNLFFBQVEsaUJBQWlCO0FBQy9CLFVBQU0sRUFBRSxNQUFNLEtBQUssSUFBSSxpQkFBaUIsV0FBVztBQUduRCxVQUFNLFFBQVEsU0FBUyxjQUFjLE9BQU87QUFDNUMsVUFBTSxjQUFjO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxvQkFXRixnQkFBZ0IsTUFBTSxPQUFPO0FBQUEsMEJBQ3ZCLGdCQUFnQixNQUFNLE1BQU07QUFBQTtBQUFBLGVBRXZDLGdCQUFnQixNQUFNLElBQUk7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsb0JBWXJCLGdCQUFnQixNQUFNLFNBQVM7QUFBQTtBQUFBLGVBRXBDLGdCQUFnQixNQUFNLFNBQVM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsb0JBaUMxQixnQkFBZ0IsTUFBTSxNQUFNO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxvQkFLNUIsZ0JBQWdCLE1BQU0sU0FBUztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsMEJBS3pCLGdCQUFnQixNQUFNLE1BQU07QUFBQSxlQUN2QyxnQkFBZ0IsTUFBTSxJQUFJO0FBQUE7QUFBQTtBQUFBO0FBQUEsb0JBSXJCLGdCQUFnQixNQUFNLE1BQU07QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsb0JBUzVCLGdCQUFnQixNQUFNLFNBQVM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsMkJBd0J4QixnQkFBZ0IsTUFBTSxTQUFTO0FBQUE7QUFBQTtBQUd4RCxTQUFLLFlBQVksS0FBSztBQUd0QixVQUFNLFFBQVEsU0FBUyxjQUFjLEtBQUs7QUFDMUMsVUFBTSxZQUFZO0FBQ2xCLFVBQU0sWUFBWTtBQUFBO0FBQUEsYUFFUCxNQUFNLEtBQUs7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBLCtDQUt1QixNQUFNLFFBQVE7QUFBQSw4Q0FDZixNQUFNLFNBQVM7QUFBQTtBQUFBO0FBQUEsOENBR2YsTUFBTSxTQUFTO0FBQUE7QUFBQTtBQUFBO0FBQUEsa0JBSTNDLE1BQU0sU0FBUztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxrQkFNZixNQUFNLElBQUk7QUFBQTtBQUFBO0FBQUE7QUFBQSxrQkFJVixNQUFNLE9BQU87QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsa0JBTWIsTUFBTSxPQUFPO0FBQUEseUNBQ1UsTUFBTSxRQUFRO0FBQUE7QUFBQTtBQUFBLGtCQUdyQyxNQUFNLFFBQVE7QUFBQTtBQUFBO0FBQUE7QUFBQSxrQkFJZCxNQUFNLE1BQU07QUFBQTtBQUFBO0FBQUE7QUFBQSx3Q0FJVSxNQUFNLFNBQVM7QUFBQTtBQUFBLDBEQUVHLE1BQU0sTUFBTTtBQUFBLCtDQUN2QixNQUFNLEtBQUs7QUFBQTtBQUFBO0FBQUE7QUFLeEQsU0FBSyxZQUFZLEtBQUs7QUFHdEIsVUFBTSxXQUFXO0FBQUEsTUFDZixRQUFRLE1BQU0sY0FBYyxTQUFTO0FBQUEsTUFDckMsU0FBUyxNQUFNLGNBQWMsV0FBVztBQUFBLE1BQ3hDLFVBQVUsTUFBTSxjQUFjLFlBQVk7QUFBQSxNQUMxQyxVQUFVLE1BQU0sY0FBYyxZQUFZO0FBQUEsTUFDMUMsV0FBVyxNQUFNLGNBQWMsYUFBYTtBQUFBLE1BQzVDLFdBQVcsTUFBTSxjQUFjLGFBQWE7QUFBQSxNQUM1QyxVQUFVLE1BQU0sY0FBYyxZQUFZO0FBQUEsTUFDMUMsWUFBWSxNQUFNLGNBQWMsY0FBYztBQUFBLE1BQzlDLFFBQVEsTUFBTSxjQUFjLFNBQVM7QUFBQSxNQUNyQyxVQUFVLE1BQU0sY0FBYyxZQUFZO0FBQUEsTUFDMUMsYUFBYSxNQUFNLGNBQWMsZUFBZTtBQUFBLE1BQ2hELGVBQWUsTUFBTSxjQUFjLGlCQUFpQjtBQUFBLE1BQ3BELGdCQUFnQixNQUFNLGNBQWMsa0JBQWtCO0FBQUEsTUFDdEQsUUFBUSxNQUFNLGNBQWMsU0FBUztBQUFBLElBQ3ZDO0FBR0Esa0JBQWMsU0FBUyxRQUFRLEtBQUs7QUFHcEMsUUFBSSxjQUFjO0FBR2xCLGFBQVMsVUFBVSxTQUFTO0FBQzFCLG9CQUFjO0FBQ2Qsb0JBQWMsY0FBYztBQUU1QixlQUFTLE9BQU8sY0FBYyxZQUFZLFNBQVMsRUFBRSxtQkFBbUIsSUFDMUMsWUFBWSxVQUFVLEVBQUUsb0JBQW9CLElBQzVDLEVBQUUsb0JBQW9CO0FBQ3BELGVBQVMsVUFBVSxXQUFXO0FBRzlCLGVBQVMsUUFBUSxVQUFVLE9BQU8sU0FBUztBQUMzQyxlQUFTLFFBQVEsVUFBVSxJQUFJLE9BQU87QUFDdEMsZUFBUyxTQUFTLFVBQVUsT0FBTyxTQUFTO0FBQzVDLGVBQVMsU0FBUyxVQUFVLElBQUksT0FBTztBQUN2QyxlQUFTLFNBQVMsVUFBVSxPQUFPLFNBQVM7QUFDNUMsZUFBUyxTQUFTLFVBQVUsSUFBSSxPQUFPO0FBRXZDLFVBQUksWUFBWSxRQUFRO0FBQ3RCLGlCQUFTLFFBQVEsVUFBVSxJQUFJLFNBQVM7QUFDeEMsaUJBQVMsUUFBUSxVQUFVLE9BQU8sT0FBTztBQUFBLE1BQzNDLFdBQVcsWUFBWSxTQUFTO0FBQzlCLGlCQUFTLFNBQVMsVUFBVSxJQUFJLFNBQVM7QUFDekMsaUJBQVMsU0FBUyxVQUFVLE9BQU8sT0FBTztBQUFBLE1BQzVDLFdBQVcsWUFBWSxTQUFTO0FBQzlCLGlCQUFTLFNBQVMsVUFBVSxJQUFJLFNBQVM7QUFDekMsaUJBQVMsU0FBUyxVQUFVLE9BQU8sT0FBTztBQUFBLE1BQzVDO0FBRUEsZUFBUyxXQUFXLGNBQWMsRUFBRSx3QkFBd0I7QUFFNUQsVUFBSSxhQUFhO0FBQ2Ysb0JBQVksT0FBTztBQUFBLE1BQ3JCO0FBQUEsSUFDRjtBQUdBLGFBQVMsUUFBUSxpQkFBaUIsU0FBUyxNQUFNLFVBQVUsTUFBTSxDQUFDO0FBQ2xFLGFBQVMsU0FBUyxpQkFBaUIsU0FBUyxNQUFNLFVBQVUsT0FBTyxDQUFDO0FBQ3BFLGFBQVMsU0FBUyxpQkFBaUIsU0FBUyxNQUFNLFVBQVUsT0FBTyxDQUFDO0FBRXBFLGFBQVMsVUFBVSxpQkFBaUIsU0FBUyxZQUFZO0FBQ3ZELFVBQUksQ0FBQyxZQUFhO0FBRWxCLGVBQVMsVUFBVSxXQUFXO0FBQzlCLGVBQVMsVUFBVSxjQUFjLEVBQUUsa0JBQWtCO0FBQ3JELGVBQVMsV0FBVyxjQUFjLEVBQUUsc0JBQXNCO0FBRTFELFVBQUk7QUFDRixZQUFJLFVBQVU7QUFDWixnQkFBTSxTQUFTLFdBQVc7QUFFMUIsa0JBQVE7QUFBQSxRQUNWO0FBQUEsTUFDRixTQUFTLE9BQU87QUFDZCxZQUFJLDJCQUFzQixLQUFLO0FBQy9CLGNBQU0sRUFBRSx1QkFBdUIsQ0FBQztBQUNoQyxpQkFBUyxVQUFVLFdBQVc7QUFDOUIsaUJBQVMsVUFBVSxjQUFjLEVBQUUsaUJBQWlCO0FBQ3BELGlCQUFTLFdBQVcsY0FBYyxFQUFFLG9CQUFvQjtBQUFBLE1BQzFEO0FBQUEsSUFDRixDQUFDO0FBR0QsYUFBUyxVQUFVO0FBQ2pCLGFBQU8sb0JBQW9CLG1CQUFtQixvQkFBb0I7QUFDbEUsVUFBSSxjQUFjLGNBQWM7QUFDOUIsZUFBTyxjQUFjLGNBQWMsWUFBWTtBQUMvQyxzQkFBYyxlQUFlO0FBQUEsTUFDL0I7QUFDQSxXQUFLLE9BQU87QUFDWixVQUFJLGlDQUEwQjtBQUFBLElBQ2hDO0FBRUEsYUFBUyxVQUFVLGlCQUFpQixTQUFTLE9BQU87QUFDcEQsYUFBUyxTQUFTLGlCQUFpQixTQUFTLE9BQU87QUFHbkQsYUFBUyxpQkFBaUIsV0FBVyxDQUFDLE1BQU07QUFDMUMsVUFBSSxFQUFFLFFBQVEsVUFBVTtBQUN0QixnQkFBUTtBQUFBLE1BQ1Y7QUFBQSxJQUNGLEdBQUcsRUFBRSxNQUFNLEtBQUssQ0FBQztBQUdqQixVQUFNLHVCQUF1QixNQUFNO0FBQ2pDLGtCQUFZO0FBQUEsSUFDZDtBQUVBLFdBQU8saUJBQWlCLG1CQUFtQixvQkFBb0I7QUFHL0QsYUFBUyxZQUFZLFVBQVU7QUF4VGpDO0FBeVRJLFVBQUksQ0FBQyxVQUFVO0FBQ2IsaUJBQVMsU0FBUyxjQUFjO0FBQ2hDLGlCQUFTLFlBQVksY0FBYztBQUNuQztBQUFBLE1BQ0Y7QUFFQSxZQUFNLE9BQU8sU0FBUyxRQUFRLFNBQVMsWUFBWTtBQUNuRCxZQUFNLFVBQVUsS0FBSyxNQUFNLFFBQU8sb0JBQVMsWUFBVCxtQkFBa0IsVUFBbEIsWUFBMkIsR0FBRyxDQUFDO0FBRWpFLGVBQVMsU0FBUyxjQUFjO0FBQ2hDLGVBQVMsWUFBWSxjQUFjLE9BQU8sU0FBUyxPQUFPLElBQUksT0FBTyxPQUFPLElBQUk7QUFBQSxJQUNsRjtBQUVBLGFBQVMsY0FBYyxZQUFZO0FBQ2pDLFVBQUksQ0FBQyxZQUFZO0FBQ2YsaUJBQVMsY0FBYyxjQUFjLEVBQUUsa0JBQWtCO0FBQ3pELGlCQUFTLGVBQWUsY0FBYztBQUN0QyxpQkFBUyxPQUFPLGNBQWM7QUFDOUI7QUFBQSxNQUNGO0FBRUEsWUFBTSxLQUFLLFFBQVEsV0FBVyxFQUFFO0FBQ2hDLFlBQU0sS0FBSyxXQUFXO0FBQ3RCLFlBQU0sU0FBUyxXQUFXLFVBQVU7QUFFcEMsZUFBUyxjQUFjLGNBQWMsS0FBSyxFQUFFLGlCQUFpQixJQUFJLEVBQUUsa0JBQWtCO0FBRXJGLFVBQUksT0FBTyxVQUFhLE9BQU8sTUFBTTtBQUNuQyxpQkFBUyxlQUFlLGNBQWM7QUFBQSxNQUN4QyxPQUFPO0FBQ0wsaUJBQVMsZUFBZSxjQUFjLEtBQUssRUFBRSxhQUFhLElBQUksRUFBRSxnQkFBZ0I7QUFBQSxNQUNsRjtBQUVBLGVBQVMsT0FBTyxjQUFjLE9BQU8sV0FBVyxXQUFXLEdBQUcsTUFBTSxNQUFPLFVBQVU7QUFBQSxJQUN2RjtBQUVBLGFBQVMsY0FBYztBQUVyQixZQUFNLFdBQVcsaUJBQWlCO0FBR2xDLFlBQU0sZUFBZSxNQUFNLGNBQWMseUJBQXlCO0FBQ2xFLFVBQUksY0FBYztBQUNoQixxQkFBYSxjQUFjLFNBQVM7QUFBQSxNQUN0QztBQUVBLFVBQUksU0FBUyxTQUFTO0FBQ3BCLGlCQUFTLFFBQVEsY0FBYyxTQUFTO0FBQUEsTUFDMUM7QUFFQSxVQUFJLFNBQVMsVUFBVTtBQUNyQixpQkFBUyxTQUFTLGNBQWMsU0FBUztBQUFBLE1BQzNDO0FBRUEsVUFBSSxTQUFTLFVBQVU7QUFDckIsaUJBQVMsU0FBUyxjQUFjLFNBQVM7QUFBQSxNQUMzQztBQUVBLFVBQUksU0FBUyxXQUFXO0FBQ3RCLGlCQUFTLFVBQVUsY0FBYyxTQUFTO0FBQUEsTUFDNUM7QUFFQSxVQUFJLFNBQVMsVUFBVTtBQUNyQixpQkFBUyxTQUFTLGNBQWMsU0FBUztBQUFBLE1BQzNDO0FBR0EsWUFBTSxnQkFBZ0IsTUFBTSxjQUFjLDRDQUE0QztBQUN0RixVQUFJLGVBQWU7QUFDakIsc0JBQWMsY0FBYyxTQUFTO0FBQUEsTUFDdkM7QUFFQSxZQUFNLFdBQVcsTUFBTSxjQUFjLCtDQUErQztBQUNwRixVQUFJLFVBQVU7QUFDWixpQkFBUyxjQUFjLFNBQVM7QUFBQSxNQUNsQztBQUVBLFlBQU0sY0FBYyxNQUFNLGNBQWMsOENBQThDO0FBQ3RGLFVBQUksYUFBYTtBQUNmLG9CQUFZLGNBQWMsU0FBUztBQUFBLE1BQ3JDO0FBRUEsWUFBTSxjQUFjLE1BQU0sY0FBYyxpREFBaUQ7QUFDekYsVUFBSSxhQUFhO0FBQ2Ysb0JBQVksY0FBYyxTQUFTO0FBQUEsTUFDckM7QUFFQSxZQUFNLGVBQWUsTUFBTSxjQUFjLGtEQUFrRDtBQUMzRixVQUFJLGNBQWM7QUFDaEIscUJBQWEsY0FBYyxTQUFTO0FBQUEsTUFDdEM7QUFFQSxZQUFNLGFBQWEsTUFBTSxjQUFjLGdEQUFnRDtBQUN2RixVQUFJLFlBQVk7QUFDZCxtQkFBVyxjQUFjLFNBQVM7QUFBQSxNQUNwQztBQUdBLFVBQUksU0FBUyxZQUFZO0FBQ3ZCLGNBQU0sZ0JBQWdCLFNBQVMsV0FBVztBQUMxQyxZQUFJLGtCQUFrQixNQUFNLGFBQWEsa0JBQWtCLFNBQVMsV0FBVztBQUM3RSxtQkFBUyxXQUFXLGNBQWMsU0FBUztBQUFBLFFBQzdDLFdBQVcsa0JBQWtCLE1BQU0sV0FBVyxrQkFBa0IsU0FBUyxTQUFTO0FBQ2hGLG1CQUFTLFdBQVcsY0FBYyxTQUFTO0FBQUEsUUFDN0MsV0FBVyxrQkFBa0IsTUFBTSxlQUFlLGtCQUFrQixTQUFTLGFBQWE7QUFDeEYsbUJBQVMsV0FBVyxjQUFjLFNBQVM7QUFBQSxRQUM3QyxXQUFXLGtCQUFrQixNQUFNLGlCQUFpQixrQkFBa0IsU0FBUyxlQUFlO0FBQzVGLG1CQUFTLFdBQVcsY0FBYyxTQUFTO0FBQUEsUUFDN0MsV0FBVyxrQkFBa0IsTUFBTSxhQUFhLGtCQUFrQixTQUFTLFdBQVc7QUFDcEYsbUJBQVMsV0FBVyxjQUFjLFNBQVM7QUFBQSxRQUM3QztBQUFBLE1BQ0Y7QUFHQSxVQUFJLFNBQVMsZUFBZTtBQUMxQixjQUFNLGlCQUFpQixTQUFTLGNBQWM7QUFDOUMsWUFBSSxtQkFBbUIsTUFBTSxVQUFVLG1CQUFtQixTQUFTLFFBQVE7QUFDekUsbUJBQVMsY0FBYyxjQUFjLFNBQVM7QUFBQSxRQUNoRCxXQUFXLG1CQUFtQixNQUFNLFdBQVcsbUJBQW1CLFNBQVMsU0FBUztBQUNsRixtQkFBUyxjQUFjLGNBQWMsU0FBUztBQUFBLFFBQ2hELFdBQVcsbUJBQW1CLE1BQU0sWUFBWSxtQkFBbUIsU0FBUyxVQUFVO0FBQ3BGLG1CQUFTLGNBQWMsY0FBYyxTQUFTO0FBQUEsUUFDaEQ7QUFBQSxNQUNGO0FBR0EsVUFBSSxTQUFTLGdCQUFnQjtBQUMzQixjQUFNLFlBQVksU0FBUyxlQUFlO0FBQzFDLFlBQUksY0FBYyxNQUFNLE1BQU0sY0FBYyxTQUFTLElBQUk7QUFDdkQsbUJBQVMsZUFBZSxjQUFjLFNBQVM7QUFBQSxRQUNqRCxXQUFXLGNBQWMsTUFBTSxTQUFTLGNBQWMsU0FBUyxPQUFPO0FBQ3BFLG1CQUFTLGVBQWUsY0FBYyxTQUFTO0FBQUEsUUFDakQ7QUFBQSxNQUNGO0FBR0EsVUFBSSxlQUFlLFNBQVMsUUFBUTtBQUNsQyxpQkFBUyxPQUFPLGNBQWMsZ0JBQWdCLFNBQVMsU0FBUyxXQUNsQyxnQkFBZ0IsVUFBVSxTQUFTLFlBQ25DLFNBQVM7QUFBQSxNQUN6QztBQUdBLGFBQU8sT0FBTyxPQUFPLFFBQVE7QUFFN0IsVUFBSSx5REFBa0QsbUJBQW1CLENBQUMsRUFBRTtBQUFBLElBQzlFO0FBRUEsUUFBSSx3Q0FBbUM7QUFFdkMsV0FBTztBQUFBLE1BQ0w7QUFBQSxNQUNBO0FBQUEsTUFDQTtBQUFBLE1BQ0E7QUFBQSxNQUNBO0FBQUEsTUFDQSxnQkFBZ0IsTUFBTTtBQUFBLElBQ3hCO0FBQUEsRUFDRjs7O0FDbmRBLGlCQUFzQixhQUFhO0FBSm5DO0FBS0UsUUFBSSxxREFBd0M7QUFFNUMsUUFBSTtBQUNGLFlBQU0sTUFBTSxNQUFNLE1BQU0sa0NBQWtDO0FBQUEsUUFDeEQsYUFBYTtBQUFBLE1BQ2YsQ0FBQztBQUVELFVBQUksQ0FBQyxJQUFJLElBQUk7QUFDWCxjQUFNLElBQUksTUFBTSxRQUFRLElBQUksTUFBTSxFQUFFO0FBQUEsTUFDdEM7QUFFQSxvQkFBYyxLQUFLLE1BQU0sSUFBSSxLQUFLO0FBQ2xDLFVBQUksa0RBQXFDLG1CQUFjLE9BQWQsbUJBQWtCLFdBQVEsbUJBQWMsT0FBZCxtQkFBa0IsYUFBWSxTQUFTO0FBRTFHLGFBQU8sY0FBYztBQUFBLElBQ3ZCLFNBQVMsT0FBTztBQUNkLFVBQUksc0NBQThCLE1BQU0sT0FBTztBQUMvQyxvQkFBYyxLQUFLO0FBQ25CLGFBQU87QUFBQSxJQUNUO0FBQUEsRUFDRjtBQUVBLGlCQUFzQixxQkFBcUI7QUEzQjNDO0FBNEJFLFFBQUksNkNBQXNDO0FBRTFDLFFBQUk7QUFDRixZQUFNLE1BQU0sTUFBTSxNQUFNLHNDQUFzQztBQUFBLFFBQzVELFFBQVE7QUFBQSxRQUNSLGFBQWE7QUFBQSxNQUNmLENBQUM7QUFFRCxVQUFJLE9BQU87QUFDWCxVQUFJO0FBQ0YsZUFBTyxNQUFNLElBQUksS0FBSztBQUFBLE1BQ3hCLFFBQVE7QUFDTixlQUFPO0FBQUEsTUFDVDtBQUVBLFVBQUksSUFBSSxNQUFNLE1BQU07QUFDbEIsc0JBQWMsU0FBUztBQUFBLFVBQ3JCLElBQUksU0FBUSxVQUFLLE9BQUwsWUFBVyxJQUFJO0FBQUEsVUFDM0IsV0FBVSxzQkFBSyxhQUFMLG1CQUFlLE9BQWYsWUFBcUIsS0FBSyxhQUExQixZQUFzQztBQUFBLFVBQ2hELFNBQVEsZ0JBQUssV0FBTCxZQUFlLEtBQUssZ0JBQXBCLFlBQW9DLE9BQU8sS0FBSyxrQkFBa0IsV0FBVyxHQUFHLEtBQUssYUFBYSxNQUFNO0FBQUEsUUFDbEg7QUFDQSxZQUFJLHVDQUFrQyxjQUFjLE1BQU07QUFBQSxNQUM1RCxPQUFPO0FBQ0wsc0JBQWMsU0FBUztBQUFBLFVBQ3JCLElBQUk7QUFBQSxVQUNKLFVBQVU7QUFBQSxVQUNWLFFBQVE7QUFBQSxRQUNWO0FBQ0EsWUFBSSxnREFBc0M7QUFBQSxNQUM1QztBQUFBLElBQ0YsU0FBUyxPQUFPO0FBQ2QsVUFBSSxxQ0FBZ0MsTUFBTSxPQUFPO0FBQ2pELG9CQUFjLFNBQVM7QUFBQSxRQUNyQixJQUFJO0FBQUEsUUFDSixVQUFVO0FBQUEsUUFDVixRQUFRO0FBQUEsTUFDVjtBQUFBLElBQ0Y7QUFFQSxXQUFPLGNBQWM7QUFBQSxFQUN2QjtBQUVBLGlCQUFzQixzQkFBc0IsU0FBUyxTQUFTO0FBQzVELFFBQUksOEJBQXVCLE9BQU8sRUFBRTtBQUVwQyxRQUFJO0FBQ0YsWUFBTSxXQUFXO0FBQUEsUUFDZixRQUFRO0FBQUEsUUFDUixTQUFTO0FBQUEsUUFDVCxTQUFTO0FBQUEsTUFDWDtBQUVBLFlBQU0sV0FBVyxTQUFTLE9BQU87QUFDakMsVUFBSSxDQUFDLFVBQVU7QUFDYixjQUFNLElBQUksTUFBTSw0QkFBNEIsT0FBTyxFQUFFO0FBQUEsTUFDdkQ7QUFFQSxZQUFNLE1BQU0sR0FBRyxPQUFPLElBQUksUUFBUTtBQUVsQyxVQUFJLGtCQUFXLEdBQUcsRUFBRTtBQUVwQixZQUFNLFdBQVcsTUFBTSxNQUFNLEdBQUc7QUFDaEMsVUFBSSxDQUFDLFNBQVMsSUFBSTtBQUNoQixjQUFNLElBQUksTUFBTSxRQUFRLFNBQVMsTUFBTSxFQUFFO0FBQUEsTUFDM0M7QUFFQSxZQUFNLE9BQU8sTUFBTSxTQUFTLEtBQUs7QUFDakMsVUFBSSwwQkFBcUIsS0FBSyxNQUFNLHdCQUF3QjtBQUc1RCxPQUFDLEdBQUcsTUFBTSxJQUFJO0FBRWQsVUFBSSxzQ0FBK0I7QUFDbkMsYUFBTztBQUFBLElBQ1QsU0FBUyxPQUFPO0FBQ2QsVUFBSSw0Q0FBdUMsTUFBTSxPQUFPO0FBQ3hELFlBQU07QUFBQSxJQUNSO0FBQUEsRUFDRjs7O0FDNUZPLFdBQVMsdUJBQXVCLFVBQVUsQ0FBQyxHQUFHO0FBQ25ELFVBQU07QUFBQSxNQUNKLG1CQUFtQjtBQUFBLE1BQ25CLFdBQVc7QUFBQSxNQUNYLFlBQVk7QUFBQSxJQUNkLElBQUk7QUFHSixVQUFNLFlBQVksU0FBUyxjQUFjLEtBQUs7QUFDOUMsY0FBVSxZQUFZO0FBR3RCLFVBQU0sU0FBUztBQUFBO0FBQUE7QUFBQSxRQUdULGtCQUFrQixRQUFRLENBQUM7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBa0dqQyxRQUFJLENBQUMsU0FBUyxjQUFjLDJCQUEyQixHQUFHO0FBQ3hELFlBQU0sYUFBYSxTQUFTLGNBQWMsT0FBTztBQUNqRCxpQkFBVyxLQUFLO0FBQ2hCLGlCQUFXLGNBQWM7QUFDekIsZUFBUyxLQUFLLFlBQVksVUFBVTtBQUFBLElBQ3RDO0FBR0EsUUFBSSxTQUFTO0FBQ2IsUUFBSSxjQUFjLG1CQUFtQjtBQUdyQyxhQUFTLFNBQVM7QUFDaEIsWUFBTSxXQUFXLG9CQUFvQixXQUFXO0FBRWhELGdCQUFVLFlBQVk7QUFBQTtBQUFBLFVBRWhCLFlBQVksK0JBQStCLFNBQVMsSUFBSSxZQUFZLEVBQUU7QUFBQSxzQ0FDMUMsU0FBUyxJQUFJO0FBQUEscURBQ0UsU0FBUyxtQkFBbUIsY0FBYztBQUFBO0FBQUEsK0NBRWhELFNBQVMsWUFBWSxFQUFFO0FBQUEsVUFDNUQsT0FBTyxRQUFRLG1CQUFtQixFQUFFLElBQUksQ0FBQyxDQUFDLE1BQU0sSUFBSSxNQUFNO0FBQUEsMkNBQ3pCLFNBQVMsY0FBYyxXQUFXLEVBQUUsZ0JBQWdCLElBQUk7QUFBQSxjQUNyRixZQUFZLCtCQUErQixLQUFLLElBQUksWUFBWSxFQUFFO0FBQUEsMENBQ3RDLEtBQUssSUFBSTtBQUFBO0FBQUEsU0FFMUMsRUFBRSxLQUFLLEVBQUUsQ0FBQztBQUFBO0FBQUE7QUFLZiwwQkFBb0I7QUFBQSxJQUN0QjtBQUdBLGFBQVMsc0JBQXNCO0FBQzdCLFlBQU0sU0FBUyxVQUFVLGNBQWMsMkJBQTJCO0FBQ2xFLFlBQU1BLFdBQVUsVUFBVSxpQkFBaUIsa0JBQWtCO0FBRzdELGFBQU8saUJBQWlCLFNBQVMsQ0FBQyxNQUFNO0FBQ3RDLFVBQUUsZ0JBQWdCO0FBQ2xCLGlCQUFTLENBQUM7QUFDVixlQUFPO0FBQUEsTUFDVCxDQUFDO0FBR0QsTUFBQUEsU0FBUSxRQUFRLFlBQVU7QUFDeEIsZUFBTyxpQkFBaUIsU0FBUyxDQUFDLE1BQU07QUFDdEMsWUFBRSxnQkFBZ0I7QUFDbEIsZ0JBQU0sZUFBZSxPQUFPLFFBQVE7QUFFcEMsY0FBSSxpQkFBaUIsYUFBYTtBQUNoQywwQkFBYztBQUNkLHdCQUFZLFlBQVk7QUFFeEIsZ0JBQUksa0JBQWtCO0FBQ3BCLCtCQUFpQixZQUFZO0FBQUEsWUFDL0I7QUFBQSxVQUNGO0FBRUEsbUJBQVM7QUFDVCxpQkFBTztBQUFBLFFBQ1QsQ0FBQztBQUFBLE1BQ0gsQ0FBQztBQUdELGVBQVMsaUJBQWlCLFNBQVMsTUFBTTtBQUN2QyxZQUFJLFFBQVE7QUFDVixtQkFBUztBQUNULGlCQUFPO0FBQUEsUUFDVDtBQUFBLE1BQ0YsQ0FBQztBQUFBLElBQ0g7QUFHQSxhQUFTLHFCQUFxQixPQUFPO0FBQ25DLFVBQUksTUFBTSxPQUFPLGFBQWEsYUFBYTtBQUN6QyxzQkFBYyxNQUFNLE9BQU87QUFDM0IsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBR0EsV0FBTyxpQkFBaUIsbUJBQW1CLG9CQUFvQjtBQUcvRCxXQUFPO0FBR1AsV0FBTztBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsTUFLTCxNQUFNLFNBQVMsU0FBUyxNQUFNO0FBQzVCLGVBQU8sWUFBWSxTQUFTO0FBQUEsTUFDOUI7QUFBQTtBQUFBO0FBQUE7QUFBQSxNQUtBLFVBQVU7QUFDUixlQUFPLG9CQUFvQixtQkFBbUIsb0JBQW9CO0FBQ2xFLFlBQUksVUFBVSxZQUFZO0FBQ3hCLG9CQUFVLFdBQVcsWUFBWSxTQUFTO0FBQUEsUUFDNUM7QUFBQSxNQUNGO0FBQUE7QUFBQTtBQUFBO0FBQUE7QUFBQSxNQU1BLFlBQVksYUFBYTtBQUN2QixrQkFBVSxNQUFNLFVBQVUsa0JBQWtCLFdBQVc7QUFBQSxNQUN6RDtBQUFBO0FBQUE7QUFBQTtBQUFBO0FBQUEsTUFNQSxhQUFhO0FBQ1gsZUFBTztBQUFBLE1BQ1Q7QUFBQTtBQUFBO0FBQUE7QUFBQSxNQUtBLFNBQVM7QUFDUCxzQkFBYyxtQkFBbUI7QUFDakMsZUFBTztBQUFBLE1BQ1Q7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQU9BLFdBQVMsa0JBQWtCLFVBQVU7QUFDbkMsVUFBTSxZQUFZO0FBQUEsTUFDaEIsYUFBYTtBQUFBLE1BQ2IsWUFBWTtBQUFBLE1BQ1osZ0JBQWdCO0FBQUEsTUFDaEIsZUFBZTtBQUFBLE1BQ2YsY0FBYztBQUFBLE1BQ2QsaUJBQWlCO0FBQUEsSUFDbkI7QUFFQSxXQUFPLFVBQVUsUUFBUSxLQUFLLFVBQVUsV0FBVztBQUFBLEVBQ3JEOzs7QUNoUkEsaUJBQXNCLGNBQWM7QUFQcEM7QUFRRSxRQUFJLCtEQUFxRDtBQUd6RCx1QkFBbUI7QUFHbkIsU0FBSSxZQUFPLGdCQUFQLG1CQUFvQixpQkFBaUI7QUFDdkMsWUFBTSwyQ0FBcUM7QUFDM0M7QUFBQSxJQUNGO0FBR0EsV0FBTyxjQUFjLEVBQUUsR0FBRyxPQUFPLGFBQWEsaUJBQWlCLEtBQUs7QUFFcEUsUUFBSTtBQUVGLFVBQUksbUJBQW1CO0FBR3ZCLFlBQU0sS0FBSyxpQkFBaUI7QUFBQSxRQUMxQixhQUFhLENBQUMsWUFBWTtBQUN4QixjQUFJLCtCQUF3QixPQUFPLEVBQUU7QUFFckMsY0FBSSxrQkFBa0I7QUFDcEIsNkJBQWlCLFFBQVE7QUFDekIsK0JBQW1CO0FBQUEsVUFDckI7QUFBQSxRQUNGO0FBQUEsUUFFQSxVQUFVLE9BQU8sWUFBWTtBQUMzQixjQUFJLDJCQUFvQixPQUFPLEVBQUU7QUFDakMsZ0JBQU0sc0JBQXNCLFNBQVMsZ0JBQWdCLFFBQVE7QUFBQSxRQUMvRDtBQUFBLFFBRUEsU0FBUyxNQUFNO0FBQ2IsY0FBSSw2QkFBc0I7QUFFMUIsY0FBSSxrQkFBa0I7QUFDcEIsNkJBQWlCLFFBQVE7QUFDekIsK0JBQW1CO0FBQUEsVUFDckI7QUFDQSxpQkFBTyxZQUFZLGtCQUFrQjtBQUFBLFFBQ3ZDO0FBQUEsTUFDRixDQUFDO0FBR0QseUJBQW1CLHVCQUF1QjtBQUFBLFFBQ3hDLFVBQVU7QUFBQTtBQUFBLFFBQ1YsV0FBVztBQUFBLFFBQ1gsa0JBQWtCLENBQUMsZ0JBQWdCO0FBQ2pDLGNBQUksZ0NBQXlCLFdBQVcsb0JBQW9CO0FBRzVELGFBQUcsWUFBWTtBQUdmLGNBQUksT0FBTyxXQUFXLGVBQWUsT0FBTyxhQUFhO0FBQ3ZELG1CQUFPLGNBQWMsSUFBSSxPQUFPLFlBQVksMkJBQTJCO0FBQUEsY0FDckUsUUFBUSxFQUFFLFVBQVUsWUFBWTtBQUFBLFlBQ2xDLENBQUMsQ0FBQztBQUFBLFVBQ0o7QUFBQSxRQUNGO0FBQUEsTUFDRixDQUFDO0FBR0QsdUJBQWlCLE1BQU07QUFHdkIsVUFBSSw4Q0FBb0M7QUFHeEMsWUFBTSxTQUFTLE1BQU0sbUJBQW1CO0FBQ3hDLFNBQUcsY0FBYyxNQUFNO0FBR3ZCLFlBQU0sT0FBTyxNQUFNLFdBQVc7QUFDOUIsU0FBRyxZQUFZLElBQUk7QUFHbkIsb0JBQWMsZUFBZSxPQUFPLFlBQVksWUFBWTtBQUMxRCxZQUFJLDBDQUFnQztBQUVwQyxZQUFJO0FBQ0YsZ0JBQU0sQ0FBQyxXQUFXLE9BQU8sSUFBSSxNQUFNLFFBQVEsSUFBSTtBQUFBLFlBQzdDLG1CQUFtQjtBQUFBLFlBQ25CLFdBQVc7QUFBQSxVQUNiLENBQUM7QUFFRCxhQUFHLGNBQWMsU0FBUztBQUMxQixhQUFHLFlBQVksT0FBTztBQUFBLFFBQ3hCLFNBQVMsT0FBTztBQUNkLGNBQUksa0RBQXVDLEtBQUs7QUFBQSxRQUNsRDtBQUFBLE1BQ0YsR0FBRyxnQkFBZ0IsZ0JBQWdCO0FBR25DLGFBQU8saUJBQWlCLGdCQUFnQixNQUFNO0FBQzVDLFdBQUcsUUFBUTtBQUNYLFlBQUksa0JBQWtCO0FBQ3BCLDJCQUFpQixRQUFRO0FBQUEsUUFDM0I7QUFDQSxlQUFPLFlBQVksa0JBQWtCO0FBQUEsTUFDdkMsQ0FBQztBQUVELFVBQUksaURBQTRDO0FBQUEsSUFFbEQsU0FBUyxPQUFPO0FBQ2QsVUFBSSw2Q0FBd0MsS0FBSztBQUNqRCxhQUFPLFlBQVksa0JBQWtCO0FBQ3JDLFlBQU07QUFBQSxJQUNSO0FBQUEsRUFDRjs7O0FDckhBLEdBQUMsTUFBTTtBQUNMO0FBSEY7QUFLRSxVQUFJLFlBQU8sZ0JBQVAsbUJBQW9CLGtCQUFlLFlBQU8sZ0JBQVAsbUJBQW9CLGVBQWM7QUFDdkUsWUFBTSx1RUFBaUU7QUFDdkU7QUFBQSxJQUNGO0FBR0EsUUFBSSxDQUFDLE9BQU8sYUFBYTtBQUN2QixhQUFPLGNBQWMsQ0FBQztBQUFBLElBQ3hCO0FBRUEsZ0JBQVksRUFBRSxNQUFNLENBQUMsTUFBTTtBQUN6QixjQUFRLE1BQU0saUNBQWlDLENBQUM7QUFFaEQsVUFBSSxPQUFPLGFBQWE7QUFDdEIsZUFBTyxZQUFZLGtCQUFrQjtBQUFBLE1BQ3ZDO0FBQ0EsWUFBTSxrREFBa0Q7QUFBQSxJQUMxRCxDQUFDO0FBQUEsRUFDSCxHQUFHOyIsCiAgIm5hbWVzIjogWyJvcHRpb25zIl0KfQo=

--- a/src/image/processor.js
+++ b/src/image/processor.js
@@ -86,13 +86,8 @@ export class ImageProcessor {
           continue;
         }
         
-        // Filtrar píxeles blancos/muy claros si está configurado
-        const isWhite = r > config.WHITE_THRESHOLD && 
-                       g > config.WHITE_THRESHOLD && 
-                       b > config.WHITE_THRESHOLD;
-        if (isWhite) {
-          continue;
-        }
+        // Nota: Removido el filtro automático de píxeles blancos
+        // para permitir el uso del color blanco (ID 5) en las imágenes
         
         // Encontrar el color más cercano en la paleta
         const closestColor = this.findClosestColor({ r, g, b }, availableColors);
@@ -208,8 +203,8 @@ export function detectAvailableColors() {
     const idStr = element.id.replace('color-', '');
     const id = parseInt(idStr);
     
-    // Filtrar colores específicos (0 y 5 según el original)
-    if (id === 0 || id === 5) {
+    // Filtrar solo el color 0 (mantener el color blanco ID 5 disponible)
+    if (id === 0) {
       continue;
     }
     


### PR DESCRIPTION
Descripción

Se habilita el uso del color blanco (ID 5) en el pipeline de imagen y se mejora la detección/asignación de color para píxeles cercanos al blanco. Se mantiene el filtrado solo del color ID 0 para evitar transparencia/negro de control, y se refactoriza la lógica de detección de color para facilitar su mantenimiento y extensibilidad futura.

Cambios
	•	✨ Permitir uso de blanco (ID 5) eliminando el filtrado automático previo de píxeles blancos.
	•	🎯 Mejora del matching de color con tolerancia para píxeles near-white (evita perder blancos por ruido/compresión).
	•	🚫 Filtrar exclusivamente color ID 0, manteniendo disponible el blanco.
	•	🧹 Refactor de la detección de color (funciones más pequeñas, testables y con responsabilidades claras).

Contexto

Anteriormente se descartaban píxeles blancos, provocando artefactos en imágenes con zonas claras o fondos blancos. Con esta mejora, el sistema representa correctamente esas áreas y reduce errores por discretización de color.

Checklist
	•	Título con Conventional Commits (feat(image): ...)
	•	Probado localmente con imágenes de ejemplo (fondos blancos y degradados).
	•	Docs/README actualizados si aplica (mencionar soporte explícito de blanco).
	•	Linter y CI verdes (Super Linter / CodeQL / Commitlint / Labeler).

Notas para reviewers
	•	Enfocarse en:
	•	Corrección del umbral de tolerancia para near-white.
	•	Claridad de nombres y separación de responsabilidades en la refactorización.
	•	Sugerencias de casos de prueba adicionales bienvenidas (patrones cuadriculados, texto sobre fondo blanco, bordes finos).
