### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,28 @@
   Un único marcador para elegir entre Auto-Farm, Auto-Image o Auto-Guard.
 
   ```javascript
-  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Launcher.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Launcher] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).\");}})();
+  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Launcher.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Launcher] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).");}})();
   ```
 
   ### 🛡️ Auto-Guard
   Protege áreas de tu pixel art y repara cambios no deseados automáticamente.
 
   ```javascript
-  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Guard.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Guard] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).\");}})();
+  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Guard.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Guard] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).");}})();
   ```
 
   ### 🌾 Auto-Farm
   Farmea experiencia automáticamente respetando los límites del servidor.
 
   ```javascript
-  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Farm.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Farm] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).\");}})();
+  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Farm.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Farm] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).");}})();
   ```
 
   ### 🎨 Auto-Image
   Pinta una imagen automáticamente como pixel art en el canvas.
 
   ```javascript
-  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Image.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Image] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).\");}})();
+  javascript:(async()=>{const U="https://raw.githubusercontent.com/Alarisco/WPlace-AutoBOT/refs/heads/main/Auto-Image.js";try{const r=await fetch(U,{cache:"no-cache"});if(!r.ok)throw new Error(r.status+" "+r.statusText);const code=await r.text();const blob=new Blob([code+"\n//# sourceURL="+U],{type:"text/javascript"});const blobUrl=URL.createObjectURL(blob);try{await new Promise((ok,err)=>{const s=document.createElement("script");s.src=blobUrl;s.onload=ok;s.onerror=err;document.documentElement.appendChild(s);});}catch(e){await import(blobUrl);}}catch(e){alert("[Auto-Image] No se pudo cargar/inyectar: "+e.message+"\nPrueba en otra página o usa la Opción C (módulo).");}})();
   ```
 - **📖 Documentación:** [GitHub Wiki](https://github.com/Alarisco/WPlace-AutoBOT)
 


### PR DESCRIPTION
# Pull Request

## Descripción
Se ha solucionado un fallo en la inyección de JavaScript causado por el uso incorrecto de `\"` al final de una cadena.  
Este carácter extra rompía el bookmarklet y también estaba presente en varias referencias dentro del README.  

## Checklist
- [x] Título con Conventional Commits (`fix:`)
- [x] Probado localmente (bookmarklet funciona sin error)
- [x] Docs/README actualizados (se han eliminado las `\` innecesarias)

## Riesgos
No hay riesgos significativos, ya que el cambio únicamente elimina un carácter de escape inválido.  
En caso de necesitar revertir, basta con restaurar la barra invertida en las líneas afectadas.
